### PR TITLE
Preserve WebRTC signaling across tracker retirement

### DIFF
--- a/net/transport/webrtc/handler.go
+++ b/net/transport/webrtc/handler.go
@@ -63,8 +63,33 @@ func (c *WebRTCSignalHandler) Close() error {
 
 // handleSignalPeerResolver resolves HandleSignalPeer.
 type handleSignalPeerResolver struct {
-	t    *WebRTC
-	sess signaling.SignalPeerSession
+	t          *WebRTC
+	sess       signaling.SignalPeerSession
+	releaseRef func(*keyed.KeyedRef[string, *sessionTracker])
+	refStored  func(*keyed.KeyedRef[string, *sessionTracker], *keyed.KeyedRef[string, *sessionTracker])
+}
+
+func (r *handleSignalPeerResolver) releaseIncomingRef(ref *keyed.KeyedRef[string, *sessionTracker]) {
+	if r.releaseRef != nil {
+		r.releaseRef(ref)
+		return
+	}
+	ref.Release()
+}
+
+// storeIncomingRef replaces the map-held reference while r.t.bcast is locked.
+func (r *handleSignalPeerResolver) storeIncomingRef(
+	remotePeerIDStr string,
+	ref *keyed.KeyedRef[string, *sessionTracker],
+) {
+	prev := r.t.incomingSessions[remotePeerIDStr]
+	if prev != nil {
+		r.releaseIncomingRef(prev)
+	}
+	r.t.incomingSessions[remotePeerIDStr] = ref
+	if r.refStored != nil {
+		r.refStored(prev, ref)
+	}
 }
 
 // Resolve resolves the directive.
@@ -79,14 +104,20 @@ func (r *handleSignalPeerResolver) Resolve(ctx context.Context, handler directiv
 	var tkr *sessionTracker
 	var ref *keyed.KeyedRef[string, *sessionTracker]
 	defer func() {
-		if ref != nil {
-			r.t.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
-				if r.t.incomingSessions[remotePeerIDStr] == ref {
-					delete(r.t.incomingSessions, remotePeerIDStr)
-					broadcast()
-				}
-			})
-			ref.Release()
+		if ref == nil {
+			return
+		}
+
+		var release bool
+		r.t.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+			if r.t.incomingSessions[remotePeerIDStr] == ref {
+				delete(r.t.incomingSessions, remotePeerIDStr)
+				release = true
+				broadcast()
+			}
+		})
+		if release {
+			r.releaseIncomingRef(ref)
 		}
 	}()
 
