### PR TITLE
fix(deps): promote GoScript errors.Is fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/s4wave/spacewave
 
 go 1.26.4
 
-require github.com/s4wave/goscript v0.2.23-0.20260718110009-63482b4c3b15 // master
+require github.com/s4wave/goscript v0.2.23 // master
 
 replace (
 	// aperture: use compatibility forks

--- a/go.sum
+++ b/go.sum
@@ -320,8 +320,8 @@ github.com/restic/chunker v0.5.0/go.mod h1:z0cH2BejpW636LXw0R/BGyv+Ey8+m9QGiOanD
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
-github.com/s4wave/goscript v0.2.23-0.20260718110009-63482b4c3b15 h1:69b0b9FkA4QCzEqUxngLRWSHTNPE/fr5V6iUbJ2kkKY=
-github.com/s4wave/goscript v0.2.23-0.20260718110009-63482b4c3b15/go.mod h1:18Xd97O2fEk+ytqITi+jvPNcZkRrQSkEfk4mavlr9to=
+github.com/s4wave/goscript v0.2.23 h1:HjNv8acpWzP8MhP4o+79gPzzXmUkYm/9W0Ls3CpKZH0=
+github.com/s4wave/goscript v0.2.23/go.mod h1:18Xd97O2fEk+ytqITi+jvPNcZkRrQSkEfk4mavlr9to=
 github.com/sasha-s/go-deadlock v0.3.9 h1:fiaT9rB7g5sr5ddNZvlwheclN9IP86eFW9WgqlEQV+w=
 github.com/sasha-s/go-deadlock v0.3.9/go.mod h1:KuZj51ZFmx42q/mPaYbRk0P1xcwe697zsJKE03vD4/Y=
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=


### PR DESCRIPTION
Spacewave was pinned to a GoScript pseudo-version that compared separately boxed named errors by identity. The translated local-provider pairing checks therefore returned the expected error text but failed errors.Is for four ConfirmPairing cases.

Promote github.com/s4wave/goscript to released v0.2.23, which contains the comparable named-value fix, and regenerate go.sum through the normal Go module flow. Spacewave source and public APIs are unchanged. The translated core/provider/local regressions and native package tests pass, and go build ./... succeeds.