### PR TITLE
Add shared E2E artifact resolver

### DIFF
--- a/e2e/harness/build-lock-unix.go
+++ b/e2e/harness/build-lock-unix.go
@@ -1,0 +1,34 @@
+//go:build !js && unix
+
+package harness
+
+import (
+	stderrors "errors"
+
+	"golang.org/x/sys/unix"
+)
+
+func (l *BuildLock) tryLock() (bool, error) {
+	err := unix.Flock(int(l.file.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+	if err == nil {
+		return true, nil
+	}
+	if stderrors.Is(err, unix.EWOULDBLOCK) || stderrors.Is(err, unix.EAGAIN) {
+		return false, nil
+	}
+	return false, err
+}
+
+func (l *BuildLock) lock() error {
+	for {
+		err := unix.Flock(int(l.file.Fd()), unix.LOCK_EX)
+		if stderrors.Is(err, unix.EINTR) {
+			continue
+		}
+		return err
+	}
+}
+
+func (l *BuildLock) unlock() error {
+	return unix.Flock(int(l.file.Fd()), unix.LOCK_UN)
+}

--- a/e2e/harness/build-lock-unsupported.go
+++ b/e2e/harness/build-lock-unsupported.go
@@ -1,0 +1,17 @@
+//go:build !js && !unix && !windows
+
+package harness
+
+import "github.com/pkg/errors"
+
+func (l *BuildLock) tryLock() (bool, error) {
+	return false, errors.New("build locking is unsupported on this platform")
+}
+
+func (l *BuildLock) lock() error {
+	return errors.New("build locking is unsupported on this platform")
+}
+
+func (l *BuildLock) unlock() error {
+	return nil
+}

--- a/e2e/harness/build-lock-windows.go
+++ b/e2e/harness/build-lock-windows.go
@@ -1,0 +1,51 @@
+//go:build !js && windows
+
+package harness
+
+import (
+	stderrors "errors"
+
+	"golang.org/x/sys/windows"
+)
+
+func (l *BuildLock) tryLock() (bool, error) {
+	var overlapped windows.Overlapped
+	err := windows.LockFileEx(
+		windows.Handle(l.file.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0,
+		1,
+		0,
+		&overlapped,
+	)
+	if err == nil {
+		return true, nil
+	}
+	if stderrors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+		return false, nil
+	}
+	return false, err
+}
+
+func (l *BuildLock) lock() error {
+	var overlapped windows.Overlapped
+	return windows.LockFileEx(
+		windows.Handle(l.file.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK,
+		0,
+		1,
+		0,
+		&overlapped,
+	)
+}
+
+func (l *BuildLock) unlock() error {
+	var overlapped windows.Overlapped
+	return windows.UnlockFileEx(
+		windows.Handle(l.file.Fd()),
+		0,
+		1,
+		0,
+		&overlapped,
+	)
+}

--- a/e2e/harness/build-lock.go
+++ b/e2e/harness/build-lock.go
@@ -1,0 +1,98 @@
+//go:build !js
+
+package harness
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// BuildLock owns one held cross-process build lock.
+type BuildLock struct {
+	file    *os.File
+	pidPath string
+}
+
+// AcquireBuildLock acquires a named cross-process build lock. Context
+// cancellation is checked before and after the kernel wait, but cannot promptly
+// interrupt a caller parked in that wait.
+func AcquireBuildLock(ctx context.Context, le *logrus.Entry, lockDir, name string) (*BuildLock, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if name == "" || name == "." || name == ".." || filepath.Base(name) != name || strings.ContainsAny(name, `/\\`) {
+		return nil, errors.Errorf("invalid build lock name %q", name)
+	}
+	if err := os.MkdirAll(lockDir, 0o755); err != nil {
+		return nil, errors.Wrap(err, "create build lock directory")
+	}
+	lockPath := filepath.Join(lockDir, name+".lock")
+	file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return nil, errors.Wrap(err, "open build lock")
+	}
+	lock := &BuildLock{file: file, pidPath: lockPath + ".pid"}
+	locked, err := lock.tryLock()
+	if err != nil {
+		lock.closeAfterError()
+		return nil, errors.Wrap(err, "lock build")
+	}
+	if !locked {
+		message := "waiting for another process to release build lock: " + lockDir
+		if pid := lock.readHolderPID(); pid != "" {
+			message = "waiting for pid " + pid + " to release build lock: " + lockDir
+		}
+		if le != nil {
+			le.Warn(message)
+		} else {
+			_, _ = os.Stderr.WriteString("warning: " + message + "\n")
+		}
+		if err := lock.lock(); err != nil {
+			lock.closeAfterError()
+			return nil, errors.Wrap(err, "wait for build lock")
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		lock.Release()
+		return nil, err
+	}
+	pid := strconv.AppendInt(nil, int64(os.Getpid()), 10)
+	pid = append(pid, '\n')
+	if err := os.WriteFile(lock.pidPath, pid, 0o644); err != nil {
+		lock.Release()
+		return nil, errors.Wrap(err, "write build lock pid")
+	}
+	return lock, nil
+}
+
+// Release unlocks and closes the build lock without unlinking its shared path.
+func (l *BuildLock) Release() {
+	if l == nil || l.file == nil {
+		return
+	}
+	_ = l.unlock()
+	_ = l.file.Close()
+	l.file = nil
+}
+
+func (l *BuildLock) readHolderPID() string {
+	data, err := os.ReadFile(l.pidPath)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+func (l *BuildLock) closeAfterError() {
+	if l == nil || l.file == nil {
+		return
+	}
+	_ = l.file.Close()
+	l.file = nil
+}

--- a/e2e/harness/build-lock_test.go
+++ b/e2e/harness/build-lock_test.go
@@ -1,0 +1,176 @@
+//go:build !js
+
+package harness
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	buildLockTestRoleEnv = "SPACEWAVE_HARNESS_BUILD_LOCK_TEST_ROLE"
+	buildLockTestDirEnv  = "SPACEWAVE_HARNESS_BUILD_LOCK_TEST_DIR"
+)
+
+func TestBuildLockValidatesNameAndCreatesDirectory(t *testing.T) {
+	for _, name := range []string{"", ".", "..", "a/b", `a\b`} {
+		if lock, err := AcquireBuildLock(context.Background(), nil, t.TempDir(), name); err == nil {
+			lock.Release()
+			t.Fatalf("AcquireBuildLock accepted %q", name)
+		}
+	}
+	lockDir := filepath.Join(t.TempDir(), "missing", "lock-dir")
+	lock, err := AcquireBuildLock(context.Background(), nil, lockDir, "build")
+	if err != nil {
+		t.Fatal(err)
+	}
+	lock.Release()
+	if _, err := os.Stat(filepath.Join(lockDir, "build.lock")); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBuildLockSerializesAndProcessExitReleases(t *testing.T) {
+	if role := os.Getenv(buildLockTestRoleEnv); role != "" {
+		runBuildLockTestRole(t, role)
+		return
+	}
+	lockDir := t.TempDir()
+	holder := buildLockTestCommand(t, lockDir, "hold")
+	holderIn, err := holder.StdinPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	holderOut, err := holder.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := holder.Start(); err != nil {
+		t.Fatal(err)
+	}
+	if ready, err := bufio.NewReader(holderOut).ReadString('\n'); err != nil || strings.TrimSpace(ready) != "ready" {
+		t.Fatalf("holder readiness = %q, %v", ready, err)
+	}
+
+	logReader, logWriter := io.Pipe()
+	logger := logrus.New()
+	logger.SetOutput(logWriter)
+	acquired := make(chan *BuildLock, 1)
+	errs := make(chan error, 1)
+	go func() {
+		lock, err := AcquireBuildLock(context.Background(), logrus.NewEntry(logger), lockDir, "build")
+		if err != nil {
+			errs <- err
+			return
+		}
+		acquired <- lock
+	}()
+	if diagnostic, err := bufio.NewReader(logReader).ReadString('\n'); err != nil || !strings.Contains(diagnostic, "waiting for pid ") {
+		t.Fatalf("wait diagnostic = %q, %v", diagnostic, err)
+	}
+	if err := holderIn.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := holder.Wait(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case lock := <-acquired:
+		lock.Release()
+	case err := <-errs:
+		t.Fatal(err)
+	}
+	_ = logWriter.Close()
+	_ = logReader.Close()
+
+	exiter := buildLockTestCommand(t, lockDir, "exit")
+	exitOut, err := exiter.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := exiter.Start(); err != nil {
+		t.Fatal(err)
+	}
+	if ready, err := bufio.NewReader(exitOut).ReadString('\n'); err != nil || strings.TrimSpace(ready) != "ready" {
+		t.Fatalf("exit holder readiness = %q, %v", ready, err)
+	}
+	if err := exiter.Wait(); err != nil {
+		t.Fatal(err)
+	}
+	lock, err := AcquireBuildLock(context.Background(), nil, lockDir, "build")
+	if err != nil {
+		t.Fatal(err)
+	}
+	lock.Release()
+}
+
+func TestBuildLockReleasesAfterCanceledWait(t *testing.T) {
+	lockDir := t.TempDir()
+	holder, err := AcquireBuildLock(context.Background(), nil, lockDir, "build")
+	if err != nil {
+		t.Fatal(err)
+	}
+	logReader, logWriter := io.Pipe()
+	logger := logrus.New()
+	logger.SetOutput(logWriter)
+	ctx, cancel := context.WithCancel(context.Background())
+	errs := make(chan error, 1)
+	go func() {
+		_, err := AcquireBuildLock(ctx, logrus.NewEntry(logger), lockDir, "build")
+		errs <- err
+	}()
+	if _, err := bufio.NewReader(logReader).ReadString('\n'); err != nil {
+		t.Fatal(err)
+	}
+	cancel()
+	holder.Release()
+	if err := <-errs; err == nil {
+		t.Fatal("canceled waiter acquired lock")
+	}
+	_ = logWriter.Close()
+	_ = logReader.Close()
+	lock, err := AcquireBuildLock(context.Background(), nil, lockDir, "build")
+	if err != nil {
+		t.Fatal(err)
+	}
+	lock.Release()
+}
+
+func runBuildLockTestRole(t *testing.T, role string) {
+	t.Helper()
+	lock, err := AcquireBuildLock(context.Background(), nil, os.Getenv(buildLockTestDirEnv), "build")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stdout.WriteString("ready\n"); err != nil {
+		t.Fatal(err)
+	}
+	if role == "exit" {
+		os.Exit(0)
+	}
+	defer lock.Release()
+	if role != "hold" {
+		t.Fatalf("unknown role %q", role)
+	}
+	if _, err := io.Copy(io.Discard, os.Stdin); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func buildLockTestCommand(t *testing.T, lockDir, role string) *exec.Cmd {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestBuildLockSerializesAndProcessExitReleases$") //nolint:gosec
+	cmd.Env = append(os.Environ(), buildLockTestRoleEnv+"="+role, buildLockTestDirEnv+"="+lockDir)
+	return cmd
+}

--- a/e2e/harness/generation.go
+++ b/e2e/harness/generation.go
@@ -1,0 +1,9 @@
+//go:build !js
+
+package harness
+
+// Generation pairs a store-owned immutable publication token with its artifact.
+type Generation[A any] struct {
+	Token    string
+	Artifact A
+}

--- a/e2e/harness/resolve-options.go
+++ b/e2e/harness/resolve-options.go
@@ -1,0 +1,10 @@
+//go:build !js
+
+package harness
+
+// ResolveOptions configures the shared artifact resolution policy.
+type ResolveOptions struct {
+	LockDir      string
+	LockName     string
+	RequireFresh bool
+}

--- a/e2e/harness/resolve.go
+++ b/e2e/harness/resolve.go
@@ -1,0 +1,82 @@
+//go:build !js
+
+package harness
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+type resolveHooks struct {
+	afterSnapshot func()
+}
+
+// Resolve returns a valid artifact, coalescing builds across processes.
+func Resolve[A any](ctx context.Context, le *logrus.Entry, opts ResolveOptions, shape Shape[A]) (A, error) {
+	return resolve(ctx, le, opts, shape, resolveHooks{})
+}
+
+func resolve[A any](ctx context.Context, le *logrus.Entry, opts ResolveOptions, shape Shape[A], hooks resolveHooks) (A, error) {
+	var zero A
+	key, err := shape.ContentKey(ctx)
+	if err != nil {
+		return zero, err
+	}
+	preLock, preSet, err := lookupGenerations(ctx, shape, key)
+	if err != nil {
+		return zero, err
+	}
+	if !opts.RequireFresh && len(preLock) != 0 {
+		return preLock[0].Artifact, nil
+	}
+	if hooks.afterSnapshot != nil {
+		hooks.afterSnapshot()
+	}
+
+	lock, err := AcquireBuildLock(ctx, le, opts.LockDir, opts.LockName)
+	if err != nil {
+		return zero, err
+	}
+	defer lock.Release()
+
+	post, _, err := lookupGenerations(ctx, shape, key)
+	if err != nil {
+		return zero, err
+	}
+	for _, generation := range post {
+		if !opts.RequireFresh {
+			return generation.Artifact, nil
+		}
+		if _, exists := preSet[generation.Token]; !exists {
+			return generation.Artifact, nil
+		}
+	}
+	generation, err := shape.Build(ctx, key)
+	if err != nil {
+		return zero, err
+	}
+	if generation.Token == "" {
+		return zero, errors.New("artifact build returned an empty generation token")
+	}
+	return generation.Artifact, nil
+}
+
+func lookupGenerations[A any](ctx context.Context, shape Shape[A], key string) ([]Generation[A], map[string]struct{}, error) {
+	generations, err := shape.Lookup(ctx, key)
+	if err != nil {
+		return nil, nil, err
+	}
+	tokens := make(map[string]struct{}, len(generations))
+	for _, generation := range generations {
+		if generation.Token == "" {
+			return nil, nil, errors.New("artifact lookup returned an empty generation token")
+		}
+		if _, exists := tokens[generation.Token]; exists {
+			return nil, nil, errors.Errorf("artifact lookup returned duplicate generation token %q", generation.Token)
+		}
+		tokens[generation.Token] = struct{}{}
+	}
+	return generations, tokens, nil
+}

--- a/e2e/harness/resolve_test.go
+++ b/e2e/harness/resolve_test.go
@@ -76,13 +76,23 @@ func (s *stubShape) Build(context.Context, string) (Generation[string], error) {
 
 type fixedShape struct {
 	generations []Generation[string]
+	lookups     [][]Generation[string]
+	lookup      int
 	builds      int
 }
 
 func (s *fixedShape) ContentKey(context.Context) (string, error) { return "key", nil }
 
 func (s *fixedShape) Lookup(context.Context, string) ([]Generation[string], error) {
-	return s.generations, nil
+	if len(s.lookups) == 0 {
+		return s.generations, nil
+	}
+	lookup := s.lookup
+	if lookup >= len(s.lookups) {
+		lookup = len(s.lookups) - 1
+	}
+	s.lookup++
+	return s.lookups[lookup], nil
 }
 
 func (s *fixedShape) Build(context.Context, string) (Generation[string], error) {
@@ -105,18 +115,66 @@ func TestResolveRejectsEmptyAndDuplicateTokens(t *testing.T) {
 	}
 }
 
-func TestResolveReusesDirectlyDiscoveredGeneration(t *testing.T) {
-	shape := &fixedShape{generations: []Generation[string]{{Token: "committed", Artifact: "artifact"}}}
+func TestResolveUsesLookupPreferenceOrder(t *testing.T) {
+	shape := &fixedShape{generations: []Generation[string]{
+		{Token: "z-current", Artifact: "current"},
+		{Token: "a-older", Artifact: "older"},
+	}}
 	lockDir := filepath.Join(t.TempDir(), "unused-lock")
 	artifact, err := Resolve(context.Background(), nil, ResolveOptions{LockDir: lockDir, LockName: "build"}, shape)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if artifact != "artifact" || shape.builds != 0 {
+	if artifact != "current" || shape.builds != 0 {
 		t.Fatalf("artifact = %q, builds = %d", artifact, shape.builds)
 	}
 	if _, err := os.Stat(lockDir); !os.IsNotExist(err) {
 		t.Fatalf("fast-path acquired lock: %v", err)
+	}
+}
+
+func TestResolveFreshExcludesEveryPreLockGeneration(t *testing.T) {
+	shape := &fixedShape{lookups: [][]Generation[string]{
+		{
+			{Token: "old-current", Artifact: "old-current"},
+			{Token: "old-fallback", Artifact: "old-fallback"},
+		},
+		{
+			{Token: "old-current", Artifact: "old-current"},
+			{Token: "old-fallback", Artifact: "old-fallback"},
+			{Token: "fresh-unpointed", Artifact: "fresh-unpointed"},
+		},
+	}}
+	artifact, err := Resolve(
+		context.Background(),
+		nil,
+		ResolveOptions{LockDir: t.TempDir(), LockName: "build", RequireFresh: true},
+		shape,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if artifact != "fresh-unpointed" || shape.builds != 0 {
+		t.Fatalf("artifact = %q, builds = %d", artifact, shape.builds)
+	}
+}
+
+func TestResolveReusesCrashRecoveredFallback(t *testing.T) {
+	shape := &fixedShape{generations: []Generation[string]{
+		{Token: "a-recovered", Artifact: "recovered"},
+		{Token: "z-older", Artifact: "older"},
+	}}
+	artifact, err := Resolve(
+		context.Background(),
+		nil,
+		ResolveOptions{LockDir: t.TempDir(), LockName: "build"},
+		shape,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if artifact != "recovered" || shape.builds != 0 {
+		t.Fatalf("artifact = %q, builds = %d", artifact, shape.builds)
 	}
 }
 

--- a/e2e/harness/resolve_test.go
+++ b/e2e/harness/resolve_test.go
@@ -1,0 +1,276 @@
+//go:build !js
+
+package harness
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	resolveTestRoleEnv  = "SPACEWAVE_HARNESS_RESOLVE_TEST_ROLE"
+	resolveTestRootEnv  = "SPACEWAVE_HARNESS_RESOLVE_TEST_ROOT"
+	resolveTestKeyEnv   = "SPACEWAVE_HARNESS_RESOLVE_TEST_KEY"
+	resolveTestFreshEnv = "SPACEWAVE_HARNESS_RESOLVE_TEST_FRESH"
+)
+
+type stubShape struct {
+	root string
+	key  string
+}
+
+func (s *stubShape) ContentKey(context.Context) (string, error) {
+	return s.key, nil
+}
+
+func (s *stubShape) Lookup(context.Context, string) ([]Generation[string], error) {
+	entries, err := os.ReadDir(filepath.Join(s.root, "tokens", s.key))
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	generations := make([]Generation[string], 0, len(entries))
+	for _, entry := range entries {
+		generations = append(generations, Generation[string]{Token: entry.Name(), Artifact: entry.Name()})
+	}
+	return generations, nil
+}
+
+func (s *stubShape) Build(context.Context, string) (Generation[string], error) {
+	countPath := filepath.Join(s.root, "builds-"+s.key)
+	data, err := os.ReadFile(countPath)
+	if err != nil && !os.IsNotExist(err) {
+		return Generation[string]{}, err
+	}
+	count := 0
+	if len(data) != 0 {
+		count, err = strconv.Atoi(strings.TrimSpace(string(data)))
+		if err != nil {
+			return Generation[string]{}, err
+		}
+	}
+	count++
+	if err := os.WriteFile(countPath, []byte(strconv.Itoa(count)+"\n"), 0o644); err != nil {
+		return Generation[string]{}, err
+	}
+	token := s.key + "-" + strconv.Itoa(count)
+	dir := filepath.Join(s.root, "tokens", s.key)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return Generation[string]{}, err
+	}
+	if err := os.WriteFile(filepath.Join(dir, token), []byte(token), 0o644); err != nil {
+		return Generation[string]{}, err
+	}
+	return Generation[string]{Token: token, Artifact: token}, nil
+}
+
+type fixedShape struct {
+	generations []Generation[string]
+	builds      int
+}
+
+func (s *fixedShape) ContentKey(context.Context) (string, error) { return "key", nil }
+
+func (s *fixedShape) Lookup(context.Context, string) ([]Generation[string], error) {
+	return s.generations, nil
+}
+
+func (s *fixedShape) Build(context.Context, string) (Generation[string], error) {
+	s.builds++
+	return Generation[string]{Token: "built", Artifact: "built"}, nil
+}
+
+func TestResolveRejectsEmptyAndDuplicateTokens(t *testing.T) {
+	for _, generations := range [][]Generation[string]{
+		{{Token: "", Artifact: "empty"}},
+		{{Token: "duplicate", Artifact: "a"}, {Token: "duplicate", Artifact: "b"}},
+	} {
+		shape := &fixedShape{generations: generations}
+		if _, err := Resolve(context.Background(), nil, ResolveOptions{LockDir: t.TempDir(), LockName: "build"}, shape); err == nil {
+			t.Fatal("Resolve accepted invalid lookup tokens")
+		}
+		if shape.builds != 0 {
+			t.Fatalf("build count = %d, want 0", shape.builds)
+		}
+	}
+}
+
+func TestResolveReusesDirectlyDiscoveredGeneration(t *testing.T) {
+	shape := &fixedShape{generations: []Generation[string]{{Token: "committed", Artifact: "artifact"}}}
+	lockDir := filepath.Join(t.TempDir(), "unused-lock")
+	artifact, err := Resolve(context.Background(), nil, ResolveOptions{LockDir: lockDir, LockName: "build"}, shape)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if artifact != "artifact" || shape.builds != 0 {
+		t.Fatalf("artifact = %q, builds = %d", artifact, shape.builds)
+	}
+	if _, err := os.Stat(lockDir); !os.IsNotExist(err) {
+		t.Fatalf("fast-path acquired lock: %v", err)
+	}
+}
+
+func TestResolveSubprocessCoalescing(t *testing.T) {
+	if os.Getenv(resolveTestRoleEnv) != "" {
+		runResolveTestRole(t)
+		return
+	}
+
+	t.Run("non-fresh same key", func(t *testing.T) {
+		root := t.TempDir()
+		results := runResolveChildren(t, root, []string{"X", "X", "X"}, false)
+		assertAllEqual(t, results)
+		assertBuildCount(t, root, "X", 1)
+	})
+	t.Run("fresh same key", func(t *testing.T) {
+		root := t.TempDir()
+		writeStubToken(t, root, "X", "X-seed")
+		results := runResolveChildren(t, root, []string{"X", "X", "X"}, true)
+		assertAllEqual(t, results)
+		if results[0] == "X-seed" {
+			t.Fatal("fresh resolve reused pre-lock generation")
+		}
+		assertBuildCount(t, root, "X", 1)
+	})
+	t.Run("different keys share lock", func(t *testing.T) {
+		root := t.TempDir()
+		results := runResolveChildren(t, root, []string{"X", "Y", "X"}, false)
+		if results[0] != results[2] || results[0] == results[1] {
+			t.Fatalf("results = %v", results)
+		}
+		assertBuildCount(t, root, "X", 1)
+		assertBuildCount(t, root, "Y", 1)
+	})
+}
+
+type resolveChild struct {
+	cmd    *exec.Cmd
+	stdin  io.WriteCloser
+	stdout *bufio.Reader
+}
+
+func runResolveChildren(t *testing.T, root string, keys []string, fresh bool) []string {
+	t.Helper()
+	children := make([]resolveChild, 0, len(keys))
+	for _, key := range keys {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		t.Cleanup(cancel)
+		cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestResolveSubprocessCoalescing$") //nolint:gosec
+		cmd.Env = append(os.Environ(),
+			resolveTestRoleEnv+"=child",
+			resolveTestRootEnv+"="+root,
+			resolveTestKeyEnv+"="+key,
+			resolveTestFreshEnv+"="+strconv.FormatBool(fresh),
+		)
+		stdout, err := cmd.StdoutPipe()
+		if err != nil {
+			t.Fatal(err)
+		}
+		stdin, err := cmd.StdinPipe()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := cmd.Start(); err != nil {
+			t.Fatal(err)
+		}
+		children = append(children, resolveChild{cmd: cmd, stdin: stdin, stdout: bufio.NewReader(stdout)})
+	}
+	for i := range children {
+		line, err := children[i].stdout.ReadString('\n')
+		if err != nil || strings.TrimSpace(line) != "ready" {
+			t.Fatalf("child %d readiness = %q, %v", i, line, err)
+		}
+	}
+	for i := range children {
+		if _, err := children[i].stdin.Write([]byte{1}); err != nil {
+			t.Fatal(err)
+		}
+		if err := children[i].stdin.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	results := make([]string, len(children))
+	for i := range children {
+		line, err := children[i].stdout.ReadString('\n')
+		if err != nil {
+			t.Fatalf("child %d result: %v", i, err)
+		}
+		results[i] = strings.TrimSpace(line)
+		if err := children[i].cmd.Wait(); err != nil {
+			t.Fatalf("child %d failed: %v", i, err)
+		}
+	}
+	return results
+}
+
+func runResolveTestRole(t *testing.T) {
+	t.Helper()
+	fresh, err := strconv.ParseBool(os.Getenv(resolveTestFreshEnv))
+	if err != nil {
+		t.Fatal(err)
+	}
+	shape := &stubShape{root: os.Getenv(resolveTestRootEnv), key: os.Getenv(resolveTestKeyEnv)}
+	artifact, err := resolve(context.Background(), nil, ResolveOptions{
+		LockDir:      filepath.Join(shape.root, "lock"),
+		LockName:     "build",
+		RequireFresh: fresh,
+	}, shape, resolveHooks{afterSnapshot: func() {
+		if _, err := os.Stdout.WriteString("ready\n"); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := io.Copy(io.Discard, os.Stdin); err != nil {
+			t.Fatal(err)
+		}
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stdout.WriteString(artifact + "\n"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeStubToken(t *testing.T, root, key, token string) {
+	t.Helper()
+	dir := filepath.Join(root, "tokens", key)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, token), []byte(token), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertAllEqual(t *testing.T, results []string) {
+	t.Helper()
+	for _, result := range results[1:] {
+		if result != results[0] {
+			t.Fatalf("results = %v", results)
+		}
+	}
+}
+
+func assertBuildCount(t *testing.T, root, key string, want int) {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(root, "builds-"+key))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("build count for %s = %d, want %d", key, got, want)
+	}
+}

--- a/e2e/harness/shape.go
+++ b/e2e/harness/shape.go
@@ -8,7 +8,8 @@ import "context"
 type Shape[A any] interface {
 	// ContentKey returns the immutable content key to resolve.
 	ContentKey(context.Context) (string, error)
-	// Lookup returns every validated publication for the content key.
+	// Lookup returns every validated publication for the content key in
+	// preference order. The first publication is the preferred result.
 	Lookup(context.Context, string) ([]Generation[A], error)
 	// Build produces and publishes one generation for the content key.
 	Build(context.Context, string) (Generation[A], error)

--- a/e2e/harness/shape.go
+++ b/e2e/harness/shape.go
@@ -1,0 +1,15 @@
+//go:build !js
+
+package harness
+
+import "context"
+
+// Shape supplies content identity, validated publication lookup, and artifact building.
+type Shape[A any] interface {
+	// ContentKey returns the immutable content key to resolve.
+	ContentKey(context.Context) (string, error)
+	// Lookup returns every validated publication for the content key.
+	Lookup(context.Context, string) ([]Generation[A], error)
+	// Build produces and publishes one generation for the content key.
+	Build(context.Context, string) (Generation[A], error)
+}

--- a/e2e/releasewasm/artifact-resolve.go
+++ b/e2e/releasewasm/artifact-resolve.go
@@ -1,0 +1,101 @@
+//go:build !js
+
+package releasewasm
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	e2eharness "github.com/s4wave/spacewave/e2e/harness"
+	"github.com/s4wave/spacewave/e2e/releasewasm/artifact"
+	"github.com/sirupsen/logrus"
+)
+
+type releaseArtifact struct {
+	releaseDir   string
+	prerenderDir string
+}
+
+type releaseShape struct {
+	le       *logrus.Entry
+	repoRoot string
+	storeDir string
+	identity *artifact.Identity
+}
+
+func newReleaseShape(le *logrus.Entry, repoRoot, storeDir string, identity *artifact.Identity) *releaseShape {
+	return &releaseShape{le: le, repoRoot: repoRoot, storeDir: storeDir, identity: identity}
+}
+
+func (s *releaseShape) ContentKey(context.Context) (string, error) {
+	return s.identity.Digest, nil
+}
+
+func (s *releaseShape) Lookup(ctx context.Context, key string) ([]e2eharness.Generation[releaseArtifact], error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	generations, err := artifact.ValidGenerations(s.storeDir, s.identity)
+	if err != nil {
+		return nil, err
+	}
+	results := make([]e2eharness.Generation[releaseArtifact], 0, len(generations))
+	for _, generation := range generations {
+		results = append(results, e2eharness.Generation[releaseArtifact]{
+			Token: generation.ID,
+			Artifact: releaseArtifact{
+				releaseDir:   generation.ReleaseDir,
+				prerenderDir: generation.PrerenderDir,
+			},
+		})
+	}
+	return results, nil
+}
+
+func (s *releaseShape) Build(ctx context.Context, key string) (e2eharness.Generation[releaseArtifact], error) {
+	if err := os.RemoveAll(filepath.Join(s.repoRoot, prerenderDistRelPath)); err != nil {
+		return e2eharness.Generation[releaseArtifact]{}, errors.Wrap(err, "clean prerender dist")
+	}
+	if err := os.RemoveAll(filepath.Join(s.repoRoot, ".bldr-dist")); err != nil {
+		return e2eharness.Generation[releaseArtifact]{}, errors.Wrap(err, "clean release dist state")
+	}
+
+	s.le.Info("building release web bundle")
+	if err := buildReleaseWeb(ctx, s.repoRoot); err != nil {
+		return e2eharness.Generation[releaseArtifact]{}, errors.Wrap(err, "build release web bundle")
+	}
+
+	distDir := filepath.Join(s.repoRoot, releaseDistRelPath)
+	s.le.Info("building prerender hydrate bundle")
+	if err := runBun(ctx, s.repoRoot, "run", "vite", "build", "--config", "app/prerender/vite.hydrate.config.ts"); err != nil {
+		return e2eharness.Generation[releaseArtifact]{}, errors.Wrap(err, "build prerender hydrate bundle")
+	}
+	s.le.Info("building prerender ssr bundle")
+	if err := runBun(ctx, s.repoRoot, "run", "vite", "build", "--config", "app/prerender/vite.ssr.config.ts"); err != nil {
+		return e2eharness.Generation[releaseArtifact]{}, errors.Wrap(err, "build prerender ssr bundle")
+	}
+	s.le.Info("running prerender build")
+	if err := runBun(ctx, s.repoRoot, "./app/prerender/ssr-dist/build.js", "--dist-dir", distDir); err != nil {
+		return e2eharness.Generation[releaseArtifact]{}, errors.Wrap(err, "run prerender build")
+	}
+
+	generation, err := artifact.PublishGeneration(
+		s.storeDir,
+		distDir,
+		filepath.Join(s.repoRoot, prerenderDistRelPath),
+		s.identity,
+	)
+	if err != nil {
+		return e2eharness.Generation[releaseArtifact]{}, errors.Wrap(err, "publish release artifact")
+	}
+	s.le.WithField("identity", s.identity.Digest).Info("release artifact rebuilt and published")
+	return e2eharness.Generation[releaseArtifact]{
+		Token: generation.ID,
+		Artifact: releaseArtifact{
+			releaseDir:   generation.ReleaseDir,
+			prerenderDir: generation.PrerenderDir,
+		},
+	}, nil
+}

--- a/e2e/releasewasm/artifact/generation.go
+++ b/e2e/releasewasm/artifact/generation.go
@@ -1,0 +1,8 @@
+package artifact
+
+// Generation identifies one immutable published release artifact.
+type Generation struct {
+	ID           string
+	ReleaseDir   string
+	PrerenderDir string
+}

--- a/e2e/releasewasm/artifact/store.go
+++ b/e2e/releasewasm/artifact/store.go
@@ -19,22 +19,38 @@ const (
 	generationsDir   = "generations"
 )
 
+type publishHooks struct {
+	beforeRename             func()
+	afterRenameBeforeCurrent func()
+}
+
 // Publish copies a complete release and prerender output pair into an immutable
 // generation, then atomically makes that generation current.
 func Publish(storeDir, releaseDir, prerenderDir string, identity *Identity) (string, string, error) {
+	generation, err := PublishGeneration(storeDir, releaseDir, prerenderDir, identity)
+	return generation.ReleaseDir, generation.PrerenderDir, err
+}
+
+// PublishGeneration copies, validates, and atomically publishes one immutable
+// release artifact generation.
+func PublishGeneration(storeDir, releaseDir, prerenderDir string, identity *Identity) (Generation, error) {
+	return publish(storeDir, releaseDir, prerenderDir, identity, publishHooks{})
+}
+
+func publish(storeDir, releaseDir, prerenderDir string, identity *Identity, hooks publishHooks) (Generation, error) {
 	if identity == nil || identity.Digest == "" || identity.Digest != identity.contentDigest() {
-		return "", "", errors.New("invalid release artifact identity")
+		return Generation{}, errors.New("invalid release artifact identity")
 	}
 	if err := validateRequiredFiles(releaseDir, prerenderDir); err != nil {
-		return "", "", err
+		return Generation{}, err
 	}
 	if err := os.MkdirAll(filepath.Join(storeDir, generationsDir), 0o755); err != nil {
-		return "", "", errors.Wrap(err, "create release artifact store")
+		return Generation{}, errors.Wrap(err, "create release artifact store")
 	}
 
 	stageDir, err := os.MkdirTemp(storeDir, ".publish-")
 	if err != nil {
-		return "", "", errors.Wrap(err, "create release artifact staging directory")
+		return Generation{}, errors.Wrap(err, "create release artifact staging directory")
 	}
 	removeStage := true
 	defer func() {
@@ -46,41 +62,51 @@ func Publish(storeDir, releaseDir, prerenderDir string, identity *Identity) (str
 	stagedRelease := filepath.Join(stageDir, "release")
 	stagedPrerender := filepath.Join(stageDir, "prerender")
 	if err := copyTree(releaseDir, stagedRelease); err != nil {
-		return "", "", errors.Wrap(err, "stage release output")
+		return Generation{}, errors.Wrap(err, "stage release output")
 	}
 	if err := copyTree(prerenderDir, stagedPrerender); err != nil {
-		return "", "", errors.Wrap(err, "stage prerender output")
+		return Generation{}, errors.Wrap(err, "stage prerender output")
 	}
 
 	releaseDigest, err := treeDigest(stagedRelease)
 	if err != nil {
-		return "", "", errors.Wrap(err, "digest staged release output")
+		return Generation{}, errors.Wrap(err, "digest staged release output")
 	}
 	prerenderDigest, err := treeDigest(stagedPrerender)
 	if err != nil {
-		return "", "", errors.Wrap(err, "digest staged prerender output")
+		return Generation{}, errors.Wrap(err, "digest staged prerender output")
 	}
 	if err := os.WriteFile(
 		filepath.Join(stagedRelease, identityFilename),
 		marshalManifest(identity, releaseDigest, prerenderDigest),
 		0o644,
 	); err != nil {
-		return "", "", errors.Wrap(err, "write staged release artifact identity")
+		return Generation{}, errors.Wrap(err, "write staged release artifact identity")
 	}
 	if err := Validate(stagedRelease, stagedPrerender, identity); err != nil {
-		return "", "", errors.Wrap(err, "validate staged release artifact")
+		return Generation{}, errors.Wrap(err, "validate staged release artifact")
 	}
 
 	generation := identity.Digest + "-" + strings.TrimPrefix(filepath.Base(stageDir), ".publish-")
 	generationDir := filepath.Join(storeDir, generationsDir, generation)
+	if hooks.beforeRename != nil {
+		hooks.beforeRename()
+	}
 	if err := os.Rename(stageDir, generationDir); err != nil {
-		return "", "", errors.Wrap(err, "commit release artifact generation")
+		return Generation{}, errors.Wrap(err, "commit release artifact generation")
 	}
 	removeStage = false
-	if err := writeCurrent(storeDir, generation); err != nil {
-		return "", "", err
+	if hooks.afterRenameBeforeCurrent != nil {
+		hooks.afterRenameBeforeCurrent()
 	}
-	return filepath.Join(generationDir, "release"), filepath.Join(generationDir, "prerender"), nil
+	if err := writeCurrent(storeDir, generation); err != nil {
+		return Generation{}, err
+	}
+	return Generation{
+		ID:           generation,
+		ReleaseDir:   filepath.Join(generationDir, "release"),
+		PrerenderDir: filepath.Join(generationDir, "prerender"),
+	}, nil
 }
 
 // Current returns the atomically published generation when it is complete and
@@ -101,6 +127,55 @@ func Current(storeDir string, expected *Identity) (string, string, error) {
 		return "", "", err
 	}
 	return releaseDir, prerenderDir, nil
+}
+
+// ValidGenerations returns every valid immutable generation matching the
+// expected content identity.
+func ValidGenerations(storeDir string, expected *Identity) ([]Generation, error) {
+	if expected == nil {
+		return nil, errors.New("missing expected release artifact identity")
+	}
+	root := filepath.Join(storeDir, generationsDir)
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, errors.Wrap(err, "read release artifact generations")
+	}
+	var generations []Generation
+	for _, entry := range entries {
+		name := entry.Name()
+		parts := strings.SplitN(name, "-", 2)
+		if parts[0] != expected.Digest {
+			continue
+		}
+		if len(parts) != 2 || parts[1] == "" {
+			return nil, errors.Errorf("invalid release artifact generation %q", name)
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return nil, errors.Errorf("release artifact generation %q is a symbolic link", name)
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return nil, errors.Wrapf(err, "inspect release artifact generation %q", name)
+		}
+		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			return nil, errors.Errorf("release artifact generation %q is not a directory", name)
+		}
+		generationDir := filepath.Join(root, name)
+		releaseDir := filepath.Join(generationDir, "release")
+		prerenderDir := filepath.Join(generationDir, "prerender")
+		if err := Validate(releaseDir, prerenderDir, expected); err != nil {
+			return nil, err
+		}
+		generations = append(generations, Generation{
+			ID:           name,
+			ReleaseDir:   releaseDir,
+			PrerenderDir: prerenderDir,
+		})
+	}
+	return generations, nil
 }
 
 // Validate rejects incomplete, modified, or stale artifact directory pairs.

--- a/e2e/releasewasm/artifact/store.go
+++ b/e2e/releasewasm/artifact/store.go
@@ -117,7 +117,7 @@ func Current(storeDir string, expected *Identity) (string, string, error) {
 		return "", "", errors.Wrap(err, "read current release artifact generation")
 	}
 	generation := strings.TrimSpace(string(data))
-	if generation == "" || filepath.Base(generation) != generation || generation == "." || generation == ".." {
+	if !validGenerationName(generation) {
 		return "", "", errors.New("invalid current release artifact generation")
 	}
 	generationDir := filepath.Join(storeDir, generationsDir, generation)
@@ -129,11 +129,26 @@ func Current(storeDir string, expected *Identity) (string, string, error) {
 	return releaseDir, prerenderDir, nil
 }
 
+func validGenerationName(generation string) bool {
+	return generation != "" && filepath.Base(generation) == generation && generation != "." && generation != ".."
+}
+
 // ValidGenerations returns every valid immutable generation matching the
-// expected content identity.
+// expected content identity, with the current generation first when valid.
 func ValidGenerations(storeDir string, expected *Identity) ([]Generation, error) {
 	if expected == nil {
 		return nil, errors.New("missing expected release artifact identity")
+	}
+	current := ""
+	data, err := os.ReadFile(filepath.Join(storeDir, currentFilename))
+	if err != nil && !os.IsNotExist(err) {
+		return nil, errors.Wrap(err, "read current release artifact generation")
+	}
+	if err == nil {
+		generation := strings.TrimSpace(string(data))
+		if validGenerationName(generation) {
+			current = generation
+		}
 	}
 	root := filepath.Join(storeDir, generationsDir)
 	entries, err := os.ReadDir(root)
@@ -144,6 +159,7 @@ func ValidGenerations(storeDir string, expected *Identity) ([]Generation, error)
 		return nil, errors.Wrap(err, "read release artifact generations")
 	}
 	var generations []Generation
+	var preferred Generation
 	for _, entry := range entries {
 		name := entry.Name()
 		parts := strings.SplitN(name, "-", 2)
@@ -169,11 +185,19 @@ func ValidGenerations(storeDir string, expected *Identity) ([]Generation, error)
 		if err := Validate(releaseDir, prerenderDir, expected); err != nil {
 			return nil, err
 		}
-		generations = append(generations, Generation{
+		generation := Generation{
 			ID:           name,
 			ReleaseDir:   releaseDir,
 			PrerenderDir: prerenderDir,
-		})
+		}
+		if name == current {
+			preferred = generation
+			continue
+		}
+		generations = append(generations, generation)
+	}
+	if preferred.ID != "" {
+		generations = append([]Generation{preferred}, generations...)
 	}
 	return generations, nil
 }

--- a/e2e/releasewasm/artifact/store_test.go
+++ b/e2e/releasewasm/artifact/store_test.go
@@ -188,6 +188,44 @@ func TestPublishGenerationAndValidGenerationsTokenParity(t *testing.T) {
 	}
 }
 
+func TestValidGenerationsOrdersNonLexicalCurrentFirst(t *testing.T) {
+	repoRoot := newIdentityTestRepo(t)
+	identity := computeTestIdentity(t, repoRoot, testBuildInputs())
+	storeDir := filepath.Join(t.TempDir(), "store")
+
+	releaseA, prerenderA := newArtifactFixture(t, "first")
+	first, err := PublishGeneration(storeDir, releaseA, prerenderA, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	releaseB, prerenderB := newArtifactFixture(t, "second")
+	second, err := PublishGeneration(storeDir, releaseB, prerenderB, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	firstID := identity.Digest + "-a"
+	secondID := identity.Digest + "-z"
+	root := filepath.Join(storeDir, generationsDir)
+	if err := os.Rename(filepath.Dir(first.ReleaseDir), filepath.Join(root, firstID)); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(filepath.Dir(second.ReleaseDir), filepath.Join(root, secondID)); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeCurrent(storeDir, secondID); err != nil {
+		t.Fatal(err)
+	}
+
+	generations, err := ValidGenerations(storeDir, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(generations) != 2 || generations[0].ID != secondID || generations[1].ID != firstID {
+		t.Fatalf("generations = %#v, want current %q before lexical-first %q", generations, secondID, firstID)
+	}
+}
+
 func TestValidGenerationsCandidatePredicate(t *testing.T) {
 	repoRoot := newIdentityTestRepo(t)
 	identity := computeTestIdentity(t, repoRoot, testBuildInputs())

--- a/e2e/releasewasm/artifact/store_test.go
+++ b/e2e/releasewasm/artifact/store_test.go
@@ -1,10 +1,13 @@
 package artifact
 
 import (
+	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 )
 
 func TestPublishLastCompleteWinsAndIgnoresPartialGeneration(t *testing.T) {
@@ -146,4 +149,199 @@ func assertArtifactMarker(t *testing.T, releaseDir, prerenderDir, want string) {
 			t.Fatalf("artifact marker = %q, want %q", data, want)
 		}
 	}
+}
+
+const (
+	publishCrashRoleEnv       = "SPACEWAVE_ARTIFACT_PUBLISH_CRASH_ROLE"
+	publishCrashStoreEnv      = "SPACEWAVE_ARTIFACT_PUBLISH_CRASH_STORE"
+	publishCrashReleaseEnv    = "SPACEWAVE_ARTIFACT_PUBLISH_CRASH_RELEASE"
+	publishCrashPrerenderEnv  = "SPACEWAVE_ARTIFACT_PUBLISH_CRASH_PRERENDER"
+	publishCrashRepositoryEnv = "SPACEWAVE_ARTIFACT_PUBLISH_CRASH_REPOSITORY"
+)
+
+func TestPublishGenerationAndValidGenerationsTokenParity(t *testing.T) {
+	repoRoot := newIdentityTestRepo(t)
+	identity := computeTestIdentity(t, repoRoot, testBuildInputs())
+	storeDir := filepath.Join(t.TempDir(), "store")
+	releaseDir, prerenderDir := newArtifactFixture(t, "generation")
+
+	generation, err := PublishGeneration(storeDir, releaseDir, prerenderDir, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if generation.ID == "" {
+		t.Fatal("published generation has an empty ID")
+	}
+	generations, err := ValidGenerations(storeDir, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(generations) != 1 || generations[0] != generation {
+		t.Fatalf("listed generations = %#v, want %#v", generations, generation)
+	}
+	currentRelease, currentPrerender, err := Current(storeDir, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if currentRelease != generation.ReleaseDir || currentPrerender != generation.PrerenderDir {
+		t.Fatalf("current = (%q, %q), want (%q, %q)", currentRelease, currentPrerender, generation.ReleaseDir, generation.PrerenderDir)
+	}
+}
+
+func TestValidGenerationsCandidatePredicate(t *testing.T) {
+	repoRoot := newIdentityTestRepo(t)
+	identity := computeTestIdentity(t, repoRoot, testBuildInputs())
+
+	t.Run("absent store is empty", func(t *testing.T) {
+		generations, err := ValidGenerations(filepath.Join(t.TempDir(), "absent"), identity)
+		if err != nil || len(generations) != 0 {
+			t.Fatalf("generations = %#v, err = %v", generations, err)
+		}
+	})
+	t.Run("other digest entry is ignored", func(t *testing.T) {
+		storeDir := t.TempDir()
+		writeTestFile(t, filepath.Join(storeDir, generationsDir, "other-entry"), "not a directory")
+		generations, err := ValidGenerations(storeDir, identity)
+		if err != nil || len(generations) != 0 {
+			t.Fatalf("generations = %#v, err = %v", generations, err)
+		}
+	})
+	for _, name := range []string{identity.Digest, identity.Digest + "-"} {
+		t.Run("malformed matching "+filepath.Base(name), func(t *testing.T) {
+			storeDir := t.TempDir()
+			writeTestFile(t, filepath.Join(storeDir, generationsDir, name), "malformed")
+			if generations, err := ValidGenerations(storeDir, identity); err == nil || len(generations) != 0 {
+				t.Fatalf("generations = %#v, err = %v", generations, err)
+			}
+		})
+	}
+	t.Run("matching validation error propagates", func(t *testing.T) {
+		storeDir := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(storeDir, generationsDir, identity.Digest+"-invalid"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if generations, err := ValidGenerations(storeDir, identity); err == nil || len(generations) != 0 {
+			t.Fatalf("generations = %#v, err = %v", generations, err)
+		}
+	})
+}
+
+func TestValidGenerationsRejectsExternalValidFixtureSymlink(t *testing.T) {
+	repoRoot := newIdentityTestRepo(t)
+	identity := computeTestIdentity(t, repoRoot, testBuildInputs())
+	externalStore := filepath.Join(t.TempDir(), "external-store")
+	releaseDir, prerenderDir := newArtifactFixture(t, "external")
+	external, err := PublishGeneration(externalStore, releaseDir, prerenderDir, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	externalDir := filepath.Dir(external.ReleaseDir)
+
+	storeDir := t.TempDir()
+	root := filepath.Join(storeDir, generationsDir)
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(externalDir, filepath.Join(root, identity.Digest+"-external")); err != nil {
+		t.Fatal(err)
+	}
+	if generations, err := ValidGenerations(storeDir, identity); err == nil || len(generations) != 0 {
+		t.Fatalf("generations = %#v, err = %v", generations, err)
+	}
+}
+
+func TestValidGenerationsRejectsMatchingNonDirectory(t *testing.T) {
+	repoRoot := newIdentityTestRepo(t)
+	identity := computeTestIdentity(t, repoRoot, testBuildInputs())
+	storeDir := t.TempDir()
+	writeTestFile(t, filepath.Join(storeDir, generationsDir, identity.Digest+"-file"), "not a directory")
+	if generations, err := ValidGenerations(storeDir, identity); err == nil || len(generations) != 0 {
+		t.Fatalf("generations = %#v, err = %v", generations, err)
+	}
+}
+
+func TestPublishCrashRecovery(t *testing.T) {
+	if role := os.Getenv(publishCrashRoleEnv); role != "" {
+		runPublishCrashRole(t, role)
+		return
+	}
+	repoRoot := newIdentityTestRepo(t)
+	identity := computeTestIdentity(t, repoRoot, testBuildInputs())
+	releaseDir, prerenderDir := newArtifactFixture(t, "crash")
+
+	t.Run("before rename leaves no generation", func(t *testing.T) {
+		storeDir := filepath.Join(t.TempDir(), "store")
+		runPublishCrashChild(t, "before-rename", storeDir, releaseDir, prerenderDir, repoRoot)
+		generations, err := ValidGenerations(storeDir, identity)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(generations) != 0 {
+			t.Fatalf("generations = %#v", generations)
+		}
+	})
+	t.Run("after rename recovers unpointed generation", func(t *testing.T) {
+		storeDir := filepath.Join(t.TempDir(), "store")
+		runPublishCrashChild(t, "after-rename", storeDir, releaseDir, prerenderDir, repoRoot)
+		generations, err := ValidGenerations(storeDir, identity)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(generations) != 1 || generations[0].ID == "" {
+			t.Fatalf("generations = %#v", generations)
+		}
+		if _, _, err := Current(storeDir, identity); err == nil {
+			t.Fatal("crashed publication unexpectedly wrote current pointer")
+		}
+	})
+}
+
+func runPublishCrashChild(t *testing.T, role, storeDir, releaseDir, prerenderDir, repoRoot string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestPublishCrashRecovery$") //nolint:gosec
+	cmd.Env = append(os.Environ(),
+		publishCrashRoleEnv+"="+role,
+		publishCrashStoreEnv+"="+storeDir,
+		publishCrashReleaseEnv+"="+releaseDir,
+		publishCrashPrerenderEnv+"="+prerenderDir,
+		publishCrashRepositoryEnv+"="+repoRoot,
+	)
+	err := cmd.Run()
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("crash child error = %v", err)
+	}
+	wantCode := 73
+	if role == "after-rename" {
+		wantCode = 74
+	}
+	if exitErr.ExitCode() != wantCode {
+		t.Fatalf("crash child exit code = %d, want %d", exitErr.ExitCode(), wantCode)
+	}
+}
+
+func runPublishCrashRole(t *testing.T, role string) {
+	t.Helper()
+	identity := computeTestIdentity(t, os.Getenv(publishCrashRepositoryEnv), testBuildInputs())
+	hooks := publishHooks{}
+	switch role {
+	case "before-rename":
+		hooks.beforeRename = func() { os.Exit(73) }
+	case "after-rename":
+		hooks.afterRenameBeforeCurrent = func() { os.Exit(74) }
+	default:
+		t.Fatalf("unknown crash role %q", role)
+	}
+	if _, err := publish(
+		os.Getenv(publishCrashStoreEnv),
+		os.Getenv(publishCrashReleaseEnv),
+		os.Getenv(publishCrashPrerenderEnv),
+		identity,
+		hooks,
+	); err != nil {
+		t.Fatal(err)
+	}
+	t.Fatal("publish crash hook did not exit")
 }

--- a/e2e/releasewasm/harness.go
+++ b/e2e/releasewasm/harness.go
@@ -23,6 +23,7 @@ import (
 	playwright "github.com/mxschmitt/playwright-go"
 	"github.com/pkg/errors"
 	api "github.com/s4wave/spacewave/core/provider/spacewave/api"
+	e2eharness "github.com/s4wave/spacewave/e2e/harness"
 	"github.com/s4wave/spacewave/e2e/releasewasm/artifact"
 	"github.com/sirupsen/logrus"
 )
@@ -205,12 +206,13 @@ func prepareReleaseWasmDist(ctx context.Context, le *logrus.Entry, repoRoot stri
 	if err != nil {
 		return releaseWasmDistDirs{}, errors.Wrap(err, "compute release artifact identity")
 	}
+	storeDir := releaseWasmArtifactStoreDir(repoRoot)
 
 	prebuiltDirs, prebuilt, err := prebuiltReleaseWasmDistDirs(repoRoot)
 	if err != nil {
 		return releaseWasmDistDirs{}, err
 	}
-	forceBuild := false
+	requireFresh := false
 	if prebuilt {
 		validationErr := artifact.Validate(prebuiltDirs.releaseDist, prebuiltDirs.prerender, identity)
 		if validationErr == nil {
@@ -221,57 +223,22 @@ func prepareReleaseWasmDist(ctx context.Context, le *logrus.Entry, repoRoot stri
 			}).Info("release artifact cache hit")
 			return prebuiltDirs, nil
 		}
-		forceBuild = true
+		requireFresh = true
 		le.WithError(validationErr).WithField("identity", identity.Digest).Info("prebuilt release artifact rejected; rebuilding")
 	}
 
-	if !forceBuild {
-		releaseDir, prerenderDir, err := artifact.Current(releaseWasmArtifactStoreDir(repoRoot), identity)
-		if err == nil {
-			le.WithField("identity", identity.Digest).Info("release artifact cache hit")
-			return releaseWasmDistDirs{releaseDist: releaseDir, prerender: prerenderDir}, nil
-		}
-		le.WithError(err).WithField("identity", identity.Digest).Info("release artifact cache miss; rebuilding")
-	}
-
-	if err := os.RemoveAll(filepath.Join(repoRoot, prerenderDistRelPath)); err != nil {
-		return releaseWasmDistDirs{}, errors.Wrap(err, "clean prerender dist")
-	}
-	if err := os.RemoveAll(filepath.Join(repoRoot, ".bldr-dist")); err != nil {
-		return releaseWasmDistDirs{}, errors.Wrap(err, "clean release dist state")
-	}
-
-	le.Info("building release web bundle")
-	if err := buildReleaseWeb(ctx, repoRoot); err != nil {
-		return releaseWasmDistDirs{}, errors.Wrap(err, "build release web bundle")
-	}
-
-	distDir := filepath.Join(repoRoot, releaseDistRelPath)
-	le.Info("building prerender hydrate bundle")
-	if err := runBun(ctx, repoRoot, "run", "vite", "build", "--config", "app/prerender/vite.hydrate.config.ts"); err != nil {
-		return releaseWasmDistDirs{}, errors.Wrap(err, "build prerender hydrate bundle")
-	}
-	le.Info("building prerender ssr bundle")
-	if err := runBun(ctx, repoRoot, "run", "vite", "build", "--config", "app/prerender/vite.ssr.config.ts"); err != nil {
-		return releaseWasmDistDirs{}, errors.Wrap(err, "build prerender ssr bundle")
-	}
-	le.Info("running prerender build")
-	if err := runBun(ctx, repoRoot, "./app/prerender/ssr-dist/build.js", "--dist-dir", distDir); err != nil {
-		return releaseWasmDistDirs{}, errors.Wrap(err, "run prerender build")
-	}
-
-	staticDir := filepath.Join(repoRoot, prerenderDistRelPath)
-	releaseDir, prerenderDir, err := artifact.Publish(
-		releaseWasmArtifactStoreDir(repoRoot),
-		distDir,
-		staticDir,
-		identity,
-	)
+	resolved, err := e2eharness.Resolve(ctx, le, e2eharness.ResolveOptions{
+		LockDir:      storeDir,
+		LockName:     "build",
+		RequireFresh: requireFresh,
+	}, newReleaseShape(le, repoRoot, storeDir, identity))
 	if err != nil {
-		return releaseWasmDistDirs{}, errors.Wrap(err, "publish release artifact")
+		return releaseWasmDistDirs{}, err
 	}
-	le.WithField("identity", identity.Digest).Info("release artifact rebuilt and published")
-	return releaseWasmDistDirs{releaseDist: releaseDir, prerender: prerenderDir}, nil
+	return releaseWasmDistDirs{
+		releaseDist: resolved.releaseDir,
+		prerender:   resolved.prerenderDir,
+	}, nil
 }
 
 func prebuiltReleaseWasmDistDirs(repoRoot string) (releaseWasmDistDirs, bool, error) {


### PR DESCRIPTION
Release WASM preparation could rebuild the same content from multiple test processes, and a crash after committing an immutable generation could leave reusable output undiscovered when the mutable current pointer was not updated.

Add a release-neutral resolver under `e2e/harness` that snapshots valid generations, acquires a kernel-backed build lock, rechecks under the lock, and builds only when no acceptable generation exists. The release WASM adapter supplies its content key, ordered generation lookup, and publisher through that resolver. Existing complete generations and the artifact-store layout remain compatible; incomplete or symlinked candidates are rejected.

Focused resolver and release-artifact tests pass with the race detector. The release WASM and WASM E2E packages compile without running browser scenarios, and the repository Go build and exact-diff whitespace check pass.