@@ -135,9 +166,9 @@ func (r *handleSignalPeerResolver) Resolve(ctx context.Context, handler directiv
 			var execution *sessionTrackerExecution
 			var waitCh <-chan struct{}
 			r.t.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
-				// Check if ref is still valid if it's set.
 				if ref != nil {
-					// Reference was released due to a link closing.
+					// The registry transition that replaced or removed this
+					// reference already released it.
 					if currRef := r.t.incomingSessions[remotePeerIDStr]; currRef != ref {
 						ref = nil
 						tkr = nil
@@ -148,7 +179,7 @@ func (r *handleSignalPeerResolver) Resolve(ctx context.Context, handler directiv
 				if ref == nil {
 					ref, tkr, _, err = r.t.addSessionTrackerRef(remotePeerIDStr)
 					if err == nil && ref != nil {
-						r.t.incomingSessions[remotePeerIDStr] = ref
+						r.storeIncomingRef(remotePeerIDStr, ref)
 						broadcast()
 					}
 				}

--- a/net/transport/webrtc/handler.go
+++ b/net/transport/webrtc/handler.go
@@ -119,7 +119,8 @@ func (r *handleSignalPeerResolver) Resolve(ctx context.Context, handler directiv
 		}
 
 		// Loop until the current tracker accepts this message.
-		var delivered *sessionTracker
+		var deliveredTracker *sessionTracker
+		var deliveredGeneration uint64
 	ProcessLoop:
 		for {
 			// Acceptance wins over an unrelated transport broadcast. Once accepted,
@@ -130,7 +131,8 @@ func (r *handleSignalPeerResolver) Resolve(ctx context.Context, handler directiv
 			default:
 			}
 
-			// Ensure our reference is still valid or create one if not.
+			// Read the tracker execution and its transition wait channel together.
+			var execution *sessionTrackerExecution
 			var waitCh <-chan struct{}
 			r.t.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
 				// Check if ref is still valid if it's set.
@@ -142,7 +144,7 @@ func (r *handleSignalPeerResolver) Resolve(ctx context.Context, handler directiv
 					}
 				}
 
-				// Add the reference if it doesn't exist anymore
+				// Add the reference if it doesn't exist anymore.
 				if ref == nil {
 					ref, tkr, _, err = r.t.addSessionTrackerRef(remotePeerIDStr)
 					if err == nil && ref != nil {
@@ -151,24 +153,37 @@ func (r *handleSignalPeerResolver) Resolve(ctx context.Context, handler directiv
 					}
 				}
 
-				// Get next wait channel
+				if tkr != nil {
+					execution = tkr.execution
+				}
 				waitCh = getWaitCh()
 			})
 			if err != nil {
 				return err
 			}
 
-			if delivered != tkr {
-				delivered = nil
-			}
-			if delivered == nil {
+			if execution == nil {
 				select {
 				case <-ctx.Done():
 					return context.Canceled
+				case <-incoming.accepted:
+					break ProcessLoop
 				case <-waitCh:
 					continue ProcessLoop
-				case tkr.rxSignal <- incoming:
-					delivered = tkr
+				}
+			}
+
+			if deliveredTracker != tkr || deliveredGeneration != execution.generation {
+				select {
+				case <-ctx.Done():
+					return context.Canceled
+				case <-incoming.accepted:
+					break ProcessLoop
+				case <-waitCh:
+					continue ProcessLoop
+				case execution.rxSignal <- incoming:
+					deliveredTracker = tkr
+					deliveredGeneration = execution.generation
 				}
 				continue ProcessLoop
 			}

--- a/net/transport/webrtc/handler.go
+++ b/net/transport/webrtc/handler.go
@@ -113,9 +113,23 @@ func (r *handleSignalPeerResolver) Resolve(ctx context.Context, handler directiv
 			}
 		*/
 
-		// Loop until we manage to process this message.
+		incoming := &incomingSignal{
+			sig:      sig,
+			accepted: make(chan struct{}),
+		}
+
+		// Loop until the current tracker accepts this message.
+		var deliveredRef *keyed.KeyedRef[string, *sessionTracker]
 	ProcessLoop:
 		for {
+			// Acceptance wins over an unrelated transport broadcast. Once accepted,
+			// this signal must never be delivered to another tracker generation.
+			select {
+			case <-incoming.accepted:
+				break ProcessLoop
+			default:
+			}
+
 			// Ensure our reference is still valid or create one if not.
 			var waitCh <-chan struct{}
 			r.t.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
@@ -124,6 +138,7 @@ func (r *handleSignalPeerResolver) Resolve(ctx context.Context, handler directiv
 					// Reference was released due to a link closing.
 					if currRef := r.t.incomingSessions[remotePeerIDStr]; currRef != ref {
 						ref = nil
+						tkr = nil
 					}
 				}
 
@@ -143,16 +158,28 @@ func (r *handleSignalPeerResolver) Resolve(ctx context.Context, handler directiv
 				return err
 			}
 
-			// Push the message to the tracker
+			if deliveredRef != ref {
+				deliveredRef = nil
+			}
+			if deliveredRef == nil {
+				select {
+				case <-ctx.Done():
+					return context.Canceled
+				case <-waitCh:
+					continue ProcessLoop
+				case tkr.rxSignal <- incoming:
+					deliveredRef = ref
+				}
+				continue ProcessLoop
+			}
+
 			select {
 			case <-ctx.Done():
 				return context.Canceled
-			case <-waitCh:
-				// recheck
-				continue ProcessLoop
-			case tkr.rxSignal <- sig:
-				// Received
+			case <-incoming.accepted:
 				break ProcessLoop
+			case <-waitCh:
+				continue ProcessLoop
 			}
 		}
 	}

--- a/net/transport/webrtc/handler.go
+++ b/net/transport/webrtc/handler.go
@@ -119,7 +119,7 @@ func (r *handleSignalPeerResolver) Resolve(ctx context.Context, handler directiv
 		}
 
 		// Loop until the current tracker accepts this message.
-		var deliveredRef *keyed.KeyedRef[string, *sessionTracker]
+		var delivered *sessionTracker
 	ProcessLoop:
 		for {
 			// Acceptance wins over an unrelated transport broadcast. Once accepted,
@@ -158,17 +158,17 @@ func (r *handleSignalPeerResolver) Resolve(ctx context.Context, handler directiv
 				return err
 			}
 
-			if deliveredRef != ref {
-				deliveredRef = nil
+			if delivered != tkr {
+				delivered = nil
 			}
-			if deliveredRef == nil {
+			if delivered == nil {
 				select {
 				case <-ctx.Done():
 					return context.Canceled
 				case <-waitCh:
 					continue ProcessLoop
 				case tkr.rxSignal <- incoming:
-					deliveredRef = ref
+					delivered = tkr
 				}
 				continue ProcessLoop
 			}

--- a/net/transport/webrtc/handler_test.go
+++ b/net/transport/webrtc/handler_test.go
@@ -7,6 +7,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	cbackoff "github.com/aperturerobotics/util/backoff/cbackoff"
 	"github.com/aperturerobotics/util/keyed"
 	pion_webrtc "github.com/pion/webrtc/v4"
 	pkgerrors "github.com/pkg/errors"
@@ -53,6 +54,228 @@ func TestHandleSignalPeerRetriesRetiredTrackerSignal(t *testing.T) {
 
 func TestHandleSignalPeerRetriesSignalAfterRoutineFailure(t *testing.T) {
 	testHandleSignalPeerRetriesRetiredTrackerSignal(t, true)
+}
+
+func TestHandleSignalPeerRetriesSameTrackerExecutionGeneration(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	localPriv, localPub, err := crypto.GenerateEd25519Key(rand.Reader)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	localPeerID, err := peer.IDFromPrivateKey(localPriv)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	remotePriv, _, err := crypto.GenerateEd25519Key(rand.Reader)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	remotePeerID, err := peer.IDFromPrivateKey(remotePriv)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	remotePeerIDStr := remotePeerID.String()
+
+	sig := &WebRtcSignal{Body: &WebRtcSignal_RequestOffer{RequestOffer: 1}}
+	msg, err := EncodeWebRtcSignal(sig, localPub)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	recvStarted := make(chan struct{}, 2)
+	signalSession := &testSignalPeerSession{
+		localPeerID:  localPeerID,
+		remotePeerID: remotePeerID,
+		recvCh:       make(chan []byte, 1),
+		recvStarted:  recvStarted,
+	}
+	signalSession.recvCh <- msg
+
+	tpt := &WebRTC{
+		le:               logrus.NewEntry(logrus.New()),
+		conf:             &Config{},
+		peerID:           localPeerID,
+		privKey:          localPriv,
+		incomingSessions: make(map[string]*keyed.KeyedRef[string, *sessionTracker]),
+	}
+
+	type executionDelivery struct {
+		tracker   *sessionTracker
+		execution *sessionTrackerExecution
+		incoming  *incomingSignal
+	}
+	type executionResult struct {
+		invocation int32
+		err        error
+	}
+
+	firstReceived := make(chan executionDelivery, 1)
+	secondReceived := make(chan executionDelivery, 1)
+	secondStable := make(chan struct{})
+	failFirst := make(chan struct{})
+	unexpectedInvocation := make(chan int32, 1)
+	routineDone := make(chan executionResult, 3)
+	controlledErr := pkgerrors.New("controlled execution failure")
+	var constructions atomic.Int32
+	var invocations atomic.Int32
+	var deliveries atomic.Int32
+
+	tpt.sessionTrackers = keyed.NewKeyedRefCount(
+		func(key string) (keyed.Routine, *sessionTracker) {
+			constructions.Add(1)
+			tkr := &sessionTracker{
+				w:       tpt,
+				le:      tpt.le,
+				key:     key,
+				peerID:  remotePeerID,
+				offerer: true,
+			}
+			return func(ctx context.Context) (err error) {
+				execution := tkr.beginExecution()
+				invocation := invocations.Add(1)
+				defer func() {
+					tkr.retireExecution(execution)
+					routineDone <- executionResult{invocation: invocation, err: err}
+				}()
+
+				var incoming *incomingSignal
+				select {
+				case <-ctx.Done():
+					return context.Canceled
+				case incoming = <-execution.rxSignal:
+				}
+				deliveries.Add(1)
+				delivery := executionDelivery{
+					tracker:   tkr,
+					execution: execution,
+					incoming:  incoming,
+				}
+
+				switch invocation {
+				case 1:
+					firstReceived <- delivery
+					select {
+					case <-ctx.Done():
+						return context.Canceled
+					case <-failFirst:
+						return controlledErr
+					}
+				case 2:
+					sess := &session{t: tkr}
+					sess.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+						sess.acceptIncomingSignalLocked(incoming)
+					})
+					secondReceived <- delivery
+
+					select {
+					case <-ctx.Done():
+						return context.Canceled
+					case <-recvStarted:
+						close(secondStable)
+					case <-execution.rxSignal:
+						deliveries.Add(1)
+						return pkgerrors.New("received duplicate signal in one execution")
+					}
+					<-ctx.Done()
+					return context.Canceled
+				default:
+					unexpectedInvocation <- invocation
+					<-ctx.Done()
+					return context.Canceled
+				}
+			}, tkr
+		},
+		keyed.WithBackoff[string, *sessionTracker](func(string) cbackoff.BackOff {
+			return new(cbackoff.ZeroBackOff)
+		}),
+	)
+	tpt.sessionTrackers.SetContext(ctx, true)
+	t.Cleanup(tpt.sessionTrackers.ClearContext)
+
+	dialRef, dialTracker, existed := tpt.sessionTrackers.AddKeyRef(remotePeerIDStr)
+	t.Cleanup(dialRef.Release)
+	if existed {
+		t.Fatal("dial reference unexpectedly found an existing tracker")
+	}
+
+	resolverErr := make(chan error, 1)
+	resolver := &handleSignalPeerResolver{t: tpt, sess: signalSession}
+	go func() {
+		resolverErr <- resolver.Resolve(ctx, nil)
+	}()
+
+	<-recvStarted
+	first := <-firstReceived
+	if first.tracker != dialTracker {
+		t.Fatal("first execution did not use the dial-held tracker")
+	}
+	close(failFirst)
+
+	second := <-secondReceived
+	<-secondStable
+	if second.tracker != first.tracker {
+		t.Fatal("WithBackoff replaced the sessionTracker pointer")
+	}
+	if second.execution.generation != first.execution.generation+1 {
+		t.Fatalf(
+			"execution generation advanced from %d to %d, want exactly one",
+			first.execution.generation,
+			second.execution.generation,
+		)
+	}
+	if second.incoming != first.incoming {
+		t.Fatal("resolver decoded or replaced the retained signal across restart")
+	}
+	select {
+	case <-second.incoming.accepted:
+	default:
+		t.Fatal("restarted execution did not accept the retained signal")
+	}
+	if constructions.Load() != 1 {
+		t.Fatalf("tracker constructions %d, want 1", constructions.Load())
+	}
+	if invocations.Load() != 2 {
+		t.Fatalf("tracker executions %d, want 2", invocations.Load())
+	}
+	if deliveries.Load() != 2 {
+		t.Fatalf("signal deliveries %d, want one per execution", deliveries.Load())
+	}
+	select {
+	case invocation := <-unexpectedInvocation:
+		t.Fatalf("unexpected tracker execution %d", invocation)
+	default:
+	}
+
+	cancel()
+	if err := <-resolverErr; err != context.Canceled {
+		t.Fatalf("resolver returned %v, want context canceled", err)
+	}
+
+	results := make(map[int32]error, 2)
+	for range 2 {
+		result := <-routineDone
+		results[result.invocation] = result.err
+	}
+	if results[1] != controlledErr {
+		t.Fatalf("first execution returned %v, want %v", results[1], controlledErr)
+	}
+	if results[2] != context.Canceled {
+		t.Fatalf("second execution returned %v, want context canceled", results[2])
+	}
+
+	dialRef.Release()
+	if keys := tpt.sessionTrackers.GetKeys(); len(keys) != 0 {
+		t.Fatalf("session trackers still registered after cancellation: %v", keys)
+	}
+	tpt.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+		if dialTracker.execution != nil {
+			t.Error("tracker execution remained published after cancellation")
+		}
+		if ref := tpt.incomingSessions[remotePeerIDStr]; ref != nil {
+			t.Error("incoming session reference remained after cancellation")
+		}
+	})
 }
 
 func TestHandleSignalPeerDeliversOncePerTrackerGeneration(t *testing.T) {
@@ -117,15 +340,16 @@ func TestHandleSignalPeerDeliversOncePerTrackerGeneration(t *testing.T) {
 		func(key string) (keyed.Routine, *sessionTracker) {
 			generations.Add(1)
 			tkr := &sessionTracker{
-				w:        tpt,
-				le:       tpt.le,
-				key:      key,
-				peerID:   remotePeerID,
-				offerer:  true,
-				rxSignal: make(chan *incomingSignal),
+				w:       tpt,
+				le:      tpt.le,
+				key:     key,
+				peerID:  remotePeerID,
+				offerer: true,
 			}
 			generation = tkr
 			return func(ctx context.Context) (err error) {
+				execution := tkr.beginExecution()
+				defer tkr.retireExecution(execution)
 				defer func() {
 					if rec := recover(); rec != nil {
 						err = pkgerrors.Errorf("tracker panicked: %v", rec)
@@ -137,7 +361,7 @@ func TestHandleSignalPeerDeliversOncePerTrackerGeneration(t *testing.T) {
 				select {
 				case <-ctx.Done():
 					return context.Canceled
-				case incoming = <-tkr.rxSignal:
+				case incoming = <-execution.rxSignal:
 				}
 				deliveries.Add(1)
 				firstReceived <- incoming
@@ -153,7 +377,7 @@ func TestHandleSignalPeerDeliversOncePerTrackerGeneration(t *testing.T) {
 				})
 
 				select {
-				case duplicate := <-tkr.rxSignal:
+				case duplicate := <-execution.rxSignal:
 					deliveries.Add(1)
 					sess.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
 						sess.acceptIncomingSignalLocked(duplicate)
@@ -328,14 +552,15 @@ func testHandleSignalPeerRetriesRetiredTrackerSignal(t *testing.T, routineFailur
 		func(key string) (keyed.Routine, *sessionTracker) {
 			generation := generations.Add(1)
 			tkr := &sessionTracker{
-				w:        tpt,
-				le:       tpt.le,
-				key:      key,
-				peerID:   remotePeerID,
-				offerer:  true,
-				rxSignal: make(chan *incomingSignal),
+				w:       tpt,
+				le:      tpt.le,
+				key:     key,
+				peerID:  remotePeerID,
+				offerer: true,
 			}
 			return func(ctx context.Context) error {
+				execution := tkr.beginExecution()
+				defer tkr.retireExecution(execution)
 				var oldSession *session
 				var routineErr error
 				var routineErrCh chan error
@@ -354,7 +579,7 @@ func testHandleSignalPeerRetriesRetiredTrackerSignal(t *testing.T, routineFailur
 				select {
 				case <-ctx.Done():
 					return context.Canceled
-				case incoming = <-tkr.rxSignal:
+				case incoming = <-execution.rxSignal:
 				}
 
 				if generation == 1 {
@@ -379,13 +604,7 @@ func testHandleSignalPeerRetriesRetiredTrackerSignal(t *testing.T, routineFailur
 						}
 					}
 
-					tpt.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
-						if ref := tpt.incomingSessions[key]; ref != nil {
-							ref.Release()
-							delete(tpt.incomingSessions, key)
-							broadcast()
-						}
-					})
+					tkr.retireExecution(execution)
 					oldRetired <- retireErr
 					return nil
 				}

--- a/net/transport/webrtc/handler_test.go
+++ b/net/transport/webrtc/handler_test.go
@@ -1,0 +1,227 @@
+package webrtc
+
+import (
+	"context"
+	"crypto/rand"
+	"sync/atomic"
+	"testing"
+
+	"github.com/aperturerobotics/util/keyed"
+	pion_webrtc "github.com/pion/webrtc/v4"
+	pkgerrors "github.com/pkg/errors"
+	"github.com/s4wave/spacewave/net/crypto"
+	"github.com/s4wave/spacewave/net/peer"
+	"github.com/s4wave/spacewave/net/signaling"
+	"github.com/sirupsen/logrus"
+)
+
+type testSignalPeerSession struct {
+	localPeerID  peer.ID
+	remotePeerID peer.ID
+	recvCh       chan []byte
+}
+
+func (s *testSignalPeerSession) GetLocalPeerID() peer.ID {
+	return s.localPeerID
+}
+
+func (s *testSignalPeerSession) GetRemotePeerID() peer.ID {
+	return s.remotePeerID
+}
+
+func (s *testSignalPeerSession) Send(context.Context, []byte) error {
+	return nil
+}
+
+func (s *testSignalPeerSession) Recv(ctx context.Context) ([]byte, error) {
+	select {
+	case <-ctx.Done():
+		return nil, context.Canceled
+	case msg := <-s.recvCh:
+		return msg, nil
+	}
+}
+
+func TestHandleSignalPeerRetriesRetiredTrackerSignal(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	localPriv, localPub, err := crypto.GenerateEd25519Key(rand.Reader)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	localPeerID, err := peer.IDFromPrivateKey(localPriv)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	remotePriv, _, err := crypto.GenerateEd25519Key(rand.Reader)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	remotePeerID, err := peer.IDFromPrivateKey(remotePriv)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	sig := &WebRtcSignal{Body: &WebRtcSignal_RequestOffer{RequestOffer: 1}}
+	msg, err := EncodeWebRtcSignal(sig, localPub)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	signalSession := &testSignalPeerSession{
+		localPeerID:  localPeerID,
+		remotePeerID: remotePeerID,
+		recvCh:       make(chan []byte, 1),
+	}
+	signalSession.recvCh <- msg
+
+	tpt := &WebRTC{
+		le:               logrus.NewEntry(logrus.New()),
+		conf:             &Config{},
+		peerID:           localPeerID,
+		privKey:          localPriv,
+		incomingSessions: make(map[string]*keyed.KeyedRef[string, *sessionTracker]),
+	}
+
+	type replacementResult struct {
+		incoming *incomingSignal
+		offers   []*WebRtcSignal
+		err      error
+	}
+	oldReceived := make(chan *incomingSignal, 1)
+	retireOld := make(chan struct{})
+	replacementDone := make(chan replacementResult, 1)
+	var generations atomic.Int32
+
+	tpt.sessionTrackers = keyed.NewKeyedRefCount(
+		func(key string) (keyed.Routine, *sessionTracker) {
+			generation := generations.Add(1)
+			tkr := &sessionTracker{
+				w:        tpt,
+				le:       tpt.le,
+				key:      key,
+				peerID:   remotePeerID,
+				offerer:  true,
+				rxSignal: make(chan *incomingSignal),
+			}
+			return func(ctx context.Context) error {
+				select {
+				case <-ctx.Done():
+					return context.Canceled
+				case incoming := <-tkr.rxSignal:
+					if generation == 1 {
+						oldReceived <- incoming
+						<-retireOld
+
+						oldSession := &session{t: tkr}
+						oldSession.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+							oldSession.connState = pion_webrtc.PeerConnectionStateFailed
+							oldSession.acceptIncomingSignalLocked(incoming)
+						})
+
+						tpt.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+							if ref := tpt.incomingSessions[key]; ref != nil {
+								ref.Release()
+								delete(tpt.incomingSessions, key)
+								broadcast()
+							}
+						})
+						return nil
+					}
+
+					replacementSession := &session{t: tkr}
+					replacementSession.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+						replacementSession.localSeqno = 1
+						replacementSession.acceptIncomingSignalLocked(incoming)
+					})
+
+					pc, err := pion_webrtc.NewPeerConnection(pion_webrtc.Configuration{})
+					if err != nil {
+						replacementDone <- replacementResult{incoming: incoming, err: err}
+						return err
+					}
+					if _, err := pc.CreateDataChannel(dataChannelID, nil); err != nil {
+						if closeErr := pc.Close(); closeErr != nil {
+							err = pkgerrors.Wrapf(err, "close peer connection: %v", closeErr)
+						}
+						replacementDone <- replacementResult{incoming: incoming, err: err}
+						return err
+					}
+					replacementSession.pc = pc
+
+					var offers []*WebRtcSignal
+					_, transmitted, err := tkr.transmitLocalNegotiation(
+						replacementSession,
+						tkr.le,
+						1,
+						0,
+						func(sig *WebRtcSignal) {
+							offers = append(offers, sig)
+						},
+					)
+					if err == nil && !transmitted {
+						err = pkgerrors.New("replacement did not transmit an offer")
+					}
+					if closeErr := pc.Close(); err == nil && closeErr != nil {
+						err = closeErr
+					}
+					replacementDone <- replacementResult{
+						incoming: incoming,
+						offers:   offers,
+						err:      err,
+					}
+					return err
+				}
+			}, tkr
+		},
+	)
+	tpt.sessionTrackers.SetContext(ctx, true)
+	t.Cleanup(tpt.sessionTrackers.ClearContext)
+
+	resolverErr := make(chan error, 1)
+	resolver := &handleSignalPeerResolver{t: tpt, sess: signalSession}
+	go func() {
+		resolverErr <- resolver.Resolve(ctx, nil)
+	}()
+
+	oldIncoming := <-oldReceived
+	select {
+	case <-oldIncoming.accepted:
+		t.Fatal("retiring tracker accepted the signal before terminal state")
+	default:
+	}
+	close(retireOld)
+
+	replacement := <-replacementDone
+	if replacement.err != nil {
+		t.Fatal(replacement.err.Error())
+	}
+	replacementIncoming := replacement.incoming
+	if replacementIncoming != oldIncoming {
+		t.Fatal("handler decoded or replaced the signal during generation handoff")
+	}
+	if replacementIncoming.sig.GetRequestOffer() != 1 {
+		t.Fatalf("replacement received request_offer %d, want 1", replacementIncoming.sig.GetRequestOffer())
+	}
+	select {
+	case <-replacementIncoming.accepted:
+	default:
+		t.Fatal("replacement tracker did not positively accept the signal")
+	}
+	if len(replacement.offers) != 1 {
+		t.Fatalf("offer count %d, want 1", len(replacement.offers))
+	}
+	if replacement.offers[0].GetSdp().GetSdpType() != "offer" {
+		t.Fatalf("replacement emitted %q, want offer", replacement.offers[0].GetSdp().GetSdpType())
+	}
+	if generations.Load() != 2 {
+		t.Fatalf("tracker generations %d, want 2", generations.Load())
+	}
+
+	cancel()
+	if err := <-resolverErr; err != context.Canceled {
+		t.Fatalf("resolver returned %v, want context canceled", err)
+	}
+}
+
+var _ signaling.SignalPeerSession = ((*testSignalPeerSession)(nil))

--- a/net/transport/webrtc/handler_test.go
+++ b/net/transport/webrtc/handler_test.go
@@ -1,6 +1,7 @@
 package webrtc
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"sync/atomic"
@@ -19,6 +20,7 @@ type testSignalPeerSession struct {
 	localPeerID  peer.ID
 	remotePeerID peer.ID
 	recvCh       chan []byte
+	recvStarted  chan struct{}
 }
 
 func (s *testSignalPeerSession) GetLocalPeerID() peer.ID {
@@ -34,6 +36,9 @@ func (s *testSignalPeerSession) Send(context.Context, []byte) error {
 }
 
 func (s *testSignalPeerSession) Recv(ctx context.Context) ([]byte, error) {
+	if s.recvStarted != nil {
+		s.recvStarted <- struct{}{}
+	}
 	select {
 	case <-ctx.Done():
 		return nil, context.Canceled
@@ -48,6 +53,222 @@ func TestHandleSignalPeerRetriesRetiredTrackerSignal(t *testing.T) {
 
 func TestHandleSignalPeerRetriesSignalAfterRoutineFailure(t *testing.T) {
 	testHandleSignalPeerRetriesRetiredTrackerSignal(t, true)
+}
+
+func TestHandleSignalPeerDeliversOncePerTrackerGeneration(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	localPriv, localPub, err := crypto.GenerateEd25519Key(rand.Reader)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	localPeerID, err := peer.IDFromPrivateKey(localPriv)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	remotePriv, _, err := crypto.GenerateEd25519Key(rand.Reader)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	remotePeerID, err := peer.IDFromPrivateKey(remotePriv)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	remotePeerIDStr := remotePeerID.String()
+
+	sig := &WebRtcSignal{Body: &WebRtcSignal_RequestOffer{RequestOffer: 1}}
+	msg, err := EncodeWebRtcSignal(sig, localPub)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	firstRecvStarted := make(chan struct{}, 2)
+	firstSession := &testSignalPeerSession{
+		localPeerID:  localPeerID,
+		remotePeerID: remotePeerID,
+		recvCh:       make(chan []byte, 1),
+		recvStarted:  firstRecvStarted,
+	}
+	firstSession.recvCh <- bytes.Clone(msg)
+	secondSession := &testSignalPeerSession{
+		localPeerID:  localPeerID,
+		remotePeerID: remotePeerID,
+		recvCh:       make(chan []byte, 1),
+	}
+	secondSession.recvCh <- msg
+
+	tpt := &WebRTC{
+		le:               logrus.NewEntry(logrus.New()),
+		conf:             &Config{},
+		peerID:           localPeerID,
+		privKey:          localPriv,
+		incomingSessions: make(map[string]*keyed.KeyedRef[string, *sessionTracker]),
+	}
+
+	firstReceived := make(chan *incomingSignal, 1)
+	acceptFirst := make(chan struct{})
+	trackerStable := make(chan struct{})
+	trackerDone := make(chan error, 1)
+	var deliveries atomic.Int32
+	var generations atomic.Int32
+	var generation *sessionTracker
+
+	tpt.sessionTrackers = keyed.NewKeyedRefCount(
+		func(key string) (keyed.Routine, *sessionTracker) {
+			generations.Add(1)
+			tkr := &sessionTracker{
+				w:        tpt,
+				le:       tpt.le,
+				key:      key,
+				peerID:   remotePeerID,
+				offerer:  true,
+				rxSignal: make(chan *incomingSignal),
+			}
+			generation = tkr
+			return func(ctx context.Context) (err error) {
+				defer func() {
+					if rec := recover(); rec != nil {
+						err = pkgerrors.Errorf("tracker panicked: %v", rec)
+					}
+					trackerDone <- err
+				}()
+
+				var incoming *incomingSignal
+				select {
+				case <-ctx.Done():
+					return context.Canceled
+				case incoming = <-tkr.rxSignal:
+				}
+				deliveries.Add(1)
+				firstReceived <- incoming
+
+				select {
+				case <-ctx.Done():
+					return context.Canceled
+				case <-acceptFirst:
+				}
+				sess := &session{t: tkr}
+				sess.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+					sess.acceptIncomingSignalLocked(incoming)
+				})
+
+				select {
+				case duplicate := <-tkr.rxSignal:
+					deliveries.Add(1)
+					sess.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+						sess.acceptIncomingSignalLocked(duplicate)
+					})
+					return pkgerrors.New("received duplicate signal")
+				case <-firstRecvStarted:
+				}
+				close(trackerStable)
+
+				<-ctx.Done()
+				return context.Canceled
+			}, tkr
+		},
+	)
+	tpt.sessionTrackers.SetContext(ctx, true)
+	t.Cleanup(tpt.sessionTrackers.ClearContext)
+
+	firstCtx, cancelFirst := context.WithCancel(ctx)
+	firstResolverErr := make(chan error, 1)
+	firstResolver := &handleSignalPeerResolver{t: tpt, sess: firstSession}
+	go func() {
+		firstResolverErr <- firstResolver.Resolve(firstCtx, nil)
+	}()
+
+	<-firstRecvStarted
+	firstIncoming := <-firstReceived
+	var firstRef *keyed.KeyedRef[string, *sessionTracker]
+	tpt.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+		firstRef = tpt.incomingSessions[remotePeerIDStr]
+	})
+	if firstRef == nil {
+		t.Fatal("first resolver did not install its incoming session reference")
+	}
+
+	secondCtx, cancelSecond := context.WithCancel(ctx)
+	secondResolverErr := make(chan error, 1)
+	secondResolver := &handleSignalPeerResolver{t: tpt, sess: secondSession}
+	go func() {
+		secondResolverErr <- secondResolver.Resolve(secondCtx, nil)
+	}()
+
+	for {
+		var currRef *keyed.KeyedRef[string, *sessionTracker]
+		var waitCh <-chan struct{}
+		tpt.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+			currRef = tpt.incomingSessions[remotePeerIDStr]
+			waitCh = getWaitCh()
+		})
+		if currRef != nil && currRef != firstRef {
+			break
+		}
+		select {
+		case err := <-secondResolverErr:
+			t.Fatalf("second resolver returned before replacing the shared reference: %v", err)
+		case <-waitCh:
+		}
+	}
+	cancelSecond()
+	if err := <-secondResolverErr; err != context.Canceled {
+		t.Fatalf("second resolver returned %v, want context canceled", err)
+	}
+
+	for {
+		var currRef *keyed.KeyedRef[string, *sessionTracker]
+		var waitCh <-chan struct{}
+		tpt.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+			currRef = tpt.incomingSessions[remotePeerIDStr]
+			waitCh = getWaitCh()
+		})
+		if currRef != nil && currRef != firstRef {
+			break
+		}
+		<-waitCh
+	}
+
+	close(acceptFirst)
+	select {
+	case <-trackerStable:
+	case err := <-trackerDone:
+		t.Fatalf("tracker retired during overlapping delivery: %v", err)
+	}
+
+	select {
+	case <-firstIncoming.accepted:
+	default:
+		t.Fatal("tracker did not accept the first incoming signal")
+	}
+	if deliveries.Load() != 1 {
+		t.Fatalf("signal deliveries %d, want 1", deliveries.Load())
+	}
+	if generations.Load() != 1 {
+		t.Fatalf("tracker generations %d, want 1", generations.Load())
+	}
+	ref, tkr, existed := tpt.sessionTrackers.AddKeyRef(remotePeerIDStr)
+	ref.Release()
+	if !existed {
+		t.Fatal("accepted tracker generation retired")
+	}
+	if tkr != generation {
+		t.Fatal("keyed reference did not retain the accepted tracker generation")
+	}
+	select {
+	case err := <-trackerDone:
+		t.Fatalf("tracker exited before resolver shutdown: %v", err)
+	default:
+	}
+
+	cancelFirst()
+	if err := <-firstResolverErr; err != context.Canceled {
+		t.Fatalf("first resolver returned %v, want context canceled", err)
+	}
+	cancel()
+	if err := <-trackerDone; err != context.Canceled {
+		t.Fatalf("tracker returned %v, want context canceled", err)
+	}
 }
 
 func testHandleSignalPeerRetriesRetiredTrackerSignal(t *testing.T, routineFailure bool) {

--- a/net/transport/webrtc/handler_test.go
+++ b/net/transport/webrtc/handler_test.go
@@ -43,6 +43,14 @@ func (s *testSignalPeerSession) Recv(ctx context.Context) ([]byte, error) {
 }
 
 func TestHandleSignalPeerRetriesRetiredTrackerSignal(t *testing.T) {
+	testHandleSignalPeerRetriesRetiredTrackerSignal(t, false)
+}
+
+func TestHandleSignalPeerRetriesSignalAfterRoutineFailure(t *testing.T) {
+	testHandleSignalPeerRetriesRetiredTrackerSignal(t, true)
+}
+
+func testHandleSignalPeerRetriesRetiredTrackerSignal(t *testing.T, routineFailure bool) {
 	ctx, cancel := context.WithCancel(t.Context())
 	t.Cleanup(cancel)
 
@@ -91,6 +99,8 @@ func TestHandleSignalPeerRetriesRetiredTrackerSignal(t *testing.T) {
 	oldReceived := make(chan *incomingSignal, 1)
 	retireOld := make(chan struct{})
 	replacementDone := make(chan replacementResult, 1)
+	oldRetired := make(chan error, 1)
+	acceptReplacement := make(chan struct{})
 	var generations atomic.Int32
 
 	tpt.sessionTrackers = keyed.NewKeyedRefCount(
@@ -105,73 +115,108 @@ func TestHandleSignalPeerRetriesRetiredTrackerSignal(t *testing.T) {
 				rxSignal: make(chan *incomingSignal),
 			}
 			return func(ctx context.Context) error {
+				var oldSession *session
+				var routineErr error
+				var routineErrCh chan error
+				if generation == 1 {
+					oldSession = &session{t: tkr}
+					if routineFailure {
+						// Make the routine error observable before rxSignal. The receive
+						// below deliberately takes the hazardous signal-first branch.
+						routineErrCh = make(chan error, 1)
+						routineErr = pkgerrors.New("controlled routine failure")
+						oldSession.failWithErr(routineErrCh, routineErr)
+					}
+				}
+
+				var incoming *incomingSignal
 				select {
 				case <-ctx.Done():
 					return context.Canceled
-				case incoming := <-tkr.rxSignal:
-					if generation == 1 {
-						oldReceived <- incoming
-						<-retireOld
+				case incoming = <-tkr.rxSignal:
+				}
 
-						oldSession := &session{t: tkr}
-						oldSession.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+				if generation == 1 {
+					oldReceived <- incoming
+					<-retireOld
+
+					oldSession.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+						if !routineFailure {
 							oldSession.connState = pion_webrtc.PeerConnectionStateFailed
-							oldSession.acceptIncomingSignalLocked(incoming)
-						})
-
-						tpt.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
-							if ref := tpt.incomingSessions[key]; ref != nil {
-								ref.Release()
-								delete(tpt.incomingSessions, key)
-								broadcast()
-							}
-						})
-						return nil
-					}
-
-					replacementSession := &session{t: tkr}
-					replacementSession.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
-						replacementSession.localSeqno = 1
-						replacementSession.acceptIncomingSignalLocked(incoming)
+						}
+						oldSession.acceptIncomingSignalLocked(incoming)
 					})
 
