### PR TITLE
fix(bldr): restore plugin startup readiness

### DIFF
--- a/bldr/e2e/comms/fixtures/go/goscript-opfs-storage/plugin.go
+++ b/bldr/e2e/comms/fixtures/go/goscript-opfs-storage/plugin.go
@@ -28,22 +28,24 @@ func run() {
 	}()
 
 	mode := readMode()
+	var err error
 	switch mode {
 	case "write":
-		if err := writeProofData(); err != nil {
-			postFailure(err)
-			return
-		}
-		postMessage(map[string]any{"type": "opfs-done", "mode": mode})
+		err = writeProofData()
 	case "read":
-		if err := readProofData(); err != nil {
-			postFailure(err)
-			return
-		}
-		postMessage(map[string]any{"type": "opfs-done", "mode": mode})
+		err = readProofData()
 	default:
-		postFailure(errors.Errorf("unknown mode %q", mode))
+		err = errors.Errorf("unknown mode %q", mode)
 	}
+	if err != nil {
+		postFailure(err)
+		return
+	}
+	if err := markReady(); err != nil {
+		postFailure(err)
+		return
+	}
+	postMessage(map[string]any{"type": "opfs-done", "mode": mode})
 }
 
 func readMode() string {
@@ -88,6 +90,15 @@ func readProofData() error {
 		return errors.Errorf("read %q, want %q", string(data), payload)
 	}
 	return opfs.DeleteEntry(root, dirName, true)
+}
+
+func markReady() error {
+	ready := js.Global().Get("BLDR_PLUGIN_MARK_READY")
+	if ready.IsUndefined() || ready.IsNull() || ready.Type() != js.TypeFunction {
+		return errors.New("BLDR_PLUGIN_MARK_READY is not a function")
+	}
+	ready.Invoke()
+	return nil
 }
 
 func postFailure(err error) {

--- a/bldr/plugin/compiler/js/entrypoint.ts
+++ b/bldr/plugin/compiler/js/entrypoint.ts
@@ -1,9 +1,9 @@
 // Import types generated from protobuf definitions.
 import { Client, isAbortError } from 'starpc'
-import type {
-  BackendAPI,
-  BackendEntrypointFunc,
-  BackendEntrypointLifecycle,
+import {
+  isBackendEntrypointFunc,
+  isBackendEntrypointLifecycle,
+  type BackendAPI,
 } from '@aptre/bldr-sdk'
 import { BackendEntrypoint, FrontendEntrypoint } from './compiler.pb.js'
 import { ConfigSet } from '@go/github.com/aperturerobotics/controllerbus/controller/configset/proto/configset.pb.js'
@@ -12,7 +12,7 @@ import {
   SetHtmlLinksRequest,
   SetRenderModeRequest,
 } from '@aptre/bldr'
-import { PluginHostRoot } from '../../../sdk/plugin/host/plugin-host-root.js'
+import { PluginHostResourceServiceClient } from '../../../sdk/plugin/host/host_srpc.pb.js'
 import { createAbortController } from '../../../web/bldr/abort.js'
 import {
   WebPlugin,
@@ -128,16 +128,6 @@ function observeBackendEntrypointCompletion(
     })
 }
 
-function isBackendEntrypointLifecycle(
-  result: ReturnType<BackendEntrypointFunc>,
-): result is BackendEntrypointLifecycle {
-  return (
-    typeof result === 'object' &&
-    result !== null &&
-    ('startup' in result || 'done' in result)
-  )
-}
-
 /**
  * Loads and executes a single backend entrypoint module.
  * @param entrypoint - The backend entrypoint configuration.
@@ -170,7 +160,7 @@ export async function startBackendEntrypoint(
     const mod = await loadModule(importPath)
     const modFunc = mod[importName]
 
-    if (typeof modFunc !== 'function') {
+    if (!isBackendEntrypointFunc(modFunc)) {
       // Backend readiness must fail closed: a configured entrypoint owns the
       // capability startup marker, so a missing export cannot be treated as
       // successful startup.
@@ -180,10 +170,7 @@ export async function startBackendEntrypoint(
     }
 
     console.debug(`Executing backend entrypoint: ${entrypointId}`)
-    const entrypointResult = (modFunc as BackendEntrypointFunc)(
-      backendAPI,
-      abortSignal,
-    )
+    const entrypointResult = modFunc(backendAPI, abortSignal)
     if (isBackendEntrypointLifecycle(entrypointResult)) {
       await entrypointResult.startup
       observeBackendEntrypointCompletion(entrypointId, entrypointResult.done)
@@ -565,20 +552,13 @@ function reportQuickJSReadiness(marker: string): void {
   }
 }
 
-function pendingForever(): Promise<never> {
-  return new Promise((resolve) => {
-    void resolve
-  })
-}
-
 async function completeInitialCapabilityRegistration(
   backendAPI: BackendAPI,
   abortSignal: AbortSignal,
 ): Promise<void> {
-  using pluginHostRoot = new PluginHostRoot(
-    await backendAPI.resourceClient.accessRootResource(),
-  )
-  await pluginHostRoot.completeInitialCapabilityRegistration(abortSignal)
+  using rootRef = await backendAPI.resourceClient.accessRootResource()
+  const svc = new PluginHostResourceServiceClient(rootRef.client)
+  await svc.CompleteInitialCapabilityRegistration({}, abortSignal)
 }
 
 /**
@@ -619,16 +599,28 @@ export default async function main(
 
   const frontendReady = loadWebPlugin(backendAPI, pluginId, abortSignal)
   const capabilityReady = loadBackendEntrypoints(backendAPI, abortSignal)
-  const capabilityFailure = capabilityReady.then(pendingForever)
+  const capabilityRegistrationReady = capabilityReady.then(() =>
+    completeInitialCapabilityRegistration(backendAPI, abortSignal),
+  )
 
-  // Keep frontend/capability marker order stable, but do not let a frontend
-  // retry loop hide backend startup rejection. Backgrounded tabs may throttle
-  // timers, so readiness is event-driven instead of timeout-driven.
-  await Promise.race([frontendReady, capabilityFailure])
-  reportQuickJSReadiness(quickJSPluginFrontendReadyMarker)
-  await capabilityReady
-  await completeInitialCapabilityRegistration(backendAPI, abortSignal)
-  reportQuickJSReadiness(quickJSPluginCapabilityReadyMarker)
+  if (isQuickJSRuntime()) {
+    const capabilityFailure = capabilityRegistrationReady.then(
+      () => Promise.withResolvers<never>().promise,
+    )
+    await Promise.race([frontendReady, capabilityFailure])
+    reportQuickJSReadiness(quickJSPluginFrontendReadyMarker)
+    await capabilityRegistrationReady
+    reportQuickJSReadiness(quickJSPluginCapabilityReadyMarker)
+  } else {
+    void frontendReady.catch((err) => {
+      if (abortSignal.aborted) return
+      const globals = globalThis as typeof globalThis & {
+        BLDR_PLUGIN_REPORT_RUNTIME_FAILURE?: (err: unknown) => void
+      }
+      globals.BLDR_PLUGIN_REPORT_RUNTIME_FAILURE?.(err)
+    })
+    await capabilityRegistrationReady
+  }
 
   console.info('Bldr JS plugin entrypoint finished initialization.')
   reportQuickJSReadiness(quickJSPluginReadyMarker)

--- a/bldr/plugin/entrypoint/common.go
+++ b/bldr/plugin/entrypoint/common.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io/fs"
 	"strings"
+	"sync"
 
 	"github.com/aperturerobotics/controllerbus/bus"
 	"github.com/aperturerobotics/controllerbus/controller"
@@ -11,6 +12,7 @@ import (
 	configset_controller "github.com/aperturerobotics/controllerbus/controller/configset/controller"
 	configset_proto "github.com/aperturerobotics/controllerbus/controller/configset/proto"
 	"github.com/aperturerobotics/starpc/srpc"
+	"github.com/pkg/errors"
 	"github.com/s4wave/spacewave/bldr/core"
 	manifest "github.com/s4wave/spacewave/bldr/manifest"
 	bldr_plugin "github.com/s4wave/spacewave/bldr/plugin"
@@ -28,6 +30,7 @@ import (
 	volume_rpc_client "github.com/s4wave/spacewave/db/volume/rpc/client"
 	bifrost_rpc "github.com/s4wave/spacewave/net/rpc"
 	bifrost_rpc_access "github.com/s4wave/spacewave/net/rpc/access"
+	sdk_plugin "github.com/s4wave/spacewave/sdk/plugin"
 	"github.com/sirupsen/logrus"
 )
 
@@ -37,6 +40,10 @@ type AddFactoryFunc func(b bus.Bus) []controller.Factory
 // BuildConfigSetFunc is a function to build a list of ConfigSet to apply.
 type BuildConfigSetFunc func(ctx context.Context, b bus.Bus, le *logrus.Entry) ([]configset.ConfigSet, error)
 
+// AcceptPluginHostStreamsFunc serves incoming plugin host streams and reports
+// when the handler is ready.
+type AcceptPluginHostStreamsFunc func(ctx context.Context, srv *srpc.Server, ready func()) error
+
 // ExecutePluginEntrypoint builds the bus & starts common controllers.
 func ExecutePluginEntrypoint(
 	rctx context.Context,
@@ -45,7 +52,7 @@ func ExecutePluginEntrypoint(
 	addFactoryFuncs []AddFactoryFunc,
 	configSetFuncs []BuildConfigSetFunc,
 	pluginHostClient srpc.Client,
-	acceptPluginHostStreams func(ctx context.Context, srv *srpc.Server) error,
+	acceptPluginHostStreams AcceptPluginHostStreamsFunc,
 ) error {
 	var rels []func()
 	rel := func() {
@@ -229,16 +236,26 @@ func ExecutePluginEntrypoint(
 	// handle incoming PluginRpc calls by forwarding to the bus
 	_ = bldr_plugin.SRPCRegisterPlugin(rpcMux, bldr_plugin.NewPluginServer(b))
 
-	// construct the rpc client controller
-	// listen for incoming requests
-	if acceptPluginHostStreams != nil {
-		go func() {
-			srv := srpc.NewServer(rpcMux)
-			if err := acceptPluginHostStreams(ctx, srv); err != nil {
-				errCh <- err
+	// listen for incoming requests before publishing initial capabilities
+	srv := srpc.NewServer(rpcMux)
+	initialRegistrationRel, err := startInitialCapabilityRegistration(
+		ctx,
+		srv,
+		acceptPluginHostStreams,
+		errCh,
+		func(ctx context.Context) (func(), error) {
+			registrations, err := sdk_plugin.RegisterObjectTypes(ctx, b)
+			if err != nil {
+				return nil, err
 			}
-		}()
+			return registrations.Release, nil
+		},
+	)
+	if err != nil {
+		rel()
+		return err
 	}
+	rels = append(rels, initialRegistrationRel)
 
 	// start the plugin storage controller and use the default storage id
 	// on js/wasm, this resolves to direct OPFS access
@@ -255,6 +272,7 @@ func ExecutePluginEntrypoint(
 	)
 	relHostStorageCtrl, err := b.AddController(ctx, hostStorageCtrl, handleErr)
 	if err != nil {
+		rel()
 		return err
 	}
 	defer relHostStorageCtrl()
@@ -269,6 +287,40 @@ func ExecutePluginEntrypoint(
 		rel()
 		return err
 	}
+}
+
+func startInitialCapabilityRegistration(
+	ctx context.Context,
+	srv *srpc.Server,
+	acceptPluginHostStreams AcceptPluginHostStreamsFunc,
+	errCh chan error,
+	complete func(context.Context) (func(), error),
+) (func(), error) {
+	if acceptPluginHostStreams == nil {
+		return nil, errors.New("plugin host stream handler is not configured")
+	}
+
+	readyCh := make(chan struct{})
+	var readyOnce sync.Once
+	go func() {
+		if err := acceptPluginHostStreams(ctx, srv, func() {
+			readyOnce.Do(func() {
+				close(readyCh)
+			})
+		}); err != nil {
+			errCh <- err
+		}
+	}()
+
+	select {
+	case <-readyCh:
+	case err := <-errCh:
+		return nil, err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+
+	return complete(ctx)
 }
 
 func handlePluginEntrypointError(errCh chan<- error, err error) {

--- a/bldr/plugin/entrypoint/common_test.go
+++ b/bldr/plugin/entrypoint/common_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"testing"
+
+	"github.com/aperturerobotics/starpc/srpc"
 )
 
 func TestHandlePluginEntrypointError(t *testing.T) {
@@ -121,5 +123,129 @@ func TestIsExpectedPluginEntrypointError(t *testing.T) {
 				)
 			}
 		})
+	}
+}
+
+func TestStartInitialCapabilityRegistration(t *testing.T) {
+	ctx := t.Context()
+
+	handlerReady := make(chan func(), 1)
+	completeCalled := make(chan struct{}, 1)
+	released := make(chan struct{}, 1)
+	resultCh := make(chan struct {
+		release func()
+		err     error
+	}, 1)
+	errCh := make(chan error, 1)
+
+	go func() {
+		release, err := startInitialCapabilityRegistration(
+			ctx,
+			nil,
+			func(ctx context.Context, _ *srpc.Server, ready func()) error {
+				handlerReady <- ready
+				<-ctx.Done()
+				return ctx.Err()
+			},
+			errCh,
+			func(context.Context) (func(), error) {
+				completeCalled <- struct{}{}
+				return func() {
+					released <- struct{}{}
+				}, nil
+			},
+		)
+		resultCh <- struct {
+			release func()
+			err     error
+		}{release: release, err: err}
+	}()
+
+	ready := <-handlerReady
+	select {
+	case <-completeCalled:
+		t.Fatal("initial capability registration completed before the stream handler was ready")
+	default:
+	}
+
+	ready()
+	result := <-resultCh
+	if result.err != nil {
+		t.Fatal(result.err)
+	}
+	select {
+	case <-completeCalled:
+	default:
+		t.Fatal("initial capability registration did not complete after the stream handler was ready")
+	}
+	select {
+	case <-released:
+		t.Fatal("initial capability registrations were released before entrypoint shutdown")
+	default:
+	}
+
+	result.release()
+	select {
+	case <-released:
+	default:
+		t.Fatal("initial capability registrations were not released at entrypoint shutdown")
+	}
+}
+
+func TestStartInitialCapabilityRegistrationHandlerFailure(t *testing.T) {
+	wantErr := errors.New("stream handler failed")
+	completeCalled := false
+
+	_, err := startInitialCapabilityRegistration(
+		context.Background(),
+		nil,
+		func(context.Context, *srpc.Server, func()) error {
+			return wantErr
+		},
+		make(chan error, 1),
+		func(context.Context) (func(), error) {
+			completeCalled = true
+			return func() {}, nil
+		},
+	)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("startInitialCapabilityRegistration() error = %v, want %v", err, wantErr)
+	}
+	if completeCalled {
+		t.Fatal("initial capability registration completed after the stream handler failed")
+	}
+}
+
+func TestStartInitialCapabilityRegistrationCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	handlerStarted := make(chan struct{})
+	resultCh := make(chan error, 1)
+	completeCalled := false
+
+	go func() {
+		_, err := startInitialCapabilityRegistration(
+			ctx,
+			nil,
+			func(ctx context.Context, _ *srpc.Server, _ func()) error {
+				close(handlerStarted)
+				<-ctx.Done()
+				return ctx.Err()
+			},
+			make(chan error, 1),
+			func(context.Context) (func(), error) {
+				completeCalled = true
+				return func() {}, nil
+			},
+		)
+		resultCh <- err
+	}()
+
+	<-handlerStarted
+	cancel()
+	if err := <-resultCh; !errors.Is(err, context.Canceled) {
+		t.Fatalf("startInitialCapabilityRegistration() error = %v, want %v", err, context.Canceled)
+	}
+	if completeCalled {
+		t.Fatal("initial capability registration completed after cancellation")
 	}
 }

--- a/bldr/plugin/entrypoint/native.go
+++ b/bldr/plugin/entrypoint/native.go
@@ -131,7 +131,8 @@ func Run(
 		addFactoryFuncs,
 		configSetFuncs,
 		srpc.NewClientWithMuxedConn(muxedConn),
-		func(ctx context.Context, srv *srpc.Server) error {
+		func(ctx context.Context, srv *srpc.Server, ready func()) error {
+			ready()
 			return srv.AcceptMuxedConn(ctx, muxedConn)
 		},
 	)

--- a/bldr/plugin/entrypoint/web.go
+++ b/bldr/plugin/entrypoint/web.go
@@ -96,8 +96,9 @@ func Run(
 
 	// dial outgoing streams and accept incoming streams
 	rpcClient := pluginIo.BuildClient()
-	acceptRpcStreams := func(ctx context.Context, srv *srpc.Server) error {
+	acceptRpcStreams := func(ctx context.Context, srv *srpc.Server, ready func()) error {
 		pluginIo.SetAcceptStreams(ctx, srv.GetInvoker())
+		ready()
 		return nil
 	}
 

--- a/bldr/sdk/plugin.ts
+++ b/bldr/sdk/plugin.ts
@@ -100,11 +100,18 @@ export interface BackendAPI {
   }
 }
 
+// BackendEntrypointResult is the startup result returned by a plugin backend entrypoint.
+export type BackendEntrypointResult =
+  | void
+  | Promise<void>
+  | BackendEntrypointLifecycle
+
 // BackendEntrypointFunc is the default function exported from a plugin backend entrypoint.
 export type BackendEntrypointFunc = (
   api: BackendAPI,
   abortSignal: AbortSignal,
-) => void | Promise<void> | BackendEntrypointLifecycle
+  runtimeWasmEnv?: Record<string, string>,
+) => BackendEntrypointResult
 
 // BackendEntrypointLifecycle lets a backend distinguish startup work from
 // process-lifetime work. The generic plugin entrypoint waits for startup before
@@ -112,4 +119,22 @@ export type BackendEntrypointFunc = (
 export interface BackendEntrypointLifecycle {
   startup?: void | Promise<void>
   done?: void | Promise<void>
+}
+
+// isBackendEntrypointFunc reports whether a module export is a backend entrypoint.
+export function isBackendEntrypointFunc(
+  entrypoint: unknown,
+): entrypoint is BackendEntrypointFunc {
+  return typeof entrypoint === 'function'
+}
+
+// isBackendEntrypointLifecycle reports whether an entrypoint separates startup from process lifetime.
+export function isBackendEntrypointLifecycle(
+  result: BackendEntrypointResult,
+): result is BackendEntrypointLifecycle {
+  return (
+    typeof result === 'object' &&
+    result !== null &&
+    ('startup' in result || 'done' in result)
+  )
 }

--- a/bldr/web/bldr/plugin-entrypoint.test.ts
+++ b/bldr/web/bldr/plugin-entrypoint.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { BackendAPI } from '@aptre/bldr-sdk'
+
+import { startWorkerPluginEntrypoint } from './plugin-entrypoint.js'
+
+describe('startWorkerPluginEntrypoint', () => {
+  it('preserves legacy promise startup semantics', async () => {
+    const lifetime = Promise.withResolvers<void>()
+    let started = false
+    const start = startWorkerPluginEntrypoint(
+      () => lifetime.promise,
+      {} as BackendAPI,
+      new AbortController().signal,
+      undefined,
+      vi.fn(),
+    ).then(() => {
+      started = true
+    })
+
+    await Promise.resolve()
+    expect(started).toBe(false)
+
+    lifetime.resolve()
+    await start
+    expect(started).toBe(true)
+  })
+
+  it('waits for lifecycle startup and reports process failure', async () => {
+    const startup = Promise.withResolvers<void>()
+    const done = Promise.withResolvers<void>()
+    const reportRuntimeFailure = vi.fn()
+    let started = false
+    const start = startWorkerPluginEntrypoint(
+      () => ({ startup: startup.promise, done: done.promise }),
+      {} as BackendAPI,
+      new AbortController().signal,
+      undefined,
+      reportRuntimeFailure,
+    ).then(() => {
+      started = true
+    })
+
+    await Promise.resolve()
+    expect(started).toBe(false)
+
+    startup.resolve()
+    await start
+    expect(started).toBe(true)
+
+    const err = new Error('plugin process failed')
+    done.reject(err)
+    await Promise.resolve()
+    expect(reportRuntimeFailure).toHaveBeenCalledWith(err)
+  })
+
+  it('propagates lifecycle startup failure', async () => {
+    const err = new Error('plugin startup failed')
+
+    await expect(
+      startWorkerPluginEntrypoint(
+        () => ({ startup: Promise.reject(err) }),
+        {} as BackendAPI,
+        new AbortController().signal,
+        undefined,
+        vi.fn(),
+      ),
+    ).rejects.toBe(err)
+  })
+})

--- a/bldr/web/bldr/plugin-entrypoint.ts
+++ b/bldr/web/bldr/plugin-entrypoint.ts
@@ -1,0 +1,23 @@
+import {
+  isBackendEntrypointLifecycle,
+  type BackendAPI,
+  type BackendEntrypointFunc,
+} from '@aptre/bldr-sdk'
+
+// startWorkerPluginEntrypoint waits for startup and observes process-lifetime failure.
+export async function startWorkerPluginEntrypoint(
+  entrypoint: BackendEntrypointFunc,
+  api: BackendAPI,
+  abortSignal: AbortSignal,
+  runtimeWasmEnv: Record<string, string> | undefined,
+  reportRuntimeFailure: (err: unknown) => void,
+): Promise<void> {
+  const result = entrypoint(api, abortSignal, runtimeWasmEnv)
+  if (!isBackendEntrypointLifecycle(result)) {
+    await result
+    return
+  }
+
+  void Promise.resolve(result.done).catch(reportRuntimeFailure)
+  await result.startup
+}

--- a/bldr/web/bldr/shared-worker.ts
+++ b/bldr/web/bldr/shared-worker.ts
@@ -11,6 +11,7 @@
 // The script provides its own message listeners and WebDocumentTracker.
 
 import { HandleStreamCtr, HandleStreamFunc } from 'starpc'
+import { isBackendEntrypointFunc } from '@aptre/bldr-sdk'
 
 import {
   checkSharedWorker,
@@ -18,6 +19,7 @@ import {
   type PluginStartOpts,
 } from '../runtime/plugin-worker.js'
 import { BackendApiImpl } from '../../sdk/impl/backend-api.js'
+import { startWorkerPluginEntrypoint } from './plugin-entrypoint.js'
 import { createTransportFactory } from './plugin-transport.js'
 import { detectWorkerCommsConfig } from './worker-comms-detect.js'
 
@@ -105,12 +107,21 @@ if (isPlugin) {
     pluginWorker.notifyStartupMark('plugin.script-import-ready', {
       path: scriptPath,
     })
-    if (typeof pluginModule.default !== 'function') {
+    if (!isBackendEntrypointFunc(pluginModule.default)) {
       throw new Error(
         `shared-worker: Imported module "${scriptPath}" does not have a default export function.`,
       )
     }
-    await pluginModule.default(backendAPI, abortSignal, opts.runtimeWasmEnv)
+    await startWorkerPluginEntrypoint(
+      pluginModule.default,
+      backendAPI,
+      abortSignal,
+      opts.runtimeWasmEnv,
+      (err) => {
+        console.warn('shared-worker: plugin runtime failed:', err)
+        void pluginWorker.reportRuntimeFailure(err)
+      },
+    )
   }
 
   const pluginWorker = new PluginWorker(

--- a/bldr/web/plugin/browser/web-plugin-browser.test.ts
+++ b/bldr/web/plugin/browser/web-plugin-browser.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const registration = vi.hoisted(() => ({
+  construct: vi.fn(),
+  complete: vi.fn(async (_request: unknown, _signal?: AbortSignal) => ({})),
+}))
+
+vi.mock('../../../sdk/plugin/host/host_srpc.pb.js', () => ({
+  PluginHostResourceServiceClient: class {
+    constructor(client: unknown) {
+      registration.construct(client)
+    }
+
+    CompleteInitialCapabilityRegistration(
+      request: unknown,
+      signal?: AbortSignal,
+    ) {
+      return registration.complete(request, signal)
+    }
+  },
+}))
+
+import main from './web-plugin-browser.js'
+
+describe('browser web plugin readiness', () => {
+  beforeEach(() => {
+    registration.construct.mockClear()
+    registration.complete.mockClear()
+  })
+
+  test('completes initial registration after installing the RPC handler', async () => {
+    const setHandler = vi.fn()
+    const disposeRoot = vi.fn()
+    const rootClient = {}
+    const accessRootResource = vi.fn(async () => ({
+      client: rootClient,
+      [Symbol.dispose]: disposeRoot,
+    }))
+    const controller = new AbortController()
+
+    await main(
+      {
+        client: {},
+        handleStreamCtr: { set: setHandler },
+        resourceClient: { accessRootResource },
+      } as never,
+      controller.signal,
+    )
+
+    expect(setHandler).toHaveBeenCalledOnce()
+    expect(accessRootResource).toHaveBeenCalledOnce()
+    expect(registration.construct).toHaveBeenCalledWith(rootClient)
+    expect(registration.complete).toHaveBeenCalledWith({}, controller.signal)
+    expect(setHandler.mock.invocationCallOrder[0]).toBeLessThan(
+      registration.complete.mock.invocationCallOrder[0],
+    )
+    expect(disposeRoot).toHaveBeenCalledOnce()
+  })
+})

--- a/bldr/web/plugin/browser/web-plugin-browser.ts
+++ b/bldr/web/plugin/browser/web-plugin-browser.ts
@@ -13,6 +13,7 @@ import {
   Plugin as SRPCPlugin,
   PluginDefinition,
 } from '../../../plugin/plugin_srpc.pb.js'
+import { PluginHostResourceServiceClient } from '../../../sdk/plugin/host/host_srpc.pb.js'
 import { WebPluginBrowserHostClient } from './browser_srpc.pb.js'
 
 // Plugin implements the bldr.plugin.Plugin service.
@@ -50,7 +51,10 @@ class Plugin implements SRPCPlugin {
  * Main execution function for the browser plugin entrypoint.
  * Initializes the connection to the host and sets up RPC handling.
  */
-export default async function main(backendAPI: BackendAPI) {
+export default async function main(
+  backendAPI: BackendAPI,
+  abortSignal: AbortSignal,
+) {
   console.log('Starting web plugin for browser...')
 
   // Initialize the client for the host service.
@@ -63,6 +67,9 @@ export default async function main(backendAPI: BackendAPI) {
   backendAPI.handleStreamCtr.set(async (channel: PacketStream) => {
     plugin.rpcServer.handlePacketStream(channel)
   })
+  using rootRef = await backendAPI.resourceClient.accessRootResource()
+  const pluginHost = new PluginHostResourceServiceClient(rootRef.client)
+  await pluginHost.CompleteInitialCapabilityRegistration({}, abortSignal)
 
   console.log('Web plugin for browser started.')
 }

--- a/bldr/web/runtime/goscript/build/build.go
+++ b/bldr/web/runtime/goscript/build/build.go
@@ -141,13 +141,13 @@ func BuildWebGoScriptPluginScriptWithOptions(
 	mainImport := "@goscript/" + strings.Trim(mainPackagePath, "/") + "/plugin.gs.js"
 	entrypoint := "import runGoScriptPlugin from " + strconv.Quote(runtimeImport) + "\n" +
 		"import { main as pluginMain } from " + strconv.Quote(mainImport) + "\n\n" +
-		"export default async function main(api) {\n" +
-		"  await runGoScriptPlugin(api, () => Promise.resolve(pluginMain))\n" +
+		"export default function main(api) {\n" +
+		"  return runGoScriptPlugin(api, () => Promise.resolve(pluginMain))\n" +
 		"}\n"
 	if codeSplitting {
 		entrypoint = "import runGoScriptPlugin from " + strconv.Quote(runtimeImport) + "\n\n" +
-			"export default async function main(api) {\n" +
-			"  await runGoScriptPlugin(api, async () => (await import(" + strconv.Quote(mainImport) + ")).main)\n" +
+			"export default function main(api) {\n" +
+			"  return runGoScriptPlugin(api, async () => (await import(" + strconv.Quote(mainImport) + ")).main)\n" +
 			"}\n"
 	}
 	if err := os.WriteFile(entrypointPath, []byte(entrypoint), 0o644); err != nil {

--- a/bldr/web/runtime/goscript/build/build_test.go
+++ b/bldr/web/runtime/goscript/build/build_test.go
@@ -731,6 +731,15 @@ export const LazyValue = "loaded from public plugin split chunk"
 	if err != nil {
 		t.Fatal(err)
 	}
+	entrypointData, err := os.ReadFile(filepath.Join(workDir, "plugin-goscript-entrypoint.ts"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	entrypointSource := string(entrypointData)
+	if !strings.Contains(entrypointSource, "export default function main(api)") ||
+		!strings.Contains(entrypointSource, "return runGoScriptPlugin") {
+		t.Fatalf("entrypoint does not return the GoScript startup lifecycle: %s", entrypointSource)
+	}
 	assertInputsContainPaths(t, inputs, mainPath, lazyPath)
 	assertBundleReport(t, GoScriptBundleReportPath(workDir), outPath, false, true, true, inputs)
 	entryMapSources := assertExternalSourceMapForOutput(t, outPath)

--- a/bldr/web/runtime/goscript/plugin-goscript.test.ts
+++ b/bldr/web/runtime/goscript/plugin-goscript.test.ts
@@ -7,45 +7,58 @@ import main from './plugin-goscript.js'
 
 const originalMessageChannel = globalThis.MessageChannel
 const originalConsoleWarn = console.warn
-let reportedFailures: unknown[]
 
 describe('plugin-goscript generation lifecycle', () => {
   beforeEach(() => {
     globalThis.MessageChannel = originalMessageChannel
     console.warn = vi.fn()
-    reportedFailures = []
     delete globalThis.BLDR_PLUGIN_START_INFO
-    globalThis.BLDR_PLUGIN_REPORT_RUNTIME_FAILURE = (err: unknown) => {
-      reportedFailures.push(err)
-    }
   })
 
   afterEach(() => {
     globalThis.MessageChannel = originalMessageChannel
     console.warn = originalConsoleWarn
+    delete globalThis.BLDR_PLUGIN_SET_ACCEPT_STREAM
   })
 
-  it('publishes start info and reports plugin main failure', async () => {
+  it('publishes start info and rejects lifecycle on plugin main failure', async () => {
     const err = new Error('fatal goscript exit')
     const api = buildBackendAPI()
-    const failureReported = new Promise<void>((resolve) => {
-      globalThis.BLDR_PLUGIN_REPORT_RUNTIME_FAILURE = (
-        reportedErr: unknown,
-      ) => {
-        reportedFailures.push(reportedErr)
-        resolve()
-      }
-    })
 
-    await main(api, async () => async () => {
+    const lifecycle = main(api, async () => async () => {
       throw err
     })
-    await failureReported
 
     expect(globalThis.BLDR_PLUGIN_START_INFO).toBe(
       btoa(PluginStartInfo.toJsonString(api.startInfo)),
     )
-    expect(reportedFailures).toEqual([err])
+    await expect(Promise.resolve(lifecycle.startup)).rejects.toBe(err)
+    await expect(Promise.resolve(lifecycle.done)).rejects.toBe(err)
+  })
+
+  it('publishes startup only after the GoScript runtime accepts streams', async () => {
+    const api = buildBackendAPI()
+    const lifecycle = main(api, async () => async () => {
+      await new Promise<void>(() => {})
+    })
+    let started = false
+    void Promise.resolve(lifecycle.startup).then(() => {
+      started = true
+    })
+
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(started).toBe(false)
+
+    const setAcceptStream = globalThis.BLDR_PLUGIN_SET_ACCEPT_STREAM
+    expect(setAcceptStream).toBeTypeOf('function')
+    if (!setAcceptStream) {
+      throw new Error('missing accept stream setter')
+    }
+    setAcceptStream(vi.fn())
+    await lifecycle.startup
+
+    expect(started).toBe(true)
   })
 
   it('turns accept-stream into a terminal error after the GoScript plugin exits', async () => {

--- a/bldr/web/runtime/goscript/plugin-goscript.test.ts
+++ b/bldr/web/runtime/goscript/plugin-goscript.test.ts
@@ -19,6 +19,7 @@ describe('plugin-goscript generation lifecycle', () => {
     globalThis.MessageChannel = originalMessageChannel
     console.warn = originalConsoleWarn
     delete globalThis.BLDR_PLUGIN_SET_ACCEPT_STREAM
+    delete globalThis.BLDR_PLUGIN_MARK_READY
   })
 
   it('publishes start info and rejects lifecycle on plugin main failure', async () => {
@@ -56,6 +57,31 @@ describe('plugin-goscript generation lifecycle', () => {
       throw new Error('missing accept stream setter')
     }
     setAcceptStream(vi.fn())
+    await lifecycle.startup
+
+    expect(started).toBe(true)
+  })
+
+  it('publishes startup when a non-stream plugin explicitly marks itself ready', async () => {
+    const api = buildBackendAPI()
+    const lifecycle = main(api, async () => async () => {
+      await new Promise<void>(() => {})
+    })
+    let started = false
+    void Promise.resolve(lifecycle.startup).then(() => {
+      started = true
+    })
+
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(started).toBe(false)
+
+    const markReady = globalThis.BLDR_PLUGIN_MARK_READY
+    expect(markReady).toBeTypeOf('function')
+    if (!markReady) {
+      throw new Error('missing explicit plugin readiness marker')
+    }
+    markReady()
     await lifecycle.startup
 
     expect(started).toBe(true)

--- a/bldr/web/runtime/goscript/plugin-goscript.ts
+++ b/bldr/web/runtime/goscript/plugin-goscript.ts
@@ -23,6 +23,7 @@ declare global {
         onReject: (errMsg: string) => void,
       ) => void)
     | undefined
+  var BLDR_PLUGIN_MARK_READY: (() => void) | undefined
   var BLDR_PLUGIN_SET_ACCEPT_STREAM:
     | ((acceptStream?: (localPort: MessagePort) => void) => void)
     | undefined
@@ -64,6 +65,13 @@ class GoScriptPluginGeneration {
     }
   }
 
+  public markReady() {
+    if (this.terminalError) {
+      return
+    }
+    this.startup.resolve()
+  }
+
   public setAcceptStream(acceptStrm?: (localPort: MessagePort) => void) {
     if (this.terminalError) {
       this.installTerminalAcceptHandler(this.terminalError)
@@ -100,7 +108,7 @@ class GoScriptPluginGeneration {
         closeMessagePortDuplex(duplex)
       }
     })
-    this.startup.resolve()
+    this.markReady()
   }
 
   private fail(err: unknown) {
@@ -200,6 +208,10 @@ export default function main(
         onReject(castToError(err).toString())
       },
     )
+  }
+
+  globalScope.BLDR_PLUGIN_MARK_READY = () => {
+    generation.markReady()
   }
 
   globalScope.BLDR_PLUGIN_SET_ACCEPT_STREAM = (

--- a/bldr/web/runtime/goscript/plugin-goscript.ts
+++ b/bldr/web/runtime/goscript/plugin-goscript.ts
@@ -1,7 +1,7 @@
 import { pipe } from 'it-pipe'
 import { pushable } from 'it-pushable'
 import type { PacketStream } from 'starpc'
-import { BackendAPI } from '@aptre/bldr-sdk'
+import type { BackendAPI, BackendEntrypointLifecycle } from '@aptre/bldr-sdk'
 import { PluginStartInfo } from '../../../plugin/plugin.pb.js'
 
 type GoPushableSink = {
@@ -15,7 +15,6 @@ export type GoScriptPluginMainLoader = () => Promise<GoScriptPluginMain>
 declare global {
   var BLDR_BASE_URL: string
   var BLDR_PLUGIN_START_INFO: string | undefined
-  var BLDR_PLUGIN_REPORT_RUNTIME_FAILURE: ((err: unknown) => void) | undefined
   var BLDR_PLUGIN_OPEN_STREAM_TO_WEB_RUNTIME:
     | ((
         onMessage: (message: Uint8Array) => void,
@@ -35,14 +34,19 @@ globalScope.BLDR_BASE_URL = baseURL
 
 class GoScriptPluginGeneration {
   private readonly activeAcceptedStreams = new Set<BrowserMessagePortDuplex>()
+  private readonly startup = Promise.withResolvers<void>()
+  private readonly done = Promise.withResolvers<void>()
   private terminalError?: Error
 
-  public constructor(private readonly api: BackendAPI) {}
+  public constructor(private readonly api: BackendAPI) {
+    void this.startup.promise.catch(() => {})
+    void this.done.promise.catch(() => {})
+  }
 
   public start(
     startInfo: PluginStartInfo,
     loadPluginMain: GoScriptPluginMainLoader,
-  ) {
+  ): BackendEntrypointLifecycle {
     const pluginStartInfoJsonB64 = btoa(PluginStartInfo.toJsonString(startInfo))
     globalScope.BLDR_PLUGIN_START_INFO = pluginStartInfoJsonB64
 
@@ -53,6 +57,11 @@ class GoScriptPluginGeneration {
         () => this.fail(new Error('GoScript plugin process exited')),
         (err) => this.fail(err),
       )
+
+    return {
+      startup: this.startup.promise,
+      done: this.done.promise,
+    }
   }
 
   public setAcceptStream(acceptStrm?: (localPort: MessagePort) => void) {
@@ -91,6 +100,7 @@ class GoScriptPluginGeneration {
         closeMessagePortDuplex(duplex)
       }
     })
+    this.startup.resolve()
   }
 
   private fail(err: unknown) {
@@ -100,13 +110,14 @@ class GoScriptPluginGeneration {
 
     const terminalError = castToError(err, 'GoScript plugin process failed')
     this.terminalError = terminalError
+    this.startup.reject(terminalError)
+    this.done.reject(terminalError)
     console.warn(
       'plugin-goscript: GoScript plugin process exited',
       terminalError,
     )
     this.closeActiveAcceptedStreams()
     this.installTerminalAcceptHandler(terminalError)
-    globalScope.BLDR_PLUGIN_REPORT_RUNTIME_FAILURE?.(terminalError)
   }
 
   private closeActiveAcceptedStreams() {
@@ -123,10 +134,10 @@ class GoScriptPluginGeneration {
   }
 }
 
-export default async function main(
+export default function main(
   api: BackendAPI,
   loadPluginMain: GoScriptPluginMainLoader,
-): Promise<void> {
+): BackendEntrypointLifecycle {
   const generation = new GoScriptPluginGeneration(api)
 
   globalScope.BLDR_PLUGIN_OPEN_STREAM_TO_WEB_RUNTIME = (
@@ -197,7 +208,7 @@ export default async function main(
     generation.setAcceptStream(acceptStrm)
   }
 
-  generation.start(api.startInfo, loadPluginMain)
+  return generation.start(api.startInfo, loadPluginMain)
 }
 
 class BrowserMessagePortDuplex {


### PR DESCRIPTION
Repro: master CI red on browser-runtime and readiness-wait clusters; Go plugins installed their RPC handlers but never completed initial capability registration, and SharedWorker startup returned before the backend entrypoint lifecycle finished, so readiness waits hung until timeout.

Cause: the common plugin entrypoint treated handler installation as registration complete (no readiness signal from the stream handler), the JS entrypoint raced frontend readiness against a capability failure promise without completing registration, and shared-worker startup did not await BackendEntrypointLifecycle.startup/done.

Fix: thread a ready callback through AcceptPluginHostStreams so the entrypoint waits for handler readiness before completing initial capability registration and retains resources for the plugin lifetime; make backend readiness fail closed on missing/invalid entrypoint exports; await the lifecycle startup marker in SharedWorker startup and surface frontend runtime failures instead of hiding backend rejection behind a frontend retry loop.

Verification: Go owner tests pass; TypeScript lifecycle tests 20/20; bldr:typecheck pass; go build ./... pass; TestSessionHarnessPeerInfo pass (86s); TestSpacewaveCoreE2E pass (45s); worktree clean. This PR's CI run is the full-matrix proof.