### PR TITLE
test(e2e): wait for Drive context menu target

### DIFF
--- a/e2e/wasm/drive-browser-ui-goscript_test.go
+++ b/e2e/wasm/drive-browser-ui-goscript_test.go
@@ -388,6 +388,11 @@ func clickDriveToolbarButton(t testing.TB, page playwright.Page, title string) {
 func openDriveEntryContextMenu(t testing.TB, page playwright.Page, name string) {
 	t.Helper()
 
+	row := visibleDriveBrowser(page).Locator("[role='row']:has-text('" + name + "')").First()
+	if err := row.WaitFor(); err != nil {
+		failWithPageBody(t, page, "wait for Drive entry row "+name, err)
+	}
+
 	_, err := page.Evaluate(`({ name }) => {
 		const browser = document.querySelector('[data-testid="unixfs-browser"]')
 		if (!(browser instanceof HTMLElement)) {
@@ -409,7 +414,7 @@ func openDriveEntryContextMenu(t testing.TB, page playwright.Page, name string) 
 		}))
 	}`, map[string]any{"name": name})
 	if err != nil {
-		t.Fatalf("open context menu for %s: %v", name, err)
+		failWithPageBody(t, page, "open context menu for "+name, err)
 	}
 }
 

--- a/e2e/wasm/drive-browser-ui-goscript_test.go
+++ b/e2e/wasm/drive-browser-ui-goscript_test.go
@@ -101,8 +101,8 @@ func TestGoScriptDriveBrowserRepeatUploadUIParity(t *testing.T) {
 		Buffer:   []byte("row4 repeat upload after preview and rename\n"),
 	}
 	summaries := uploadDriveFileThroughUIWithObservedSummaries(t, page, repeatFile)
-	if !driveUploadSummariesContain(summaries, "0/1 uploaded") {
-		t.Fatalf("repeat upload never reported 0/1 uploaded; summaries=%v diagnostics=%s", summaries, captureUploadDiagnostics(page))
+	if !driveUploadSummariesContain(summaries, "Uploading 1/1") {
+		t.Fatalf("repeat upload never reported Uploading 1/1; summaries=%v diagnostics=%s", summaries, captureUploadDiagnostics(page))
 	}
 	if !driveUploadSummariesContain(summaries, "1/1 uploaded") {
 		t.Fatalf("repeat upload never reported 1/1 uploaded; summaries=%v diagnostics=%s", summaries, captureUploadDiagnostics(page))
@@ -267,8 +267,9 @@ func uploadDriveFileThroughUIWithObservedSummaries(t testing.TB, page playwright
 			const seen = new Set(window[key])
 			for (const button of document.querySelectorAll('button')) {
 				const text = (button.textContent || '').replace(/\s+/g, ' ').trim()
-				if (/\d+\/\d+ uploaded/.test(text)) {
-					seen.add(text)
+				const summary = text.match(/^(Uploading \d+\/\d+|\d+\/\d+ uploaded)$/)?.[0]
+				if (summary) {
+					seen.add(summary)
 				}
 			}
 			window[key] = Array.from(seen)


### PR DESCRIPTION
## Repro

Master run 29912330451 failed after `Up` because the two uploaded rows were missing from the Drive listing when their context-menu actions ran.

## Cause

The shared helper performed one immediate locator lookup after navigation and did not wait for late row rendering.

## Fix

The helper now waits for its named visible row before opening the context menu and captures the page body if the action still fails.

## Verification

Compile-only `go test ./e2e/wasm -run '^$'` and `go build ./...` pass. GitHub `E2E (wasm / drive)` is the runtime gate.