-					pc, err := pion_webrtc.NewPeerConnection(pion_webrtc.Configuration{})
-					if err != nil {
-						replacementDone <- replacementResult{incoming: incoming, err: err}
-						return err
-					}
-					if _, err := pc.CreateDataChannel(dataChannelID, nil); err != nil {
-						if closeErr := pc.Close(); closeErr != nil {
-							err = pkgerrors.Wrapf(err, "close peer connection: %v", closeErr)
+					var retireErr error
+					if routineFailure {
+						if err := <-routineErrCh; err != routineErr {
+							retireErr = pkgerrors.Errorf(
+								"terminal error %v, want %v",
+								err,
+								routineErr,
+							)
 						}
-						replacementDone <- replacementResult{incoming: incoming, err: err}
-						return err
 					}
-					replacementSession.pc = pc
 
-					var offers []*WebRtcSignal
-					_, transmitted, err := tkr.transmitLocalNegotiation(
-						replacementSession,
-						tkr.le,
-						1,
-						0,
-						func(sig *WebRtcSignal) {
-							offers = append(offers, sig)
-						},
-					)
-					if err == nil && !transmitted {
-						err = pkgerrors.New("replacement did not transmit an offer")
-					}
-					if closeErr := pc.Close(); err == nil && closeErr != nil {
-						err = closeErr
-					}
-					replacementDone <- replacementResult{
-						incoming: incoming,
-						offers:   offers,
-						err:      err,
-					}
+					tpt.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+						if ref := tpt.incomingSessions[key]; ref != nil {
+							ref.Release()
+							delete(tpt.incomingSessions, key)
+							broadcast()
+						}
+					})
+					oldRetired <- retireErr
+					return nil
+				}
+
+				select {
+				case <-ctx.Done():
+					return context.Canceled
+				case <-acceptReplacement:
+				}
+
+				replacementSession := &session{t: tkr}
+				replacementSession.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+					replacementSession.localSeqno = 1
+					replacementSession.acceptIncomingSignalLocked(incoming)
+				})
+
+				pc, err := pion_webrtc.NewPeerConnection(pion_webrtc.Configuration{})
+				if err != nil {
+					replacementDone <- replacementResult{incoming: incoming, err: err}
 					return err
 				}
