### PR TITLE
fix(e2e): observe Forge completion from World

### DIFF
--- a/e2e/wasm/forge-resource.go
+++ b/e2e/wasm/forge-resource.go
@@ -12,11 +12,12 @@ import (
 	forge_task "github.com/s4wave/spacewave/forge/task"
 	s4wave_sobject "github.com/s4wave/spacewave/sdk/sobject"
 	s4wave_space "github.com/s4wave/spacewave/sdk/space"
-	s4wave_world "github.com/s4wave/spacewave/sdk/world"
+	sdk_world_engine "github.com/s4wave/spacewave/sdk/world/engine"
 )
 
 type mountedForgeSpace struct {
-	engine          *s4wave_world.Engine
+	eng             *sdk_world_engine.SDKEngine
+	engWs           hydra_world.WorldState
 	sharedObjectRef resource_client.ResourceRef
 	spaceRef        resource_client.ResourceRef
 	contentsRef     resource_client.ResourceRef
@@ -74,7 +75,7 @@ func mountForgeSpace(
 	}
 
 	engineRef := sess.ResourceClient().CreateResourceReference(accessWorldResp.GetResourceId())
-	engine, err := s4wave_world.NewEngine(sess.ResourceClient(), engineRef)
+	eng, err := sdk_world_engine.NewSDKEngine(sess.ResourceClient(), engineRef)
 	if err != nil {
 		engineRef.Release()
 		spaceRef.Release()
@@ -84,7 +85,7 @@ func mountForgeSpace(
 
 	contentsResp, err := spaceSvc.MountSpaceContents(ctx, &s4wave_space.MountSpaceContentsRequest{})
 	if err != nil {
-		engine.Release()
+		eng.Release()
 		spaceRef.Release()
 		sharedObjectRef.Release()
 		t.Fatalf("MountSpaceContents: %v", err)
@@ -94,14 +95,15 @@ func mountForgeSpace(
 	contentsSrpcClient, err := contentsRef.GetClient()
 	if err != nil {
 		contentsRef.Release()
-		engine.Release()
+		eng.Release()
 		spaceRef.Release()
 		sharedObjectRef.Release()
 		t.Fatalf("GetClient(contents): %v", err)
 	}
 
 	return &mountedForgeSpace{
-		engine:          engine,
+		eng:             eng,
+		engWs:           hydra_world.NewEngineWorldState(eng, false),
 		sharedObjectRef: sharedObjectRef,
 		spaceRef:        spaceRef,
 		contentsRef:     contentsRef,
@@ -113,8 +115,8 @@ func (m *mountedForgeSpace) Release() {
 	if m.contentsRef != nil {
 		m.contentsRef.Release()
 	}
-	if m.engine != nil {
-		m.engine.Release()
+	if m.eng != nil {
+		m.eng.Release()
 	}
 	if m.spaceRef != nil {
 		m.spaceRef.Release()
@@ -126,7 +128,7 @@ func (m *mountedForgeSpace) Release() {
 
 func listLinkedObjectKeys(
 	ctx context.Context,
-	tx *s4wave_world.Tx,
+	tx hydra_world.WorldState,
 	predicate string,
 	subjectKeys ...string,
 ) ([]string, error) {
@@ -159,7 +161,7 @@ func listLinkedObjectKeys(
 func assertNoForgePasses(
 	ctx context.Context,
 	t testing.TB,
-	engine *s4wave_world.Engine,
+	engine hydra_world.Engine,
 	jobKey string,
 ) {
 	t.Helper()
@@ -168,7 +170,7 @@ func assertNoForgePasses(
 	if err != nil {
 		t.Fatalf("NewTransaction: %v", err)
 	}
-	defer tx.Discard(ctx)
+	defer tx.Discard()
 
 	taskKeys, err := listLinkedObjectKeys(ctx, tx, forge_job.PredJobToTask.String(), jobKey)
 	if err != nil {

--- a/e2e/wasm/harness_test.go
+++ b/e2e/wasm/harness_test.go
@@ -24,6 +24,7 @@ import (
 	space "github.com/s4wave/spacewave/core/space"
 	trace_service "github.com/s4wave/spacewave/core/trace/service"
 	e2e_wasm_session "github.com/s4wave/spacewave/e2e/wasm/session"
+	forge_job "github.com/s4wave/spacewave/forge/job"
 	s4wave_space "github.com/s4wave/spacewave/sdk/space"
 	"github.com/sirupsen/logrus"
 	exptrace "golang.org/x/exp/trace"
@@ -2427,39 +2428,15 @@ func TestForgeScenarioSequence(t *testing.T) {
 	})
 }
 
-func waitForConsoleMessage(
-	ctx context.Context,
-	t testing.TB,
-	messages <-chan string,
-	substring string,
-) {
-	t.Helper()
-
-	for {
-		select {
-		case msg, ok := <-messages:
-			if !ok {
-				t.Fatalf("console closed before message %q", substring)
-			}
-			if strings.Contains(msg, substring) {
-				return
-			}
-		case <-ctx.Done():
-			t.Fatalf("wait for console message %q: %v", substring, ctx.Err())
-		}
-	}
-}
-
 // TestForgeWorkerExecution verifies binding approval starts the quickstart
-// worker and drives the Forge pass/execution path to completion with logs.
+// worker and drives the Forge pass/execution path to a completed Job.
 func TestForgeWorkerExecution(t *testing.T) {
-	sess := harness(t).NewCleanSession(t)
-	console, stopConsole := sess.WatchConsole()
-	defer stopConsole()
+	h := harness(t)
+	sess := h.NewCleanSession(t)
 
-	scenario := CreateForgeScenario(t, harness(t), sess)
+	scenario := CreateForgeScenario(t, h, sess)
 	page := scenario.GetSession().Page()
-	WaitForForgeReady(t, harness(t), page)
+	WaitForForgeReady(t, h, page)
 
 	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Minute)
 	defer cancel()
@@ -2470,7 +2447,7 @@ func TestForgeWorkerExecution(t *testing.T) {
 	const jobKey = "sample-job"
 	const workerKey = "session-worker"
 
-	assertNoForgePasses(ctx, t, mounted.engine, jobKey)
+	assertNoForgePasses(ctx, t, mounted.eng, jobKey)
 
 	_, err := mounted.contentsSvc.SetProcessBinding(ctx, &s4wave_space.SetProcessBindingRequest{
 		ObjectKey: workerKey,
@@ -2494,7 +2471,16 @@ func TestForgeWorkerExecution(t *testing.T) {
 		t.Fatalf("expected approved worker binding, got %+v", state.GetProcessBindings())
 	}
 
-	waitForConsoleMessage(ctx, t, console, "marking job as complete")
+	job, err := forge_job.WaitJobComplete(ctx, h.le, mounted.engWs, jobKey)
+	if err != nil {
+		t.Fatalf("WaitJobComplete: %v", err)
+	}
+	if err := job.Validate(); err != nil {
+		t.Fatalf("validate completed Job: %v", err)
+	}
+	if failErr := job.GetResult().GetFailError(); failErr != "" {
+		t.Fatalf("completed Job failed: %s", failErr)
+	}
 }
 
 // TestQuickstartForgeTrace writes a trace artifact for the forge quickstart


### PR DESCRIPTION
## Repro

The wasm `forge-blog` E2E timed out after about 228 seconds waiting for the console substring `marking job as complete` on master and PR bases 318 and 319. The focused in-memory Forge paths pass:

`go test ./forge/cluster/controller ./forge/worker/controller -run 'TestTaskTrackerWakesParentOnFirstComplete|TestWorkerController' -count=1`

The browser E2E is intentionally not run locally; GitHub CI owns that proof.

## Cause

The test used a 64-message console watcher as its completion oracle. `TestSession.emitConsole` drops messages when that bounded watcher buffer is full, and the test only drained it after Forge setup and state readback. The durable Job state could complete while the terminal Info log was lost.

## Fix

Mount the SDK World engine and read-only WorldState adapter, then wait for the persisted Job to reach COMPLETE. Validate the completed Job and reject a failed result. Remove the lossy console watcher and helper. Production Forge completion semantics are unchanged.

## Verification

- `go test ./forge/cluster/controller ./forge/worker/controller -run 'TestTaskTrackerWakesParentOnFirstComplete|TestWorkerController' -count=1`
- `go test ./e2e/wasm -run '^$' -count=1`
- `go fix ./e2e/wasm`
- `git diff --check`

The expensive `forge-blog` browser scenario remains delegated to this PR's GitHub CI.