### PR TITLE
fix(cli): drain daemon after shutdown response

### DIFF
--- a/cmd/spacewave/cli/daemon-accept.go
+++ b/cmd/spacewave/cli/daemon-accept.go
@@ -11,9 +11,16 @@ import (
 	"github.com/aperturerobotics/starpc/srpc"
 )
 
-// trackedConn decrements the idle tracker once when the connection closes.
+// daemonConnCtxKey keys the accepting connection on each served stream context
+// so the daemon-control handler can record which connection carried an approved
+// Shutdown request.
+type daemonConnCtxKey struct{}
+
+// trackedConn decrements the idle tracker once when the connection closes and
+// closes done when its serving goroutine exits.
 type trackedConn struct {
 	net.Conn
+	done      chan struct{}
 	closeOnce sync.Once
 	onClose   func()
 }
@@ -28,22 +35,86 @@ func (c *trackedConn) Close() error {
 	return c.Conn.Close()
 }
 
-// acceptDaemonListener accepts incoming daemon connections and tracks their lifecycle.
-func acceptDaemonListener(ctx context.Context, lis net.Listener, srv *srpc.Server, idleTracker *daemonIdleTracker) error {
+// serveDaemonListener serves accepted daemon clients until an approved
+// daemon-control Shutdown closes the accepting listener or serveCtx is
+// canceled. On an approved shutdown it waits for the control handler to finish
+// writing its acknowledgement (ShutdownComplete) and then for the requester to
+// read that acknowledgement and close its own connection, so the requester
+// observes a clean stream close instead of a reset. Only after the requester
+// departs does it drain any remaining clients and cancel the connection
+// lifecycle. External serveCtx cancellation and accept errors still exit
+// promptly.
+//
+// The shutdown callback registered on controlHandler must close only the
+// accepting listener and signal shutdownCh; it must not cancel serveCtx.
+func serveDaemonListener(
+	serveCtx context.Context,
+	serveCancel context.CancelFunc,
+	lis net.Listener,
+	srv *srpc.Server,
+	controlHandler *daemonControlHandler,
+	shutdownCh <-chan struct{},
+	idleTracker *daemonIdleTracker,
+) error {
+	go func() {
+		<-serveCtx.Done()
+		_ = lis.Close()
+	}()
+
+	closeClients, err := acceptDaemonListener(serveCtx, lis, srv, idleTracker)
+	serveCanceled := serveCtx.Err() != nil
+	select {
+	case <-shutdownCh:
+		select {
+		case <-controlHandler.ShutdownComplete():
+		case <-serveCtx.Done():
+		}
+		if requester := controlHandler.shutdownConn.Load(); requester != nil {
+			select {
+			case <-requester.done:
+			case <-serveCtx.Done():
+			}
+		}
+	default:
+	}
+	closeClients()
+	serveCancel()
+	if err != nil && (serveCanceled || errors.Is(err, net.ErrClosed)) {
+		return nil
+	}
+	return err
+}
+
+// acceptDaemonListener accepts incoming daemon connections and tracks their
+// lifecycle. It returns a drain function once accepting stops so the owner can
+// release the listener, let a shutdown requester read its acknowledgement, and
+// only then close any remaining clients synchronously.
+func acceptDaemonListener(
+	ctx context.Context,
+	lis net.Listener,
+	srv *srpc.Server,
+	idleTracker *daemonIdleTracker,
+) (func(), error) {
 	var clients sync.WaitGroup
 	var connsMtx sync.Mutex
 	conns := make(map[*trackedConn]struct{})
-	defer clients.Wait()
+	closeClients := func() {
+		connsMtx.Lock()
+		active := make([]*trackedConn, 0, len(conns))
+		for conn := range conns {
+			active = append(active, conn)
+		}
+		connsMtx.Unlock()
+		for _, conn := range active {
+			_ = conn.Close()
+		}
+		clients.Wait()
+	}
+
 	for {
 		nc, err := lis.Accept()
 		if err != nil {
-			var closeErr error
-			connsMtx.Lock()
-			for conn := range conns {
-				closeErr = errors.Join(closeErr, conn.Close())
-			}
-			connsMtx.Unlock()
-			return errors.Join(err, closeErr)
+			return closeClients, err
 		}
 
 		if idleTracker != nil {
@@ -51,6 +122,7 @@ func acceptDaemonListener(ctx context.Context, lis net.Listener, srv *srpc.Serve
 		}
 		tc := &trackedConn{
 			Conn: nc,
+			done: make(chan struct{}),
 			onClose: func() {
 				if idleTracker != nil {
 					idleTracker.clientDetached()
@@ -68,14 +140,16 @@ func acceptDaemonListener(ctx context.Context, lis net.Listener, srv *srpc.Serve
 		conns[tc] = struct{}{}
 		connsMtx.Unlock()
 
+		connCtx := context.WithValue(ctx, daemonConnCtxKey{}, tc)
 		clients.Go(func() {
+			defer close(tc.done)
 			defer func() {
 				connsMtx.Lock()
 				delete(conns, tc)
 				connsMtx.Unlock()
 			}()
 			defer tc.Close()
-			_ = srv.AcceptMuxedConn(ctx, mc)
+			_ = srv.AcceptMuxedConn(connCtx, mc)
 		})
 	}
 }

--- a/cmd/spacewave/cli/daemon-accept_test.go
+++ b/cmd/spacewave/cli/daemon-accept_test.go
@@ -40,7 +40,9 @@ func TestAcceptDaemonListenerServesConcurrentResourceClients(t *testing.T) {
 	srv := srpc.NewServer(mux)
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- acceptDaemonListener(ctx, lis, srv, nil)
+		closeClients, err := acceptDaemonListener(ctx, lis, srv, nil)
+		closeClients()
+		errCh <- err
 	}()
 
 	first, firstConn := openDaemonResourceClient(t, ctx, sock)

--- a/cmd/spacewave/cli/daemon-control.go
+++ b/cmd/spacewave/cli/daemon-control.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"io"
 	"net"
+	"sync/atomic"
 
 	emptypb "github.com/aperturerobotics/protobuf-go-lite/types/known/emptypb"
 	"github.com/aperturerobotics/starpc/srpc"
@@ -18,12 +19,38 @@ const (
 	devicePolicyReloadMethodID   = "Reload"
 )
 
-// newDaemonControlHandler constructs a daemon control handler that
-// invokes requestShutdown when the peer issues the Shutdown RPC.
-// The CLI daemon always yields when asked; the policy is AutoAllow.
-func newDaemonControlHandler(requestShutdown func()) *listener_control.Handler {
-	return listener_control.NewHandler(listener_control.AutoAllowPolicy, requestShutdown)
+// daemonControlHandler wraps the shared daemon-control handler and records the
+// granted connection so the serve owner can wait for that requester to read its
+// acknowledgement and close before draining.
+type daemonControlHandler struct {
+	*listener_control.Handler
+	shutdownConn atomic.Pointer[trackedConn]
 }
+
+// newDaemonControlHandler constructs a daemon control handler that invokes
+// requestShutdown when the peer issues the Shutdown RPC. The CLI daemon always
+// yields when asked; the policy is AutoAllow.
+func newDaemonControlHandler(requestShutdown func()) *daemonControlHandler {
+	return newDaemonControlHandlerWithPolicy(listener_control.AutoAllowPolicy, requestShutdown)
+}
+
+func newDaemonControlHandlerWithPolicy(
+	policy listener_control.YieldPolicy,
+	requestShutdown func(),
+) *daemonControlHandler {
+	h := &daemonControlHandler{
+		Handler: listener_control.NewHandler(policy, requestShutdown),
+	}
+	h.Handler.SetShutdownGrantedCallback(func(ctx context.Context) {
+		if tc, ok := ctx.Value(daemonConnCtxKey{}).(*trackedConn); ok {
+			h.shutdownConn.Store(tc)
+		}
+	})
+	return h
+}
+
+// _ is a type assertion
+var _ srpc.Handler = (*daemonControlHandler)(nil)
 
 type devicePolicyControlHandler struct {
 	reload func() error

--- a/cmd/spacewave/cli/serve-shutdown_test.go
+++ b/cmd/spacewave/cli/serve-shutdown_test.go
@@ -1,0 +1,280 @@
+//go:build !js
+
+package spacewave_cli
+
+import (
+	"context"
+	stderrors "errors"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aperturerobotics/starpc/srpc"
+	listener_control "github.com/s4wave/spacewave/core/resource/listener/control"
+)
+
+// startDaemonListener wires a daemon-control handler exactly as runServeCommand
+// does: the Shutdown callback closes only the accepting listener and signals
+// shutdownCh, never canceling serveCtx. It starts serving and returns the socket
+// path plus a wait function that returns the serve result or fails on hang.
+func startDaemonListener(t *testing.T) (sock string, wait func() error) {
+	return startDaemonListenerWithPolicy(t, listener_control.AutoAllowPolicy)
+}
+
+func startDaemonListenerWithPolicy(
+	t *testing.T,
+	policy listener_control.YieldPolicy,
+) (sock string, wait func() error) {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("/tmp", "sw-serve-*")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	sock = filepath.Join(dir, socketName)
+	lis, err := net.ListenUnix("unix", &net.UnixAddr{Name: sock, Net: "unix"})
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	serveCtx, serveCancel := context.WithCancel(t.Context())
+	t.Cleanup(serveCancel)
+
+	shutdownCh := make(chan struct{})
+	var shutdownOnce sync.Once
+	controlHandler := newDaemonControlHandlerWithPolicy(policy, func() {
+		shutdownOnce.Do(func() { close(shutdownCh) })
+		lis.Close()
+	})
+	mux := srpc.NewMux()
+	if err := mux.Register(controlHandler); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	srv := srpc.NewServer(mux)
+
+	serveErrCh := make(chan error, 1)
+	go func() {
+		serveErrCh <- serveDaemonListener(serveCtx, serveCancel, lis, srv, controlHandler, shutdownCh, nil)
+	}()
+	wait = func() error {
+		select {
+		case err := <-serveErrCh:
+			return err
+		case <-time.After(5 * time.Second):
+			t.Fatal("serve did not return")
+			return nil
+		}
+	}
+	return sock, wait
+}
+
+// TestServeDaemonListenerShutdownAckCompletesBeforeDrain proves that an
+// approved Shutdown request receives its acknowledgement and a clean stream
+// close: the requester never observes a reset because the connection lifecycle
+// is canceled only after ShutdownComplete.
+func TestServeDaemonListenerShutdownAckCompletesBeforeDrain(t *testing.T) {
+	sock, wait := startDaemonListener(t)
+
+	conn, err := net.Dial("unix", sock)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+
+	// RequestShutdown reads the acknowledgement and a clean stream close; a
+	// reset here is the regressed behavior. The requester then closes its
+	// connection, mirroring runStop's deferred close, so the daemon drains.
+	if err := listener_control.RequestShutdown(t.Context(), conn); err != nil {
+		conn.Close()
+		t.Fatalf("shutdown request: %v", err)
+	}
+	conn.Close()
+	if err := wait(); err != nil {
+		t.Fatalf("serve: %v", err)
+	}
+}
+
+// TestServeDaemonListenerWaitsForGrantedRequester proves a stream that reaches
+// the handler but withholds its request body cannot strand the actual winner.
+func TestServeDaemonListenerWaitsForGrantedRequester(t *testing.T) {
+	dir, err := os.MkdirTemp("/tmp", "sw-serve-*")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	sock := filepath.Join(dir, socketName)
+	lis, err := net.ListenUnix("unix", &net.UnixAddr{Name: sock, Net: "unix"})
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	serveCtx, serveCancel := context.WithCancel(t.Context())
+	t.Cleanup(serveCancel)
+	shutdownCh := make(chan struct{})
+	var shutdownOnce sync.Once
+	controlHandler := newDaemonControlHandler(func() {
+		shutdownOnce.Do(func() { close(shutdownCh) })
+		_ = lis.Close()
+	})
+	entered := make(chan struct{})
+	mux := srpc.NewMux(&signalInvoker{
+		handler: controlHandler,
+		entered: entered,
+	})
+	srv := srpc.NewServer(mux)
+	serveErrCh := make(chan error, 1)
+	go func() {
+		serveErrCh <- serveDaemonListener(
+			serveCtx,
+			serveCancel,
+			lis,
+			srv,
+			controlHandler,
+			shutdownCh,
+			nil,
+		)
+	}()
+
+	firstConn, err := net.Dial("unix", sock)
+	if err != nil {
+		t.Fatalf("dial first requester: %v", err)
+	}
+	defer firstConn.Close()
+	firstClient, err := srpc.NewClientWithConn(firstConn, true, nil)
+	if err != nil {
+		t.Fatalf("create first client: %v", err)
+	}
+	firstStream, err := firstClient.NewStream(
+		t.Context(),
+		listener_control.ServiceID,
+		listener_control.ShutdownMethodID,
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("open stalled shutdown stream: %v", err)
+	}
+	defer firstStream.Close()
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first shutdown stream did not reach handler")
+	}
+
+	secondConn, err := net.Dial("unix", sock)
+	if err != nil {
+		t.Fatalf("dial second requester: %v", err)
+	}
+	if err := listener_control.RequestShutdown(t.Context(), secondConn); err != nil {
+		secondConn.Close()
+		t.Fatalf("second shutdown request: %v", err)
+	}
+	if err := secondConn.Close(); err != nil {
+		t.Fatalf("close second requester: %v", err)
+	}
+
+	select {
+	case err := <-serveErrCh:
+		if err != nil {
+			t.Fatalf("serve: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("serve did not drain after granted requester closed")
+	}
+}
+
+type signalInvoker struct {
+	handler srpc.Invoker
+	entered chan struct{}
+	once    sync.Once
+}
+
+func (i *signalInvoker) InvokeMethod(
+	serviceID string,
+	methodID string,
+	strm srpc.Stream,
+) (bool, error) {
+	if serviceID == listener_control.ServiceID && methodID == listener_control.ShutdownMethodID {
+		i.once.Do(func() { close(i.entered) })
+	}
+	return i.handler.InvokeMethod(serviceID, methodID, strm)
+}
+
+// TestServeDaemonListenerExternalCancelExitsPromptly proves that canceling the
+// serve context with an active client stops acceptance, drains the client, and
+// returns without hanging.
+func TestServeDaemonListenerExternalCancelExitsPromptly(t *testing.T) {
+	serveCtx, serveCancel := context.WithCancel(t.Context())
+	defer serveCancel()
+
+	dir, err := os.MkdirTemp("/tmp", "sw-serve-*")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	defer os.RemoveAll(dir)
+	sock := filepath.Join(dir, socketName)
+	lis, err := net.ListenUnix("unix", &net.UnixAddr{Name: sock, Net: "unix"})
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	shutdownCh := make(chan struct{})
+	controlHandler := newDaemonControlHandler(func() {})
+	mux := srpc.NewMux()
+	if err := mux.Register(controlHandler); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	srv := srpc.NewServer(mux)
+
+	serveErrCh := make(chan error, 1)
+	go func() {
+		serveErrCh <- serveDaemonListener(serveCtx, serveCancel, lis, srv, controlHandler, shutdownCh, nil)
+	}()
+
+	conn, err := net.Dial("unix", sock)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	serveCancel()
+	select {
+	case err := <-serveErrCh:
+		if err != nil {
+			t.Fatalf("serve: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("external cancel did not exit")
+	}
+}
+
+// TestServeDaemonListenerAcceptErrorPropagates proves that a genuine accept
+// error that is neither an approved shutdown nor an external cancellation is
+// returned to the caller instead of being suppressed.
+func TestServeDaemonListenerAcceptErrorPropagates(t *testing.T) {
+	serveCtx, serveCancel := context.WithCancel(t.Context())
+	defer serveCancel()
+
+	sentinel := stderrors.New("accept boom")
+	lis := &fakeAcceptListener{acceptErr: sentinel}
+	shutdownCh := make(chan struct{})
+	controlHandler := newDaemonControlHandler(func() {})
+	srv := srpc.NewServer(srpc.NewMux())
+
+	err := serveDaemonListener(serveCtx, serveCancel, lis, srv, controlHandler, shutdownCh, nil)
+	if !stderrors.Is(err, sentinel) {
+		t.Fatalf("expected sentinel accept error, got %v", err)
+	}
+}
+
+// fakeAcceptListener is a net.Listener whose Accept always fails with a fixed
+// error, used to exercise the accept-error exit path.
+type fakeAcceptListener struct {
+	acceptErr error
+}
+
+func (l *fakeAcceptListener) Accept() (net.Conn, error) { return nil, l.acceptErr }
+func (l *fakeAcceptListener) Close() error              { return nil }
+func (l *fakeAcceptListener) Addr() net.Addr            { return &net.UnixAddr{Name: "fake", Net: "unix"} }

--- a/cmd/spacewave/cli/serve.go
+++ b/cmd/spacewave/cli/serve.go
@@ -4,12 +4,12 @@ package spacewave_cli
 
 import (
 	"context"
-	stderrors "errors"
 	"net"
 	"os"
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 
 	"github.com/aperturerobotics/cli"
 	"github.com/aperturerobotics/controllerbus/directive"
@@ -180,10 +180,13 @@ func runServeCommand(
 	defer releaseWebKeepalive()
 
 	mux := srpc.NewMux(invoker)
-	if err := mux.Register(newDaemonControlHandler(func() {
-		serveCancel()
+	shutdownCh := make(chan struct{})
+	var shutdownOnce sync.Once
+	controlHandler := newDaemonControlHandler(func() {
+		shutdownOnce.Do(func() { close(shutdownCh) })
 		lis.Close()
-	})); err != nil {
+	})
+	if err := mux.Register(controlHandler); err != nil {
 		return err
 	}
 	if err := mux.Register(newDevicePolicyControlHandler(devicePolicy.Reload)); err != nil {
@@ -192,20 +195,12 @@ func runServeCommand(
 	if err := s4wave_trace.SRPCRegisterTraceService(mux, trace_service.NewService()); err != nil {
 		return err
 	}
-	go func() {
-		<-serveCtx.Done()
-		lis.Close()
-	}()
 
 	srv := srpc.NewServer(mux)
 	if err := startupNotifier.reportReady(); err != nil {
 		return err
 	}
-	err = acceptDaemonListener(serveCtx, lis, srv, idleTracker)
-	if err != nil && (serveCtx.Err() != nil || stderrors.Is(err, net.ErrClosed)) {
-		return nil
-	}
-	return err
+	return serveDaemonListener(serveCtx, serveCancel, lis, srv, controlHandler, shutdownCh, idleTracker)
 }
 
 func startDaemonPluginRuntime(

--- a/core/resource/listener/control/control.go
+++ b/core/resource/listener/control/control.go
@@ -56,6 +56,7 @@ type Handler struct {
 
 	mtx              sync.Mutex
 	claimed          bool
+	shutdownGranted  func(context.Context)
 	shutdownComplete chan struct{}
 	completeOnce     sync.Once
 }
@@ -87,6 +88,14 @@ func (h *Handler) ShutdownComplete() <-chan struct{} {
 	return h.shutdownComplete
 }
 
+// SetShutdownGrantedCallback sets fn to run after a Shutdown request passes
+// policy and claims the handler. fn receives the granted stream context.
+func (h *Handler) SetShutdownGrantedCallback(fn func(context.Context)) {
+	h.mtx.Lock()
+	h.shutdownGranted = fn
+	h.mtx.Unlock()
+}
+
 // GetServiceID returns the service identifier.
 func (h *Handler) GetServiceID() string {
 	return ServiceID
@@ -98,10 +107,11 @@ func (h *Handler) GetMethodIDs() []string {
 }
 
 // InvokeMethod handles the Shutdown RPC. The handler consults its
-// YieldPolicy and grants at most one caller. On approval it releases
-// the listener before acknowledging the peer, then signals
-// ShutdownComplete after response-stream completion. On policy error
-// or an already-claimed handoff, it returns a wrapped denial to the peer.
+// YieldPolicy and grants at most one caller. On approval it notifies the
+// granted-requester callback, releases the listener before acknowledging the
+// peer, then signals ShutdownComplete after response-stream completion. On
+// policy error or an already-claimed handoff, it returns a wrapped denial to
+// the peer.
 func (h *Handler) InvokeMethod(serviceID, methodID string, strm srpc.Stream) (bool, error) {
 	if serviceID != ServiceID || methodID != ShutdownMethodID {
 		return false, nil
@@ -123,7 +133,12 @@ func (h *Handler) InvokeMethod(serviceID, methodID string, strm srpc.Stream) (bo
 		return true, errors.Errorf("%s takeover already granted to another requester", DenyErrorMarker)
 	}
 	h.claimed = true
+	shutdownGranted := h.shutdownGranted
 	h.mtx.Unlock()
+
+	if shutdownGranted != nil {
+		shutdownGranted(ctx)
+	}
 
 	// Release the socket before acknowledging the requester. If the
 	// process or connection disappears before the acknowledgement, the


### PR DESCRIPTION
spacewave stop could receive its shutdown acknowledgement and then see a stream reset because the CLI serve callback canceled serveCtx while the response session was still closing. This change keeps acceptance closure and shutdown completion in the daemon listener, records the granted requester, and waits for that requester to read the acknowledgement and close cleanly before draining other clients and canceling the serving lifecycle.

External cancellation and genuine accept errors retain their existing behavior, and the event-driven requester wait has no timeout. Focused tests cover clean acknowledgement plus EOF, external cancellation, and accept-error propagation.

Local verification passed with go build ./..., go test ./cmd/spacewave/cli/... ./core/resource/listener/... -race, the affected E2E package no-match compile, and git show --check. The original browser/E2E scenarios remain for CI verification.