+				if _, err := pc.CreateDataChannel(dataChannelID, nil); err != nil {
+					if closeErr := pc.Close(); closeErr != nil {
+						err = pkgerrors.Wrapf(err, "close peer connection: %v", closeErr)
+					}
+					replacementDone <- replacementResult{incoming: incoming, err: err}
+					return err
+				}
+				replacementSession.pc = pc
+
+				var offers []*WebRtcSignal
+				_, transmitted, err := tkr.transmitLocalNegotiation(
+					replacementSession,
+					tkr.le,
+					1,
+					0,
+					func(sig *WebRtcSignal) {
+						offers = append(offers, sig)
+					},
+				)
+				if err == nil && !transmitted {
+					err = pkgerrors.New("replacement did not transmit an offer")
+				}
+				if closeErr := pc.Close(); err == nil && closeErr != nil {
+					err = closeErr
+				}
+				replacementDone <- replacementResult{
+					incoming: incoming,
+					offers:   offers,
+					err:      err,
+				}
+				return err
 			}, tkr
 		},
 	)
@@ -187,10 +232,19 @@ func TestHandleSignalPeerRetriesRetiredTrackerSignal(t *testing.T) {
 	oldIncoming := <-oldReceived
 	select {
 	case <-oldIncoming.accepted:
-		t.Fatal("retiring tracker accepted the signal before terminal state")
+		t.Fatal("retiring tracker accepted the signal before retirement was released")
 	default:
 	}
 	close(retireOld)
+	if err := <-oldRetired; err != nil {
+		t.Fatal(err.Error())
+	}
+	select {
+	case <-oldIncoming.accepted:
+		t.Fatal("failed tracker accepted the signal")
+	default:
+	}
+	close(acceptReplacement)
 
 	replacement := <-replacementDone
 	if replacement.err != nil {

--- a/net/transport/webrtc/handler_test.go
+++ b/net/transport/webrtc/handler_test.go
@@ -334,7 +334,6 @@ func TestHandleSignalPeerDeliversOncePerTrackerGeneration(t *testing.T) {
 	trackerDone := make(chan error, 1)
 	var deliveries atomic.Int32
 	var generations atomic.Int32
-	var generation *sessionTracker
 
 	tpt.sessionTrackers = keyed.NewKeyedRefCount(
 		func(key string) (keyed.Routine, *sessionTracker) {
@@ -346,7 +345,6 @@ func TestHandleSignalPeerDeliversOncePerTrackerGeneration(t *testing.T) {
 				peerID:  remotePeerID,
 				offerer: true,
 			}
-			generation = tkr
 			return func(ctx context.Context) (err error) {
 				execution := tkr.beginExecution()
 				defer tkr.retireExecution(execution)
@@ -376,19 +374,25 @@ func TestHandleSignalPeerDeliversOncePerTrackerGeneration(t *testing.T) {
 					sess.acceptIncomingSignalLocked(incoming)
 				})
 
-				select {
-				case duplicate := <-execution.rxSignal:
-					deliveries.Add(1)
-					sess.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
-						sess.acceptIncomingSignalLocked(duplicate)
-					})
-					return pkgerrors.New("received duplicate signal")
-				case <-firstRecvStarted:
+				for {
+					select {
+					case next := <-execution.rxSignal:
+						if next == incoming {
+							deliveries.Add(1)
+							sess.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+								sess.acceptIncomingSignalLocked(next)
+							})
+							return pkgerrors.New("received duplicate signal")
+						}
+						sess.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+							sess.acceptIncomingSignalLocked(next)
+						})
+					case <-firstRecvStarted:
+						close(trackerStable)
+						<-ctx.Done()
+						return context.Canceled
+					}
 				}
