### PR TITLE
refactor: simplify cleanPath

### DIFF
--- a/app/wizard/GitRepoWizardViewer.test.tsx
+++ b/app/wizard/GitRepoWizardViewer.test.tsx
@@ -42,8 +42,7 @@ vi.mock('@aptre/bldr', () => ({
   get isDesktop() {
     return h.isDesktop
   },
-  cleanPath: (path: string) =>
-    ('/' + path.split('/').filter(Boolean).join('/')).replace(/^\/$/, '/'),
+  cleanPath: (path: string) => '/' + path.split('/').filter(Boolean).join('/'),
 }))
 
 vi.mock('@aptre/bldr-sdk/hooks/useStreamingResource.js', () => ({


### PR DESCRIPTION
Remove the redundant `.replace(/^\/$/, '/')` from the mocked `cleanPath` implementation in `app/wizard/GitRepoWizardViewer.test.tsx` line 46.