### PR TITLE
fix(resource): use generated terminal kind

### DIFF
--- a/bldr/resource/server/server.go
+++ b/bldr/resource/server/server.go
@@ -244,7 +244,7 @@ func (c *resourceServerClientInvoker) InvokeMethod(serviceID, methodID string, s
 		return false, errors.New("resource invocation context unavailable")
 	}
 	kind, waitErr := invocation.WaitTerminal(c.client.Context())
-	resourceCtx.finish(kind == srpc.TerminalCommitted && waitErr == nil)
+	resourceCtx.finish(kind == srpc.TerminalKind_TERMINAL_KIND_COMMITTED && waitErr == nil)
 	if waitErr != nil {
 		return ok, waitErr
 	}


### PR DESCRIPTION
Repro

At Spacewave master `1152ca7f`, `go build ./...` fails in `bldr/resource/server/server.go` with `undefined: srpc.TerminalCommitted` after the Starpc v0.49.21 dependency update.

Cause

Starpc v0.49.21 removed handwritten terminal aliases in favor of the generated `TerminalKind` constants. The resource server still referenced the removed committed alias.

Fix

Compare the invocation result with `TerminalKind_TERMINAL_KIND_COMMITTED`. This changes only the Go identifier; resource adoption and terminal semantics remain unchanged.

Verification

`go test ./bldr/resource/server`

`go fix ./bldr/resource/server`

`go build ./...`

`git diff --check HEAD^ HEAD`