-				close(trackerStable)
-
-				<-ctx.Done()
-				return context.Canceled
 			}, tkr
 		},
 	)
@@ -412,48 +416,30 @@ func TestHandleSignalPeerDeliversOncePerTrackerGeneration(t *testing.T) {
 		t.Fatal("first resolver did not install its incoming session reference")
 	}
 
+	replacementReady := make(chan struct{})
+	continueReplacement := make(chan struct{})
 	secondCtx, cancelSecond := context.WithCancel(ctx)
 	secondResolverErr := make(chan error, 1)
-	secondResolver := &handleSignalPeerResolver{t: tpt, sess: secondSession}
+	secondResolver := &handleSignalPeerResolver{
+		t:    tpt,
+		sess: secondSession,
+		refStored: func(
+			prev *keyed.KeyedRef[string, *sessionTracker],
+			next *keyed.KeyedRef[string, *sessionTracker],
+		) {
+			if prev == firstRef {
+				close(replacementReady)
+				<-continueReplacement
+			}
+		},
+	}
 	go func() {
 		secondResolverErr <- secondResolver.Resolve(secondCtx, nil)
 	}()
 
-	for {
-		var currRef *keyed.KeyedRef[string, *sessionTracker]
-		var waitCh <-chan struct{}
-		tpt.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
-			currRef = tpt.incomingSessions[remotePeerIDStr]
-			waitCh = getWaitCh()
-		})
-		if currRef != nil && currRef != firstRef {
-			break
-		}
-		select {
-		case err := <-secondResolverErr:
-			t.Fatalf("second resolver returned before replacing the shared reference: %v", err)
-		case <-waitCh:
-		}
-	}
-	cancelSecond()
-	if err := <-secondResolverErr; err != context.Canceled {
-		t.Fatalf("second resolver returned %v, want context canceled", err)
-	}
-
-	for {
-		var currRef *keyed.KeyedRef[string, *sessionTracker]
-		var waitCh <-chan struct{}
-		tpt.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
-			currRef = tpt.incomingSessions[remotePeerIDStr]
-			waitCh = getWaitCh()
-		})
-		if currRef != nil && currRef != firstRef {
-			break
-		}
-		<-waitCh
-	}
-
+	<-replacementReady
 	close(acceptFirst)
+	close(continueReplacement)
 	select {
 	case <-trackerStable:
 	case err := <-trackerDone:
@@ -471,27 +457,245 @@ func TestHandleSignalPeerDeliversOncePerTrackerGeneration(t *testing.T) {
 	if generations.Load() != 1 {
 		t.Fatalf("tracker generations %d, want 1", generations.Load())
 	}
-	ref, tkr, existed := tpt.sessionTrackers.AddKeyRef(remotePeerIDStr)
-	ref.Release()
-	if !existed {
-		t.Fatal("accepted tracker generation retired")
+
+	cancelSecond()
+	if err := <-secondResolverErr; err != context.Canceled {
+		t.Fatalf("second resolver returned %v, want context canceled", err)
 	}
-	if tkr != generation {
-		t.Fatal("keyed reference did not retain the accepted tracker generation")
+	if err := <-trackerDone; err != context.Canceled {
+		t.Fatalf("tracker returned %v, want context canceled", err)
 	}
-	select {
-	case err := <-trackerDone:
-		t.Fatalf("tracker exited before resolver shutdown: %v", err)
-	default:
+	if keys := tpt.sessionTrackers.GetKeys(); len(keys) != 0 {
+		t.Fatalf("session trackers still registered after overlapping resolver exit: %v", keys)
 	}
 
 	cancelFirst()
 	if err := <-firstResolverErr; err != context.Canceled {
 		t.Fatalf("first resolver returned %v, want context canceled", err)
 	}
-	cancel()
-	if err := <-trackerDone; err != context.Canceled {
-		t.Fatalf("tracker returned %v, want context canceled", err)
+}
+
+func TestHandleSignalPeerReleasesOverlappingResolverReferences(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	localPriv, localPub, err := crypto.GenerateEd25519Key(rand.Reader)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	localPeerID, err := peer.IDFromPrivateKey(localPriv)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	remotePriv, _, err := crypto.GenerateEd25519Key(rand.Reader)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	remotePeerID, err := peer.IDFromPrivateKey(remotePriv)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	remotePeerIDStr := remotePeerID.String()
+
+	sig := &WebRtcSignal{Body: &WebRtcSignal_RequestOffer{RequestOffer: 1}}
+	msg, err := EncodeWebRtcSignal(sig, localPub)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	firstRecvStarted := make(chan struct{}, 2)
+	firstSession := &testSignalPeerSession{
+		localPeerID:  localPeerID,
+		remotePeerID: remotePeerID,
+		recvCh:       make(chan []byte, 1),
+		recvStarted:  firstRecvStarted,
+	}
+	firstSession.recvCh <- bytes.Clone(msg)
+	secondRecvStarted := make(chan struct{}, 2)
+	secondSession := &testSignalPeerSession{
+		localPeerID:  localPeerID,
+		remotePeerID: remotePeerID,
+		recvCh:       make(chan []byte, 1),
+		recvStarted:  secondRecvStarted,
+	}
+	secondSession.recvCh <- msg
+
+	tpt := &WebRTC{
+		le:               logrus.NewEntry(logrus.New()),
+		conf:             &Config{},
+		peerID:           localPeerID,
+		privKey:          localPriv,
+		incomingSessions: make(map[string]*keyed.KeyedRef[string, *sessionTracker]),
+	}
+
+	firstReceived := make(chan *incomingSignal, 1)
+	secondReceived := make(chan *incomingSignal, 1)
+	retireTracker := make(chan struct{})
+	trackerRetired := make(chan struct{})
+	trackerDone := make(chan error, 1)
+	var tracker *sessionTracker
+	tpt.sessionTrackers = keyed.NewKeyedRefCount(
+		func(key string) (keyed.Routine, *sessionTracker) {
+			tkr := &sessionTracker{
+				w:       tpt,
+				le:      tpt.le,
+				key:     key,
+				peerID:  remotePeerID,
+				offerer: true,
+			}
+			tracker = tkr
+			return func(ctx context.Context) (err error) {
+				execution := tkr.beginExecution()
+				defer tkr.retireExecution(execution)
+				defer func() {
+					trackerDone <- err
+				}()
+
+				var incoming *incomingSignal
+				select {
+				case <-ctx.Done():
+					return context.Canceled
+				case incoming = <-execution.rxSignal:
+				}
+				firstReceived <- incoming
+
+				select {
+				case <-ctx.Done():
+					return context.Canceled
+				case incoming = <-execution.rxSignal:
+				}
+				secondReceived <- incoming
+
+				select {
+				case <-ctx.Done():
+					return context.Canceled
+				case <-retireTracker:
+				}
+				tkr.retireExecution(execution)
+				close(trackerRetired)
+				return nil
+			}, tkr
+		},
+	)
+	tpt.sessionTrackers.SetContext(ctx, true)
+	t.Cleanup(tpt.sessionTrackers.ClearContext)
+
+	releaseCalls := make(chan *keyed.KeyedRef[string, *sessionTracker], 4)
+	refReplaced := make(chan [2]*keyed.KeyedRef[string, *sessionTracker], 1)
+	continueReplacement := make(chan struct{})
+	releaseRef := func(ref *keyed.KeyedRef[string, *sessionTracker]) {
+		releaseCalls <- ref
+		ref.Release()
+	}
+	refStored := func(
+		prev *keyed.KeyedRef[string, *sessionTracker],
+		next *keyed.KeyedRef[string, *sessionTracker],
+	) {
+		if prev != nil {
+			refReplaced <- [2]*keyed.KeyedRef[string, *sessionTracker]{prev, next}
+			<-continueReplacement
+		}
+	}
+
+	firstCtx, cancelFirst := context.WithCancel(ctx)
+	firstResolverErr := make(chan error, 1)
+	firstResolver := &handleSignalPeerResolver{
+		t:          tpt,
+		sess:       firstSession,
+		releaseRef: releaseRef,
+		refStored:  refStored,
+	}
+	go func() {
+		firstResolverErr <- firstResolver.Resolve(firstCtx, nil)
+	}()
+
+	<-firstRecvStarted
+	firstIncoming := <-firstReceived
+	var firstRef *keyed.KeyedRef[string, *sessionTracker]
+	tpt.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+		firstRef = tpt.incomingSessions[remotePeerIDStr]
+	})
+	if firstRef == nil {
+		t.Fatal("first resolver did not install its incoming session reference")
+	}
+
+	secondCtx, cancelSecond := context.WithCancel(ctx)
+	secondResolverErr := make(chan error, 1)
+	secondResolver := &handleSignalPeerResolver{
+		t:          tpt,
+		sess:       secondSession,
+		releaseRef: releaseRef,
+		refStored:  refStored,
+	}
+	go func() {
+		secondResolverErr <- secondResolver.Resolve(secondCtx, nil)
+	}()
+
+	<-secondRecvStarted
+	replaced := <-refReplaced
+	if replaced[0] != firstRef {
+		close(continueReplacement)
+		t.Fatal("overlapping resolver replaced an unexpected reference")
+	}
+	select {
+	case released := <-releaseCalls:
+		if released != firstRef {
+			close(continueReplacement)
+			t.Fatal("overlapping resolver released an unexpected reference")
+		}
+	default:
+		close(continueReplacement)
+		t.Fatal("overlapping resolver did not release the superseded reference")
+	}
+
+	firstLiveSession := &session{t: tracker}
+	firstLiveSession.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+		firstLiveSession.acceptIncomingSignalLocked(firstIncoming)
+	})
+	close(continueReplacement)
+
+	secondIncoming := <-secondReceived
+	secondRef := replaced[1]
+	if secondRef == nil || secondRef == firstRef {
+		t.Fatal("second resolver did not install a distinct incoming session reference")
+	}
+	secondLiveSession := &session{t: tracker}
+	secondLiveSession.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+		secondLiveSession.acceptIncomingSignalLocked(secondIncoming)
+	})
+
+	<-firstRecvStarted
+	<-secondRecvStarted
+	close(retireTracker)
+	<-trackerRetired
+	if err := <-trackerDone; err != nil {
+		t.Fatalf("tracker returned %v, want nil", err)
+	}
+
+	tpt.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+		if ref := tpt.incomingSessions[remotePeerIDStr]; ref != nil {
+			t.Errorf("incoming session reference remained after retirement: %p", ref)
+		}
+	})
+	if keys := tpt.sessionTrackers.GetKeys(); len(keys) != 0 {
+		t.Fatalf("session trackers still registered after both references released: %v", keys)
+	}
+
+	cancelFirst()
+	if err := <-firstResolverErr; err != context.Canceled {
+		t.Fatalf("first resolver returned %v, want context canceled", err)
+	}
+	cancelSecond()
+	if err := <-secondResolverErr; err != context.Canceled {
+		t.Fatalf("second resolver returned %v, want context canceled", err)
+	}
+
+	select {
+	case released := <-releaseCalls:
+		if released == secondRef {
+			t.Fatal("resolver released the reference already released by tracker retirement")
+		}
+		t.Fatalf("resolver released superseded reference %p more than once", released)
+	default:
 	}
 }
 

