### PR TITLE
fix(e2e): start Forge wait budget after setup

### DIFF
--- a/e2e/wasm/harness_test.go
+++ b/e2e/wasm/harness_test.go
@@ -2438,9 +2438,7 @@ func TestForgeWorkerExecution(t *testing.T) {
 	page := scenario.GetSession().Page()
 	WaitForForgeReady(t, h, page)
 
-	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Minute)
-	defer cancel()
-
+	ctx := t.Context()
 	mounted := mountForgeSpace(ctx, t, sess, scenario.GetSessionIndex(), scenario.GetSpaceID())
 	defer mounted.Release()
 
@@ -2471,7 +2469,11 @@ func TestForgeWorkerExecution(t *testing.T) {
 		t.Fatalf("expected approved worker binding, got %+v", state.GetProcessBindings())
 	}
 
-	job, err := forge_job.WaitJobComplete(ctx, h.le, mounted.engWs, jobKey)
+	// Start the completion budget after setup has observed the approved worker.
+	// Browser/plugin startup and World mounting must not consume wait time.
+	waitCtx, cancel := context.WithTimeout(ctx, 3*time.Minute)
+	defer cancel()
+	job, err := forge_job.WaitJobComplete(waitCtx, h.le, mounted.engWs, jobKey)
 	if err != nil {
 		t.Fatalf("WaitJobComplete: %v", err)
 	}


### PR DESCRIPTION
Repro
Master 46785720e intermittently failed E2E (wasm / forge-blog) in TestForgeWorkerExecution with WaitJobComplete: context canceled. The failed run 29645147604 took 231.350s; passing PR-320 run 29644264965 completed the same test in 164.07s.

Cause
The E2E created its 3-minute context before World mounting, binding approval, and state-watch setup. The failed timeline spent about 51s in browser/plugin/resource startup before the Job was first observed, then the wait budget expired while the Job remained RUNNING. WaitJobComplete itself owns no deadline; the E2E caller owns the context.

Fix
Use the test lifetime context for setup, then create the 3-minute completion context after the approved worker binding is observed. This preserves a bounded completion wait without masking a real Forge completion stall.

Verification
Focused Forge worker and cluster tests pass. go test ./e2e/wasm -run '^$' passes. GitHub CI run 29646466958 passed the wasm/forge-blog slice twice: attempt 1 passed TestForgeWorkerExecution in 164.07s, and the rerun passed it in 199.87s. Both observed PENDING -> RUNNING -> COMPLETE. The baseline flake rate was one observed failure in three master runs (about 1/3); no post-fix failure occurred in these two runs.