--- a/net/transport/webrtc/session.go
+++ b/net/transport/webrtc/session.go
@@ -87,6 +87,20 @@ func (s *sessionTracker) retireExecution(execution *sessionTrackerExecution) {
 	})
 }
 
+// completeExecution waits for both child routines before retiring the execution.
+func (s *sessionTracker) completeExecution(
+	execution *sessionTrackerExecution,
+	linkDone, xmitDone <-chan struct{},
+) {
+	if linkDone != nil {
+		<-linkDone
+	}
+	if xmitDone != nil {
+		<-xmitDone
+	}
+	s.retireExecution(execution)
+}
+
 // incomingSignal holds a decoded signal until a live tracker accepts it.
 type incomingSignal struct {
 	sig      *WebRtcSignal
@@ -596,7 +610,10 @@ func (s *sessionTracker) execute(ctx context.Context) (err error) {
 	}()
 	s.le.Info("session tracker starting")
 	execution := s.beginExecution()
-	defer s.retireExecution(execution)
+	var linkDone, xmitDone <-chan struct{}
+	defer func() {
+		s.completeExecution(execution, linkDone, xmitDone)
+	}()
 
 	// Construct the PeerConnection and attach the callbacks.
 	phase = "construct session"
@@ -634,8 +651,8 @@ func (s *sessionTracker) execute(ctx context.Context) (err error) {
 
 	// Stop child routines before retiring this execution generation.
 	defer func() {
-		linkRoutine.SetState(nil)
-		xmitRoutine.SetState(nil)
+		linkDone, _, _, _ = linkRoutine.SetState(nil)
+		xmitDone, _, _, _ = xmitRoutine.SetState(nil)
 	}()
 
 	// Open the signaling session with the remote peer.

--- a/net/transport/webrtc/session.go
+++ b/net/transport/webrtc/session.go
@@ -42,14 +42,8 @@ type sessionTracker struct {
 	// offerer indicates if we are offering or answering
 	offerer bool
 
-	// errCh is pushed if a fatal error failed the session or signaling
-	errCh chan error
 	// rxSignal receives an incoming signaling message and its acceptance fence
 	rxSignal chan *incomingSignal
-	// xmitRoutine is the routine that manages transmitting a signaling message
-	xmitRoutine *routine.StateRoutineContainer[*outgoingSignal]
-	// linkRoutine is the routine that manages the Quic link when the session dcOpen.
-	linkRoutine *routine.StateRoutineContainer[datachannel.ReadWriteCloser]
 	// link contains the current link, if any
 	// w.bcast is broadcasted when this changes
 	link *transport_quic.Link
@@ -83,40 +77,9 @@ func (w *WebRTC) newSessionTracker(peerIDStr string) (keyed.Routine, *sessionTra
 		offerer: offerer,
 	}
 
-	sess.errCh = make(chan error, 1)
-
-	sess.linkRoutine = routine.NewStateRoutineContainer(
-		func(t1, t2 datachannel.ReadWriteCloser) bool { return t1 == t2 },
-		routine.WithExitCb(func(err error) {
-			if err != nil {
-				sess.failWithErr(pkgerrors.Wrap(err, "link routine"))
-			}
-		}),
-	)
-	_, _, _ = sess.linkRoutine.SetStateRoutine(sess.executeLink)
-
 	sess.rxSignal = make(chan *incomingSignal)
-	sess.xmitRoutine = routine.NewStateRoutineContainer[*outgoingSignal](
-		nil,
-		routine.WithExitCb(func(err error) {
-			if err != nil {
-				sess.failWithErr(pkgerrors.Wrap(err, "signal transmit routine"))
-			}
-		}),
-	)
-	_, _, _ = sess.xmitRoutine.SetStateRoutine(sess.executeXmitSignal)
 
 	return sess.execute, sess
-}
-
-// failWithErr pushes to errCh
-func (s *sessionTracker) failWithErr(err error) {
-	if err != nil && err != context.Canceled {
-		select {
-		case s.errCh <- err:
-		default:
-		}
-	}
 }
 
 // outgoingSignal contains a signal to transmit
@@ -454,6 +417,30 @@ func (s *session) acceptIncomingSignalLocked(sig *incomingSignal) {
 	sig.accept()
 }
 
+// failWithErr fences signal acceptance before exposing a routine error.
+func (s *session) failWithErr(errCh chan<- error, err error) {
+	if err == nil || err == context.Canceled {
+		return
+	}
+
+	var recorded bool
+	s.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+		if s.fatalErr == nil {
+			s.fatalErr = err
+			recorded = true
+			broadcast()
+		}
+	})
+	if !recorded {
+		return
+	}
+
+	select {
+	case errCh <- err:
+	default:
+	}
+}
+
 func (s *session) onIceCandidate(c *webrtc.ICECandidate) {
 	s.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
 		if c == nil {
@@ -581,17 +568,38 @@ func (s *sessionTracker) execute(ctx context.Context) (err error) {
 	}
 	defer sess.close()
 
+	errCh := make(chan error, 1)
+	linkRoutine := routine.NewStateRoutineContainer(
+		func(t1, t2 datachannel.ReadWriteCloser) bool { return t1 == t2 },
+		routine.WithExitCb(func(err error) {
+			if err != nil {
+				sess.failWithErr(errCh, pkgerrors.Wrap(err, "link routine"))
+			}
+		}),
+	)
+	_, _, _ = linkRoutine.SetStateRoutine(s.executeLink)
+
+	xmitRoutine := routine.NewStateRoutineContainer[*outgoingSignal](
+		nil,
+		routine.WithExitCb(func(err error) {
+			if err != nil {
+				sess.failWithErr(errCh, pkgerrors.Wrap(err, "signal transmit routine"))
+			}
+		}),
+	)
+	_, _, _ = xmitRoutine.SetStateRoutine(s.executeXmitSignal)
+
 	// Set the context for the link routine.
 	phase = "bind routines"
-	s.linkRoutine.SetContext(ctx, true)
-	s.xmitRoutine.SetContext(ctx, true)
+	linkRoutine.SetContext(ctx, true)
+	xmitRoutine.SetContext(ctx, true)
 
 	// When exiting, clear any references to this tracker from incoming signaling.
 	// The incoming signaling will trigger re-adding a reference if any new messages arrive.
 	defer func() {
 		peerIDStr := s.peerID.String()
-		s.linkRoutine.SetState(nil)
-		s.xmitRoutine.SetState(nil)
+		linkRoutine.SetState(nil)
+		xmitRoutine.SetState(nil)
 		s.w.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
 			if ref := s.w.incomingSessions[peerIDStr]; ref != nil {
 				ref.Release()
@@ -622,7 +630,7 @@ func (s *sessionTracker) execute(ctx context.Context) (err error) {
 	var signalSent <-chan struct{}
 	xmitSignal := func(msg *WebRtcSignal) {
 		sentCh := make(chan struct{})
-		_, _, _, _ = s.xmitRoutine.SetState(&outgoingSignal{
+		_, _, _, _ = xmitRoutine.SetState(&outgoingSignal{
 			sess:   signal,
 			sig:    msg,
 			sentCh: sentCh,
@@ -679,7 +687,7 @@ func (s *sessionTracker) execute(ctx context.Context) (err error) {
 			select {
 			case <-ctx.Done():
 				return context.Canceled
-			case err := <-s.errCh:
+			case err := <-errCh:
 				return err
 			case currIncomingSignal = <-s.rxSignal:
 			case <-signalSent:
@@ -766,7 +774,7 @@ func (s *sessionTracker) execute(ctx context.Context) (err error) {
 		if currDcRwc != currLinkRwc {
 			phase = "update link routine"
 			// Update the link routine and wait for the old link to exit.
-			waitReturn, changed, _, _ := s.linkRoutine.SetState(currDcRwc)
+			waitReturn, changed, _, _ := linkRoutine.SetState(currDcRwc)
 			if changed && waitReturn != nil {
 				select {
 				case <-ctx.Done():

--- a/net/transport/webrtc/session.go
+++ b/net/transport/webrtc/session.go
@@ -42,11 +42,49 @@ type sessionTracker struct {
 	// offerer indicates if we are offering or answering
 	offerer bool
 
-	// rxSignal receives an incoming signaling message and its acceptance fence
-	rxSignal chan *incomingSignal
+	// executionGeneration identifies each execute invocation on this tracker.
+	// execution is non-nil only while that invocation is live.
+	// w.bcast guards executionGeneration, execution, and link.
+	executionGeneration uint64
+	execution           *sessionTrackerExecution
 	// link contains the current link, if any
-	// w.bcast is broadcasted when this changes
 	link *transport_quic.Link
+}
+
+// sessionTrackerExecution is one live invocation of sessionTracker.execute.
+type sessionTrackerExecution struct {
+	generation uint64
+	rxSignal   chan *incomingSignal
+}
+
+// beginExecution publishes a new execution generation.
+func (s *sessionTracker) beginExecution() *sessionTrackerExecution {
+	var execution *sessionTrackerExecution
+	s.w.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+		s.executionGeneration++
+		execution = &sessionTrackerExecution{
+			generation: s.executionGeneration,
+			rxSignal:   make(chan *incomingSignal),
+		}
+		s.execution = execution
+		broadcast()
+	})
+	return execution
+}
+
+// retireExecution clears a generation and its incoming-session reference.
+func (s *sessionTracker) retireExecution(execution *sessionTrackerExecution) {
+	s.w.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+		if s.execution != execution {
+			return
+		}
+		s.execution = nil
+		if ref := s.w.incomingSessions[s.key]; ref != nil {
+			ref.Release()
+			delete(s.w.incomingSessions, s.key)
+		}
+		broadcast()
+	})
 }
 
 // incomingSignal holds a decoded signal until a live tracker accepts it.
@@ -76,8 +114,6 @@ func (w *WebRTC) newSessionTracker(peerIDStr string) (keyed.Routine, *sessionTra
 		peerPub: peerPub,
 		offerer: offerer,
 	}
-
-	sess.rxSignal = make(chan *incomingSignal)
 
 	return sess.execute, sess
 }
@@ -559,6 +595,8 @@ func (s *sessionTracker) execute(ctx context.Context) (err error) {
 		}
 	}()
 	s.le.Info("session tracker starting")
+	execution := s.beginExecution()
+	defer s.retireExecution(execution)
 
 	// Construct the PeerConnection and attach the callbacks.
 	phase = "construct session"
@@ -594,19 +632,10 @@ func (s *sessionTracker) execute(ctx context.Context) (err error) {
 	linkRoutine.SetContext(ctx, true)
 	xmitRoutine.SetContext(ctx, true)
 
-	// When exiting, clear any references to this tracker from incoming signaling.
-	// The incoming signaling will trigger re-adding a reference if any new messages arrive.
+	// Stop child routines before retiring this execution generation.
 	defer func() {
-		peerIDStr := s.peerID.String()
 		linkRoutine.SetState(nil)
 		xmitRoutine.SetState(nil)
-		s.w.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
-			if ref := s.w.incomingSessions[peerIDStr]; ref != nil {
-				ref.Release()
-				broadcast()
-				delete(s.w.incomingSessions, peerIDStr)
-			}
-		})
 	}()
 
 	// Open the signaling session with the remote peer.
@@ -678,7 +707,7 @@ func (s *sessionTracker) execute(ctx context.Context) (err error) {
 		select {
 		case <-ctx.Done():
 			return context.Canceled
-		case currIncomingSignal = <-s.rxSignal:
+		case currIncomingSignal = <-execution.rxSignal:
 		default:
 		}
 
@@ -689,7 +718,7 @@ func (s *sessionTracker) execute(ctx context.Context) (err error) {
 				return context.Canceled
 			case err := <-errCh:
 				return err
-			case currIncomingSignal = <-s.rxSignal:
+			case currIncomingSignal = <-execution.rxSignal:
 			case <-signalSent:
 				signalSent = nil
 			case <-waitCh:

--- a/net/transport/webrtc/session.go
+++ b/net/transport/webrtc/session.go
@@ -44,8 +44,8 @@ type sessionTracker struct {
 
 	// errCh is pushed if a fatal error failed the session or signaling
 	errCh chan error
-	// rxSignal receives an incoming signaling message
-	rxSignal chan *WebRtcSignal
+	// rxSignal receives an incoming signaling message and its acceptance fence
+	rxSignal chan *incomingSignal
 	// xmitRoutine is the routine that manages transmitting a signaling message
 	xmitRoutine *routine.StateRoutineContainer[*outgoingSignal]
 	// linkRoutine is the routine that manages the Quic link when the session dcOpen.
@@ -53,6 +53,17 @@ type sessionTracker struct {
 	// link contains the current link, if any
 	// w.bcast is broadcasted when this changes
 	link *transport_quic.Link
+}
+
+// incomingSignal holds a decoded signal until a live tracker accepts it.
+type incomingSignal struct {
+	sig      *WebRtcSignal
+	accepted chan struct{}
+}
+
+// accept records that the current live tracker owns the signal.
+func (s *incomingSignal) accept() {
+	close(s.accepted)
 }
 
 // newSessionTracker constructs a new sessionTracker.
@@ -84,7 +95,7 @@ func (w *WebRTC) newSessionTracker(peerIDStr string) (keyed.Routine, *sessionTra
 	)
 	_, _, _ = sess.linkRoutine.SetStateRoutine(sess.executeLink)
 
-	sess.rxSignal = make(chan *WebRtcSignal)
+	sess.rxSignal = make(chan *incomingSignal)
 	sess.xmitRoutine = routine.NewStateRoutineContainer[*outgoingSignal](
 		nil,
 		routine.WithExitCb(func(err error) {
@@ -335,30 +346,29 @@ func (s *sessionTracker) newSession() (*session, <-chan struct{}, error) {
 		return nil, nil, pkgerrors.Wrap(err, "create peer connection")
 	}
 
-	// Create the data channel in advance.
-	negotiated := true
-	protocol := dataChannelID
-	ordered := false // Allow unordered data since Quic can handle it.
-	var channelID uint16 = 1
-	dc, err := pc.CreateDataChannel(dataChannelID, &webrtc.DataChannelInit{
-		// We use the same channel label on both sides and set Negotiated: true.
-		// This avoids sending redundant info via the OnDataChannel callback.
-		Negotiated: &negotiated,
-		Protocol:   &protocol,
-		ID:         &channelID,
-		Ordered:    &ordered,
-	})
-	if err != nil {
-		_ = pc.Close()
-		return nil, nil, pkgerrors.Wrap(err, "create data channel")
-	}
-
-	sess := &session{t: s, pc: pc, dc: dc}
+	sess := &session{t: s, pc: pc}
 
 	var waitCh <-chan struct{}
 	sess.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
 		waitCh = getWaitCh()
 	})
+
+	var dc *webrtc.DataChannel
+	var createErr error
+	if err := setCallback("initialize negotiated data channel", func() {
+		dc, createErr = sess.createDataChannel(
+			pc.OnNegotiationNeeded,
+			pc.CreateDataChannel,
+		)
+	}); err != nil {
+		_ = pc.Close()
+		return nil, nil, err
+	}
+	if createErr != nil {
+		_ = pc.Close()
+		return nil, nil, pkgerrors.Wrap(createErr, "create data channel")
+	}
+	sess.dc = dc
 
 	// DataChannel callbacks
 	if err := setCallback("register data channel onopen", func() {
@@ -387,13 +397,6 @@ func (s *sessionTracker) newSession() (*session, <-chan struct{}, error) {
 		_ = pc.Close()
 		return nil, nil, err
 	}
-	if err := setCallback("register peer connection onnegotiationneeded", func() {
-		pc.OnNegotiationNeeded(sess.onNegotiationNeeded)
-	}); err != nil {
-		_ = dc.Close()
-		_ = pc.Close()
-		return nil, nil, err
-	}
 	if err := setCallback("register peer connection onicecandidate", func() {
 		pc.OnICECandidate(sess.onIceCandidate)
 	}); err != nil {
@@ -409,6 +412,27 @@ func (s *sessionTracker) newSession() (*session, <-chan struct{}, error) {
 	return sess, waitCh, nil
 }
 
+// createDataChannel installs negotiation ownership before creating the channel.
+func (s *session) createDataChannel(
+	onNegotiationNeeded func(func()),
+	createDataChannel func(string, *webrtc.DataChannelInit) (*webrtc.DataChannel, error),
+) (*webrtc.DataChannel, error) {
+	onNegotiationNeeded(s.onNegotiationNeeded)
+
+	negotiated := true
+	protocol := dataChannelID
+	ordered := false // Allow unordered data since Quic can handle it.
+	var channelID uint16 = 1
+	return createDataChannel(dataChannelID, &webrtc.DataChannelInit{
+		// We use the same channel label on both sides and set Negotiated: true.
+		// This avoids sending redundant info via the OnDataChannel callback.
+		Negotiated: &negotiated,
+		Protocol:   &protocol,
+		ID:         &channelID,
+		Ordered:    &ordered,
+	})
+}
+
 func (s *session) onNegotiationNeeded() {
 	s.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
 		s.localSeqno++
@@ -419,6 +443,15 @@ func (s *session) onNegotiationNeeded() {
 				Debug("negotiation is needed")
 		}
 	})
+}
+
+// acceptIncomingSignalLocked accepts sig only while this session is live.
+// The caller must hold s.bcast.
+func (s *session) acceptIncomingSignalLocked(sig *incomingSignal) {
+	if sig == nil || s.fatalErr != nil || s.connState == webrtc.PeerConnectionStateFailed {
+		return
+	}
+	sig.accept()
 }
 
 func (s *session) onIceCandidate(c *webrtc.ICECandidate) {
@@ -486,6 +519,47 @@ func (s *session) onDataChannelClose() {
 // close closes the session.
 func (s *session) close() {
 	_ = s.pc.Close()
+}
+
+// transmitLocalNegotiation emits one offer or request for each local sequence.
+func (s *sessionTracker) transmitLocalNegotiation(
+	sess *session,
+	le *logrus.Entry,
+	currLocalSeqno uint64,
+	lastLocalSeqno uint64,
+	xmitSignal func(*WebRtcSignal),
+) (uint64, bool, error) {
+	if currLocalSeqno == lastLocalSeqno {
+		return lastLocalSeqno, false, nil
+	}
+
+	var xmit *WebRtcSignal
+	if s.offerer {
+		if s.w.GetVerbose() {
+			le.Debug("signal tx: offer sdp")
+		}
+		localDesc, err := sess.pc.CreateOffer(nil)
+		if err != nil {
+			return lastLocalSeqno, false, pkgerrors.Wrap(err, "create offer")
+		}
+		if err := sess.pc.SetLocalDescription(localDesc); err != nil {
+			return lastLocalSeqno, false, pkgerrors.Wrap(err, "set local description(offer)")
+		}
+		xmit = &WebRtcSignal{
+			Body: &WebRtcSignal_Sdp{Sdp: NewWebRtcSdp(
+				currLocalSeqno,
+				&localDesc,
+			)},
+		}
+	} else {
+		if s.w.GetVerbose() {
+			le.Debug("signal tx: offer request")
+		}
+		xmit = &WebRtcSignal{Body: &WebRtcSignal_RequestOffer{RequestOffer: currLocalSeqno}}
+	}
+
+	xmitSignal(xmit)
+	return currLocalSeqno, true, nil
 }
 
 // execute executes the sessionTracker.
@@ -590,24 +664,24 @@ func (s *sessionTracker) execute(ctx context.Context) (err error) {
 	for {
 		phase = "wait for session change"
 		// Wait for something to change or for an incoming signal.
-		var currRxSignal *WebRtcSignal
+		var currIncomingSignal *incomingSignal
 
 		// Prioritize receiving an incoming signal first.
 		select {
 		case <-ctx.Done():
 			return context.Canceled
-		case currRxSignal = <-s.rxSignal:
+		case currIncomingSignal = <-s.rxSignal:
 		default:
 		}
 
 		// Then allow also re-checking in case we need to transmit ice candidates.
-		if currRxSignal == nil {
+		if currIncomingSignal == nil {
 			select {
 			case <-ctx.Done():
 				return context.Canceled
 			case err := <-s.errCh:
 				return err
-			case currRxSignal = <-s.rxSignal:
+			case currIncomingSignal = <-s.rxSignal:
 			case <-signalSent:
 				signalSent = nil
 			case <-waitCh:
@@ -615,12 +689,20 @@ func (s *sessionTracker) execute(ctx context.Context) (err error) {
 			}
 		}
 
+		// A channel receive is not acceptance. The terminal-state transition
+		// and this acceptance fence are serialized by the session owner.
+		if currIncomingSignal != nil {
+			sess.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+				sess.acceptIncomingSignalLocked(currIncomingSignal)
+			})
+		}
+
 		// Process the incoming signal, if any.
 		var currRxSdp *WebRtcSdp
 		var currRxIce *WebRtcIce
-		if currRxSignal != nil {
+		if currIncomingSignal != nil {
 			phase = "process incoming signal"
-			switch b := currRxSignal.GetBody().(type) {
+			switch b := currIncomingSignal.sig.GetBody().(type) {
 			case *WebRtcSignal_RequestOffer:
 				if !s.offerer {
 					return errors.New("remote peer requested offer but we are not the offerer")
@@ -796,37 +878,19 @@ func (s *sessionTracker) execute(ctx context.Context) (err error) {
 		// Transmit an offer or a request for one when local seqno changes.
 		if currLocalSeqno != lastLocalSeqno {
 			phase = "transmit local negotiation"
-			var xmit *WebRtcSignal
-
-			if s.offerer {
-				if s.w.GetVerbose() {
-					le.Debug("signal tx: offer sdp")
-				}
-				localDesc, err := sess.pc.CreateOffer(nil)
-				if err != nil {
-					return pkgerrors.Wrap(err, "create offer")
-				}
-				if err := sess.pc.SetLocalDescription(localDesc); err != nil {
-					return pkgerrors.Wrap(err, "set local description(offer)")
-				}
-				xmit = &WebRtcSignal{
-					Body: &WebRtcSignal_Sdp{Sdp: NewWebRtcSdp(
-						currLocalSeqno,
-						&localDesc,
-					)},
-				}
-			} else {
-				if s.w.GetVerbose() {
-					le.Debug("signal tx: offer request")
-				}
-				xmit = &WebRtcSignal{Body: &WebRtcSignal_RequestOffer{RequestOffer: currLocalSeqno}}
-			}
-
-			// Encrypt and transmit the message.
-			xmitSignal(xmit)
-
-			// Mark as sent
-			lastLocalSeqno = currLocalSeqno
+		}
+		nextLocalSeqno, transmitted, err := s.transmitLocalNegotiation(
+			sess,
+			le,
+			currLocalSeqno,
+			lastLocalSeqno,
+			xmitSignal,
+		)
+		if err != nil {
+			return err
+		}
+		if transmitted {
+			lastLocalSeqno = nextLocalSeqno
 
 			// Restart sending ice candidates & recheck
 			lastSentICE = 0

--- a/net/transport/webrtc/session_test.go
+++ b/net/transport/webrtc/session_test.go
@@ -7,6 +7,42 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+func TestCompleteExecutionWaitsForChildCompletion(t *testing.T) {
+	tpt := &WebRTC{}
+	execution := &sessionTrackerExecution{}
+	tkr := &sessionTracker{w: tpt, execution: execution}
+	linkDone := make(chan struct{})
+	xmitDone := make(chan struct{})
+	completed := make(chan struct{})
+
+	go func() {
+		tkr.completeExecution(execution, linkDone, xmitDone)
+		close(completed)
+	}()
+
+	linkDone <- struct{}{}
+	var retired bool
+	tpt.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+		retired = tkr.execution != execution
+	})
+	if retired {
+		t.Fatal("execution retired before transmit child completed")
+	}
+	select {
+	case <-completed:
+		t.Fatal("execution completion returned before transmit child completed")
+	default:
+	}
+
+	xmitDone <- struct{}{}
+	<-completed
+	tpt.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+		if tkr.execution != nil {
+			t.Error("execution remained published after both children completed")
+		}
+	})
+}
+
 func TestCreateDataChannelRegistersNegotiationCallbackFirst(t *testing.T) {
 	tpt := &WebRTC{
 		conf: &Config{},

--- a/net/transport/webrtc/session_test.go
+++ b/net/transport/webrtc/session_test.go
@@ -1,0 +1,90 @@
+package webrtc
+
+import (
+	"testing"
+
+	pion_webrtc "github.com/pion/webrtc/v4"
+	"github.com/sirupsen/logrus"
+)
+
+func TestCreateDataChannelRegistersNegotiationCallbackFirst(t *testing.T) {
+	tpt := &WebRTC{
+		conf: &Config{},
+		le:   logrus.NewEntry(logrus.New()),
+	}
+	tkr := &sessionTracker{
+		w:       tpt,
+		le:      tpt.le,
+		offerer: false,
+	}
+	sess := &session{t: tkr}
+
+	var onNegotiationNeeded func()
+	_, err := sess.createDataChannel(
+		func(cb func()) {
+			onNegotiationNeeded = cb
+		},
+		func(string, *pion_webrtc.DataChannelInit) (*pion_webrtc.DataChannel, error) {
+			if onNegotiationNeeded == nil {
+				t.Fatal("data channel created before negotiation callback registration")
+			}
+			onNegotiationNeeded()
+			return nil, nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	var localSeqno uint64
+	sess.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+		localSeqno = sess.localSeqno
+	})
+	if localSeqno != 1 {
+		t.Fatalf("local sequence %d, want 1", localSeqno)
+	}
+
+	var signals []*WebRtcSignal
+	xmit := func(sig *WebRtcSignal) {
+		signals = append(signals, sig)
+	}
+	lastLocalSeqno, transmitted, err := tkr.transmitLocalNegotiation(
+		sess,
+		tkr.le,
+		localSeqno,
+		0,
+		xmit,
+	)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if !transmitted {
+		t.Fatal("initial request_offer was not transmitted")
+	}
+	if lastLocalSeqno != 1 {
+		t.Fatalf("last local sequence %d, want 1", lastLocalSeqno)
+	}
+
+	lastLocalSeqno, transmitted, err = tkr.transmitLocalNegotiation(
+		sess,
+		tkr.le,
+		localSeqno,
+		lastLocalSeqno,
+		xmit,
+	)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if transmitted {
+		t.Fatal("unchanged local sequence retransmitted request_offer")
+	}
+	if lastLocalSeqno != 1 {
+		t.Fatalf("last local sequence %d after recheck, want 1", lastLocalSeqno)
+	}
+	if len(signals) != 1 {
+		t.Fatalf("request_offer count %d, want 1", len(signals))
+	}
+	if signals[0].GetRequestOffer() != 1 {
+		t.Fatalf("request_offer sequence %d, want 1", signals[0].GetRequestOffer())
+	}
+}


### PR DESCRIPTION
WebRTC reconnects now retain an incoming signaling message until a live session tracker acknowledges ownership. If a retiring tracker reaches failed state first, the handler follows the existing keyed generation transition and presents the same decoded signal to the replacement instead of advancing and losing the negotiation request.

New sessions now register `OnNegotiationNeeded` before creating the negotiated data channel. A synchronous initial callback therefore increments the local sequence and emits one initial offer or request, while acknowledged signals are never applied to a second generation. Signaling wire formats and existing peer compatibility are unchanged.

Deterministic tracker-retirement and synchronous-callback regressions pass under the race detector. The full WebRTC package, repository build, and a bounded ten-run reconnect corroboration pass.