### PR TITLE
bldr: boot manifests from no-copy source buckets

### DIFF
--- a/.protoc-manifest.json
+++ b/.protoc-manifest.json
@@ -12,9 +12,7 @@
         "auth/derive/derive.pb.rs",
         "auth/derive/derive.pb.ts"
       ],
-      "protoFiles": [
-        "auth/derive/derive.proto"
-      ]
+      "protoFiles": ["auth/derive/derive.proto"]
     },
     "github.com/s4wave/spacewave/auth/method/controller": {
       "hash": "b88f10684c042a791bdbbcc20c7cf7fe2965a5ff96b8e00e650a15be64de1495",
@@ -25,9 +23,7 @@
         "auth/method/controller/controller.pb.rs",
         "auth/method/controller/controller.pb.ts"
       ],
-      "protoFiles": [
-        "auth/method/controller/controller.proto"
-      ]
+      "protoFiles": ["auth/method/controller/controller.proto"]
     },
     "github.com/s4wave/spacewave/auth/method/password": {
       "hash": "21ee91433fcb103c6b034d6f54852686f8f14d8fdba6ae3973090bc21593e0f6",
@@ -38,9 +34,7 @@
         "auth/method/password/password.pb.rs",
         "auth/method/password/password.pb.ts"
       ],
-      "protoFiles": [
-        "auth/method/password/password.proto"
-      ]
+      "protoFiles": ["auth/method/password/password.proto"]
     },
     "github.com/s4wave/spacewave/bldr/cli/compiler": {
       "hash": "164ae3e5a40130d19a143c2a2d40aa13ff23b52a6d56a35c0e4c74d56a1e2688",
@@ -51,9 +45,7 @@
         "bldr/cli/compiler/compiler.pb.rs",
         "bldr/cli/compiler/compiler.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/cli/compiler/compiler.proto"
-      ]
+      "protoFiles": ["bldr/cli/compiler/compiler.proto"]
     },
     "github.com/s4wave/spacewave/bldr/desktop/tray": {
       "hash": "83c55210ab3bbcd6d68b394730ca231b0794a13008242d32e105bfe07ebcbb9b",
@@ -68,9 +60,7 @@
         "bldr/desktop/tray/tray_srpc.pb.rs",
         "bldr/desktop/tray/tray_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/desktop/tray/tray.proto"
-      ]
+      "protoFiles": ["bldr/desktop/tray/tray.proto"]
     },
     "github.com/s4wave/spacewave/bldr/devtool/status": {
       "hash": "ba0e3bf51464cdaa03f8b59f8c9fa50426dc12b704720a651e43be735723c787",
@@ -84,9 +74,7 @@
         "bldr/devtool/status/status_srpc.pb.rs",
         "bldr/devtool/status/status_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/devtool/status/status.proto"
-      ]
+      "protoFiles": ["bldr/devtool/status/status.proto"]
     },
     "github.com/s4wave/spacewave/bldr/devtool/web": {
       "hash": "5c769040e039f1ffb10193454ee1ee6d8c732be26cdaaf2236be7dc0fb27208a",
@@ -97,9 +85,7 @@
         "bldr/devtool/web/web.pb.rs",
         "bldr/devtool/web/web.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/devtool/web/web.proto"
-      ]
+      "protoFiles": ["bldr/devtool/web/web.proto"]
     },
     "github.com/s4wave/spacewave/bldr/dist": {
       "hash": "1ae5c11222438d5788187e69954b6e9b8f3e4a1808d1b7b7fd593adecccb0f5f",
@@ -110,9 +96,7 @@
         "bldr/dist/dist.pb.rs",
         "bldr/dist/dist.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/dist/dist.proto"
-      ]
+      "protoFiles": ["bldr/dist/dist.proto"]
     },
     "github.com/s4wave/spacewave/bldr/dist/compiler": {
       "hash": "1ec82cc342dbb61903b4dd8a0bbd2f46501ed6d0f166dd512002b7074f4fb292",
@@ -123,9 +107,7 @@
         "bldr/dist/compiler/config.pb.rs",
         "bldr/dist/compiler/config.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/dist/compiler/config.proto"
-      ]
+      "protoFiles": ["bldr/dist/compiler/config.proto"]
     },
     "github.com/s4wave/spacewave/bldr/example": {
       "hash": "842597efe94512f2cbc5bbbd4df6aa1d5e16ea9a1b5c194bc8e2c34054a11845",
@@ -136,9 +118,7 @@
         "bldr/example/example.pb.rs",
         "bldr/example/example.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/example/example.proto"
-      ]
+      "protoFiles": ["bldr/example/example.proto"]
     },
     "github.com/s4wave/spacewave/bldr/manifest": {
       "hash": "40e9c2562128f19fd1eaf7f65bccf1e0c4671a2f7d81eafe88f535f4e1837a88",
@@ -152,9 +132,7 @@
         "bldr/manifest/manifest_srpc.pb.rs",
         "bldr/manifest/manifest_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/manifest/manifest.proto"
-      ]
+      "protoFiles": ["bldr/manifest/manifest.proto"]
     },
     "github.com/s4wave/spacewave/bldr/manifest/build": {
       "hash": "f417a6a5108266ea1d6c1d71ef96491c6cf2784bfbb9a7431e6fec92a8689a6a",
@@ -165,9 +143,7 @@
         "bldr/manifest/build/policy.pb.rs",
         "bldr/manifest/build/policy.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/manifest/build/policy.proto"
-      ]
+      "protoFiles": ["bldr/manifest/build/policy.proto"]
     },
     "github.com/s4wave/spacewave/bldr/manifest/builder": {
       "hash": "84d8b6275c383e0828a1467ac218f1aaa2970406727c5ceab7880576211c5814",
@@ -178,9 +154,7 @@
         "bldr/manifest/builder/builder.pb.rs",
         "bldr/manifest/builder/builder.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/manifest/builder/builder.proto"
-      ]
+      "protoFiles": ["bldr/manifest/builder/builder.proto"]
     },
     "github.com/s4wave/spacewave/bldr/manifest/builder/controller": {
       "hash": "323a43448021e48307448f54dc0d616adbf66e90cb477107b0b794cb9bbe6203",
@@ -191,9 +165,7 @@
         "bldr/manifest/builder/controller/config.pb.rs",
         "bldr/manifest/builder/controller/config.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/manifest/builder/controller/config.proto"
-      ]
+      "protoFiles": ["bldr/manifest/builder/controller/config.proto"]
     },
     "github.com/s4wave/spacewave/bldr/manifest/fetch/plugin": {
       "hash": "32d55e0fb72d648c0b6b1a6df209d692e58d125e87d68d5888c7c7c74fc96379",
@@ -204,9 +176,7 @@
         "bldr/manifest/fetch/plugin/config.pb.rs",
         "bldr/manifest/fetch/plugin/config.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/manifest/fetch/plugin/config.proto"
-      ]
+      "protoFiles": ["bldr/manifest/fetch/plugin/config.proto"]
     },
     "github.com/s4wave/spacewave/bldr/manifest/fetch/rpc": {
       "hash": "4d23d92582603f022c9672ff482c3c637e476454f088bb481d03ef19aed4f7df",
@@ -217,9 +187,7 @@
         "bldr/manifest/fetch/rpc/config.pb.rs",
         "bldr/manifest/fetch/rpc/config.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/manifest/fetch/rpc/config.proto"
-      ]
+      "protoFiles": ["bldr/manifest/fetch/rpc/config.proto"]
     },
     "github.com/s4wave/spacewave/bldr/manifest/fetch/world": {
       "hash": "e47753c24d180e1056e0b9418793c156882254aed761cf71df4c7f63cdf341c1",
@@ -230,9 +198,7 @@
         "bldr/manifest/fetch/world/config.pb.rs",
         "bldr/manifest/fetch/world/config.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/manifest/fetch/world/config.proto"
-      ]
+      "protoFiles": ["bldr/manifest/fetch/world/config.proto"]
     },
     "github.com/s4wave/spacewave/bldr/manifest/pack": {
       "hash": "fcb522142c11ec696baca5d8aedcba93eab742bc3bfb9889b58e75651a5d0c4c",
@@ -243,9 +209,7 @@
         "bldr/manifest/pack/metadata.pb.rs",
         "bldr/manifest/pack/metadata.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/manifest/pack/metadata.proto"
-      ]
+      "protoFiles": ["bldr/manifest/pack/metadata.proto"]
     },
     "github.com/s4wave/spacewave/bldr/manifest/world": {
       "hash": "fcb092bcea518a47c5ab4fdc92a05dd5096920b6360618a74120df95a2d010d8",
@@ -256,9 +220,7 @@
         "bldr/manifest/world/world.pb.rs",
         "bldr/manifest/world/world.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/manifest/world/world.proto"
-      ]
+      "protoFiles": ["bldr/manifest/world/world.proto"]
     },
     "github.com/s4wave/spacewave/bldr/plugin": {
       "hash": "0d8c46e08af376ce9592dee7e6810298a640cf5d1c7b0052160542eede9f4264",
@@ -272,9 +234,7 @@
         "bldr/plugin/plugin_srpc.pb.rs",
         "bldr/plugin/plugin_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/plugin/plugin.proto"
-      ]
+      "protoFiles": ["bldr/plugin/plugin.proto"]
     },
     "github.com/s4wave/spacewave/bldr/plugin/assets/http": {
       "hash": "75bcb9120da6b47bf8694ad9ae54824bebe75534b3ffc378797232c986f99a25",
@@ -285,9 +245,7 @@
         "bldr/plugin/assets/http/config.pb.rs",
         "bldr/plugin/assets/http/config.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/plugin/assets/http/config.proto"
-      ]
+      "protoFiles": ["bldr/plugin/assets/http/config.proto"]
     },
     "github.com/s4wave/spacewave/bldr/plugin/compiler/go": {
       "hash": "1938fc258a2e921e0cceebc80047f966b65d4cbe05c6e1b486d665f32f11457b",
@@ -298,9 +256,7 @@
         "bldr/plugin/compiler/go/compiler.pb.rs",
         "bldr/plugin/compiler/go/compiler.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/plugin/compiler/go/compiler.proto"
-      ]
+      "protoFiles": ["bldr/plugin/compiler/go/compiler.proto"]
     },
     "github.com/s4wave/spacewave/bldr/plugin/compiler/js": {
       "hash": "510010b3bb7f3fbd2d1b7aa4b9cc506e90a98b0c89dcb1828edd4bdc963c5de7",
@@ -311,9 +267,7 @@
         "bldr/plugin/compiler/js/compiler.pb.rs",
         "bldr/plugin/compiler/js/compiler.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/plugin/compiler/js/compiler.proto"
-      ]
+      "protoFiles": ["bldr/plugin/compiler/js/compiler.proto"]
     },
     "github.com/s4wave/spacewave/bldr/plugin/forward-lookup-block": {
       "hash": "db2fff282591f30b03caed95210bfcf3467940c553454f19ea68f08fbe33df95",
@@ -324,9 +278,7 @@
         "bldr/plugin/forward-lookup-block/config.pb.rs",
         "bldr/plugin/forward-lookup-block/config.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/plugin/forward-lookup-block/config.proto"
-      ]
+      "protoFiles": ["bldr/plugin/forward-lookup-block/config.proto"]
     },
     "github.com/s4wave/spacewave/bldr/plugin/forward-rpc-service": {
       "hash": "555f43989fae22a7901168fa1790ef5a06eef8e5f9f92bd391d813eeb24121d8",
@@ -337,9 +289,7 @@
         "bldr/plugin/forward-rpc-service/config.pb.rs",
         "bldr/plugin/forward-rpc-service/config.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/plugin/forward-rpc-service/config.proto"
-      ]
+      "protoFiles": ["bldr/plugin/forward-rpc-service/config.proto"]
     },
     "github.com/s4wave/spacewave/bldr/plugin/handle-web-view": {
       "hash": "df2807f9e9d948aed534c68ce5c94d7d371d8f1de12154c70da2ff0bbeae59d0",
@@ -350,9 +300,7 @@
         "bldr/plugin/handle-web-view/config.pb.rs",
         "bldr/plugin/handle-web-view/config.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/plugin/handle-web-view/config.proto"
-      ]
+      "protoFiles": ["bldr/plugin/handle-web-view/config.proto"]
     },
     "github.com/s4wave/spacewave/bldr/plugin/host/configset": {
       "hash": "9609ec6dbe478499f92cac61b7a22f1825c1b120b27e5e2108abbafb3bdf9fbc",
@@ -363,9 +311,7 @@
         "bldr/plugin/host/configset/config.pb.rs",
         "bldr/plugin/host/configset/config.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/plugin/host/configset/config.proto"
-      ]
+      "protoFiles": ["bldr/plugin/host/configset/config.proto"]
     },
     "github.com/s4wave/spacewave/bldr/plugin/host/logs": {
       "hash": "3214612d49d35f92b13e311e00a337752f62f6c19137a694a532ef1045523bc4",
@@ -376,9 +322,7 @@
         "bldr/plugin/host/logs/logs.pb.rs",
         "bldr/plugin/host/logs/logs.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/plugin/host/logs/logs.proto"
-      ]
+      "protoFiles": ["bldr/plugin/host/logs/logs.proto"]
     },
     "github.com/s4wave/spacewave/bldr/plugin/host/process": {
       "hash": "777f640773172648118f4515536376e9bca7efe88948bd86d2e627f18b909b56",
@@ -389,12 +333,10 @@
         "bldr/plugin/host/process/config.pb.rs",
         "bldr/plugin/host/process/config.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/plugin/host/process/config.proto"
-      ]
+      "protoFiles": ["bldr/plugin/host/process/config.proto"]
     },
     "github.com/s4wave/spacewave/bldr/plugin/host/scheduler": {
-      "hash": "a09728be2344b8c47ee4b851d175ca23a1495e7ec6870933df364b835b9167f1",
+      "hash": "95d5e1c13103d5176131cb2c612c493b33af46154228fb8380d9117e5e78dc75",
       "generatedFiles": [
         "bldr/plugin/host/scheduler/config.pb.cc",
         "bldr/plugin/host/scheduler/config.pb.go",
@@ -402,9 +344,7 @@
         "bldr/plugin/host/scheduler/config.pb.rs",
         "bldr/plugin/host/scheduler/config.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/plugin/host/scheduler/config.proto"
-      ]
+      "protoFiles": ["bldr/plugin/host/scheduler/config.proto"]
     },
     "github.com/s4wave/spacewave/bldr/plugin/host/storage/volume": {
       "hash": "51002cccd69a7e9c352e2dab0d0558bcf63c7485b753faf29bdccf904c8def3c",
@@ -415,9 +355,7 @@
         "bldr/plugin/host/storage/volume/config.pb.rs",
         "bldr/plugin/host/storage/volume/config.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/plugin/host/storage/volume/config.proto"
-      ]
+      "protoFiles": ["bldr/plugin/host/storage/volume/config.proto"]
     },
     "github.com/s4wave/spacewave/bldr/plugin/host/wazero-quickjs": {
       "hash": "87b6a455ad439d51a7f208fe5828665fa52803afdb6156762bdca0a1cd710761",
@@ -428,9 +366,7 @@
         "bldr/plugin/host/wazero-quickjs/config.pb.rs",
         "bldr/plugin/host/wazero-quickjs/config.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/plugin/host/wazero-quickjs/config.proto"
-      ]
+      "protoFiles": ["bldr/plugin/host/wazero-quickjs/config.proto"]
     },
     "github.com/s4wave/spacewave/bldr/plugin/host/web": {
       "hash": "f2f9fffbb2958baa269398b58ed14817d53810c1fb564ece538ee7d3b6031b04",
@@ -441,9 +377,7 @@
         "bldr/plugin/host/web/config.pb.rs",
         "bldr/plugin/host/web/config.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/plugin/host/web/config.proto"
-      ]
+      "protoFiles": ["bldr/plugin/host/web/config.proto"]
     },
     "github.com/s4wave/spacewave/bldr/plugin/load": {
       "hash": "52774f58155e02f5d6da952f2962c57cd4407629027e89d2a0963ba54c81e6b6",
@@ -454,9 +388,7 @@
         "bldr/plugin/load/config.pb.rs",
         "bldr/plugin/load/config.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/plugin/load/config.proto"
-      ]
+      "protoFiles": ["bldr/plugin/load/config.proto"]
     },
     "github.com/s4wave/spacewave/bldr/plugin/vardef": {
       "hash": "11fc63019a50adde683cea403d4ceef8655ac5cda8cc31f157154305d6ddd5d3",
@@ -467,9 +399,7 @@
         "bldr/plugin/vardef/vardef.pb.rs",
         "bldr/plugin/vardef/vardef.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/plugin/vardef/vardef.proto"
-      ]
+      "protoFiles": ["bldr/plugin/vardef/vardef.proto"]
     },
     "github.com/s4wave/spacewave/bldr/project": {
       "hash": "20b11a2abe357fdb0aa12a5798c24090916e9b8fc40e44bcc0f78e2647d9eb3c",
@@ -480,9 +410,7 @@
         "bldr/project/project.pb.rs",
         "bldr/project/project.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/project/project.proto"
-      ]
+      "protoFiles": ["bldr/project/project.proto"]
     },
     "github.com/s4wave/spacewave/bldr/project/controller": {
       "hash": "2c30f73e47cf49779c7f1c21537b2c527d321272eb33b92ad6e5640e7aa867ea",
@@ -493,9 +421,7 @@
         "bldr/project/controller/config.pb.rs",
         "bldr/project/controller/config.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/project/controller/config.proto"
-      ]
+      "protoFiles": ["bldr/project/controller/config.proto"]
     },
     "github.com/s4wave/spacewave/bldr/project/watcher": {
       "hash": "d5512405dc7e19374f75c2d38e2ef20c5aee6b224ff0e55c4d3304351258a226",
@@ -506,9 +432,7 @@
         "bldr/project/watcher/watcher.pb.rs",
         "bldr/project/watcher/watcher.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/project/watcher/watcher.proto"
-      ]
+      "protoFiles": ["bldr/project/watcher/watcher.proto"]
     },
     "github.com/s4wave/spacewave/bldr/prototypes/simple/app": {
       "hash": "911b75c8b67a49225806bdc3da0b9337bbe543939968a891988b4b0b91e3c44d",
@@ -519,9 +443,7 @@
         "bldr/prototypes/simple/app/app.pb.rs",
         "bldr/prototypes/simple/app/app.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/prototypes/simple/app/app.proto"
-      ]
+      "protoFiles": ["bldr/prototypes/simple/app/app.proto"]
     },
     "github.com/s4wave/spacewave/bldr/prototypes/webworker-rpcstream/app1": {
       "hash": "f5a8f3d426826f2c1d2b52137f9d8b44557c403dd1a7cca4f573db331f52427a",
@@ -532,9 +454,7 @@
         "bldr/prototypes/webworker-rpcstream/app1/app1.pb.rs",
         "bldr/prototypes/webworker-rpcstream/app1/app1.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/prototypes/webworker-rpcstream/app1/app1.proto"
-      ]
+      "protoFiles": ["bldr/prototypes/webworker-rpcstream/app1/app1.proto"]
     },
     "github.com/s4wave/spacewave/bldr/prototypes/webworker-rpcstream/app2": {
       "hash": "761a90d4571c6dd773be0199314c7c7f51ded2417a783705a8fbc82db8a9ed19",
@@ -545,9 +465,7 @@
         "bldr/prototypes/webworker-rpcstream/app2/app2.pb.rs",
         "bldr/prototypes/webworker-rpcstream/app2/app2.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/prototypes/webworker-rpcstream/app2/app2.proto"
-      ]
+      "protoFiles": ["bldr/prototypes/webworker-rpcstream/app2/app2.proto"]
     },
     "github.com/s4wave/spacewave/bldr/prototypes/webworker-rpcstream/common": {
       "hash": "0c0eb1bf6d3c64fd9a70b1a8a5ae6a31b251009ee5750e82bf6299d9e61d2629",
@@ -561,9 +479,7 @@
         "bldr/prototypes/webworker-rpcstream/common/common_srpc.pb.rs",
         "bldr/prototypes/webworker-rpcstream/common/common_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/prototypes/webworker-rpcstream/common/common.proto"
-      ]
+      "protoFiles": ["bldr/prototypes/webworker-rpcstream/common/common.proto"]
     },
     "github.com/s4wave/spacewave/bldr/resource": {
       "hash": "f4de2b07dcd957290cf08428f3e8b8369068b7431d6a6450a88c40a36972856a",
@@ -578,9 +494,7 @@
         "bldr/resource/resource_srpc.pb.rs",
         "bldr/resource/resource_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/resource/resource.proto"
-      ]
+      "protoFiles": ["bldr/resource/resource.proto"]
     },
     "github.com/s4wave/spacewave/bldr/resource/state": {
       "hash": "ce4e11ad2570425c9b43857850ee38ed0f00625773308dd6d9d9e9df8a6d7f25",
@@ -594,9 +508,7 @@
         "bldr/resource/state/state_srpc.pb.rs",
         "bldr/resource/state/state_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/resource/state/state.proto"
-      ]
+      "protoFiles": ["bldr/resource/state/state.proto"]
     },
     "github.com/s4wave/spacewave/bldr/sdk/plugin/host": {
       "hash": "d9b0c7555d2c74157360ccea6c6db5f15fa5992f339b458c2bab01154a794b51",
@@ -611,9 +523,7 @@
         "bldr/sdk/plugin/host/host_srpc.pb.rs",
         "bldr/sdk/plugin/host/host_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/sdk/plugin/host/host.proto"
-      ]
+      "protoFiles": ["bldr/sdk/plugin/host/host.proto"]
     },
     "github.com/s4wave/spacewave/bldr/storage": {
       "hash": "b82cf006e731e1578779799a75e8730af6914b939f0702447420742fdb8a4277",
@@ -624,9 +534,7 @@
         "bldr/storage/runtime.pb.rs",
         "bldr/storage/runtime.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/storage/runtime.proto"
-      ]
+      "protoFiles": ["bldr/storage/runtime.proto"]
     },
     "github.com/s4wave/spacewave/bldr/storage/default": {
       "hash": "833ff35170eaf2170447ba2be9163206513ad27570d47355c19dc2f7bd8259ad",
@@ -637,9 +545,7 @@
         "bldr/storage/default/config.pb.rs",
         "bldr/storage/default/config.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/storage/default/config.proto"
-      ]
+      "protoFiles": ["bldr/storage/default/config.proto"]
     },
     "github.com/s4wave/spacewave/bldr/storage/volume": {
       "hash": "bc0ac8b77cdc43adb9fa3a1c6981eb8aa38d46d6e9aaf7eea1551347977a58f1",
@@ -650,9 +556,7 @@
         "bldr/storage/volume/config.pb.rs",
         "bldr/storage/volume/config.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/storage/volume/config.proto"
-      ]
+      "protoFiles": ["bldr/storage/volume/config.proto"]
     },
     "github.com/s4wave/spacewave/bldr/web/bundler": {
       "hash": "a1427fd54fcf839f2fdd0eb6525aca8974363fcd96404fa6eaf18208972a7e0c",
@@ -663,9 +567,7 @@
         "bldr/web/bundler/bundler.pb.rs",
         "bldr/web/bundler/bundler.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/web/bundler/bundler.proto"
-      ]
+      "protoFiles": ["bldr/web/bundler/bundler.proto"]
     },
     "github.com/s4wave/spacewave/bldr/web/bundler/esbuild": {
       "hash": "8702f23e985f5cf8ad9a2d20f5b05f238f95ade5f637feb3bc3ff4caa963eaf0",
@@ -676,9 +578,7 @@
         "bldr/web/bundler/esbuild/esbuild.pb.rs",
         "bldr/web/bundler/esbuild/esbuild.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/web/bundler/esbuild/esbuild.proto"
-      ]
+      "protoFiles": ["bldr/web/bundler/esbuild/esbuild.proto"]
     },
     "github.com/s4wave/spacewave/bldr/web/bundler/esbuild/compiler": {
       "hash": "b8d6206716413bb644f7eaa3f4b2804d68b79f66327387ba095bd3626b6b83cb",
@@ -689,9 +589,7 @@
         "bldr/web/bundler/esbuild/compiler/compiler.pb.rs",
         "bldr/web/bundler/esbuild/compiler/compiler.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/web/bundler/esbuild/compiler/compiler.proto"
-      ]
+      "protoFiles": ["bldr/web/bundler/esbuild/compiler/compiler.proto"]
     },
     "github.com/s4wave/spacewave/bldr/web/bundler/vite": {
       "hash": "edc873f8e12b0f18b9b9a6f55c1d872a1f12453b04add1c83183c97df6a2f1b4",
@@ -705,9 +603,7 @@
         "bldr/web/bundler/vite/vite_srpc.pb.rs",
         "bldr/web/bundler/vite/vite_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/web/bundler/vite/vite.proto"
-      ]
+      "protoFiles": ["bldr/web/bundler/vite/vite.proto"]
     },
     "github.com/s4wave/spacewave/bldr/web/bundler/vite/compiler": {
       "hash": "17f258710775e45c8d34137aab7f56c66dca2adf00356782412d8293953686f8",
@@ -718,9 +614,7 @@
         "bldr/web/bundler/vite/compiler/compiler.pb.rs",
         "bldr/web/bundler/vite/compiler/compiler.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/web/bundler/vite/compiler/compiler.proto"
-      ]
+      "protoFiles": ["bldr/web/bundler/vite/compiler/compiler.proto"]
     },
     "github.com/s4wave/spacewave/bldr/web/document": {
       "hash": "9ca801db48dec38b8c166f33335ee9af77348ee222f14829d415e3eb4cffa0d4",
@@ -734,9 +628,7 @@
         "bldr/web/document/document_srpc.pb.rs",
         "bldr/web/document/document_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/web/document/document.proto"
-      ]
+      "protoFiles": ["bldr/web/document/document.proto"]
     },
     "github.com/s4wave/spacewave/bldr/web/electron/desktop-runtime": {
       "hash": "ff97834d197ae82e0e3df89eef874304ae4fe8d1bf7d1953eb5aadd0a3ada88b",
@@ -750,9 +642,7 @@
         "bldr/web/electron/desktop-runtime/desktop-runtime_srpc.pb.rs",
         "bldr/web/electron/desktop-runtime/desktop-runtime_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/web/electron/desktop-runtime/desktop-runtime.proto"
-      ]
+      "protoFiles": ["bldr/web/electron/desktop-runtime/desktop-runtime.proto"]
     },
     "github.com/s4wave/spacewave/bldr/web/entrypoint/browser": {
       "hash": "6db81bbd7cf2834896cfea4fb88fff90292cefd42ae0c76e216b73492d149ed8",
@@ -763,9 +653,7 @@
         "bldr/web/entrypoint/browser/browser.pb.rs",
         "bldr/web/entrypoint/browser/browser.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/web/entrypoint/browser/browser.proto"
-      ]
+      "protoFiles": ["bldr/web/entrypoint/browser/browser.proto"]
     },
     "github.com/s4wave/spacewave/bldr/web/fetch": {
       "hash": "a6af469ad4130039cbaaec92d8e92cee37917f24bd8cc702eec6bee56e5b5ce6",
@@ -779,9 +667,7 @@
         "bldr/web/fetch/fetch_srpc.pb.rs",
         "bldr/web/fetch/fetch_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/web/fetch/fetch.proto"
-      ]
+      "protoFiles": ["bldr/web/fetch/fetch.proto"]
     },
     "github.com/s4wave/spacewave/bldr/web/fetch/service": {
       "hash": "7384b6be4b8437b6ff781bd0ddd01655cd5ce0e51f5cf755a05c6109794f580a",
@@ -792,9 +678,7 @@
         "bldr/web/fetch/service/config.pb.rs",
         "bldr/web/fetch/service/config.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/web/fetch/service/config.proto"
-      ]
+      "protoFiles": ["bldr/web/fetch/service/config.proto"]
     },
     "github.com/s4wave/spacewave/bldr/web/pkg": {
       "hash": "b86c32fb4388d21b81181fbebfbef06a90a4914f20de73e10f41b03b233f4ffe",
@@ -805,9 +689,7 @@
         "bldr/web/pkg/pkg.pb.rs",
         "bldr/web/pkg/pkg.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/web/pkg/pkg.proto"
-      ]
+      "protoFiles": ["bldr/web/pkg/pkg.proto"]
     },
     "github.com/s4wave/spacewave/bldr/web/pkg/compiler": {
       "hash": "867c73a301ad34f89f692bebc4ee19490bf0344d1b253c0929ace50fa32924d5",
@@ -818,9 +700,7 @@
         "bldr/web/pkg/compiler/config.pb.rs",
         "bldr/web/pkg/compiler/config.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/web/pkg/compiler/config.proto"
-      ]
+      "protoFiles": ["bldr/web/pkg/compiler/config.proto"]
     },
     "github.com/s4wave/spacewave/bldr/web/pkg/fs/controller": {
       "hash": "74202e4de8dd43e572e7f0010d5f74712fbc7b6bd9d79061e74488605de2e5c0",
@@ -831,9 +711,7 @@
         "bldr/web/pkg/fs/controller/config.pb.rs",
         "bldr/web/pkg/fs/controller/config.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/web/pkg/fs/controller/config.proto"
-      ]
+      "protoFiles": ["bldr/web/pkg/fs/controller/config.proto"]
     },
     "github.com/s4wave/spacewave/bldr/web/pkg/rpc": {
       "hash": "84cc3d9edc1a9cd52db81f48f533791ee9c7c49386718b744b646eb953566e5c",
@@ -847,9 +725,7 @@
         "bldr/web/pkg/rpc/rpc_srpc.pb.rs",
         "bldr/web/pkg/rpc/rpc_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/web/pkg/rpc/rpc.proto"
-      ]
+      "protoFiles": ["bldr/web/pkg/rpc/rpc.proto"]
     },
     "github.com/s4wave/spacewave/bldr/web/pkg/rpc/client": {
       "hash": "06df7b688a267fbcd2d81f2402b3e1a644576704b4f75b156d21ecc87dc5832a",
@@ -860,9 +736,7 @@
         "bldr/web/pkg/rpc/client/config.pb.rs",
         "bldr/web/pkg/rpc/client/config.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/web/pkg/rpc/client/config.proto"
-      ]
+      "protoFiles": ["bldr/web/pkg/rpc/client/config.proto"]
     },
     "github.com/s4wave/spacewave/bldr/web/pkg/rpc/server": {
       "hash": "039039caedf2327e7a52da4e49f01dadfef5b9fbe32b08f2c05200268d687684",
@@ -873,9 +747,7 @@
         "bldr/web/pkg/rpc/server/config.pb.rs",
         "bldr/web/pkg/rpc/server/config.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/web/pkg/rpc/server/config.proto"
-      ]
+      "protoFiles": ["bldr/web/pkg/rpc/server/config.proto"]
     },
     "github.com/s4wave/spacewave/bldr/web/plugin": {
       "hash": "3672aedc3b745a567350c232cebf04856906dea5a2e113500879ce295d194b94",
@@ -889,9 +761,7 @@
         "bldr/web/plugin/plugin_srpc.pb.rs",
         "bldr/web/plugin/plugin_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/web/plugin/plugin.proto"
-      ]
+      "protoFiles": ["bldr/web/plugin/plugin.proto"]
     },
     "github.com/s4wave/spacewave/bldr/web/plugin/browser": {
       "hash": "329c7f9ed8dfa321d859c0b89773c71b88a2795e1d5075a6a252893661ceac82",
@@ -905,9 +775,7 @@
         "bldr/web/plugin/browser/browser_srpc.pb.rs",
         "bldr/web/plugin/browser/browser_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/web/plugin/browser/browser.proto"
-      ]
+      "protoFiles": ["bldr/web/plugin/browser/browser.proto"]
     },
     "github.com/s4wave/spacewave/bldr/web/plugin/browser/controller": {
       "hash": "3e6a43625f5d3d13ccac0d6242fb4efe906f13032063856b61fc5d41c194b38d",
@@ -918,9 +786,7 @@
         "bldr/web/plugin/browser/controller/config.pb.rs",
         "bldr/web/plugin/browser/controller/config.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/web/plugin/browser/controller/config.proto"
-      ]
+      "protoFiles": ["bldr/web/plugin/browser/controller/config.proto"]
     },
     "github.com/s4wave/spacewave/bldr/web/plugin/compiler": {
       "hash": "b9261c6635ee4bf2cf71669c98ea01fa994d81d7b1adc7bcdf913ad9d952d7fc",
@@ -931,9 +797,7 @@
         "bldr/web/plugin/compiler/config.pb.rs",
         "bldr/web/plugin/compiler/config.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/web/plugin/compiler/config.proto"
-      ]
+      "protoFiles": ["bldr/web/plugin/compiler/config.proto"]
     },
     "github.com/s4wave/spacewave/bldr/web/plugin/controller": {
       "hash": "8e3517bae21a139aac2ebcee7e1cadbed3e5b7adbf8e90b9c9bcd7c559c3ee67",
@@ -944,9 +808,7 @@
         "bldr/web/plugin/controller/config.pb.rs",
         "bldr/web/plugin/controller/config.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/web/plugin/controller/config.proto"
-      ]
+      "protoFiles": ["bldr/web/plugin/controller/config.proto"]
     },
     "github.com/s4wave/spacewave/bldr/web/plugin/electron": {
       "hash": "b0094817d815c20ec58ca34b5a70a6c35eca50595f60a2d0e105394d2d139fef",
@@ -957,9 +819,7 @@
         "bldr/web/plugin/electron/electron.pb.rs",
         "bldr/web/plugin/electron/electron.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/web/plugin/electron/electron.proto"
-      ]
+      "protoFiles": ["bldr/web/plugin/electron/electron.proto"]
     },
     "github.com/s4wave/spacewave/bldr/web/plugin/handle-rpc": {
       "hash": "9a2e6e26e30858c508b7cb93f073dfbe7437f07a6df43161b2362b73accd35ca",
@@ -970,9 +830,7 @@
         "bldr/web/plugin/handle-rpc/config.pb.rs",
         "bldr/web/plugin/handle-rpc/config.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/web/plugin/handle-rpc/config.proto"
-      ]
+      "protoFiles": ["bldr/web/plugin/handle-rpc/config.proto"]
     },
     "github.com/s4wave/spacewave/bldr/web/plugin/handle-web-pkg-assets": {
       "hash": "ffa45d670a96c6e5d60fca8c1e997e3df5107e6469bf749f0d91ff128d888815",
@@ -983,9 +841,7 @@
         "bldr/web/plugin/handle-web-pkg-assets/config.pb.rs",
         "bldr/web/plugin/handle-web-pkg-assets/config.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/web/plugin/handle-web-pkg-assets/config.proto"
-      ]
+      "protoFiles": ["bldr/web/plugin/handle-web-pkg-assets/config.proto"]
     },
     "github.com/s4wave/spacewave/bldr/web/plugin/handle-web-pkg-rpc": {
       "hash": "e35fd704f3a9300fa7d52d1c849e90603b960c89aed00bc540347b867b8a806f",
@@ -996,9 +852,7 @@
         "bldr/web/plugin/handle-web-pkg-rpc/config.pb.rs",
         "bldr/web/plugin/handle-web-pkg-rpc/config.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/web/plugin/handle-web-pkg-rpc/config.proto"
-      ]
+      "protoFiles": ["bldr/web/plugin/handle-web-pkg-rpc/config.proto"]
     },
     "github.com/s4wave/spacewave/bldr/web/plugin/handle-web-view-rpc": {
       "hash": "55fb1028b2e6a123eac3fb357010e81910366bbb3a9ff6ef6d8a8f850f83a415",
@@ -1009,9 +863,7 @@
         "bldr/web/plugin/handle-web-view-rpc/config.pb.rs",
         "bldr/web/plugin/handle-web-view-rpc/config.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/web/plugin/handle-web-view-rpc/config.proto"
-      ]
+      "protoFiles": ["bldr/web/plugin/handle-web-view-rpc/config.proto"]
     },
     "github.com/s4wave/spacewave/bldr/web/plugin/saucer": {
       "hash": "ae571ce0d32d6dd8b9668ffa163d05fde215c218538b11356113f9dcbfb716be",
@@ -1025,9 +877,7 @@
         "bldr/web/plugin/saucer/saucer_srpc.pb.rs",
         "bldr/web/plugin/saucer/saucer_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/web/plugin/saucer/saucer.proto"
-      ]
+      "protoFiles": ["bldr/web/plugin/saucer/saucer.proto"]
     },
     "github.com/s4wave/spacewave/bldr/web/runtime": {
       "hash": "82c1f498c9d02df52d2aaf8cc4983c387a4f43401b925dc74cf8c9e8d1dd3a11",
@@ -1041,9 +891,7 @@
         "bldr/web/runtime/runtime_srpc.pb.rs",
         "bldr/web/runtime/runtime_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/web/runtime/runtime.proto"
-      ]
+      "protoFiles": ["bldr/web/runtime/runtime.proto"]
     },
     "github.com/s4wave/spacewave/bldr/web/runtime/sw": {
       "hash": "e26b464f88b116c9e2f54d9a1bf4a661ed13d48a4c562cc5643c9f855f95b587",
@@ -1057,9 +905,7 @@
         "bldr/web/runtime/sw/sw_srpc.pb.rs",
         "bldr/web/runtime/sw/sw_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/web/runtime/sw/sw.proto"
-      ]
+      "protoFiles": ["bldr/web/runtime/sw/sw.proto"]
     },
     "github.com/s4wave/spacewave/bldr/web/runtime/wasm": {
       "hash": "b17d993fabfcff4c163967645ee38578641891a42c9c3cedf767a89494f00179",
@@ -1070,9 +916,7 @@
         "bldr/web/runtime/wasm/wasm.pb.rs",
         "bldr/web/runtime/wasm/wasm.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/web/runtime/wasm/wasm.proto"
-      ]
+      "protoFiles": ["bldr/web/runtime/wasm/wasm.proto"]
     },
     "github.com/s4wave/spacewave/bldr/web/view": {
       "hash": "1f67e25171b39faf6c762b35a71a8433d73f3b504c6d8084fdff938ad85de982",
@@ -1086,9 +930,7 @@
         "bldr/web/view/view_srpc.pb.rs",
         "bldr/web/view/view_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/web/view/view.proto"
-      ]
+      "protoFiles": ["bldr/web/view/view.proto"]
     },
     "github.com/s4wave/spacewave/bldr/web/view/handler": {
       "hash": "f94a29b6e7617a82cdbef6f6cbbd272ffb35178ae7b1c93ab5e5498df0382601",
@@ -1120,9 +962,7 @@
         "bldr/web/view/handler/controller/config.pb.rs",
         "bldr/web/view/handler/controller/config.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/web/view/handler/controller/config.proto"
-      ]
+      "protoFiles": ["bldr/web/view/handler/controller/config.proto"]
     },
     "github.com/s4wave/spacewave/bldr/web/view/handler/server": {
       "hash": "5dd7c7d4d66b23762ab681491a73822936fadf60fa53e1b20b22b027f5644200",
@@ -1133,9 +973,7 @@
         "bldr/web/view/handler/server/config.pb.rs",
         "bldr/web/view/handler/server/config.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/web/view/handler/server/config.proto"
-      ]
+      "protoFiles": ["bldr/web/view/handler/server/config.proto"]
     },
     "github.com/s4wave/spacewave/bldr/web/view/observer": {
       "hash": "253acd525c0816b442b4b409c849a4d1904be9983029eb4861562b9551f3c286",
@@ -1146,9 +984,7 @@
         "bldr/web/view/observer/config.pb.rs",
         "bldr/web/view/observer/config.pb.ts"
       ],
-      "protoFiles": [
-        "bldr/web/view/observer/config.proto"
-      ]
+      "protoFiles": ["bldr/web/view/observer/config.proto"]
     },
     "github.com/s4wave/spacewave/core/account/settings": {
       "hash": "52c05de97ce4559a3f53471c41e58b6c6c50afca9d874d1e56a7b83a9a14698c",
@@ -1159,9 +995,7 @@
         "core/account/settings/settings.pb.rs",
         "core/account/settings/settings.pb.ts"
       ],
-      "protoFiles": [
-        "core/account/settings/settings.proto"
-      ]
+      "protoFiles": ["core/account/settings/settings.proto"]
     },
     "github.com/s4wave/spacewave/core/bstore": {
       "hash": "961e3bfad2a3f3e1cfc936bc227c50160ee1c52ddffcfd06182bc1baca2bd26c",
@@ -1172,9 +1006,7 @@
         "core/bstore/bstore.pb.rs",
         "core/bstore/bstore.pb.ts"
       ],
-      "protoFiles": [
-        "core/bstore/bstore.proto"
-      ]
+      "protoFiles": ["core/bstore/bstore.proto"]
     },
     "github.com/s4wave/spacewave/core/bstore/world": {
       "hash": "bff914c004294c4b0248b0faa06366e4eaea7768744d5b8b19a2ec72242d0c40",
@@ -1185,9 +1017,7 @@
         "core/bstore/world/world.pb.rs",
         "core/bstore/world/world.pb.ts"
       ],
-      "protoFiles": [
-        "core/bstore/world/world.proto"
-      ]
+      "protoFiles": ["core/bstore/world/world.proto"]
     },
     "github.com/s4wave/spacewave/core/cdn": {
       "hash": "1676801b8370249512ea0af55c9e85e7cd87f756ac2f1e8782fffb231a420ffc",
@@ -1198,9 +1028,7 @@
         "core/cdn/cdn.pb.rs",
         "core/cdn/cdn.pb.ts"
       ],
-      "protoFiles": [
-        "core/cdn/cdn.proto"
-      ]
+      "protoFiles": ["core/cdn/cdn.proto"]
     },
     "github.com/s4wave/spacewave/core/cdn/bstore/controller": {
       "hash": "b1ad3ce7433986b2d68ed5d6baf93222ccf1b12e4294e3db6bcebd2b1a87e02b",
@@ -1211,9 +1039,7 @@
         "core/cdn/bstore/controller/controller.pb.rs",
         "core/cdn/bstore/controller/controller.pb.ts"
       ],
-      "protoFiles": [
-        "core/cdn/bstore/controller/controller.proto"
-      ]
+      "protoFiles": ["core/cdn/bstore/controller/controller.proto"]
     },
     "github.com/s4wave/spacewave/core/cdn/world/controller": {
       "hash": "41a2075ad6d843e2042c58bbd601b5a51f54b77e33578753e567535b529f0551",
@@ -1224,9 +1050,7 @@
         "core/cdn/world/controller/controller.pb.rs",
         "core/cdn/world/controller/controller.pb.ts"
       ],
-      "protoFiles": [
-        "core/cdn/world/controller/controller.proto"
-      ]
+      "protoFiles": ["core/cdn/world/controller/controller.proto"]
     },
     "github.com/s4wave/spacewave/core/changelog": {
       "hash": "9d399103924a5a2e2b242a214b99d19e18ac6cb1e15b9fd5d7e2926d55000f80",
@@ -1237,9 +1061,7 @@
         "core/changelog/changelog.pb.rs",
         "core/changelog/changelog.pb.ts"
       ],
-      "protoFiles": [
-        "core/changelog/changelog.proto"
-      ]
+      "protoFiles": ["core/changelog/changelog.proto"]
     },
     "github.com/s4wave/spacewave/core/debug/bridge": {
       "hash": "240bfaabed961e9bb83212846449749a1eb789a0b8c1694b090f00dcc5305e6d",
@@ -1250,9 +1072,7 @@
         "core/debug/bridge/config.pb.rs",
         "core/debug/bridge/config.pb.ts"
       ],
-      "protoFiles": [
-        "core/debug/bridge/config.proto"
-      ]
+      "protoFiles": ["core/debug/bridge/config.proto"]
     },
     "github.com/s4wave/spacewave/core/debug/trace": {
       "hash": "317034f906d55ef744eca5534900159a188f4bb88c34207ac0002ae6a71d5a18",
@@ -1263,9 +1083,7 @@
         "core/debug/trace/config.pb.rs",
         "core/debug/trace/config.pb.ts"
       ],
-      "protoFiles": [
-        "core/debug/trace/config.proto"
-      ]
+      "protoFiles": ["core/debug/trace/config.proto"]
     },
     "github.com/s4wave/spacewave/core/device/policy": {
       "hash": "44bf242cf4ff4a6ac21d7bc5c1c199ea99d390a1dd7f27d8a88238d283a40f41",
@@ -1276,9 +1094,7 @@
         "core/device/policy/policy.pb.rs",
         "core/device/policy/policy.pb.ts"
       ],
-      "protoFiles": [
-        "core/device/policy/policy.proto"
-      ]
+      "protoFiles": ["core/device/policy/policy.proto"]
     },
     "github.com/s4wave/spacewave/core/forge/dashboard": {
       "hash": "c99502560a151928f2a0394a26fac3846a7ee8993b27d1db5028ca69940bbfd8",
@@ -1289,9 +1105,7 @@
         "core/forge/dashboard/dashboard.pb.rs",
         "core/forge/dashboard/dashboard.pb.ts"
       ],
-      "protoFiles": [
-        "core/forge/dashboard/dashboard.proto"
-      ]
+      "protoFiles": ["core/forge/dashboard/dashboard.proto"]
     },
     "github.com/s4wave/spacewave/core/forge/exec": {
       "hash": "3228ae0dc700bd344c19e61283ba9e844822ead6914e4e788798fd6089035c87",
@@ -1305,9 +1119,7 @@
         "core/forge/exec/plugin_srpc.pb.rs",
         "core/forge/exec/plugin_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "core/forge/exec/plugin.proto"
-      ]
+      "protoFiles": ["core/forge/exec/plugin.proto"]
     },
     "github.com/s4wave/spacewave/core/forge/job": {
       "hash": "68ed41193d8bdb37d0b7738cec1c6c1db6acf5d53e3a4e6696e8eec6b9ae8b37",
@@ -1318,9 +1130,7 @@
         "core/forge/job/job.pb.rs",
         "core/forge/job/job.pb.ts"
       ],
-      "protoFiles": [
-        "core/forge/job/job.proto"
-      ]
+      "protoFiles": ["core/forge/job/job.proto"]
     },
     "github.com/s4wave/spacewave/core/forge/task": {
       "hash": "68a062c97de23753ed60b721eda3bf072843409880bbfee9fafb21eca878b854",
@@ -1331,9 +1141,7 @@
         "core/forge/task/task.pb.rs",
         "core/forge/task/task.pb.ts"
       ],
-      "protoFiles": [
-        "core/forge/task/task.proto"
-      ]
+      "protoFiles": ["core/forge/task/task.proto"]
     },
     "github.com/s4wave/spacewave/core/git": {
       "hash": "94a4798a2e993ddbce6202817a3fc6a8fc774251985757f2e82c2b3643849fae",
@@ -1344,9 +1152,7 @@
         "core/git/git.pb.rs",
         "core/git/git.pb.ts"
       ],
-      "protoFiles": [
-        "core/git/git.proto"
-      ]
+      "protoFiles": ["core/git/git.proto"]
     },
     "github.com/s4wave/spacewave/core/launcher/helper": {
       "hash": "33403362074735d879e78de3adfd33eaf391c5b1f634de81654a1a422c42dd2c",
@@ -1357,9 +1163,7 @@
         "core/launcher/helper/helper.pb.rs",
         "core/launcher/helper/helper.pb.ts"
       ],
-      "protoFiles": [
-        "core/launcher/helper/helper.proto"
-      ]
+      "protoFiles": ["core/launcher/helper/helper.proto"]
     },
     "github.com/s4wave/spacewave/core/node/world": {
       "hash": "942482bab0085a6a63369e18029f2d01e91b705e8fa45edbc3cb35bf58dfdaba",
@@ -1370,9 +1174,7 @@
         "core/node/world/world.pb.rs",
         "core/node/world/world.pb.ts"
       ],
-      "protoFiles": [
-        "core/node/world/world.proto"
-      ]
+      "protoFiles": ["core/node/world/world.proto"]
     },
     "github.com/s4wave/spacewave/core/plugin/list": {
       "hash": "834c7e539cbe0a10752998980754176effa75e0ee09c1a6c3883f3a92ac6b3c7",
@@ -1383,9 +1185,7 @@
         "core/plugin/list/list.pb.rs",
         "core/plugin/list/list.pb.ts"
       ],
-      "protoFiles": [
-        "core/plugin/list/list.proto"
-      ]
+      "protoFiles": ["core/plugin/list/list.proto"]
     },
     "github.com/s4wave/spacewave/core/plugin/space": {
       "hash": "6de06b652970c3073b62f87556f1b0140494a082b07cda52d26fbb68f0af6d1a",
@@ -1396,9 +1196,7 @@
         "core/plugin/space/config.pb.rs",
         "core/plugin/space/config.pb.ts"
       ],
-      "protoFiles": [
-        "core/plugin/space/config.proto"
-      ]
+      "protoFiles": ["core/plugin/space/config.proto"]
     },
     "github.com/s4wave/spacewave/core/provider": {
       "hash": "61b102930ceaf9896412f50b2d26497e000d20ab0fe8e6acc15dedac3cc1a14b",
@@ -1409,9 +1207,7 @@
         "core/provider/provider.pb.rs",
         "core/provider/provider.pb.ts"
       ],
-      "protoFiles": [
-        "core/provider/provider.proto"
-      ]
+      "protoFiles": ["core/provider/provider.proto"]
     },
     "github.com/s4wave/spacewave/core/provider/local": {
       "hash": "d0ce6674f5d2867a238f696fc0ece00a400e35c3e9e31fbd9b6ac457356eba1b",
@@ -1422,9 +1218,7 @@
         "core/provider/local/local.pb.rs",
         "core/provider/local/local.pb.ts"
       ],
-      "protoFiles": [
-        "core/provider/local/local.proto"
-      ]
+      "protoFiles": ["core/provider/local/local.proto"]
     },
     "github.com/s4wave/spacewave/core/provider/spacewave": {
       "hash": "d53023978a8314f741f55054ec4d62cc205a49a87a2e2840442b1831c2c4c3d1",
@@ -1454,9 +1248,7 @@
         "core/provider/spacewave/api/api.pb.rs",
         "core/provider/spacewave/api/api.pb.ts"
       ],
-      "protoFiles": [
-        "core/provider/spacewave/api/api.proto"
-      ]
+      "protoFiles": ["core/provider/spacewave/api/api.proto"]
     },
     "github.com/s4wave/spacewave/core/provider/spacewave/cacheseed": {
       "hash": "a1f8f621606375510bb4a80fd7a39bdcea7c32c9bbdcbb6957ac59d7a85847fe",
@@ -1470,9 +1262,7 @@
         "core/provider/spacewave/cacheseed/cacheseed_srpc.pb.rs",
         "core/provider/spacewave/cacheseed/cacheseed_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "core/provider/spacewave/cacheseed/cacheseed.proto"
-      ]
+      "protoFiles": ["core/provider/spacewave/cacheseed/cacheseed.proto"]
     },
     "github.com/s4wave/spacewave/core/provider/spacewave/launcher": {
       "hash": "5d8cc05d6180e69fa143b243a514c3870b100094baabde691e7dd2eda411a373",
@@ -1486,9 +1276,7 @@
         "core/provider/spacewave/launcher/launcher_srpc.pb.rs",
         "core/provider/spacewave/launcher/launcher_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "core/provider/spacewave/launcher/launcher.proto"
-      ]
+      "protoFiles": ["core/provider/spacewave/launcher/launcher.proto"]
     },
     "github.com/s4wave/spacewave/core/provider/spacewave/launcher/controller": {
       "hash": "85b826ae10ada3ba51882f5bf663fc745efacf7bcbdb82372a45a19d6d35ecc6",
@@ -1499,9 +1287,7 @@
         "core/provider/spacewave/launcher/controller/config.pb.rs",
         "core/provider/spacewave/launcher/controller/config.pb.ts"
       ],
-      "protoFiles": [
-        "core/provider/spacewave/launcher/controller/config.proto"
-      ]
+      "protoFiles": ["core/provider/spacewave/launcher/controller/config.proto"]
     },
     "github.com/s4wave/spacewave/core/provider/spacewave/loader/controller": {
       "hash": "62c530974d8a49434eb0a16ee2ee17a049ae2b5b8d220735d9788a148ff58e20",
@@ -1512,9 +1298,7 @@
         "core/provider/spacewave/loader/controller/config.pb.rs",
         "core/provider/spacewave/loader/controller/config.pb.ts"
       ],
-      "protoFiles": [
-        "core/provider/spacewave/loader/controller/config.proto"
-      ]
+      "protoFiles": ["core/provider/spacewave/loader/controller/config.proto"]
     },
     "github.com/s4wave/spacewave/core/provider/spacewave/packfile": {
       "hash": "d5f9becfbbf6e772836ade8174846d76fa108d8df1eb51862c2029028f423720",
@@ -1525,9 +1309,7 @@
         "core/provider/spacewave/packfile/packfile.pb.rs",
         "core/provider/spacewave/packfile/packfile.pb.ts"
       ],
-      "protoFiles": [
-        "core/provider/spacewave/packfile/packfile.proto"
-      ]
+      "protoFiles": ["core/provider/spacewave/packfile/packfile.proto"]
     },
     "github.com/s4wave/spacewave/core/provider/spacewave/packfile/order": {
       "hash": "b21b2db0d44fb1d3b358da72e041052e5bdb5ad8471e56dc0950cc9d4a8bc713",
@@ -1538,9 +1320,7 @@
         "core/provider/spacewave/packfile/order/order.pb.rs",
         "core/provider/spacewave/packfile/order/order.pb.ts"
       ],
-      "protoFiles": [
-        "core/provider/spacewave/packfile/order/order.proto"
-      ]
+      "protoFiles": ["core/provider/spacewave/packfile/order/order.proto"]
     },
     "github.com/s4wave/spacewave/core/provider/transfer": {
       "hash": "03c61d4fe8572de99642e96c26a40a740d2589f99f9f14d0eca1ece9d467e054",
@@ -1551,9 +1331,7 @@
         "core/provider/transfer/transfer.pb.rs",
         "core/provider/transfer/transfer.pb.ts"
       ],
-      "protoFiles": [
-        "core/provider/transfer/transfer.proto"
-      ]
+      "protoFiles": ["core/provider/transfer/transfer.proto"]
     },
     "github.com/s4wave/spacewave/core/rbac": {
       "hash": "d979c6757c7dd5f6dbd3e62bb1a53a5b87096e063cc88bfc042d9b1b866d2bf1",
@@ -1564,9 +1342,7 @@
         "core/rbac/rbac.pb.rs",
         "core/rbac/rbac.pb.ts"
       ],
-      "protoFiles": [
-        "core/rbac/rbac.proto"
-      ]
+      "protoFiles": ["core/rbac/rbac.proto"]
     },
     "github.com/s4wave/spacewave/core/release": {
       "hash": "e059ae17072032c35b66f9e13bb50a0bb94a693dc44b21c726d11f3ba6bf9075",
@@ -1577,9 +1353,7 @@
         "core/release/release.pb.rs",
         "core/release/release.pb.ts"
       ],
-      "protoFiles": [
-        "core/release/release.proto"
-      ]
+      "protoFiles": ["core/release/release.proto"]
     },
     "github.com/s4wave/spacewave/core/resource/desktop/statusprojector": {
       "hash": "82d01b51d5ec0182f9aac5e5a92b5ab3f148f019f1717666616cbe097425abbc",
@@ -1590,9 +1364,7 @@
         "core/resource/desktop/statusprojector/config.pb.rs",
         "core/resource/desktop/statusprojector/config.pb.ts"
       ],
-      "protoFiles": [
-        "core/resource/desktop/statusprojector/config.proto"
-      ]
+      "protoFiles": ["core/resource/desktop/statusprojector/config.proto"]
     },
     "github.com/s4wave/spacewave/core/resource/listener": {
       "hash": "8a6d54b944a2eddb756ebd93777c947dbc833c51aadea479f59f175a5b6aab68",
@@ -1603,9 +1375,7 @@
         "core/resource/listener/config.pb.rs",
         "core/resource/listener/config.pb.ts"
       ],
-      "protoFiles": [
-        "core/resource/listener/config.proto"
-      ]
+      "protoFiles": ["core/resource/listener/config.proto"]
     },
     "github.com/s4wave/spacewave/core/resource/root/controller": {
       "hash": "8d3ec1f91e0c66cc6b7a159f4b42499fc3ef12498aa97ac493626b2b75b5757a",
@@ -1616,9 +1386,7 @@
         "core/resource/root/controller/config.pb.rs",
         "core/resource/root/controller/config.pb.ts"
       ],
-      "protoFiles": [
-        "core/resource/root/controller/config.proto"
-      ]
+      "protoFiles": ["core/resource/root/controller/config.proto"]
     },
     "github.com/s4wave/spacewave/core/session": {
       "hash": "93cf21953f762a88c5a30f7f1972f936cefe5416167a05af5f3d69deb5313a84",
@@ -1629,9 +1397,7 @@
         "core/session/session.pb.rs",
         "core/session/session.pb.ts"
       ],
-      "protoFiles": [
-        "core/session/session.proto"
-      ]
+      "protoFiles": ["core/session/session.proto"]
     },
     "github.com/s4wave/spacewave/core/session/controller": {
       "hash": "45a86ee9e72e55268de31144ab7897068e792e3b25671b53d82a1fce8d99475e",
@@ -1642,9 +1408,7 @@
         "core/session/controller/config.pb.rs",
         "core/session/controller/config.pb.ts"
       ],
-      "protoFiles": [
-        "core/session/controller/config.proto"
-      ]
+      "protoFiles": ["core/session/controller/config.proto"]
     },
     "github.com/s4wave/spacewave/core/session/handoff": {
       "hash": "fb7339442f52c2ede8e0883947293a79f035a87ab1b78367cbce9b04870be289",
@@ -1655,9 +1419,7 @@
         "core/session/handoff/handoff.pb.rs",
         "core/session/handoff/handoff.pb.ts"
       ],
-      "protoFiles": [
-        "core/session/handoff/handoff.proto"
-      ]
+      "protoFiles": ["core/session/handoff/handoff.proto"]
     },
     "github.com/s4wave/spacewave/core/sobject": {
       "hash": "fa5895f6018937523748b446f72a765eff9958a36fa4e01cdd80c32bdc7c49d8",
@@ -1668,9 +1430,7 @@
         "core/sobject/sobject.pb.rs",
         "core/sobject/sobject.pb.ts"
       ],
-      "protoFiles": [
-        "core/sobject/sobject.proto"
-      ]
+      "protoFiles": ["core/sobject/sobject.proto"]
     },
     "github.com/s4wave/spacewave/core/sobject/invite": {
       "hash": "980d8b2b717748577bc604f6c0134a25c618244c60da8e63aff850192525b14a",
@@ -1684,9 +1444,7 @@
         "core/sobject/invite/invite_srpc.pb.rs",
         "core/sobject/invite/invite_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "core/sobject/invite/invite.proto"
-      ]
+      "protoFiles": ["core/sobject/invite/invite.proto"]
     },
     "github.com/s4wave/spacewave/core/sobject/sync": {
       "hash": "6f15498689badf5e4e1058464e1403b7bc52f6d5d988a9c0495a7b319b8cbffb",
@@ -1697,9 +1455,7 @@
         "core/sobject/sync/sync.pb.rs",
         "core/sobject/sync/sync.pb.ts"
       ],
-      "protoFiles": [
-        "core/sobject/sync/sync.proto"
-      ]
+      "protoFiles": ["core/sobject/sync/sync.proto"]
     },
     "github.com/s4wave/spacewave/core/sobject/world/engine": {
       "hash": "bf6526f418a58e97fdf57eb47f565a5a5fcf3f7361155f369c937ad6a395db44",
@@ -1710,9 +1466,7 @@
         "core/sobject/world/engine/engine.pb.rs",
         "core/sobject/world/engine/engine.pb.ts"
       ],
-      "protoFiles": [
-        "core/sobject/world/engine/engine.proto"
-      ]
+      "protoFiles": ["core/sobject/world/engine/engine.proto"]
     },
     "github.com/s4wave/spacewave/core/space": {
       "hash": "639b744ddbf93b8219573990c0bd1ea3098610ca84cdcbdd03630be01bb7b251",
@@ -1723,9 +1477,7 @@
         "core/space/space.pb.rs",
         "core/space/space.pb.ts"
       ],
-      "protoFiles": [
-        "core/space/space.proto"
-      ]
+      "protoFiles": ["core/space/space.proto"]
     },
     "github.com/s4wave/spacewave/core/space/http/download": {
       "hash": "13c559129a6148090a3fed45e619f68992e4e290f5962e6555592552b4e3bd2a",
@@ -1736,9 +1488,7 @@
         "core/space/http/download/config.pb.rs",
         "core/space/http/download/config.pb.ts"
       ],
-      "protoFiles": [
-        "core/space/http/download/config.proto"
-      ]
+      "protoFiles": ["core/space/http/download/config.proto"]
     },
     "github.com/s4wave/spacewave/core/space/http/export": {
       "hash": "f2b408f281c05ffade648ae8c3c990614f792e7011332b28c5b23c083b7b27ab",
@@ -1749,9 +1499,7 @@
         "core/space/http/export/config.pb.rs",
         "core/space/http/export/config.pb.ts"
       ],
-      "protoFiles": [
-        "core/space/http/export/config.proto"
-      ]
+      "protoFiles": ["core/space/http/export/config.proto"]
     },
     "github.com/s4wave/spacewave/core/space/migration": {
       "hash": "1aade0fccb6af357e644a0fac4e52ad3ff7589d9c638736c098556e2e928d29f",
@@ -1762,9 +1510,7 @@
         "core/space/migration/migration.pb.rs",
         "core/space/migration/migration.pb.ts"
       ],
-      "protoFiles": [
-        "core/space/migration/migration.proto"
-      ]
+      "protoFiles": ["core/space/migration/migration.proto"]
     },
     "github.com/s4wave/spacewave/core/space/sobject": {
       "hash": "c47a015ba0304c3a3a3dd6ec453c2eb6c77105ead743450a31f8de0c9ac8c1be",
@@ -1775,9 +1521,7 @@
         "core/space/sobject/config.pb.rs",
         "core/space/sobject/config.pb.ts"
       ],
-      "protoFiles": [
-        "core/space/sobject/config.proto"
-      ]
+      "protoFiles": ["core/space/sobject/config.proto"]
     },
     "github.com/s4wave/spacewave/core/space/world": {
       "hash": "5c4a209a5a8db64ab97b62a5d6e3dee5df432c646af58f88346187965d21bc2e",
@@ -1788,9 +1532,7 @@
         "core/space/world/world.pb.rs",
         "core/space/world/world.pb.ts"
       ],
-      "protoFiles": [
-        "core/space/world/world.proto"
-      ]
+      "protoFiles": ["core/space/world/world.proto"]
     },
     "github.com/s4wave/spacewave/core/space/world/ops": {
       "hash": "8af62947c4a3670a8c0401a5816633638951f4477980b922812dcc2c6c936936",
@@ -1801,9 +1543,7 @@
         "core/space/world/ops/ops.pb.rs",
         "core/space/world/ops/ops.pb.ts"
       ],
-      "protoFiles": [
-        "core/space/world/ops/ops.proto"
-      ]
+      "protoFiles": ["core/space/world/ops/ops.proto"]
     },
     "github.com/s4wave/spacewave/core/trace/service": {
       "hash": "08cc1227c38d118eaa335009abc0d940e509700ae6e1c4c29ad9f479c1766529",
@@ -1814,9 +1554,7 @@
         "core/trace/service/config.pb.rs",
         "core/trace/service/config.pb.ts"
       ],
-      "protoFiles": [
-        "core/trace/service/config.proto"
-      ]
+      "protoFiles": ["core/trace/service/config.proto"]
     },
     "github.com/s4wave/spacewave/db/block": {
       "hash": "4c7a96f85400f593c894cb27525f1d6d9ee1baaf9cc6544841b6b22144226fbe",
@@ -1827,9 +1565,7 @@
         "db/block/block.pb.rs",
         "db/block/block.pb.ts"
       ],
-      "protoFiles": [
-        "db/block/block.proto"
-      ]
+      "protoFiles": ["db/block/block.proto"]
     },
     "github.com/s4wave/spacewave/db/block/bitset": {
       "hash": "a1cda932b8b42714e52bc6c8a8b742ea327da856ba46d6fba725ec9ec6e1fd53",
@@ -1840,9 +1576,7 @@
         "db/block/bitset/bitset.pb.rs",
         "db/block/bitset/bitset.pb.ts"
       ],
-      "protoFiles": [
-        "db/block/bitset/bitset.proto"
-      ]
+      "protoFiles": ["db/block/bitset/bitset.proto"]
     },
     "github.com/s4wave/spacewave/db/block/blob": {
       "hash": "fc534802cf2ea6197185cd92a6a8c21f0a8437c3495c26dfdacd802973f608d1",
@@ -1853,9 +1587,7 @@
         "db/block/blob/blob.pb.rs",
         "db/block/blob/blob.pb.ts"
       ],
-      "protoFiles": [
-        "db/block/blob/blob.proto"
-      ]
+      "protoFiles": ["db/block/blob/blob.proto"]
     },
     "github.com/s4wave/spacewave/db/block/bloom": {
       "hash": "7a9dda41bd1b3572c4b05fac4822768baf105bde519a89a87a0e47c41ef854c1",
@@ -1866,9 +1598,7 @@
         "db/block/bloom/bloom.pb.rs",
         "db/block/bloom/bloom.pb.ts"
       ],
-      "protoFiles": [
-        "db/block/bloom/bloom.proto"
-      ]
+      "protoFiles": ["db/block/bloom/bloom.proto"]
     },
     "github.com/s4wave/spacewave/db/block/file": {
       "hash": "9c5e0aa901e2c9ef26a9bf8c91faf958e0655b9ecaec497c9d0341dc5d03f122",
@@ -1879,9 +1609,7 @@
         "db/block/file/file.pb.rs",
         "db/block/file/file.pb.ts"
       ],
-      "protoFiles": [
-        "db/block/file/file.proto"
-      ]
+      "protoFiles": ["db/block/file/file.proto"]
     },
     "github.com/s4wave/spacewave/db/block/filters": {
       "hash": "94b8256ea64f9d8696a6014af8b284229856785123459174f857b0c86f7a70da",
@@ -1892,9 +1620,7 @@
         "db/block/filters/filters.pb.rs",
         "db/block/filters/filters.pb.ts"
       ],
-      "protoFiles": [
-        "db/block/filters/filters.proto"
-      ]
+      "protoFiles": ["db/block/filters/filters.proto"]
     },
     "github.com/s4wave/spacewave/db/block/gc/rpc": {
       "hash": "7a945b1544e24c0a1cf6fc39a546eb49e71ca3c654183b97de91395369f08b3e",
@@ -1908,9 +1634,7 @@
         "db/block/gc/rpc/refgraph_srpc.pb.rs",
         "db/block/gc/rpc/refgraph_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "db/block/gc/rpc/refgraph.proto"
-      ]
+      "protoFiles": ["db/block/gc/rpc/refgraph.proto"]
     },
     "github.com/s4wave/spacewave/db/block/gc/wal": {
       "hash": "823fa611fa27745b60f9804bd7df013d833bba4b603634babe3079ff246b84cb",
@@ -1921,9 +1645,7 @@
         "db/block/gc/wal/wal.pb.rs",
         "db/block/gc/wal/wal.pb.ts"
       ],
-      "protoFiles": [
-        "db/block/gc/wal/wal.proto"
-      ]
+      "protoFiles": ["db/block/gc/wal/wal.proto"]
     },
     "github.com/s4wave/spacewave/db/block/mock": {
       "hash": "bad57a79760d0b54d399ebc14ce8b75fb025105498dfed4ec810c55d728022e9",
@@ -1934,9 +1656,7 @@
         "db/block/mock/mock.pb.rs",
         "db/block/mock/mock.pb.ts"
       ],
-      "protoFiles": [
-        "db/block/mock/mock.proto"
-      ]
+      "protoFiles": ["db/block/mock/mock.proto"]
     },
     "github.com/s4wave/spacewave/db/block/msgpack": {
       "hash": "50c80967340d79fed596620cb8c4d3f5ef8a5cf7c9018928ddc5015b31563f90",
@@ -1947,9 +1667,7 @@
         "db/block/msgpack/msgpack.pb.rs",
         "db/block/msgpack/msgpack.pb.ts"
       ],
-      "protoFiles": [
-        "db/block/msgpack/msgpack.proto"
-      ]
+      "protoFiles": ["db/block/msgpack/msgpack.proto"]
     },
     "github.com/s4wave/spacewave/db/block/quad": {
       "hash": "86e37f56f4809d1b7455a592370ad636db2a1b188fa10c4daa16165435938a39",
@@ -1960,9 +1678,7 @@
         "db/block/quad/quad.pb.rs",
         "db/block/quad/quad.pb.ts"
       ],
-      "protoFiles": [
-        "db/block/quad/quad.proto"
-      ]
+      "protoFiles": ["db/block/quad/quad.proto"]
     },
     "github.com/s4wave/spacewave/db/block/rpc": {
       "hash": "bfdb9bb2883252f93e9e4aae899612db32bdc6dee6b08dd7c005b8aa8d582842",
@@ -1976,9 +1692,7 @@
         "db/block/rpc/block_srpc.pb.rs",
         "db/block/rpc/block_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "db/block/rpc/block.proto"
-      ]
+      "protoFiles": ["db/block/rpc/block.proto"]
     },
     "github.com/s4wave/spacewave/db/block/store/bucket": {
       "hash": "47cb87f159c3dca8cc44b677f96a69c80992409eb58b694407c32a01b41473e6",
@@ -1989,9 +1703,7 @@
         "db/block/store/bucket/config.pb.rs",
         "db/block/store/bucket/config.pb.ts"
       ],
-      "protoFiles": [
-        "db/block/store/bucket/config.proto"
-      ]
+      "protoFiles": ["db/block/store/bucket/config.proto"]
     },
     "github.com/s4wave/spacewave/db/block/store/http": {
       "hash": "97b64d13e6ad1be7c9852ba83930df3b6c22d798744ea21956f147e3be18f3f7",
@@ -2002,9 +1714,7 @@
         "db/block/store/http/http.pb.rs",
         "db/block/store/http/http.pb.ts"
       ],
-      "protoFiles": [
-        "db/block/store/http/http.proto"
-      ]
+      "protoFiles": ["db/block/store/http/http.proto"]
     },
     "github.com/s4wave/spacewave/db/block/store/http/lookup": {
       "hash": "555d41c1bd3350628a22fa6804838c2d5fb2c28ad3f142dfbeec5408a3955c41",
@@ -2015,9 +1725,7 @@
         "db/block/store/http/lookup/lookup.pb.rs",
         "db/block/store/http/lookup/lookup.pb.ts"
       ],
-      "protoFiles": [
-        "db/block/store/http/lookup/lookup.proto"
-      ]
+      "protoFiles": ["db/block/store/http/lookup/lookup.proto"]
     },
     "github.com/s4wave/spacewave/db/block/store/http/server": {
       "hash": "14a64f4ff6cbbf6934b1d72a3e4682be2f64b34bba0134cba033941f9cf5e79a",
@@ -2028,9 +1736,7 @@
         "db/block/store/http/server/config.pb.rs",
         "db/block/store/http/server/config.pb.ts"
       ],
-      "protoFiles": [
-        "db/block/store/http/server/config.proto"
-      ]
+      "protoFiles": ["db/block/store/http/server/config.proto"]
     },
     "github.com/s4wave/spacewave/db/block/store/inmem": {
       "hash": "b7ab0753986e42d79c3fabe0a48c1c572c752c661d549ebb1a11586a0e2c422b",
@@ -2041,9 +1747,7 @@
         "db/block/store/inmem/inmem.pb.rs",
         "db/block/store/inmem/inmem.pb.ts"
       ],
-      "protoFiles": [
-        "db/block/store/inmem/inmem.proto"
-      ]
+      "protoFiles": ["db/block/store/inmem/inmem.proto"]
     },
     "github.com/s4wave/spacewave/db/block/store/kvfile/http": {
       "hash": "410affb79d5b058c13a76448f1bf1502a806d88c6352f48ff14a2cba4667108f",
@@ -2054,9 +1758,7 @@
         "db/block/store/kvfile/http/http.pb.rs",
         "db/block/store/kvfile/http/http.pb.ts"
       ],
-      "protoFiles": [
-        "db/block/store/kvfile/http/http.proto"
-      ]
+      "protoFiles": ["db/block/store/kvfile/http/http.proto"]
     },
     "github.com/s4wave/spacewave/db/block/store/overlay": {
       "hash": "233d491bcbb02a6ac8977bb8ac8c6256c1dc12774babe1003ce83d940192104a",
@@ -2067,9 +1769,7 @@
         "db/block/store/overlay/overlay.pb.rs",
         "db/block/store/overlay/overlay.pb.ts"
       ],
-      "protoFiles": [
-        "db/block/store/overlay/overlay.proto"
-      ]
+      "protoFiles": ["db/block/store/overlay/overlay.proto"]
     },
     "github.com/s4wave/spacewave/db/block/store/redis": {
       "hash": "9fcc9a13a901b8af3c8e7bf97541fb04ccd4a61071d5adb53373793777e7f699",
@@ -2080,9 +1780,7 @@
         "db/block/store/redis/redis.pb.rs",
         "db/block/store/redis/redis.pb.ts"
       ],
-      "protoFiles": [
-        "db/block/store/redis/redis.proto"
-      ]
+      "protoFiles": ["db/block/store/redis/redis.proto"]
     },
     "github.com/s4wave/spacewave/db/block/store/ristretto": {
       "hash": "9c7d28b381f093af518646f29a8b250a49e28612ee6ea8d79e6c7c9390aa7ff1",
@@ -2093,9 +1791,7 @@
         "db/block/store/ristretto/ristretto.pb.rs",
         "db/block/store/ristretto/ristretto.pb.ts"
       ],
-      "protoFiles": [
-        "db/block/store/ristretto/ristretto.proto"
-      ]
+      "protoFiles": ["db/block/store/ristretto/ristretto.proto"]
     },
     "github.com/s4wave/spacewave/db/block/store/rpc": {
       "hash": "b77e689b3f3b74a70f3213317ecbf4cdf1667fd4dd1b834d686c8f1ac2bdd409",
@@ -2106,9 +1802,7 @@
         "db/block/store/rpc/rpc.pb.rs",
         "db/block/store/rpc/rpc.pb.ts"
       ],
-      "protoFiles": [
-        "db/block/store/rpc/rpc.proto"
-      ]
+      "protoFiles": ["db/block/store/rpc/rpc.proto"]
     },
     "github.com/s4wave/spacewave/db/block/store/rpc/lookup": {
       "hash": "f3d56dacfcded21d78713db47c4086200b331bb7a823087ecb23d244b9451441",
@@ -2119,9 +1813,7 @@
         "db/block/store/rpc/lookup/lookup.pb.rs",
         "db/block/store/rpc/lookup/lookup.pb.ts"
       ],
-      "protoFiles": [
-        "db/block/store/rpc/lookup/lookup.proto"
-      ]
+      "protoFiles": ["db/block/store/rpc/lookup/lookup.proto"]
     },
     "github.com/s4wave/spacewave/db/block/store/rpc/server": {
       "hash": "48737e21312733adf50a4d9f55a37e1fad39b3b1e3ac1e33158e95177bda40d7",
@@ -2132,9 +1824,7 @@
         "db/block/store/rpc/server/config.pb.rs",
         "db/block/store/rpc/server/config.pb.ts"
       ],
-      "protoFiles": [
-        "db/block/store/rpc/server/config.proto"
-      ]
+      "protoFiles": ["db/block/store/rpc/server/config.proto"]
     },
     "github.com/s4wave/spacewave/db/block/store/rpc/server/bucket": {
       "hash": "ca1451bdd6543037838622711e62b0bc9fd65ac80cfdd30375cce4dee31d360f",
@@ -2145,9 +1835,7 @@
         "db/block/store/rpc/server/bucket/config.pb.rs",
         "db/block/store/rpc/server/bucket/config.pb.ts"
       ],
-      "protoFiles": [
-        "db/block/store/rpc/server/bucket/config.proto"
-      ]
+      "protoFiles": ["db/block/store/rpc/server/bucket/config.proto"]
     },
     "github.com/s4wave/spacewave/db/block/store/s3": {
       "hash": "b7231d148e41d2f425144d20d2120182239203e6b8e1fc79b2c3e566f0167efc",
@@ -2158,9 +1846,7 @@
         "db/block/store/s3/s3.pb.rs",
         "db/block/store/s3/s3.pb.ts"
       ],
-      "protoFiles": [
-        "db/block/store/s3/s3.proto"
-      ]
+      "protoFiles": ["db/block/store/s3/s3.proto"]
     },
     "github.com/s4wave/spacewave/db/block/store/s3/lookup": {
       "hash": "a26a6ee8ebfe3bb7965b7fec49cec1af39301ca9b589cd7121904ccf7f186e10",
@@ -2171,9 +1857,7 @@
         "db/block/store/s3/lookup/lookup.pb.rs",
         "db/block/store/s3/lookup/lookup.pb.ts"
       ],
-      "protoFiles": [
-        "db/block/store/s3/lookup/lookup.proto"
-      ]
+      "protoFiles": ["db/block/store/s3/lookup/lookup.proto"]
     },
     "github.com/s4wave/spacewave/db/block/transform": {
       "hash": "2ed62cdc77c7a9cc8f3667ba01115d10254e11fd64f4398d0ef9a2fa66eef84d",
@@ -2184,9 +1868,7 @@
         "db/block/transform/transform.pb.rs",
         "db/block/transform/transform.pb.ts"
       ],
-      "protoFiles": [
-        "db/block/transform/transform.proto"
-      ]
+      "protoFiles": ["db/block/transform/transform.proto"]
     },
     "github.com/s4wave/spacewave/db/block/transform/blockenc": {
       "hash": "cbd62e42f6bef5e23f29ce4207e93bf50a262d65e052b846606316209ff7ddcd",
@@ -2197,9 +1879,7 @@
         "db/block/transform/blockenc/blockenc.pb.rs",
         "db/block/transform/blockenc/blockenc.pb.ts"
       ],
-      "protoFiles": [
-        "db/block/transform/blockenc/blockenc.proto"
-      ]
+      "protoFiles": ["db/block/transform/blockenc/blockenc.proto"]
     },
     "github.com/s4wave/spacewave/db/block/transform/chksum": {
       "hash": "dbd4bb56f6d77a5edc38b12e08b436322421b52a180f8d1311b715e88181014c",
@@ -2210,9 +1890,7 @@
         "db/block/transform/chksum/chksum.pb.rs",
         "db/block/transform/chksum/chksum.pb.ts"
       ],
-      "protoFiles": [
-        "db/block/transform/chksum/chksum.proto"
-      ]
+      "protoFiles": ["db/block/transform/chksum/chksum.proto"]
     },
     "github.com/s4wave/spacewave/db/block/transform/gzip": {
       "hash": "74d8692b642d83f9b0a4f13bacb7e7a431e01f519f82e76b20eb172d252e44d6",
@@ -2223,9 +1901,7 @@
         "db/block/transform/gzip/gzip.pb.rs",
         "db/block/transform/gzip/gzip.pb.ts"
       ],
-      "protoFiles": [
-        "db/block/transform/gzip/gzip.proto"
-      ]
+      "protoFiles": ["db/block/transform/gzip/gzip.proto"]
     },
     "github.com/s4wave/spacewave/db/block/transform/lz4": {
       "hash": "9a9fa00f78ba013a50e306e38714e5160cf24de8ce432b5994cb9c8f57e52f79",
@@ -2236,9 +1912,7 @@
         "db/block/transform/lz4/lz4.pb.rs",
         "db/block/transform/lz4/lz4.pb.ts"
       ],
-      "protoFiles": [
-        "db/block/transform/lz4/lz4.proto"
-      ]
+      "protoFiles": ["db/block/transform/lz4/lz4.proto"]
     },
     "github.com/s4wave/spacewave/db/block/transform/s2": {
       "hash": "ef1ce938d2480a69ccb53594c26102ed44e68bffbcb8a4876f3a0da408d9b6b8",
@@ -2249,9 +1923,7 @@
         "db/block/transform/s2/s2.pb.rs",
         "db/block/transform/s2/s2.pb.ts"
       ],
-      "protoFiles": [
-        "db/block/transform/s2/s2.proto"
-      ]
+      "protoFiles": ["db/block/transform/s2/s2.proto"]
     },
     "github.com/s4wave/spacewave/db/block/transform/snappy": {
       "hash": "edd2723c72e80be5080e60324c54b8925cc8feb110cb7d79f62f01b839193619",
@@ -2262,9 +1934,7 @@
         "db/block/transform/snappy/snappy.pb.rs",
         "db/block/transform/snappy/snappy.pb.ts"
       ],
-      "protoFiles": [
-        "db/block/transform/snappy/snappy.proto"
-      ]
+      "protoFiles": ["db/block/transform/snappy/snappy.proto"]
     },
     "github.com/s4wave/spacewave/db/blocktype/controller-factory": {
       "hash": "84865f0a2e7702910d657824a9400cb670c55c47b0ebae4bbdc4f4a3db3cb8c3",
@@ -2275,9 +1945,7 @@
         "db/blocktype/controller-factory/controller.pb.rs",
         "db/blocktype/controller-factory/controller.pb.ts"
       ],
-      "protoFiles": [
-        "db/blocktype/controller-factory/controller.proto"
-      ]
+      "protoFiles": ["db/blocktype/controller-factory/controller.proto"]
     },
     "github.com/s4wave/spacewave/db/bucket": {
       "hash": "ae7306e4efaf7d01b2f88d93b71ffa18440ea926fb04cfa3cb3d9eee4c62fa6f",
@@ -2288,9 +1956,7 @@
         "db/bucket/bucket.pb.rs",
         "db/bucket/bucket.pb.ts"
       ],
-      "protoFiles": [
-        "db/bucket/bucket.proto"
-      ]
+      "protoFiles": ["db/bucket/bucket.proto"]
     },
     "github.com/s4wave/spacewave/db/bucket/event": {
       "hash": "a28c5f6204de10b6049e48874141df70813f1423dd4195b39b512b4d1442c2dc",
@@ -2301,9 +1967,7 @@
         "db/bucket/event/event.pb.rs",
         "db/bucket/event/event.pb.ts"
       ],
-      "protoFiles": [
-        "db/bucket/event/event.proto"
-      ]
+      "protoFiles": ["db/bucket/event/event.proto"]
     },
     "github.com/s4wave/spacewave/db/bucket/http/server": {
       "hash": "38da8b82b71719599966d331fa37fe474db9da3d1a981a91d0c5a416c0272a94",
@@ -2314,9 +1978,7 @@
         "db/bucket/http/server/config.pb.rs",
         "db/bucket/http/server/config.pb.ts"
       ],
-      "protoFiles": [
-        "db/bucket/http/server/config.proto"
-      ]
+      "protoFiles": ["db/bucket/http/server/config.proto"]
     },
     "github.com/s4wave/spacewave/db/bucket/lookup/concurrent": {
       "hash": "070b07586da8367be91065ba8b709fcffe0ef5030f6821bee95957f4212e7c50",
@@ -2327,9 +1989,7 @@
         "db/bucket/lookup/concurrent/concurrent.pb.rs",
         "db/bucket/lookup/concurrent/concurrent.pb.ts"
       ],
-      "protoFiles": [
-        "db/bucket/lookup/concurrent/concurrent.proto"
-      ]
+      "protoFiles": ["db/bucket/lookup/concurrent/concurrent.proto"]
     },
     "github.com/s4wave/spacewave/db/bucket/mock": {
       "hash": "b5dddf81eaac278fdb5701eb1ebeb1def4533629bc3f0f42bf0feac395db67f9",
@@ -2340,9 +2000,7 @@
         "db/bucket/mock/mock.pb.rs",
         "db/bucket/mock/mock.pb.ts"
       ],
-      "protoFiles": [
-        "db/bucket/mock/mock.proto"
-      ]
+      "protoFiles": ["db/bucket/mock/mock.proto"]
     },
     "github.com/s4wave/spacewave/db/bucket/setup": {
       "hash": "efdb53b64f53f29bbf91a7187383625bb5fb265f4e09303f661672311ec784c2",
@@ -2353,9 +2011,7 @@
         "db/bucket/setup/config.pb.rs",
         "db/bucket/setup/config.pb.ts"
       ],
-      "protoFiles": [
-        "db/bucket/setup/config.proto"
-      ]
+      "protoFiles": ["db/bucket/setup/config.proto"]
     },
     "github.com/s4wave/spacewave/db/bucket/store/rpc": {
       "hash": "04cb7d2ccc88e8ea42ac79892cccc0111282f3158ad7c5193cc81af48aa0bfa9",
@@ -2369,9 +2025,7 @@
         "db/bucket/store/rpc/bucket_srpc.pb.rs",
         "db/bucket/store/rpc/bucket_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "db/bucket/store/rpc/bucket.proto"
-      ]
+      "protoFiles": ["db/bucket/store/rpc/bucket.proto"]
     },
     "github.com/s4wave/spacewave/db/daemon/api": {
       "hash": "b9ff90f3a219199f4eed4af63004c82bc5868fd54b875e3166423c7ec47c4ded",
@@ -2385,9 +2039,7 @@
         "db/daemon/api/api_srpc.pb.rs",
         "db/daemon/api/api_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "db/daemon/api/api.proto"
-      ]
+      "protoFiles": ["db/daemon/api/api.proto"]
     },
     "github.com/s4wave/spacewave/db/daemon/api/controller": {
       "hash": "e74fef85ed2d4373cdd02cdb49bab0e02777a9c1346db1944c1e539b0f5d7045",
@@ -2398,9 +2050,7 @@
         "db/daemon/api/controller/controller.pb.rs",
         "db/daemon/api/controller/controller.pb.ts"
       ],
-      "protoFiles": [
-        "db/daemon/api/controller/controller.proto"
-      ]
+      "protoFiles": ["db/daemon/api/controller/controller.proto"]
     },
     "github.com/s4wave/spacewave/db/dex": {
       "hash": "daff3cad0f8d8a9ba9066ab96c53e1bfcf29cf0b949ed20e46e16f218562f273",
@@ -2411,9 +2061,7 @@
         "db/dex/directive.pb.rs",
         "db/dex/directive.pb.ts"
       ],
-      "protoFiles": [
-        "db/dex/directive.proto"
-      ]
+      "protoFiles": ["db/dex/directive.proto"]
     },
     "github.com/s4wave/spacewave/db/dex/psecho": {
       "hash": "66c72bc2059cb2d87dd460745b4fcb096908453e2b73a22824ef1a17f0b38df6",
@@ -2447,9 +2095,7 @@
         "db/dex/session/session.pb.rs",
         "db/dex/session/session.pb.ts"
       ],
-      "protoFiles": [
-        "db/dex/session/session.proto"
-      ]
+      "protoFiles": ["db/dex/session/session.proto"]
     },
     "github.com/s4wave/spacewave/db/dex/solicit": {
       "hash": "ac70ce4a8ab6ab22d783d4973e567b3081866c8044adc74f49d8c3f846ce1ff2",
@@ -2464,10 +2110,7 @@
         "db/dex/solicit/dex.pb.h",
         "db/dex/solicit/dex.pb.ts"
       ],
-      "protoFiles": [
-        "db/dex/solicit/config.proto",
-        "db/dex/solicit/dex.proto"
-      ]
+      "protoFiles": ["db/dex/solicit/config.proto", "db/dex/solicit/dex.proto"]
     },
     "github.com/s4wave/spacewave/db/git/block": {
       "hash": "1104a1c3423843a40d92f0a876acf5e766d3b3e3f751459af3b080a1261173f7",
@@ -2478,9 +2121,7 @@
         "db/git/block/git.pb.rs",
         "db/git/block/git.pb.ts"
       ],
-      "protoFiles": [
-        "db/git/block/git.proto"
-      ]
+      "protoFiles": ["db/git/block/git.proto"]
     },
     "github.com/s4wave/spacewave/db/git/world": {
       "hash": "fecadd0e55dad31fb220aaa6aca50032f8e7da75418c4eafbb85fc4cd9d9015a",
@@ -2491,9 +2132,7 @@
         "db/git/world/git.pb.rs",
         "db/git/world/git.pb.ts"
       ],
-      "protoFiles": [
-        "db/git/world/git.proto"
-      ]
+      "protoFiles": ["db/git/world/git.proto"]
     },
     "github.com/s4wave/spacewave/db/kvtx/block": {
       "hash": "1e91fc6571a9f257dc74a621295586ad96a031c48536ceb99d9ea50feac37fe6",
@@ -2504,9 +2143,7 @@
         "db/kvtx/block/kvtx.pb.rs",
         "db/kvtx/block/kvtx.pb.ts"
       ],
-      "protoFiles": [
-        "db/kvtx/block/kvtx.proto"
-      ]
+      "protoFiles": ["db/kvtx/block/kvtx.proto"]
     },
     "github.com/s4wave/spacewave/db/kvtx/block/iavl": {
       "hash": "4c7445086d9675f29c57d05306cd4ba12b53d17f01a4efe813f54df176d9ec9a",
@@ -2517,9 +2154,7 @@
         "db/kvtx/block/iavl/iavl.pb.rs",
         "db/kvtx/block/iavl/iavl.pb.ts"
       ],
-      "protoFiles": [
-        "db/kvtx/block/iavl/iavl.proto"
-      ]
+      "protoFiles": ["db/kvtx/block/iavl/iavl.proto"]
     },
     "github.com/s4wave/spacewave/db/kvtx/block/okra": {
       "hash": "e110ffa74d657473ffc283a46e2410e71b4801040efb43b0d0e9793ea1da6b52",
@@ -2530,9 +2165,7 @@
         "db/kvtx/block/okra/okra.pb.rs",
         "db/kvtx/block/okra/okra.pb.ts"
       ],
-      "protoFiles": [
-        "db/kvtx/block/okra/okra.proto"
-      ]
+      "protoFiles": ["db/kvtx/block/okra/okra.proto"]
     },
     "github.com/s4wave/spacewave/db/kvtx/fibheap": {
       "hash": "b3a929ac5a557196de94890bacfc1508085de05c20b057e50e33a7cba0cf4841",
@@ -2543,9 +2176,7 @@
         "db/kvtx/fibheap/fibheap.pb.rs",
         "db/kvtx/fibheap/fibheap.pb.ts"
       ],
-      "protoFiles": [
-        "db/kvtx/fibheap/fibheap.proto"
-      ]
+      "protoFiles": ["db/kvtx/fibheap/fibheap.proto"]
     },
     "github.com/s4wave/spacewave/db/kvtx/rpc": {
       "hash": "3a97152eba43e6e53d3767fd1298b462af96ba75e9d83227293730f6ba160701",
@@ -2559,9 +2190,7 @@
         "db/kvtx/rpc/kvtx_srpc.pb.rs",
         "db/kvtx/rpc/kvtx_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "db/kvtx/rpc/kvtx.proto"
-      ]
+      "protoFiles": ["db/kvtx/rpc/kvtx.proto"]
     },
     "github.com/s4wave/spacewave/db/node/controller": {
       "hash": "a4f650fbd8196b2a269bc75038120b2d161709bacd3e136ab7878373960987e9",
@@ -2572,9 +2201,7 @@
         "db/node/controller/config.pb.rs",
         "db/node/controller/config.pb.ts"
       ],
-      "protoFiles": [
-        "db/node/controller/config.proto"
-      ]
+      "protoFiles": ["db/node/controller/config.proto"]
     },
     "github.com/s4wave/spacewave/db/object/peer": {
       "hash": "e95585fd3b81a1b771281274de75255b324f2bee902171eadd3fb611ef3c4fd6",
@@ -2585,9 +2212,7 @@
         "db/object/peer/peer.pb.rs",
         "db/object/peer/peer.pb.ts"
       ],
-      "protoFiles": [
-        "db/object/peer/peer.proto"
-      ]
+      "protoFiles": ["db/object/peer/peer.proto"]
     },
     "github.com/s4wave/spacewave/db/object/rpc": {
       "hash": "8d5454ff6475ba6a1f4fd12c40fd9a5821ec842b8ad775c5d5e1eea70970bf33",
@@ -2601,9 +2226,7 @@
         "db/object/rpc/object_srpc.pb.rs",
         "db/object/rpc/object_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "db/object/rpc/object.proto"
-      ]
+      "protoFiles": ["db/object/rpc/object.proto"]
     },
     "github.com/s4wave/spacewave/db/sql": {
       "hash": "e4b59ae5f23148e39ca3551e1b181e4c5e198ebde7eac532f56e46b7145f81bd",
@@ -2614,9 +2237,7 @@
         "db/sql/sql.pb.rs",
         "db/sql/sql.pb.ts"
       ],
-      "protoFiles": [
-        "db/sql/sql.proto"
-      ]
+      "protoFiles": ["db/sql/sql.proto"]
     },
     "github.com/s4wave/spacewave/db/sql/mysql": {
       "hash": "1dc4b58bea6fb58b94a922b82d0f660e5f477c8e3b6f39711f4cfc080a7cde7a",
@@ -2627,9 +2248,7 @@
         "db/sql/mysql/mysql.pb.rs",
         "db/sql/mysql/mysql.pb.ts"
       ],
-      "protoFiles": [
-        "db/sql/mysql/mysql.proto"
-      ]
+      "protoFiles": ["db/sql/mysql/mysql.proto"]
     },
     "github.com/s4wave/spacewave/db/sql/mysql/controller": {
       "hash": "22bda978e3b310e1bfa10f30f8e619f495134b755e18d4b5970a6b93c9925f1b",
@@ -2640,9 +2259,7 @@
         "db/sql/mysql/controller/config.pb.rs",
         "db/sql/mysql/controller/config.pb.ts"
       ],
-      "protoFiles": [
-        "db/sql/mysql/controller/config.proto"
-      ]
+      "protoFiles": ["db/sql/mysql/controller/config.proto"]
     },
     "github.com/s4wave/spacewave/db/sql/rpc": {
       "hash": "6f8ab9edefab13e976576f5e6766cc8eefded6d1cfc7053e9acbbabfab276537",
@@ -2656,9 +2273,7 @@
         "db/sql/rpc/sql_srpc.pb.rs",
         "db/sql/rpc/sql_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "db/sql/rpc/sql.proto"
-      ]
+      "protoFiles": ["db/sql/rpc/sql.proto"]
     },
     "github.com/s4wave/spacewave/db/sql/sqlite-wasm/rpc": {
       "hash": "700bc9f262d8a437a85be52f73c23db30922b2d8d5bed0c1ff5986cba06ef299",
@@ -2672,9 +2287,7 @@
         "db/sql/sqlite-wasm/rpc/sqlite-bridge_srpc.pb.rs",
         "db/sql/sqlite-wasm/rpc/sqlite-bridge_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "db/sql/sqlite-wasm/rpc/sqlite-bridge.proto"
-      ]
+      "protoFiles": ["db/sql/sqlite-wasm/rpc/sqlite-bridge.proto"]
     },
     "github.com/s4wave/spacewave/db/store/kvkey": {
       "hash": "82600508c21b871a3600e379842e2df39ae83b6b691a7b39ae33371df138cbd8",
@@ -2685,9 +2298,7 @@
         "db/store/kvkey/kvkey.pb.rs",
         "db/store/kvkey/kvkey.pb.ts"
       ],
-      "protoFiles": [
-        "db/store/kvkey/kvkey.proto"
-      ]
+      "protoFiles": ["db/store/kvkey/kvkey.proto"]
     },
     "github.com/s4wave/spacewave/db/store/kvtx": {
       "hash": "f348ffe29f5e51136cca5f4e40575144b4c0a7ece8cce8e26625ea4d13f98a8a",
@@ -2698,9 +2309,7 @@
         "db/store/kvtx/kvtx.pb.rs",
         "db/store/kvtx/kvtx.pb.ts"
       ],
-      "protoFiles": [
-        "db/store/kvtx/kvtx.proto"
-      ]
+      "protoFiles": ["db/store/kvtx/kvtx.proto"]
     },
     "github.com/s4wave/spacewave/db/store/kvtx/redis": {
       "hash": "738f1c85152317e7dc79b670e178005ff0108de6b84e950ba141f902b81729c6",
@@ -2711,9 +2320,7 @@
         "db/store/kvtx/redis/redis.pb.rs",
         "db/store/kvtx/redis/redis.pb.ts"
       ],
-      "protoFiles": [
-        "db/store/kvtx/redis/redis.proto"
-      ]
+      "protoFiles": ["db/store/kvtx/redis/redis.proto"]
     },
     "github.com/s4wave/spacewave/db/store/kvtx/ristretto": {
       "hash": "cd854b4980ed6f8e82cf12b1713c259be778dffb9f701e25d02346d5b9539be1",
@@ -2724,9 +2331,7 @@
         "db/store/kvtx/ristretto/ristretto.pb.rs",
         "db/store/kvtx/ristretto/ristretto.pb.ts"
       ],
-      "protoFiles": [
-        "db/store/kvtx/ristretto/ristretto.proto"
-      ]
+      "protoFiles": ["db/store/kvtx/ristretto/ristretto.proto"]
     },
     "github.com/s4wave/spacewave/db/unixfs/access/http": {
       "hash": "8371331b742f2e5be2053bdb79975b1184bec32394281db7cc07bcc088234eba",
@@ -2737,9 +2342,7 @@
         "db/unixfs/access/http/config.pb.rs",
         "db/unixfs/access/http/config.pb.ts"
       ],
-      "protoFiles": [
-        "db/unixfs/access/http/config.proto"
-      ]
+      "protoFiles": ["db/unixfs/access/http/config.proto"]
     },
     "github.com/s4wave/spacewave/db/unixfs/block": {
       "hash": "6f170e25b008209c1be4bb03862c6e44e743af0c536091d3fe6226ec8943dbc6",
@@ -2750,9 +2353,7 @@
         "db/unixfs/block/fstree.pb.rs",
         "db/unixfs/block/fstree.pb.ts"
       ],
-      "protoFiles": [
-        "db/unixfs/block/fstree.proto"
-      ]
+      "protoFiles": ["db/unixfs/block/fstree.proto"]
     },
     "github.com/s4wave/spacewave/db/unixfs/errors": {
       "hash": "08501ba0f4cee216bb06f902dd805c26d44a442b77a783b9b8d5fa6219d45c8a",
@@ -2763,9 +2364,7 @@
         "db/unixfs/errors/errors.pb.rs",
         "db/unixfs/errors/errors.pb.ts"
       ],
-      "protoFiles": [
-        "db/unixfs/errors/errors.proto"
-      ]
+      "protoFiles": ["db/unixfs/errors/errors.proto"]
     },
     "github.com/s4wave/spacewave/db/unixfs/mount/checkout": {
       "hash": "88d2c22370fb6d062d724a27a651523eb891865ae67f492e397abcb1cd5eb3af",
@@ -2776,9 +2375,7 @@
         "db/unixfs/mount/checkout/checkout.pb.rs",
         "db/unixfs/mount/checkout/checkout.pb.ts"
       ],
-      "protoFiles": [
-        "db/unixfs/mount/checkout/checkout.proto"
-      ]
+      "protoFiles": ["db/unixfs/mount/checkout/checkout.proto"]
     },
     "github.com/s4wave/spacewave/db/unixfs/mount/fuse": {
       "hash": "e8d50fbfc3f3e6cb9d5121a0dd789077d356fadb7e0858a79ab3c580f589e171",
@@ -2789,9 +2386,7 @@
         "db/unixfs/mount/fuse/fuse.pb.rs",
         "db/unixfs/mount/fuse/fuse.pb.ts"
       ],
-      "protoFiles": [
-        "db/unixfs/mount/fuse/fuse.proto"
-      ]
+      "protoFiles": ["db/unixfs/mount/fuse/fuse.proto"]
     },
     "github.com/s4wave/spacewave/db/unixfs/rpc": {
       "hash": "0868e804514e59e5bab2b3cdf77b4c8cce1924dd77fa8e717730ec9ecc28f25c",
@@ -2805,9 +2400,7 @@
         "db/unixfs/rpc/rpc_srpc.pb.rs",
         "db/unixfs/rpc/rpc_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "db/unixfs/rpc/rpc.proto"
-      ]
+      "protoFiles": ["db/unixfs/rpc/rpc.proto"]
     },
     "github.com/s4wave/spacewave/db/unixfs/sync": {
       "hash": "0450ce3b3c543a59d6a9ff0a88ccd5f9a3d2de4c7d1c6380cda7d5f9d3e42ef2",
@@ -2818,9 +2411,7 @@
         "db/unixfs/sync/sync.pb.rs",
         "db/unixfs/sync/sync.pb.ts"
       ],
-      "protoFiles": [
-        "db/unixfs/sync/sync.proto"
-      ]
+      "protoFiles": ["db/unixfs/sync/sync.proto"]
     },
     "github.com/s4wave/spacewave/db/unixfs/v86fs": {
       "hash": "6ffe25beae311bdb6aa4efd581c8fb11aa2025118cedfa5a2422209319602667",
@@ -2834,9 +2425,7 @@
         "db/unixfs/v86fs/v86fs_srpc.pb.rs",
         "db/unixfs/v86fs/v86fs_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "db/unixfs/v86fs/v86fs.proto"
-      ]
+      "protoFiles": ["db/unixfs/v86fs/v86fs.proto"]
     },
     "github.com/s4wave/spacewave/db/unixfs/world": {
       "hash": "4538a6f1a3fb176f234c55d33addfc342114bd092249960777905e3033ec2026",
@@ -2847,9 +2436,7 @@
         "db/unixfs/world/unixfs.pb.rs",
         "db/unixfs/world/unixfs.pb.ts"
       ],
-      "protoFiles": [
-        "db/unixfs/world/unixfs.proto"
-      ]
+      "protoFiles": ["db/unixfs/world/unixfs.proto"]
     },
     "github.com/s4wave/spacewave/db/unixfs/world/access": {
       "hash": "c7a69b4abc1c65cfcc6df17c2e801f843524ca3b468bd99d8221cd15fd12c854",
@@ -2860,9 +2447,7 @@
         "db/unixfs/world/access/access.pb.rs",
         "db/unixfs/world/access/access.pb.ts"
       ],
-      "protoFiles": [
-        "db/unixfs/world/access/access.proto"
-      ]
+      "protoFiles": ["db/unixfs/world/access/access.proto"]
     },
     "github.com/s4wave/spacewave/db/unixfs/world/e2e": {
       "hash": "f1ed834f37cb3bb7db0fe3562408a3647008f90031daee3c8ec6be35309a9e7f",
@@ -2873,9 +2458,7 @@
         "db/unixfs/world/e2e/init_unixfs_demo.pb.rs",
         "db/unixfs/world/e2e/init_unixfs_demo.pb.ts"
       ],
-      "protoFiles": [
-        "db/unixfs/world/e2e/init_unixfs_demo.proto"
-      ]
+      "protoFiles": ["db/unixfs/world/e2e/init_unixfs_demo.proto"]
     },
     "github.com/s4wave/spacewave/db/util/blockenc": {
       "hash": "3a18b69be602ce8b24f8cf6b857ff50e3e0918e015a030380235cdbe8462faa0",
@@ -2886,9 +2469,7 @@
         "db/util/blockenc/blockenc.pb.rs",
         "db/util/blockenc/blockenc.pb.ts"
       ],
-      "protoFiles": [
-        "db/util/blockenc/blockenc.proto"
-      ]
+      "protoFiles": ["db/util/blockenc/blockenc.proto"]
     },
     "github.com/s4wave/spacewave/db/volume": {
       "hash": "8afe95688f59467578e48a6fad63847c6a8f0b570194a6cc3de6b0125b674d74",
@@ -2899,9 +2480,7 @@
         "db/volume/volume.pb.rs",
         "db/volume/volume.pb.ts"
       ],
-      "protoFiles": [
-        "db/volume/volume.proto"
-      ]
+      "protoFiles": ["db/volume/volume.proto"]
     },
     "github.com/s4wave/spacewave/db/volume/badger": {
       "hash": "12af54a02640193fcf79d0b86987371c4f9758f439364907a5bd6616fb247d15",
@@ -2912,9 +2491,7 @@
         "db/volume/badger/badger.pb.rs",
         "db/volume/badger/badger.pb.ts"
       ],
-      "protoFiles": [
-        "db/volume/badger/badger.proto"
-      ]
+      "protoFiles": ["db/volume/badger/badger.proto"]
     },
     "github.com/s4wave/spacewave/db/volume/block": {
       "hash": "c0a8e14226fe6aaf7340b1ebd95a05e08e0e101423e82edf343bc3304b37c654",
@@ -2925,9 +2502,7 @@
         "db/volume/block/volume.pb.rs",
         "db/volume/block/volume.pb.ts"
       ],
-      "protoFiles": [
-        "db/volume/block/volume.proto"
-      ]
+      "protoFiles": ["db/volume/block/volume.proto"]
     },
     "github.com/s4wave/spacewave/db/volume/bolt": {
       "hash": "4d66ae5d509d8158aeb2ca5cc8d2887da0219b50712ed5ce1bad421a4a7c6841",
@@ -2938,9 +2513,7 @@
         "db/volume/bolt/bolt.pb.rs",
         "db/volume/bolt/bolt.pb.ts"
       ],
-      "protoFiles": [
-        "db/volume/bolt/bolt.proto"
-      ]
+      "protoFiles": ["db/volume/bolt/bolt.proto"]
     },
     "github.com/s4wave/spacewave/db/volume/controller": {
       "hash": "9d5210effc74524d7c9ad499ac32d5544117bce9a5537b19a0dabee2ea384e67",
@@ -2951,9 +2524,7 @@
         "db/volume/controller/controller.pb.rs",
         "db/volume/controller/controller.pb.ts"
       ],
-      "protoFiles": [
-        "db/volume/controller/controller.proto"
-      ]
+      "protoFiles": ["db/volume/controller/controller.proto"]
     },
     "github.com/s4wave/spacewave/db/volume/js/indexeddb": {
       "hash": "f8c656b2e56c773ed4bb0e5a13167df0424b427d5b861a13c27bc0e94ce17c84",
@@ -2964,9 +2535,7 @@
         "db/volume/js/indexeddb/indexeddb.pb.rs",
         "db/volume/js/indexeddb/indexeddb.pb.ts"
       ],
-      "protoFiles": [
-        "db/volume/js/indexeddb/indexeddb.proto"
-      ]
+      "protoFiles": ["db/volume/js/indexeddb/indexeddb.proto"]
     },
     "github.com/s4wave/spacewave/db/volume/js/opfs": {
       "hash": "f4c073f32ba06b9aa971f1ef5684fb95da0e66ee472541c0e12474b4417bb8ca",
@@ -2977,9 +2546,7 @@
         "db/volume/js/opfs/opfs.pb.rs",
         "db/volume/js/opfs/opfs.pb.ts"
       ],
-      "protoFiles": [
-        "db/volume/js/opfs/opfs.proto"
-      ]
+      "protoFiles": ["db/volume/js/opfs/opfs.proto"]
     },
     "github.com/s4wave/spacewave/db/volume/kvfile": {
       "hash": "2e5553b294a83f437a60ceeb9e963fac1df6e8c3a642d9d727173f9d13dc4e32",
@@ -2990,9 +2557,7 @@
         "db/volume/kvfile/kvfile.pb.rs",
         "db/volume/kvfile/kvfile.pb.ts"
       ],
-      "protoFiles": [
-        "db/volume/kvfile/kvfile.proto"
-      ]
+      "protoFiles": ["db/volume/kvfile/kvfile.proto"]
     },
     "github.com/s4wave/spacewave/db/volume/kvtxinmem": {
       "hash": "d913200f2eecb83be3d38f8526769014167f5f040a0ab3a38fc130fb1e584793",
@@ -3003,9 +2568,7 @@
         "db/volume/kvtxinmem/kvtxinmem.pb.rs",
         "db/volume/kvtxinmem/kvtxinmem.pb.ts"
       ],
-      "protoFiles": [
-        "db/volume/kvtxinmem/kvtxinmem.proto"
-      ]
+      "protoFiles": ["db/volume/kvtxinmem/kvtxinmem.proto"]
     },
     "github.com/s4wave/spacewave/db/volume/redis": {
       "hash": "b76321b44bc0fb3d85070bc9dd44fc9c1b45d1c958502f32b8501d07d1cebee2",
@@ -3016,9 +2579,7 @@
         "db/volume/redis/redis.pb.rs",
         "db/volume/redis/redis.pb.ts"
       ],
-      "protoFiles": [
-        "db/volume/redis/redis.proto"
-      ]
+      "protoFiles": ["db/volume/redis/redis.proto"]
     },
     "github.com/s4wave/spacewave/db/volume/rpc": {
       "hash": "a3039807420daeada81bb6f3ac6cf302e3e29e9c86538500e60716da95cd5f5b",
@@ -3032,9 +2593,7 @@
         "db/volume/rpc/volume_srpc.pb.rs",
         "db/volume/rpc/volume_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "db/volume/rpc/volume.proto"
-      ]
+      "protoFiles": ["db/volume/rpc/volume.proto"]
     },
     "github.com/s4wave/spacewave/db/volume/rpc/client": {
       "hash": "c654fca43212b8647b9b8967beddcccf6b286d410aef7e516c1ca3903f8d816f",
@@ -3045,9 +2604,7 @@
         "db/volume/rpc/client/config.pb.rs",
         "db/volume/rpc/client/config.pb.ts"
       ],
-      "protoFiles": [
-        "db/volume/rpc/client/config.proto"
-      ]
+      "protoFiles": ["db/volume/rpc/client/config.proto"]
     },
     "github.com/s4wave/spacewave/db/volume/rpc/server": {
       "hash": "9deca876c35d11a6b80c7b6725f80a62a61cefaf5fb841c1ff6ce9c571843734",
@@ -3058,9 +2615,7 @@
         "db/volume/rpc/server/config.pb.rs",
         "db/volume/rpc/server/config.pb.ts"
       ],
-      "protoFiles": [
-        "db/volume/rpc/server/config.proto"
-      ]
+      "protoFiles": ["db/volume/rpc/server/config.proto"]
     },
     "github.com/s4wave/spacewave/db/volume/sqlite": {
       "hash": "75b27dbd647620e5c5f21e604593e441ff75eecf9f39cb8ac92bf96355aaedfc",
@@ -3071,9 +2626,7 @@
         "db/volume/sqlite/sqlite.pb.rs",
         "db/volume/sqlite/sqlite.pb.ts"
       ],
-      "protoFiles": [
-        "db/volume/sqlite/sqlite.proto"
-      ]
+      "protoFiles": ["db/volume/sqlite/sqlite.proto"]
     },
     "github.com/s4wave/spacewave/db/volume/world": {
       "hash": "caad70bbe5d0068c0c0f3f467250f45298954bd1c40bf873baf608494039f6f0",
@@ -3084,9 +2637,7 @@
         "db/volume/world/volume.pb.rs",
         "db/volume/world/volume.pb.ts"
       ],
-      "protoFiles": [
-        "db/volume/world/volume.proto"
-      ]
+      "protoFiles": ["db/volume/world/volume.proto"]
     },
     "github.com/s4wave/spacewave/db/world/block": {
       "hash": "5af4364419532810cf908600b41bae2bef6405c100c8366891cd3045137fd6e1",
@@ -3097,9 +2648,7 @@
         "db/world/block/world.pb.rs",
         "db/world/block/world.pb.ts"
       ],
-      "protoFiles": [
-        "db/world/block/world.proto"
-      ]
+      "protoFiles": ["db/world/block/world.proto"]
     },
     "github.com/s4wave/spacewave/db/world/block/engine": {
       "hash": "6aa20271840786406b41db931c238eea9d276ba14f8bfc9e85dcf0cd4058a6c3",
@@ -3110,9 +2659,7 @@
         "db/world/block/engine/engine.pb.rs",
         "db/world/block/engine/engine.pb.ts"
       ],
-      "protoFiles": [
-        "db/world/block/engine/engine.proto"
-      ]
+      "protoFiles": ["db/world/block/engine/engine.proto"]
     },
     "github.com/s4wave/spacewave/db/world/block/tx": {
       "hash": "063ddcf67bb30d501241651c240ab5f5230d3e68f56d6fd284ab6f43d4ac0457",
@@ -3123,9 +2670,7 @@
         "db/world/block/tx/tx.pb.rs",
         "db/world/block/tx/tx.pb.ts"
       ],
-      "protoFiles": [
-        "db/world/block/tx/tx.proto"
-      ]
+      "protoFiles": ["db/world/block/tx/tx.proto"]
     },
     "github.com/s4wave/spacewave/db/world/mock": {
       "hash": "f237fe126bd6def27e4a8045d27dc56e518cc69e9b91c3dfe07949dfe7ea7a39",
@@ -3136,9 +2681,7 @@
         "db/world/mock/mock.pb.rs",
         "db/world/mock/mock.pb.ts"
       ],
-      "protoFiles": [
-        "db/world/mock/mock.proto"
-      ]
+      "protoFiles": ["db/world/mock/mock.proto"]
     },
     "github.com/s4wave/spacewave/e2e/wasm/session": {
       "hash": "2dc06dc204a31cdced455e188ceb9ad07fab23da74fd534af3c4a7f6d63d83c6",
@@ -3171,9 +2714,7 @@
         "forge/cluster/cluster.pb.rs",
         "forge/cluster/cluster.pb.ts"
       ],
-      "protoFiles": [
-        "forge/cluster/cluster.proto"
-      ]
+      "protoFiles": ["forge/cluster/cluster.proto"]
     },
     "github.com/s4wave/spacewave/forge/cluster/controller": {
       "hash": "eed0d68e49f0586faa52503082e341108411e4a4c5bff2850292baaea3944ecd",
@@ -3184,9 +2725,7 @@
         "forge/cluster/controller/config.pb.rs",
         "forge/cluster/controller/config.pb.ts"
       ],
-      "protoFiles": [
-        "forge/cluster/controller/config.proto"
-      ]
+      "protoFiles": ["forge/cluster/controller/config.proto"]
     },
     "github.com/s4wave/spacewave/forge/cluster/tx": {
       "hash": "bf2ac680a861a4ed6dd1c466a8be2bc6a25e618b823e56179a916173e197b8a4",
@@ -3197,9 +2736,7 @@
         "forge/cluster/tx/tx.pb.rs",
         "forge/cluster/tx/tx.pb.ts"
       ],
-      "protoFiles": [
-        "forge/cluster/tx/tx.proto"
-      ]
+      "protoFiles": ["forge/cluster/tx/tx.proto"]
     },
     "github.com/s4wave/spacewave/forge/daemon/api": {
       "hash": "4b7562763d6a3fcfb8bbe2b217491fc2825da609240c2658a9d2cf2749602c7e",
@@ -3213,9 +2750,7 @@
         "forge/daemon/api/api_srpc.pb.rs",
         "forge/daemon/api/api_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "forge/daemon/api/api.proto"
-      ]
+      "protoFiles": ["forge/daemon/api/api.proto"]
     },
     "github.com/s4wave/spacewave/forge/daemon/api/controller": {
       "hash": "b65da413f11e2ad51d345bfab970403bd3092c824cfa6a295f6319cfa5c6f3ba",
@@ -3226,9 +2761,7 @@
         "forge/daemon/api/controller/controller.pb.rs",
         "forge/daemon/api/controller/controller.pb.ts"
       ],
-      "protoFiles": [
-        "forge/daemon/api/controller/controller.proto"
-      ]
+      "protoFiles": ["forge/daemon/api/controller/controller.proto"]
     },
     "github.com/s4wave/spacewave/forge/execution": {
       "hash": "968a70f891dbda775a0bfddc0fdcdae7ef16332129cd1ec8a12825699bbf5d4d",
@@ -3239,9 +2772,7 @@
         "forge/execution/execution.pb.rs",
         "forge/execution/execution.pb.ts"
       ],
-      "protoFiles": [
-        "forge/execution/execution.proto"
-      ]
+      "protoFiles": ["forge/execution/execution.proto"]
     },
     "github.com/s4wave/spacewave/forge/execution/controller": {
       "hash": "62775bf9700e4ad285efa4e67db39e83da9c178e5eedafcbe1829e8698b7b3c3",
@@ -3252,9 +2783,7 @@
         "forge/execution/controller/config.pb.rs",
         "forge/execution/controller/config.pb.ts"
       ],
-      "protoFiles": [
-        "forge/execution/controller/config.proto"
-      ]
+      "protoFiles": ["forge/execution/controller/config.proto"]
     },
     "github.com/s4wave/spacewave/forge/execution/tx": {
       "hash": "b012516dcd142bd8b116284c035879a3839e5d81a9a9070cab6cd07568270a7c",
@@ -3265,9 +2794,7 @@
         "forge/execution/tx/tx.pb.rs",
         "forge/execution/tx/tx.pb.ts"
       ],
-      "protoFiles": [
-        "forge/execution/tx/tx.proto"
-      ]
+      "protoFiles": ["forge/execution/tx/tx.proto"]
     },
     "github.com/s4wave/spacewave/forge/job": {
       "hash": "215586a49a74458014b91900531898c3c32b093b8760063f4316ea23c68d4c6b",
@@ -3278,9 +2805,7 @@
         "forge/job/job.pb.rs",
         "forge/job/job.pb.ts"
       ],
-      "protoFiles": [
-        "forge/job/job.proto"
-      ]
+      "protoFiles": ["forge/job/job.proto"]
     },
     "github.com/s4wave/spacewave/forge/lib/docker": {
       "hash": "c16d3c5ffb37c7d864f73dc3839248a1b68e4e0196686190e0ba708ba7551b2c",
@@ -3291,9 +2816,7 @@
         "forge/lib/docker/config.pb.rs",
         "forge/lib/docker/config.pb.ts"
       ],
-      "protoFiles": [
-        "forge/lib/docker/config.proto"
-      ]
+      "protoFiles": ["forge/lib/docker/config.proto"]
     },
     "github.com/s4wave/spacewave/forge/lib/git/clone": {
       "hash": "dacd57a37858e38b08cedfd2027e576a0b57cb25d68ab6da8c662e3bce5ca06e",
@@ -3304,9 +2827,7 @@
         "forge/lib/git/clone/config.pb.rs",
         "forge/lib/git/clone/config.pb.ts"
       ],
-      "protoFiles": [
-        "forge/lib/git/clone/config.proto"
-      ]
+      "protoFiles": ["forge/lib/git/clone/config.proto"]
     },
     "github.com/s4wave/spacewave/forge/lib/kvtx": {
       "hash": "59e850c914d79adc08983a26d666b8e61c0886bdb9eba4b10dd1a17ebe50c8b9",
@@ -3317,9 +2838,7 @@
         "forge/lib/kvtx/config.pb.rs",
         "forge/lib/kvtx/config.pb.ts"
       ],
-      "protoFiles": [
-        "forge/lib/kvtx/config.proto"
-      ]
+      "protoFiles": ["forge/lib/kvtx/config.proto"]
     },
     "github.com/s4wave/spacewave/forge/lib/util/wait": {
       "hash": "4c407676c0c7a654195662d02258a4cba1bc8d9877805cc03bdbef70f8412f88",
@@ -3330,9 +2849,7 @@
         "forge/lib/util/wait/config.pb.rs",
         "forge/lib/util/wait/config.pb.ts"
       ],
-      "protoFiles": [
-        "forge/lib/util/wait/config.proto"
-      ]
+      "protoFiles": ["forge/lib/util/wait/config.proto"]
     },
     "github.com/s4wave/spacewave/forge/lib/v86/bun": {
       "hash": "7133ba2955470859a1f3c5d0e33ec46d675731cfbb4691c6fa75f42df287a5d7",
@@ -3343,9 +2860,7 @@
         "forge/lib/v86/bun/config.pb.rs",
         "forge/lib/v86/bun/config.pb.ts"
       ],
-      "protoFiles": [
-        "forge/lib/v86/bun/config.proto"
-      ]
+      "protoFiles": ["forge/lib/v86/bun/config.proto"]
     },
     "github.com/s4wave/spacewave/forge/pass": {
       "hash": "65e3cb8634dee08b2c82775587df23d74890d1858456e6761c00190b02422ca5",
@@ -3356,9 +2871,7 @@
         "forge/pass/pass.pb.rs",
         "forge/pass/pass.pb.ts"
       ],
-      "protoFiles": [
-        "forge/pass/pass.proto"
-      ]
+      "protoFiles": ["forge/pass/pass.proto"]
     },
     "github.com/s4wave/spacewave/forge/pass/controller": {
       "hash": "65c6cd4bb2d191f27c0abdd277f9d7f8929fc5e796d1338de7048ab37f73387d",
@@ -3369,9 +2882,7 @@
         "forge/pass/controller/config.pb.rs",
         "forge/pass/controller/config.pb.ts"
       ],
-      "protoFiles": [
-        "forge/pass/controller/config.proto"
-      ]
+      "protoFiles": ["forge/pass/controller/config.proto"]
     },
     "github.com/s4wave/spacewave/forge/pass/tx": {
       "hash": "9f2092830402e87597d631dad63d63058d2f2ffbaa00512473d7a43373a4dac5",
@@ -3382,9 +2893,7 @@
         "forge/pass/tx/tx.pb.rs",
         "forge/pass/tx/tx.pb.ts"
       ],
-      "protoFiles": [
-        "forge/pass/tx/tx.proto"
-      ]
+      "protoFiles": ["forge/pass/tx/tx.proto"]
     },
     "github.com/s4wave/spacewave/forge/target": {
       "hash": "8de8d1a73e849518b50166924fa2442a0a0fb5382e0c9af31945e226011bcac4",
@@ -3395,9 +2904,7 @@
         "forge/target/target.pb.rs",
         "forge/target/target.pb.ts"
       ],
-      "protoFiles": [
-        "forge/target/target.proto"
-      ]
+      "protoFiles": ["forge/target/target.proto"]
     },
     "github.com/s4wave/spacewave/forge/task": {
       "hash": "2b2f792f78c9bba00ed714c5cc89425af2fab7b58fb84ef4bd3b3813ef67f4fe",
@@ -3408,9 +2915,7 @@
         "forge/task/task.pb.rs",
         "forge/task/task.pb.ts"
       ],
-      "protoFiles": [
-        "forge/task/task.proto"
-      ]
+      "protoFiles": ["forge/task/task.proto"]
     },
     "github.com/s4wave/spacewave/forge/task/controller": {
       "hash": "67b454aed9abe97ca94950074b1e174cfeb0787fc93ef6098335c0783b74debc",
@@ -3421,9 +2926,7 @@
         "forge/task/controller/config.pb.rs",
         "forge/task/controller/config.pb.ts"
       ],
-      "protoFiles": [
-        "forge/task/controller/config.proto"
-      ]
+      "protoFiles": ["forge/task/controller/config.proto"]
     },
     "github.com/s4wave/spacewave/forge/task/tx": {
       "hash": "deb4f3cecd636b2be0beb4af9ad7c76343e757fe35949e7cef926dff5063287e",
@@ -3434,9 +2937,7 @@
         "forge/task/tx/tx.pb.rs",
         "forge/task/tx/tx.pb.ts"
       ],
-      "protoFiles": [
-        "forge/task/tx/tx.proto"
-      ]
+      "protoFiles": ["forge/task/tx/tx.proto"]
     },
     "github.com/s4wave/spacewave/forge/value": {
       "hash": "d97e23be1c53d24d3bf78203fd3fa85b6a94d2c58452dc9da933a93c00c26d95",
@@ -3447,9 +2948,7 @@
         "forge/value/value.pb.rs",
         "forge/value/value.pb.ts"
       ],
-      "protoFiles": [
-        "forge/value/value.proto"
-      ]
+      "protoFiles": ["forge/value/value.proto"]
     },
     "github.com/s4wave/spacewave/forge/worker": {
       "hash": "e10088236530261febe1765c112a286075d880e2b5c6a5194cf5a30352ef0cd5",
@@ -3460,9 +2959,7 @@
         "forge/worker/worker.pb.rs",
         "forge/worker/worker.pb.ts"
       ],
-      "protoFiles": [
-        "forge/worker/worker.proto"
-      ]
+      "protoFiles": ["forge/worker/worker.proto"]
     },
     "github.com/s4wave/spacewave/forge/worker/controller": {
       "hash": "989f5b72991ba528a8027e041878cc4f91468e19610f14790795ebd2a013e244",
@@ -3473,9 +2970,7 @@
         "forge/worker/controller/config.pb.rs",
         "forge/worker/controller/config.pb.ts"
       ],
-      "protoFiles": [
-        "forge/worker/controller/config.proto"
-      ]
+      "protoFiles": ["forge/worker/controller/config.proto"]
     },
     "github.com/s4wave/spacewave/identity": {
       "hash": "85f02e1d0a08c32b101b666fd9bad9a7715f3eba38bc680e62af0f0a396669c8",
@@ -3486,9 +2981,7 @@
         "identity/identity.pb.rs",
         "identity/identity.pb.ts"
       ],
-      "protoFiles": [
-        "identity/identity.proto"
-      ]
+      "protoFiles": ["identity/identity.proto"]
     },
     "github.com/s4wave/spacewave/identity/domain": {
       "hash": "a5c438808e98d8d4abaea79924391d666c0019914fff100ae1a14271c6b9346b",
@@ -3499,9 +2992,7 @@
         "identity/domain/domain.pb.rs",
         "identity/domain/domain.pb.ts"
       ],
-      "protoFiles": [
-        "identity/domain/domain.proto"
-      ]
+      "protoFiles": ["identity/domain/domain.proto"]
     },
     "github.com/s4wave/spacewave/identity/domain/service": {
       "hash": "f4b5e4ad5733faee5d1ef9b863dc94ea26103ad99f7391113b22122c8d0a3b60",
@@ -3515,9 +3006,7 @@
         "identity/domain/service/service_srpc.pb.rs",
         "identity/domain/service/service_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "identity/domain/service/service.proto"
-      ]
+      "protoFiles": ["identity/domain/service/service.proto"]
     },
     "github.com/s4wave/spacewave/identity/domain/service/client": {
       "hash": "273c541cdf8d2a485179ef8bf10e56cd94808663b2284c507c0309b50328e22d",
@@ -3528,9 +3017,7 @@
         "identity/domain/service/client/client.pb.rs",
         "identity/domain/service/client/client.pb.ts"
       ],
-      "protoFiles": [
-        "identity/domain/service/client/client.proto"
-      ]
+      "protoFiles": ["identity/domain/service/client/client.proto"]
     },
     "github.com/s4wave/spacewave/identity/domain/service/server": {
       "hash": "cc5ef104e9e00beb89b45dccb9ed77503a6d247829c0a8f3e0984faba8ced6ee",
@@ -3541,9 +3028,7 @@
         "identity/domain/service/server/server.pb.rs",
         "identity/domain/service/server/server.pb.ts"
       ],
-      "protoFiles": [
-        "identity/domain/service/server/server.proto"
-      ]
+      "protoFiles": ["identity/domain/service/server/server.proto"]
     },
     "github.com/s4wave/spacewave/identity/domain/static": {
       "hash": "857b79da83170b094a064f9a451587138d75acc78f1692f6b89eb6093e6df2f8",
@@ -3553,9 +3038,7 @@
         "identity/domain/static/static.pb.h",
         "identity/domain/static/static.pb.ts"
       ],
-      "protoFiles": [
-        "identity/domain/static/static.proto"
-      ]
+      "protoFiles": ["identity/domain/static/static.proto"]
     },
     "github.com/s4wave/spacewave/identity/world": {
       "hash": "2ab06aef2cb50820f0ac90275c59867054a154af184f9456d70a2da2d6817b8b",
@@ -3566,9 +3049,7 @@
         "identity/world/world.pb.rs",
         "identity/world/world.pb.ts"
       ],
-      "protoFiles": [
-        "identity/world/world.proto"
-      ]
+      "protoFiles": ["identity/world/world.proto"]
     },
     "github.com/s4wave/spacewave/net/crypto": {
       "hash": "faec094f89ce61ecd3d9aa7f43aae69aa48a33893fbe0d46ac958c5cf2304e08",
@@ -3579,9 +3060,7 @@
         "net/crypto/crypto.pb.rs",
         "net/crypto/crypto.pb.ts"
       ],
-      "protoFiles": [
-        "net/crypto/crypto.proto"
-      ]
+      "protoFiles": ["net/crypto/crypto.proto"]
     },
     "github.com/s4wave/spacewave/net/daemon/api": {
       "hash": "7460ffa41b91f326e25ed25fd915a3e6161e6c04d3e2ff1d341c897868d31c20",
@@ -3592,9 +3071,7 @@
         "net/daemon/api/api.pb.rs",
         "net/daemon/api/api.pb.ts"
       ],
-      "protoFiles": [
-        "net/daemon/api/api.proto"
-      ]
+      "protoFiles": ["net/daemon/api/api.proto"]
     },
     "github.com/s4wave/spacewave/net/daemon/api/controller": {
       "hash": "e99e28d80ebaf3d92751bb9060a6c8be159164a15ea7f439744d73f4ba9b624b",
@@ -3605,9 +3082,7 @@
         "net/daemon/api/controller/controller.pb.rs",
         "net/daemon/api/controller/controller.pb.ts"
       ],
-      "protoFiles": [
-        "net/daemon/api/controller/controller.proto"
-      ]
+      "protoFiles": ["net/daemon/api/controller/controller.proto"]
     },
     "github.com/s4wave/spacewave/net/envelope": {
       "hash": "9bfd0c45e1e4c919eee92c54e1db76c16847555d85213565fb3999bb7c2d1308",
@@ -3618,9 +3093,7 @@
         "net/envelope/envelope.pb.rs",
         "net/envelope/envelope.pb.ts"
       ],
-      "protoFiles": [
-        "net/envelope/envelope.proto"
-      ]
+      "protoFiles": ["net/envelope/envelope.proto"]
     },
     "github.com/s4wave/spacewave/net/hash": {
       "hash": "7821cabc28f3cbd73f00096d85d5291591b4430315e6138cd6d25b2b32ff3262",
@@ -3631,9 +3104,7 @@
         "net/hash/hash.pb.rs",
         "net/hash/hash.pb.ts"
       ],
-      "protoFiles": [
-        "net/hash/hash.proto"
-      ]
+      "protoFiles": ["net/hash/hash.proto"]
     },
     "github.com/s4wave/spacewave/net/http/listener": {
       "hash": "6ed30b40772af143c291efd1b5c40e20fead7b876df1ebbca412842db33480e9",
@@ -3644,9 +3115,7 @@
         "net/http/listener/config.pb.rs",
         "net/http/listener/config.pb.ts"
       ],
-      "protoFiles": [
-        "net/http/listener/config.proto"
-      ]
+      "protoFiles": ["net/http/listener/config.proto"]
     },
     "github.com/s4wave/spacewave/net/link/establish": {
       "hash": "3867a07d382c63f6a0221ca464fef49fd90ce138b09614bfba1470b069f1ccf2",
@@ -3657,9 +3126,7 @@
         "net/link/establish/config.pb.rs",
         "net/link/establish/config.pb.ts"
       ],
-      "protoFiles": [
-        "net/link/establish/config.proto"
-      ]
+      "protoFiles": ["net/link/establish/config.proto"]
     },
     "github.com/s4wave/spacewave/net/link/hold-open": {
       "hash": "6ff0ba85bc63c48eba78cbec67410ac62af232ff31350c1449fdf5b93b0d46f7",
@@ -3670,9 +3137,7 @@
         "net/link/hold-open/config.pb.rs",
         "net/link/hold-open/config.pb.ts"
       ],
-      "protoFiles": [
-        "net/link/hold-open/config.proto"
-      ]
+      "protoFiles": ["net/link/hold-open/config.proto"]
     },
     "github.com/s4wave/spacewave/net/link/solicit": {
       "hash": "78e9d5dcabd1de669bf8ab750e79af172016e20a2eb591469c78408ad39aba28",
@@ -3683,9 +3148,7 @@
         "net/link/solicit/solicit.pb.rs",
         "net/link/solicit/solicit.pb.ts"
       ],
-      "protoFiles": [
-        "net/link/solicit/solicit.proto"
-      ]
+      "protoFiles": ["net/link/solicit/solicit.proto"]
     },
     "github.com/s4wave/spacewave/net/link/solicit/controller": {
       "hash": "ff241394127f59ccfd8586de328620fc92b3eef574b7a47e90f4b8544541cb15",
@@ -3696,9 +3159,7 @@
         "net/link/solicit/controller/config.pb.rs",
         "net/link/solicit/controller/config.pb.ts"
       ],
-      "protoFiles": [
-        "net/link/solicit/controller/config.proto"
-      ]
+      "protoFiles": ["net/link/solicit/controller/config.proto"]
     },
     "github.com/s4wave/spacewave/net/peer": {
       "hash": "2346cf06eeabfee6965d5986c7ffe3923380988ba8f7c557ee48a9741f92c26c",
@@ -3709,9 +3170,7 @@
         "net/peer/peer.pb.rs",
         "net/peer/peer.pb.ts"
       ],
-      "protoFiles": [
-        "net/peer/peer.proto"
-      ]
+      "protoFiles": ["net/peer/peer.proto"]
     },
     "github.com/s4wave/spacewave/net/peer/api": {
       "hash": "f55dd9d3f6f987b26ea967ab221beb761849b76e0d1a1aec6294fbfd120d9fd9",
@@ -3725,9 +3184,7 @@
         "net/peer/api/api_srpc.pb.rs",
         "net/peer/api/api_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "net/peer/api/api.proto"
-      ]
+      "protoFiles": ["net/peer/api/api.proto"]
     },
     "github.com/s4wave/spacewave/net/peer/controller": {
       "hash": "bef5f1329d9eb5695065660e8289d9655b34264780343d958377b09195b7f878",
@@ -3738,9 +3195,7 @@
         "net/peer/controller/config.pb.rs",
         "net/peer/controller/config.pb.ts"
       ],
-      "protoFiles": [
-        "net/peer/controller/config.proto"
-      ]
+      "protoFiles": ["net/peer/controller/config.proto"]
     },
     "github.com/s4wave/spacewave/net/pubsub/api": {
       "hash": "5644a36cdb635d613b33fe269ead7d302d7912a9634d7bc24ae9d9e51e82c5ca",
@@ -3754,9 +3209,7 @@
         "net/pubsub/api/api_srpc.pb.rs",
         "net/pubsub/api/api_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "net/pubsub/api/api.proto"
-      ]
+      "protoFiles": ["net/pubsub/api/api.proto"]
     },
     "github.com/s4wave/spacewave/net/pubsub/floodsub": {
       "hash": "aea7d0225e6e0906a9a8e8c5f399ceaaafd5dd6f7506aed47d9612e68f51a852",
@@ -3767,9 +3220,7 @@
         "net/pubsub/floodsub/floodsub.pb.rs",
         "net/pubsub/floodsub/floodsub.pb.ts"
       ],
-      "protoFiles": [
-        "net/pubsub/floodsub/floodsub.proto"
-      ]
+      "protoFiles": ["net/pubsub/floodsub/floodsub.proto"]
     },
     "github.com/s4wave/spacewave/net/pubsub/floodsub/controller": {
       "hash": "23cc67daee645830d7a3d88e89cc1cbdd94b94dcaa32f419925acf9e61670dfa",
@@ -3780,9 +3231,7 @@
         "net/pubsub/floodsub/controller/config.pb.rs",
         "net/pubsub/floodsub/controller/config.pb.ts"
       ],
-      "protoFiles": [
-        "net/pubsub/floodsub/controller/config.proto"
-      ]
+      "protoFiles": ["net/pubsub/floodsub/controller/config.proto"]
     },
     "github.com/s4wave/spacewave/net/pubsub/relay": {
       "hash": "03b8efb0212176d191f5edd375c5e8e3ac1e20efa72ca197f0e678dae82c643d",
@@ -3793,9 +3242,7 @@
         "net/pubsub/relay/config.pb.rs",
         "net/pubsub/relay/config.pb.ts"
       ],
-      "protoFiles": [
-        "net/pubsub/relay/config.proto"
-      ]
+      "protoFiles": ["net/pubsub/relay/config.proto"]
     },
     "github.com/s4wave/spacewave/net/pubsub/util/pubmessage": {
       "hash": "3d7134063da5c9e5d94c8afd45237000f35b1f40a073ca9cfc47d35c80121506",
@@ -3806,9 +3253,7 @@
         "net/pubsub/util/pubmessage/pubmessage.pb.rs",
         "net/pubsub/util/pubmessage/pubmessage.pb.ts"
       ],
-      "protoFiles": [
-        "net/pubsub/util/pubmessage/pubmessage.proto"
-      ]
+      "protoFiles": ["net/pubsub/util/pubmessage/pubmessage.proto"]
     },
     "github.com/s4wave/spacewave/net/rpc/access": {
       "hash": "996ee28514cab12c93c227de8d7ac5aa533efc16541fcb9ff6e029029c4dd92e",
@@ -3822,9 +3267,7 @@
         "net/rpc/access/access_srpc.pb.rs",
         "net/rpc/access/access_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "net/rpc/access/access.proto"
-      ]
+      "protoFiles": ["net/rpc/access/access.proto"]
     },
     "github.com/s4wave/spacewave/net/signaling/echo": {
       "hash": "00783efaa9542efc121b6e3a53e8c2fd6877f6b974f711ca2f48051db4e7a4d7",
@@ -3835,9 +3278,7 @@
         "net/signaling/echo/echo.pb.rs",
         "net/signaling/echo/echo.pb.ts"
       ],
-      "protoFiles": [
-        "net/signaling/echo/echo.proto"
-      ]
+      "protoFiles": ["net/signaling/echo/echo.proto"]
     },
     "github.com/s4wave/spacewave/net/signaling/rpc": {
       "hash": "9f167198e1573a55de38f16c75307efc05eaf49f550b92cee2d75162c63d5307",
@@ -3851,9 +3292,7 @@
         "net/signaling/rpc/signaling_srpc.pb.rs",
         "net/signaling/rpc/signaling_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "net/signaling/rpc/signaling.proto"
-      ]
+      "protoFiles": ["net/signaling/rpc/signaling.proto"]
     },
     "github.com/s4wave/spacewave/net/signaling/rpc/client": {
       "hash": "42db435a66197ffa107a6a266ec556b4f00a3ef08206c62b7f75c3c535a4753f",
@@ -3864,9 +3303,7 @@
         "net/signaling/rpc/client/config.pb.rs",
         "net/signaling/rpc/client/config.pb.ts"
       ],
-      "protoFiles": [
-        "net/signaling/rpc/client/config.proto"
-      ]
+      "protoFiles": ["net/signaling/rpc/client/config.proto"]
     },
     "github.com/s4wave/spacewave/net/signaling/rpc/server": {
       "hash": "c1faee12801d403d7c1c661e52727965998c398229b62ac9310cf11c779add6c",
@@ -3877,9 +3314,7 @@
         "net/signaling/rpc/server/server.pb.rs",
         "net/signaling/rpc/server/server.pb.ts"
       ],
-      "protoFiles": [
-        "net/signaling/rpc/server/server.proto"
-      ]
+      "protoFiles": ["net/signaling/rpc/server/server.proto"]
     },
     "github.com/s4wave/spacewave/net/stream/api": {
       "hash": "34663fea3889d810211e6f047bb9bf7c1333b3ac5e99d423a205642e473d15a5",
@@ -3893,9 +3328,7 @@
         "net/stream/api/api_srpc.pb.rs",
         "net/stream/api/api_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "net/stream/api/api.proto"
-      ]
+      "protoFiles": ["net/stream/api/api.proto"]
     },
     "github.com/s4wave/spacewave/net/stream/api/accept": {
       "hash": "aeacaf707aa228052bfbac082d5fc9f1eb181103029861e806b23e696ceb2493",
@@ -3906,9 +3339,7 @@
         "net/stream/api/accept/accept.pb.rs",
         "net/stream/api/accept/accept.pb.ts"
       ],
-      "protoFiles": [
-        "net/stream/api/accept/accept.proto"
-      ]
+      "protoFiles": ["net/stream/api/accept/accept.proto"]
     },
     "github.com/s4wave/spacewave/net/stream/api/dial": {
       "hash": "77f821ca322e878db33534607c080720fbef47a1dc62f06700d5b26295a0e5ae",
@@ -3919,9 +3350,7 @@
         "net/stream/api/dial/dial.pb.rs",
         "net/stream/api/dial/dial.pb.ts"
       ],
-      "protoFiles": [
-        "net/stream/api/dial/dial.proto"
-      ]
+      "protoFiles": ["net/stream/api/dial/dial.proto"]
     },
     "github.com/s4wave/spacewave/net/stream/api/rpc": {
       "hash": "6d3ee1ef1106786d5e0dfa514d8fa94bc31398809344fc6b9bb98a02b03ea087",
@@ -3932,9 +3361,7 @@
         "net/stream/api/rpc/rpc.pb.rs",
         "net/stream/api/rpc/rpc.pb.ts"
       ],
-      "protoFiles": [
-        "net/stream/api/rpc/rpc.proto"
-      ]
+      "protoFiles": ["net/stream/api/rpc/rpc.proto"]
     },
     "github.com/s4wave/spacewave/net/stream/echo": {
       "hash": "8265aae27ff725831784b30fb71e9b34b0d80b46fac5e3f94febf163a45fafe8",
@@ -3945,9 +3372,7 @@
         "net/stream/echo/echo.pb.rs",
         "net/stream/echo/echo.pb.ts"
       ],
-      "protoFiles": [
-        "net/stream/echo/echo.proto"
-      ]
+      "protoFiles": ["net/stream/echo/echo.proto"]
     },
     "github.com/s4wave/spacewave/net/stream/forwarding": {
       "hash": "5cf54efb5fe44a94bee4cfd7efa8e2ea11712f3ceca0269ae5301ecb9fd82f5b",
@@ -3958,9 +3383,7 @@
         "net/stream/forwarding/forwarding.pb.rs",
         "net/stream/forwarding/forwarding.pb.ts"
       ],
-      "protoFiles": [
-        "net/stream/forwarding/forwarding.proto"
-      ]
+      "protoFiles": ["net/stream/forwarding/forwarding.proto"]
     },
     "github.com/s4wave/spacewave/net/stream/listening": {
       "hash": "fcc5b3d38d528a7632f14d90284b2bf95b854fe613473be399f64296712f2ccb",
@@ -3971,9 +3394,7 @@
         "net/stream/listening/listening.pb.rs",
         "net/stream/listening/listening.pb.ts"
       ],
-      "protoFiles": [
-        "net/stream/listening/listening.proto"
-      ]
+      "protoFiles": ["net/stream/listening/listening.proto"]
     },
     "github.com/s4wave/spacewave/net/stream/relay": {
       "hash": "8a96fb3e832db5930dbd83f404964ab14707a51543f2f1c3e62b2717cf9f9f40",
@@ -3984,9 +3405,7 @@
         "net/stream/relay/relay.pb.rs",
         "net/stream/relay/relay.pb.ts"
       ],
-      "protoFiles": [
-        "net/stream/relay/relay.proto"
-      ]
+      "protoFiles": ["net/stream/relay/relay.proto"]
     },
     "github.com/s4wave/spacewave/net/stream/srpc/client": {
       "hash": "fa742733261c07f5c2f25f6802e8b3ccb36a3c10d1403f952624f44baa2dd9a8",
@@ -3997,9 +3416,7 @@
         "net/stream/srpc/client/client.pb.rs",
         "net/stream/srpc/client/client.pb.ts"
       ],
-      "protoFiles": [
-        "net/stream/srpc/client/client.proto"
-      ]
+      "protoFiles": ["net/stream/srpc/client/client.proto"]
     },
     "github.com/s4wave/spacewave/net/stream/srpc/client/controller": {
       "hash": "9139f27f22df378c1063bc858640bd6f598af8189d521e07593ffe1fa70ea402",
@@ -4010,9 +3427,7 @@
         "net/stream/srpc/client/controller/config.pb.rs",
         "net/stream/srpc/client/controller/config.pb.ts"
       ],
-      "protoFiles": [
-        "net/stream/srpc/client/controller/config.proto"
-      ]
+      "protoFiles": ["net/stream/srpc/client/controller/config.proto"]
     },
     "github.com/s4wave/spacewave/net/stream/srpc/server": {
       "hash": "79898099620ab4b430cbc153874883068db18989f17e417b27f38303bf71ef47",
@@ -4023,9 +3438,7 @@
         "net/stream/srpc/server/server.pb.rs",
         "net/stream/srpc/server/server.pb.ts"
       ],
-      "protoFiles": [
-        "net/stream/srpc/server/server.proto"
-      ]
+      "protoFiles": ["net/stream/srpc/server/server.proto"]
     },
     "github.com/s4wave/spacewave/net/stream/srpc/server/lookup": {
       "hash": "943ef86d8a910275258cf9198bf62876ba24f97aa9fb4b27eb5e9415fa6eee04",
@@ -4036,9 +3449,7 @@
         "net/stream/srpc/server/lookup/lookup.pb.rs",
         "net/stream/srpc/server/lookup/lookup.pb.ts"
       ],
-      "protoFiles": [
-        "net/stream/srpc/server/lookup/lookup.proto"
-      ]
+      "protoFiles": ["net/stream/srpc/server/lookup/lookup.proto"]
     },
     "github.com/s4wave/spacewave/net/tptaddr/controller": {
       "hash": "dfe61e2111af539f2d8e9924c507ed8f0cd1682c604c5eaefcd1fe06863d0f89",
@@ -4049,9 +3460,7 @@
         "net/tptaddr/controller/config.pb.rs",
         "net/tptaddr/controller/config.pb.ts"
       ],
-      "protoFiles": [
-        "net/tptaddr/controller/config.proto"
-      ]
+      "protoFiles": ["net/tptaddr/controller/config.proto"]
     },
     "github.com/s4wave/spacewave/net/tptaddr/static": {
       "hash": "6c12470098a27b5cce4ae99019c4cd8eea33e41e92c9f2ff2ae2e3207d0b94d5",
@@ -4061,9 +3470,7 @@
         "net/tptaddr/static/static.pb.h",
         "net/tptaddr/static/static.pb.ts"
       ],
-      "protoFiles": [
-        "net/tptaddr/static/static.proto"
-      ]
+      "protoFiles": ["net/tptaddr/static/static.proto"]
     },
     "github.com/s4wave/spacewave/net/transport/common/conn": {
       "hash": "d08173827d0a6b556f01acaa35a9e5fbf82c7d40067ab03a947d2b3f21fae452",
@@ -4074,9 +3481,7 @@
         "net/transport/common/conn/conn.pb.rs",
         "net/transport/common/conn/conn.pb.ts"
       ],
-      "protoFiles": [
-        "net/transport/common/conn/conn.proto"
-      ]
+      "protoFiles": ["net/transport/common/conn/conn.proto"]
     },
     "github.com/s4wave/spacewave/net/transport/common/dialer": {
       "hash": "0dcbd20a5e6b0298f64acff7e70d3e2936b9d2677f61ba7402fbb756f92ba704",
@@ -4087,9 +3492,7 @@
         "net/transport/common/dialer/dialer.pb.rs",
         "net/transport/common/dialer/dialer.pb.ts"
       ],
-      "protoFiles": [
-        "net/transport/common/dialer/dialer.proto"
-      ]
+      "protoFiles": ["net/transport/common/dialer/dialer.proto"]
     },
     "github.com/s4wave/spacewave/net/transport/common/pconn": {
       "hash": "41660109cdb9caac1264b1c48719548a3650f289f785692ef68cecd26cad54f1",
@@ -4100,9 +3503,7 @@
         "net/transport/common/pconn/pconn.pb.rs",
         "net/transport/common/pconn/pconn.pb.ts"
       ],
-      "protoFiles": [
-        "net/transport/common/pconn/pconn.proto"
-      ]
+      "protoFiles": ["net/transport/common/pconn/pconn.proto"]
     },
     "github.com/s4wave/spacewave/net/transport/common/quic": {
       "hash": "740e04057545916392ca9eef0fa7cad03204c4a0eda9cfcf2a91eced89d7695d",
@@ -4113,9 +3514,7 @@
         "net/transport/common/quic/quic.pb.rs",
         "net/transport/common/quic/quic.pb.ts"
       ],
-      "protoFiles": [
-        "net/transport/common/quic/quic.proto"
-      ]
+      "protoFiles": ["net/transport/common/quic/quic.proto"]
     },
     "github.com/s4wave/spacewave/net/transport/controller": {
       "hash": "7d3f1d85d22b518cdab8ef0c5e742162d1af1ff78fdda815558fd40071a5eb05",
@@ -4126,9 +3525,7 @@
         "net/transport/controller/controller.pb.rs",
         "net/transport/controller/controller.pb.ts"
       ],
-      "protoFiles": [
-        "net/transport/controller/controller.proto"
-      ]
+      "protoFiles": ["net/transport/controller/controller.proto"]
     },
     "github.com/s4wave/spacewave/net/transport/inproc": {
       "hash": "815f351bffe4b30d42abce423abffcf7c0fe998883e1ab9eec994bea262201da",
@@ -4139,9 +3536,7 @@
         "net/transport/inproc/inproc.pb.rs",
         "net/transport/inproc/inproc.pb.ts"
       ],
-      "protoFiles": [
-        "net/transport/inproc/inproc.proto"
-      ]
+      "protoFiles": ["net/transport/inproc/inproc.proto"]
     },
     "github.com/s4wave/spacewave/net/transport/udp": {
       "hash": "1a49fd08d0fe677a493b7f7447cc1d9e2496a14e9c0e423ab80f7eb546daae60",
@@ -4152,9 +3547,7 @@
         "net/transport/udp/udp.pb.rs",
         "net/transport/udp/udp.pb.ts"
       ],
-      "protoFiles": [
-        "net/transport/udp/udp.proto"
-      ]
+      "protoFiles": ["net/transport/udp/udp.proto"]
     },
     "github.com/s4wave/spacewave/net/transport/webrtc": {
       "hash": "950f9dbddcb36675295910f527bd0dbf77af7f7d082a46dff7fddd937f7d0907",
@@ -4165,9 +3558,7 @@
         "net/transport/webrtc/webrtc.pb.rs",
         "net/transport/webrtc/webrtc.pb.ts"
       ],
-      "protoFiles": [
-        "net/transport/webrtc/webrtc.proto"
-      ]
+      "protoFiles": ["net/transport/webrtc/webrtc.proto"]
     },
     "github.com/s4wave/spacewave/net/transport/websocket": {
       "hash": "0b5cfa0c101017e7371ea92f7a995ff5571097ecc79904f52bbb5bc8ff6f2458",
@@ -4178,9 +3569,7 @@
         "net/transport/websocket/websocket.pb.rs",
         "net/transport/websocket/websocket.pb.ts"
       ],
-      "protoFiles": [
-        "net/transport/websocket/websocket.proto"
-      ]
+      "protoFiles": ["net/transport/websocket/websocket.proto"]
     },
     "github.com/s4wave/spacewave/net/transport/websocket/http": {
       "hash": "57291338ec118539ac73f2e1de1a1a74360438dbd04ca0a5f12f799ba94762f5",
@@ -4191,9 +3580,7 @@
         "net/transport/websocket/http/http.pb.rs",
         "net/transport/websocket/http/http.pb.ts"
       ],
-      "protoFiles": [
-        "net/transport/websocket/http/http.proto"
-      ]
+      "protoFiles": ["net/transport/websocket/http/http.proto"]
     },
     "github.com/s4wave/spacewave/plugin/cli": {
       "hash": "f490b6db60121269dd0cae1f27c9c156d2e19dca2f8f744931a98ebb5d857be0",
@@ -4204,9 +3591,7 @@
         "plugin/cli/config.pb.rs",
         "plugin/cli/config.pb.ts"
       ],
-      "protoFiles": [
-        "plugin/cli/config.proto"
-      ]
+      "protoFiles": ["plugin/cli/config.proto"]
     },
     "github.com/s4wave/spacewave/plugin/notes/proto": {
       "hash": "89b74d7830aa2c6b7d62c47ff1d7a01e37592a821dd0d80a88a8d7a4c77dd415",
@@ -4274,9 +3659,7 @@
         "plugin/sql/config.pb.rs",
         "plugin/sql/config.pb.ts"
       ],
-      "protoFiles": [
-        "plugin/sql/config.proto"
-      ]
+      "protoFiles": ["plugin/sql/config.proto"]
     },
     "github.com/s4wave/spacewave/sdk/account": {
       "hash": "f69ba591db8e8d79e093f73d2480a83157a90033690146d4125a392a39794d9d",
@@ -4290,9 +3673,7 @@
         "sdk/account/account_srpc.pb.rs",
         "sdk/account/account_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/account/account.proto"
-      ]
+      "protoFiles": ["sdk/account/account.proto"]
     },
     "github.com/s4wave/spacewave/sdk/apt": {
       "hash": "586f1dc9f2da9830fc7518d629da9697a9b3a3a8138dd3b8ba4fcbe4ff81ac80",
@@ -4303,9 +3684,7 @@
         "sdk/apt/repository.pb.rs",
         "sdk/apt/repository.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/apt/repository.proto"
-      ]
+      "protoFiles": ["sdk/apt/repository.proto"]
     },
     "github.com/s4wave/spacewave/sdk/block/cursor": {
       "hash": "32902675a5720a126ef2db0e13529f2f3b2ab2e570d55f9405c0f131007c7dbe",
@@ -4320,9 +3699,7 @@
         "sdk/block/cursor/cursor_srpc.pb.rs",
         "sdk/block/cursor/cursor_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/block/cursor/cursor.proto"
-      ]
+      "protoFiles": ["sdk/block/cursor/cursor.proto"]
     },
     "github.com/s4wave/spacewave/sdk/block/transaction": {
       "hash": "230f3b2bb21776b31e8d0cf6ee56734dafae5270f88fbbbff4a415eabd658e06",
@@ -4337,9 +3714,7 @@
         "sdk/block/transaction/transaction_srpc.pb.rs",
         "sdk/block/transaction/transaction_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/block/transaction/transaction.proto"
-      ]
+      "protoFiles": ["sdk/block/transaction/transaction.proto"]
     },
     "github.com/s4wave/spacewave/sdk/bucket/lookup": {
       "hash": "7caef9f3a1ea32ba85a34204fda07dd3fe2175119600578338205929b891f0f3",
@@ -4354,9 +3729,7 @@
         "sdk/bucket/lookup/lookup_srpc.pb.rs",
         "sdk/bucket/lookup/lookup_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/bucket/lookup/lookup.proto"
-      ]
+      "protoFiles": ["sdk/bucket/lookup/lookup.proto"]
     },
     "github.com/s4wave/spacewave/sdk/canvas": {
       "hash": "ea5a28557460e75539709c74e599aab779fe128ccd6391b74e7af7b707f21d44",
@@ -4370,9 +3743,7 @@
         "sdk/canvas/canvas_srpc.pb.rs",
         "sdk/canvas/canvas_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/canvas/canvas.proto"
-      ]
+      "protoFiles": ["sdk/canvas/canvas.proto"]
     },
     "github.com/s4wave/spacewave/sdk/cdn": {
       "hash": "27254c78b2cb50478d15eeb0668f7b0140e6cbcab8833cb889fb2d6b206085ac",
@@ -4387,9 +3758,7 @@
         "sdk/cdn/cdn-resource_srpc.pb.rs",
         "sdk/cdn/cdn-resource_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/cdn/cdn-resource.proto"
-      ]
+      "protoFiles": ["sdk/cdn/cdn-resource.proto"]
     },
     "github.com/s4wave/spacewave/sdk/chat": {
       "hash": "2aa8ab5b6f97c3ccd63289ad1301b5352ab005844503ce1e0ade58296438005b",
@@ -4400,9 +3769,7 @@
         "sdk/chat/chat.pb.rs",
         "sdk/chat/chat.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/chat/chat.proto"
-      ]
+      "protoFiles": ["sdk/chat/chat.proto"]
     },
     "github.com/s4wave/spacewave/sdk/chat/rpc": {
       "hash": "eb01384a052236f845acad9a9c29a4624d2b4a33cb92b98b7a95c8dd5d8ff075",
@@ -4416,9 +3783,7 @@
         "sdk/chat/rpc/rpc_srpc.pb.rs",
         "sdk/chat/rpc/rpc_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/chat/rpc/rpc.proto"
-      ]
+      "protoFiles": ["sdk/chat/rpc/rpc.proto"]
     },
     "github.com/s4wave/spacewave/sdk/cli/terminal": {
       "hash": "17388b21c791b477d18b5d89a683c42c010224d3773a5d544ba19b888b57d096",
@@ -4432,9 +3797,7 @@
         "sdk/cli/terminal/terminal_srpc.pb.rs",
         "sdk/cli/terminal/terminal_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/cli/terminal/terminal.proto"
-      ]
+      "protoFiles": ["sdk/cli/terminal/terminal.proto"]
     },
     "github.com/s4wave/spacewave/sdk/command": {
       "hash": "fa0be9272aa697790c4904119bc1ae5ea033fa263d4a8d18ca03f5f19a593534",
@@ -4445,9 +3808,7 @@
         "sdk/command/command.pb.rs",
         "sdk/command/command.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/command/command.proto"
-      ]
+      "protoFiles": ["sdk/command/command.proto"]
     },
     "github.com/s4wave/spacewave/sdk/command/registry": {
       "hash": "4e13aabd7189daf7e243cc2a2b5333e2e0d1e23e33ede30b24c78b9a9f3e12c4",
@@ -4462,9 +3823,7 @@
         "sdk/command/registry/registry_srpc.pb.rs",
         "sdk/command/registry/registry_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/command/registry/registry.proto"
-      ]
+      "protoFiles": ["sdk/command/registry/registry.proto"]
     },
     "github.com/s4wave/spacewave/sdk/configtype/registry": {
       "hash": "93ca3eaa5144cd4b284ed5691be7cb441ae5de4f9e12393e45fa01926387012c",
@@ -4479,9 +3838,7 @@
         "sdk/configtype/registry/registry_srpc.pb.rs",
         "sdk/configtype/registry/registry_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/configtype/registry/registry.proto"
-      ]
+      "protoFiles": ["sdk/configtype/registry/registry.proto"]
     },
     "github.com/s4wave/spacewave/sdk/debug": {
       "hash": "147382c90138d2b6b999e6657f8a3e66b2164624030799bd78fec979629f0251",
@@ -4495,9 +3852,7 @@
         "sdk/debug/debug_srpc.pb.rs",
         "sdk/debug/debug_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/debug/debug.proto"
-      ]
+      "protoFiles": ["sdk/debug/debug.proto"]
     },
     "github.com/s4wave/spacewave/sdk/debugdb": {
       "hash": "db72c24d6b91dd4c052ad2671551e07b1dfbb29e4f64dfc16d83fef1850e8770",
@@ -4512,9 +3867,7 @@
         "sdk/debugdb/debugdb_srpc.pb.rs",
         "sdk/debugdb/debugdb_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/debugdb/debugdb.proto"
-      ]
+      "protoFiles": ["sdk/debugdb/debugdb.proto"]
     },
     "github.com/s4wave/spacewave/sdk/deploy": {
       "hash": "4acfff8eb0ff430160d820c0b9068528ebfd26be3a555ec5533d18426d41111a",
@@ -4528,9 +3881,7 @@
         "sdk/deploy/deploy_srpc.pb.rs",
         "sdk/deploy/deploy_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/deploy/deploy.proto"
-      ]
+      "protoFiles": ["sdk/deploy/deploy.proto"]
     },
     "github.com/s4wave/spacewave/sdk/device": {
       "hash": "96476b4e7dc443cb922b11aefea8ad72145740326afd7108f9d01d3250478ebb",
@@ -4545,9 +3896,7 @@
         "sdk/device/device_srpc.pb.rs",
         "sdk/device/device_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/device/device.proto"
-      ]
+      "protoFiles": ["sdk/device/device.proto"]
     },
     "github.com/s4wave/spacewave/sdk/docs": {
       "hash": "ffe537eb3f7a941e18dab9eef69d044a97aaf4d9e4debff5382a045d41881550",
@@ -4558,9 +3907,7 @@
         "sdk/docs/docs.pb.rs",
         "sdk/docs/docs.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/docs/docs.proto"
-      ]
+      "protoFiles": ["sdk/docs/docs.proto"]
     },
     "github.com/s4wave/spacewave/sdk/git": {
       "hash": "b9933af8f863cb71fc9c844f9e462d98f8c4002692a67a44818ddcb7744f855b",
@@ -4584,10 +3931,7 @@
         "sdk/git/worktree_srpc.pb.rs",
         "sdk/git/worktree_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/git/repo.proto",
-        "sdk/git/worktree.proto"
-      ]
+      "protoFiles": ["sdk/git/repo.proto", "sdk/git/worktree.proto"]
     },
     "github.com/s4wave/spacewave/sdk/kv/world": {
       "hash": "0f1a4dfdcd9557d249f80773cdaaa9a7eb8e463af58332439d7f292aacb39656",
@@ -4598,9 +3942,7 @@
         "sdk/kv/world/world.pb.rs",
         "sdk/kv/world/world.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/kv/world/world.proto"
-      ]
+      "protoFiles": ["sdk/kv/world/world.proto"]
     },
     "github.com/s4wave/spacewave/sdk/layout": {
       "hash": "fd38937e5b59a969428fb01baf22851bd16ff7bfa036896f46f47fd0988e365a",
@@ -4614,9 +3956,7 @@
         "sdk/layout/layout_srpc.pb.rs",
         "sdk/layout/layout_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/layout/layout.proto"
-      ]
+      "protoFiles": ["sdk/layout/layout.proto"]
     },
     "github.com/s4wave/spacewave/sdk/layout/world": {
       "hash": "df4e1a4662be3a4cc6bcdc417dfb2c7df8a5423c2c86ad5e89b4949d5effb182",
@@ -4627,9 +3967,7 @@
         "sdk/layout/world/world.pb.rs",
         "sdk/layout/world/world.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/layout/world/world.proto"
-      ]
+      "protoFiles": ["sdk/layout/world/world.proto"]
     },
     "github.com/s4wave/spacewave/sdk/objecttype/registry": {
       "hash": "5bcea4a33d7f43aaed84bf86f2d272e7b7f51b487ef06587ed041ade5a81d5a8",
@@ -4644,9 +3982,7 @@
         "sdk/objecttype/registry/registry_srpc.pb.rs",
         "sdk/objecttype/registry/registry_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/objecttype/registry/registry.proto"
-      ]
+      "protoFiles": ["sdk/objecttype/registry/registry.proto"]
     },
     "github.com/s4wave/spacewave/sdk/org": {
       "hash": "c5dd58831885b6eaf7304987e5eed975b954c01747aa34d79296bd46f41516fc",
@@ -4660,9 +3996,7 @@
         "sdk/org/org_srpc.pb.rs",
         "sdk/org/org_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/org/org.proto"
-      ]
+      "protoFiles": ["sdk/org/org.proto"]
     },
     "github.com/s4wave/spacewave/sdk/process": {
       "hash": "ac0035e41b71286f582b5695193712e33e9be718330eac2cedbb1c9f91af8bfa",
@@ -4681,10 +4015,7 @@
         "sdk/process/process_srpc.pb.rs",
         "sdk/process/process_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/process/binding.proto",
-        "sdk/process/process.proto"
-      ]
+      "protoFiles": ["sdk/process/binding.proto", "sdk/process/process.proto"]
     },
     "github.com/s4wave/spacewave/sdk/provider": {
       "hash": "73593cb1345abc82415e699a256180c5fa57505be878351d988baf2ffe7f29af",
@@ -4699,9 +4030,7 @@
         "sdk/provider/provider_srpc.pb.rs",
         "sdk/provider/provider_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/provider/provider.proto"
-      ]
+      "protoFiles": ["sdk/provider/provider.proto"]
     },
     "github.com/s4wave/spacewave/sdk/provider/local": {
       "hash": "0df6122cfbc51aa414ac4bd82c6e0cd52e499606a85c4473191e6f9d425cc2c3",
@@ -4715,9 +4044,7 @@
         "sdk/provider/local/local_srpc.pb.rs",
         "sdk/provider/local/local_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/provider/local/local.proto"
-      ]
+      "protoFiles": ["sdk/provider/local/local.proto"]
     },
     "github.com/s4wave/spacewave/sdk/provider/spacewave": {
       "hash": "787b168151e9ea1684afe35e689a13db5623433615806c9c80a025799f399e2b",
@@ -4731,9 +4058,7 @@
         "sdk/provider/spacewave/spacewave_srpc.pb.rs",
         "sdk/provider/spacewave/spacewave_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/provider/spacewave/spacewave.proto"
-      ]
+      "protoFiles": ["sdk/provider/spacewave/spacewave.proto"]
     },
     "github.com/s4wave/spacewave/sdk/quickstart/registry": {
       "hash": "e8841a98c09529d7267e0679b391ce42921116c05adbcc7a3cb63770253d9611",
@@ -4748,9 +4073,7 @@
         "sdk/quickstart/registry/registry_srpc.pb.rs",
         "sdk/quickstart/registry/registry_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/quickstart/registry/registry.proto"
-      ]
+      "protoFiles": ["sdk/quickstart/registry/registry.proto"]
     },
     "github.com/s4wave/spacewave/sdk/root": {
       "hash": "5aeebb71216eceb3652cf73233461310579c3b61b55a062f9857d93958cda37e",
@@ -4765,9 +4088,7 @@
         "sdk/root/root_srpc.pb.rs",
         "sdk/root/root_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/root/root.proto"
-      ]
+      "protoFiles": ["sdk/root/root.proto"]
     },
     "github.com/s4wave/spacewave/sdk/secret": {
       "hash": "0017714fe83010bd9a944bf6213dd1623ed4f55e29ca02e9463a0c0d09c75777",
@@ -4781,9 +4102,7 @@
         "sdk/secret/secret_srpc.pb.rs",
         "sdk/secret/secret_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/secret/secret.proto"
-      ]
+      "protoFiles": ["sdk/secret/secret.proto"]
     },
     "github.com/s4wave/spacewave/sdk/session": {
       "hash": "abde3d6011986331ae827a1d6f9db54766413bfd9768df4bc6094828b6de0c0f",
@@ -4842,9 +4161,7 @@
         "sdk/sobject/sobject_srpc.pb.rs",
         "sdk/sobject/sobject_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/sobject/sobject.proto"
-      ]
+      "protoFiles": ["sdk/sobject/sobject.proto"]
     },
     "github.com/s4wave/spacewave/sdk/space": {
       "hash": "88ecf14150812c0f6ecdd6685a925b0f22732726c7881c93f9ca115cb37672bf",
@@ -4859,9 +4176,7 @@
         "sdk/space/space_srpc.pb.rs",
         "sdk/space/space_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/space/space.proto"
-      ]
+      "protoFiles": ["sdk/space/space.proto"]
     },
     "github.com/s4wave/spacewave/sdk/sql/query": {
       "hash": "18ac70b50bf9bb531184f48c988aca6515a2eba0fccc4e367e88b238de59a8f3",
@@ -4875,9 +4190,7 @@
         "sdk/sql/query/query_srpc.pb.rs",
         "sdk/sql/query/query_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/sql/query/query.proto"
-      ]
+      "protoFiles": ["sdk/sql/query/query.proto"]
     },
     "github.com/s4wave/spacewave/sdk/sql/query-result": {
       "hash": "3e59406297e6dcc9dc8b476e28225a6fd8b512a507c4a4d38ca1839f773d13d7",
@@ -4891,9 +4204,7 @@
         "sdk/sql/query-result/query-result_srpc.pb.rs",
         "sdk/sql/query-result/query-result_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/sql/query-result/query-result.proto"
-      ]
+      "protoFiles": ["sdk/sql/query-result/query-result.proto"]
     },
     "github.com/s4wave/spacewave/sdk/sql/query-result/world": {
       "hash": "df781769f7734c63fa8261678cab34fad56debe9307c519a4cd3f1363fdb3fbf",
@@ -4904,9 +4215,7 @@
         "sdk/sql/query-result/world/world.pb.rs",
         "sdk/sql/query-result/world/world.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/sql/query-result/world/world.proto"
-      ]
+      "protoFiles": ["sdk/sql/query-result/world/world.proto"]
     },
     "github.com/s4wave/spacewave/sdk/sql/query/world": {
       "hash": "cc3ba113358056f194d1e142562568641c2fb4b15d8b2c1f12591fc6c1f0e4d2",
@@ -4917,9 +4226,7 @@
         "sdk/sql/query/world/world.pb.rs",
         "sdk/sql/query/world/world.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/sql/query/world/world.proto"
-      ]
+      "protoFiles": ["sdk/sql/query/world/world.proto"]
     },
     "github.com/s4wave/spacewave/sdk/sql/schema": {
       "hash": "a29770e87d9542ff77d034ce4b8b78b58d140e6fdcd68086cdca73a3109e1c79",
@@ -4933,9 +4240,7 @@
         "sdk/sql/schema/schema_srpc.pb.rs",
         "sdk/sql/schema/schema_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/sql/schema/schema.proto"
-      ]
+      "protoFiles": ["sdk/sql/schema/schema.proto"]
     },
     "github.com/s4wave/spacewave/sdk/sql/schema/world": {
       "hash": "28da4df20da60dcf4a4fbb5ee24057e0ea36207f890fee24cff457491a5f4e8a",
@@ -4946,9 +4251,7 @@
         "sdk/sql/schema/world/world.pb.rs",
         "sdk/sql/schema/world/world.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/sql/schema/world/world.proto"
-      ]
+      "protoFiles": ["sdk/sql/schema/world/world.proto"]
     },
     "github.com/s4wave/spacewave/sdk/sql/table-view": {
       "hash": "2f3da559eccff52e59eac6686b07e9625610747bf094645eaa639310e0d7f3e0",
@@ -4962,9 +4265,7 @@
         "sdk/sql/table-view/table-view_srpc.pb.rs",
         "sdk/sql/table-view/table-view_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/sql/table-view/table-view.proto"
-      ]
+      "protoFiles": ["sdk/sql/table-view/table-view.proto"]
     },
     "github.com/s4wave/spacewave/sdk/sql/table-view/world": {
       "hash": "7febd0f235cc34690312145508935e089b3103abfa211424ad230b5286e2dfff",
@@ -4975,9 +4276,7 @@
         "sdk/sql/table-view/world/world.pb.rs",
         "sdk/sql/table-view/world/world.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/sql/table-view/world/world.proto"
-      ]
+      "protoFiles": ["sdk/sql/table-view/world/world.proto"]
     },
     "github.com/s4wave/spacewave/sdk/sql/workbench": {
       "hash": "854d940d6489256a56799c508c42aa8ba819eb1b538e8e34c82cdf63b28b4597",
@@ -4991,9 +4290,7 @@
         "sdk/sql/workbench/workbench_srpc.pb.rs",
         "sdk/sql/workbench/workbench_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/sql/workbench/workbench.proto"
-      ]
+      "protoFiles": ["sdk/sql/workbench/workbench.proto"]
     },
     "github.com/s4wave/spacewave/sdk/sql/workbench/world": {
       "hash": "31944e5cc2b636b46df64a764f3d1e289db6021db9e4b1557e2d9c57c58e2792",
@@ -5004,9 +4301,7 @@
         "sdk/sql/workbench/world/world.pb.rs",
         "sdk/sql/workbench/world/world.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/sql/workbench/world/world.proto"
-      ]
+      "protoFiles": ["sdk/sql/workbench/world/world.proto"]
     },
     "github.com/s4wave/spacewave/sdk/sql/world": {
       "hash": "4e92d51c8a67dca5b0c52781be527357bddd80942bb8c909503b4cd30e8246aa",
@@ -5017,9 +4312,7 @@
         "sdk/sql/world/world.pb.rs",
         "sdk/sql/world/world.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/sql/world/world.proto"
-      ]
+      "protoFiles": ["sdk/sql/world/world.proto"]
     },
     "github.com/s4wave/spacewave/sdk/sshhost": {
       "hash": "6485936bc9a4bca3763ab6162a25cd72c9fdb80e39d2ad15609c2883f69633df",
@@ -5033,9 +4326,7 @@
         "sdk/sshhost/sshhost_srpc.pb.rs",
         "sdk/sshhost/sshhost_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/sshhost/sshhost.proto"
-      ]
+      "protoFiles": ["sdk/sshhost/sshhost.proto"]
     },
     "github.com/s4wave/spacewave/sdk/status": {
       "hash": "16bf10b99bb17fc63b6066380f7939a9ae51f3759b617b43af82e672ca2070c2",
@@ -5049,9 +4340,7 @@
         "sdk/status/status_srpc.pb.rs",
         "sdk/status/status_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/status/status.proto"
-      ]
+      "protoFiles": ["sdk/status/status.proto"]
     },
     "github.com/s4wave/spacewave/sdk/terminal": {
       "hash": "8631d8a557a41406a1f4c63bd93374c369229b1c7aca81a15f2dc4cbfa180e8d",
@@ -5065,9 +4354,7 @@
         "sdk/terminal/terminal_srpc.pb.rs",
         "sdk/terminal/terminal_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/terminal/terminal.proto"
-      ]
+      "protoFiles": ["sdk/terminal/terminal.proto"]
     },
     "github.com/s4wave/spacewave/sdk/testbed": {
       "hash": "6fdb236d08f006ec029563383861b6a7cdd1c0ba79030f3cc544e10365264c56",
@@ -5082,9 +4369,7 @@
         "sdk/testbed/testbed_srpc.pb.rs",
         "sdk/testbed/testbed_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/testbed/testbed.proto"
-      ]
+      "protoFiles": ["sdk/testbed/testbed.proto"]
     },
     "github.com/s4wave/spacewave/sdk/trace": {
       "hash": "3fa94a40da16f0d249a26b7c934cf3e69d60313f896d4db4d6897fc62570910c",
@@ -5098,9 +4383,7 @@
         "sdk/trace/trace_srpc.pb.rs",
         "sdk/trace/trace_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/trace/trace.proto"
-      ]
+      "protoFiles": ["sdk/trace/trace.proto"]
     },
     "github.com/s4wave/spacewave/sdk/unixfs": {
       "hash": "e0ebda8355be81ee17b710173375a3796af230d798da9c0c83fa2c374daa859e",
@@ -5115,9 +4398,7 @@
         "sdk/unixfs/handle_srpc.pb.rs",
         "sdk/unixfs/handle_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/unixfs/handle.proto"
-      ]
+      "protoFiles": ["sdk/unixfs/handle.proto"]
     },
     "github.com/s4wave/spacewave/sdk/viewer/registry": {
       "hash": "4ff475fdd597dc05a1530b57fd0e7e957ab50b16631b1b9c30392c36449cc0da",
@@ -5132,9 +4413,7 @@
         "sdk/viewer/registry/registry_srpc.pb.rs",
         "sdk/viewer/registry/registry_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/viewer/registry/registry.proto"
-      ]
+      "protoFiles": ["sdk/viewer/registry/registry.proto"]
     },
     "github.com/s4wave/spacewave/sdk/vm": {
       "hash": "9e685d76405e22c4670ed34371cc75c70540afd5c34dece9dc2940f8402147f7",
@@ -5156,10 +4435,7 @@
         "sdk/vm/v86_srpc.pb.rs",
         "sdk/vm/v86_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/vm/v86-wizard.proto",
-        "sdk/vm/v86.proto"
-      ]
+      "protoFiles": ["sdk/vm/v86-wizard.proto", "sdk/vm/v86.proto"]
     },
     "github.com/s4wave/spacewave/sdk/world": {
       "hash": "220ed53dc2a89a0d9ecbda302d14c50507584b332d24cd99a4604e7b26c9ec1c",
@@ -5174,9 +4450,7 @@
         "sdk/world/world_srpc.pb.rs",
         "sdk/world/world_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/world/world.proto"
-      ]
+      "protoFiles": ["sdk/world/world.proto"]
     },
     "github.com/s4wave/spacewave/sdk/world/wizard": {
       "hash": "733f85459f3396d9603acc7201c9caf7a6e71056265f93454bb62a44e8cead17",
@@ -5191,9 +4465,7 @@
         "sdk/world/wizard/wizard_srpc.pb.rs",
         "sdk/world/wizard/wizard_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/world/wizard/wizard.proto"
-      ]
+      "protoFiles": ["sdk/world/wizard/wizard.proto"]
     },
     "github.com/s4wave/spacewave/sdk/worldop/registry": {
       "hash": "9e3c7a0bd1f04b4660f36f4d1944a02322d06d2fc87beef64efc1d346d1330a9",
@@ -5208,9 +4480,7 @@
         "sdk/worldop/registry/registry_srpc.pb.rs",
         "sdk/worldop/registry/registry_srpc.pb.ts"
       ],
-      "protoFiles": [
-        "sdk/worldop/registry/registry.proto"
-      ]
+      "protoFiles": ["sdk/worldop/registry/registry.proto"]
     },
     "github.com/s4wave/spacewave/web/object": {
       "hash": "053f755915426494b49ed7c785d86528a8421cc8fa414e217d66a03b98c07640",
@@ -5221,9 +4491,7 @@
         "web/object/object.pb.rs",
         "web/object/object.pb.ts"
       ],
-      "protoFiles": [
-        "web/object/object.proto"
-      ]
+      "protoFiles": ["web/object/object.proto"]
     }
   }
 }

--- a/bldr/devtool/web/entrypoint/controller/controller.go
+++ b/bldr/devtool/web/entrypoint/controller/controller.go
@@ -19,6 +19,7 @@ import (
 	bldr_manifest_world "github.com/s4wave/spacewave/bldr/manifest/world"
 	bldr_platform "github.com/s4wave/spacewave/bldr/platform"
 	bldr_plugin "github.com/s4wave/spacewave/bldr/plugin"
+	plugin_entrypoint_controller "github.com/s4wave/spacewave/bldr/plugin/entrypoint/controller"
 	plugin_host_default "github.com/s4wave/spacewave/bldr/plugin/host/default"
 	plugin_host_scheduler "github.com/s4wave/spacewave/bldr/plugin/host/scheduler"
 	plugin_host_web "github.com/s4wave/spacewave/bldr/plugin/host/web"
@@ -304,6 +305,11 @@ func (c *Controller) Execute(ctx context.Context) (rerr error) {
 		return err
 	}
 	defer pluginSchecCtrlRel()
+	startupGroup := plugin_entrypoint_controller.NewStartupGroupCoordinator(
+		devtoolInfo.GetStartPlugins(),
+		pluginSchedCtrl,
+	)
+	pluginSchedCtrl.SetManifestCopyGate(startupGroup)
 
 	// run the web browser plugin loader implementation (for "web/js/wasm" platform)
 	webPluginHostCtrl, webPluginHost, err := plugin_host_web.NewWebHostController(le, b, &plugin_host_web.Config{
@@ -354,6 +360,9 @@ func (c *Controller) Execute(ctx context.Context) (rerr error) {
 			return err
 		}
 		defer plugRef.Release()
+	}
+	if err := startupGroup.Start(ctx); err != nil {
+		return err
 	}
 
 	le.Debug("browser RPC server ready for BrowserProtocolID streams")

--- a/bldr/dist/entrypoint/bus.go
+++ b/bldr/dist/entrypoint/bus.go
@@ -385,29 +385,32 @@ func BuildDistBus(
 	}
 
 	// build the plugin scheduler
-	pluginSchedCtrl, pluginSchedCtrlRel, err := plugin_host_default.StartPluginScheduler(
-		ctx,
-		b,
+	pluginSchedConf := plugin_host_default.NewSchedulerConfig(
 		engineID,
 		pluginHostObjectKey,
 		vol.GetID(),
 		vol.GetPeerID().String(),
 		true,  // Watch FetchManifest on the bus so we can do auto-update via plugins.
-		false, // Enable copying the manifest root to the plugin host storage.
+		false, // Enable storing the manifest root in the plugin host world.
 
-		// Enable copying the manifest contents to the plugin host storage.
-		//
-		// This is particularly necessary since the plugin that provided the
-		// manifest might exit before being restarted, thereby creating a
-		// situation where we depend on that plugin for the data to start it,
-		// but that plugin is not running, so nothing happens (stuck).
+		// Dynamic providers can exit before a dependent plugin restarts, so
+		// their manifest contents still need a complete local copy.
 		false,
+	)
+	// The embedded distribution bucket remains mounted for the entrypoint
+	// lifetime and stays authoritative without a complete local copy.
+	pluginSchedConf.NoCopyBucketIds = []string{bldr_dist.GetDistBucketID(projectID)}
+	pluginSchedCtrl, _, pluginSchedCtrlRef, err := loader.WaitExecControllerRunningTyped[*plugin_host_scheduler.Controller](
+		ctx,
+		b,
+		resolver.NewLoadControllerWithConfig(pluginSchedConf),
+		nil,
 	)
 	if err != nil {
 		rel()
 		return nil, err
 	}
-	rels = append(rels, pluginSchedCtrlRel)
+	rels = append(rels, pluginSchedCtrlRef.Release)
 
 	// build the plugin host controller
 	pluginHostCtrl, pluginHostRel, err := plugin_host_default.StartPluginHost(

--- a/bldr/dist/entrypoint/bus.go
+++ b/bldr/dist/entrypoint/bus.go
@@ -20,6 +20,7 @@ import (
 	manifest_fetch_world "github.com/s4wave/spacewave/bldr/manifest/fetch/world"
 	bldr_manifest_world "github.com/s4wave/spacewave/bldr/manifest/world"
 	bldr_plugin "github.com/s4wave/spacewave/bldr/plugin"
+	plugin_entrypoint_controller "github.com/s4wave/spacewave/bldr/plugin/entrypoint/controller"
 	plugin_host_default "github.com/s4wave/spacewave/bldr/plugin/host/default"
 	plugin_host_scheduler "github.com/s4wave/spacewave/bldr/plugin/host/scheduler"
 	default_storage "github.com/s4wave/spacewave/bldr/storage/default"
@@ -411,6 +412,11 @@ func BuildDistBus(
 		return nil, err
 	}
 	rels = append(rels, pluginSchedCtrlRef.Release)
+	startupGroup := plugin_entrypoint_controller.NewStartupGroupCoordinator(
+		distMeta.GetStartupPlugins(),
+		pluginSchedCtrl,
+	)
+	pluginSchedCtrl.SetManifestCopyGate(startupGroup)
 
 	// build the plugin host controller
 	pluginHostCtrl, pluginHostRel, err := plugin_host_default.StartPluginHost(
@@ -434,6 +440,10 @@ func BuildDistBus(
 			continue
 		}
 		rels = append(rels, pluginRef.Release)
+	}
+	if err := startupGroup.Start(ctx); err != nil {
+		rel()
+		return nil, err
 	}
 
 	distBus.worldEngineID = engineID

--- a/bldr/plugin/entrypoint/controller/startup-group-coordinator.go
+++ b/bldr/plugin/entrypoint/controller/startup-group-coordinator.go
@@ -3,7 +3,6 @@ package plugin_entrypoint_controller
 import (
 	"context"
 	"slices"
-	"sync"
 
 	"github.com/aperturerobotics/util/broadcast"
 	"github.com/aperturerobotics/util/ccontainer"
@@ -29,9 +28,6 @@ type StartupGroupCoordinator struct {
 	// bcast guards terminalByPluginID.
 	bcast              broadcast.Broadcast
 	terminalByPluginID map[string]bool
-
-	startOnce sync.Once
-	startErr  error
 }
 
 // NewStartupGroupCoordinator constructs a startup group coordinator.
@@ -63,21 +59,21 @@ func (c *StartupGroupCoordinator) IsReady() bool {
 }
 
 // Start begins watching the configured startup plugins.
+//
+// Start is idempotent: the readiness container and keyed watcher set both
+// diff internally, so repeated calls are no-ops.
 func (c *StartupGroupCoordinator) Start(ctx context.Context) error {
-	c.startOnce.Do(func() {
-		if len(c.pluginIDs) == 0 {
-			c.readyCtr.SetValue(true)
-			return
-		}
-		if c.source == nil {
-			c.startErr = errors.New("startup plugin reference source is required")
-			return
-		}
+	if len(c.pluginIDs) == 0 {
+		c.readyCtr.SetValue(true)
+		return nil
+	}
+	if c.source == nil {
+		return errors.New("startup plugin reference source is required")
+	}
 
-		c.watchers.SetContext(ctx, true)
-		c.watchers.SyncKeys(c.pluginIDs, false)
-	})
-	return c.startErr
+	c.watchers.SetContext(ctx, true)
+	c.watchers.SyncKeys(c.pluginIDs, false)
+	return nil
 }
 
 // WaitReady waits for the startup group or context cancellation.

--- a/bldr/plugin/entrypoint/controller/startup-group-coordinator.go
+++ b/bldr/plugin/entrypoint/controller/startup-group-coordinator.go
@@ -1,0 +1,119 @@
+package plugin_entrypoint_controller
+
+import (
+	"context"
+	"slices"
+	"sync"
+	"sync/atomic"
+
+	"github.com/aperturerobotics/util/ccontainer"
+	"github.com/pkg/errors"
+	bldr_plugin "github.com/s4wave/spacewave/bldr/plugin"
+)
+
+// StartupPluginReferenceSource opens readiness references for startup plugins.
+type StartupPluginReferenceSource interface {
+	// AddPluginReference opens a readiness reference and its release function.
+	AddPluginReference(pluginID, instanceKey string) (bldr_plugin.RunningPluginRef, func())
+}
+
+// StartupGroupCoordinator publishes one ready transition after every configured
+// startup plugin completes or terminates initial capability registration.
+type StartupGroupCoordinator struct {
+	pluginIDs []string
+	source    StartupPluginReferenceSource
+	readyCtr  *ccontainer.CContainer[bool]
+	remaining atomic.Int64
+	startOnce sync.Once
+	readyOnce sync.Once
+	startErr  error
+}
+
+// NewStartupGroupCoordinator constructs a startup group coordinator.
+func NewStartupGroupCoordinator(
+	pluginIDs []string,
+	source StartupPluginReferenceSource,
+) *StartupGroupCoordinator {
+	pluginIDs = slices.Clone(pluginIDs)
+	slices.Sort(pluginIDs)
+	pluginIDs = slices.Compact(pluginIDs)
+	return &StartupGroupCoordinator{
+		pluginIDs: pluginIDs,
+		source:    source,
+		readyCtr:  ccontainer.NewCContainer(false),
+	}
+}
+
+// GetReadyCtr returns the watchable startup-group readiness state.
+func (c *StartupGroupCoordinator) GetReadyCtr() ccontainer.Watchable[bool] {
+	return c.readyCtr
+}
+
+// IsReady reports whether the startup group reached its terminal ready state.
+func (c *StartupGroupCoordinator) IsReady() bool {
+	return c.readyCtr.GetValue()
+}
+
+// Start begins watching the configured startup plugins.
+func (c *StartupGroupCoordinator) Start(ctx context.Context) error {
+	c.startOnce.Do(func() {
+		if len(c.pluginIDs) == 0 {
+			c.markReady()
+			return
+		}
+		if c.source == nil {
+			c.startErr = errors.New("startup plugin reference source is required")
+			return
+		}
+
+		c.remaining.Store(int64(len(c.pluginIDs)))
+		for _, pluginID := range c.pluginIDs {
+			ref, release := c.source.AddPluginReference(pluginID, "")
+			go c.watchPlugin(ctx, ref, release)
+		}
+	})
+	return c.startErr
+}
+
+// WaitReady waits for the startup group or context cancellation.
+func (c *StartupGroupCoordinator) WaitReady(ctx context.Context) error {
+	_, err := c.readyCtr.WaitValue(ctx, nil)
+	return err
+}
+
+func (c *StartupGroupCoordinator) watchPlugin(
+	ctx context.Context,
+	ref bldr_plugin.RunningPluginRef,
+	release func(),
+) {
+	if release != nil {
+		defer release()
+	}
+	if ref == nil {
+		return
+	}
+
+	stateCtr := ref.GetPluginLoadStateCtr()
+	var current bldr_plugin.PluginLoadState
+	for {
+		next, err := stateCtr.WaitValueChange(ctx, current, nil)
+		if err != nil {
+			return
+		}
+		current = next
+		switch next.GetInitialCapabilityRegistrationState() {
+		case bldr_plugin.InitialCapabilityRegistrationComplete,
+			bldr_plugin.InitialCapabilityRegistrationFailed:
+			if c.remaining.Add(-1) == 0 {
+				c.markReady()
+			}
+			return
+		}
+	}
+}
+
+func (c *StartupGroupCoordinator) markReady() {
+	c.readyOnce.Do(func() {
+		c.readyCtr.SetValue(true)
+	})
+}

--- a/bldr/plugin/entrypoint/controller/startup-group-coordinator.go
+++ b/bldr/plugin/entrypoint/controller/startup-group-coordinator.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"slices"
 	"sync"
-	"sync/atomic"
 
+	"github.com/aperturerobotics/util/broadcast"
 	"github.com/aperturerobotics/util/ccontainer"
+	"github.com/aperturerobotics/util/keyed"
 	"github.com/pkg/errors"
 	bldr_plugin "github.com/s4wave/spacewave/bldr/plugin"
 )
@@ -23,9 +24,13 @@ type StartupGroupCoordinator struct {
 	pluginIDs []string
 	source    StartupPluginReferenceSource
 	readyCtr  *ccontainer.CContainer[bool]
-	remaining atomic.Int64
+	watchers  *keyed.Keyed[string, struct{}]
+
+	// bcast guards terminalByPluginID.
+	bcast              broadcast.Broadcast
+	terminalByPluginID map[string]bool
+
 	startOnce sync.Once
-	readyOnce sync.Once
 	startErr  error
 }
 
@@ -37,11 +42,14 @@ func NewStartupGroupCoordinator(
 	pluginIDs = slices.Clone(pluginIDs)
 	slices.Sort(pluginIDs)
 	pluginIDs = slices.Compact(pluginIDs)
-	return &StartupGroupCoordinator{
-		pluginIDs: pluginIDs,
-		source:    source,
-		readyCtr:  ccontainer.NewCContainer(false),
+	c := &StartupGroupCoordinator{
+		pluginIDs:          pluginIDs,
+		source:             source,
+		readyCtr:           ccontainer.NewCContainer(false),
+		terminalByPluginID: make(map[string]bool, len(pluginIDs)),
 	}
+	c.watchers = keyed.NewKeyed(c.newPluginWatcher)
+	return c
 }
 
 // GetReadyCtr returns the watchable startup-group readiness state.
@@ -58,7 +66,7 @@ func (c *StartupGroupCoordinator) IsReady() bool {
 func (c *StartupGroupCoordinator) Start(ctx context.Context) error {
 	c.startOnce.Do(func() {
 		if len(c.pluginIDs) == 0 {
-			c.markReady()
+			c.readyCtr.SetValue(true)
 			return
 		}
 		if c.source == nil {
@@ -66,11 +74,8 @@ func (c *StartupGroupCoordinator) Start(ctx context.Context) error {
 			return
 		}
 
-		c.remaining.Store(int64(len(c.pluginIDs)))
-		for _, pluginID := range c.pluginIDs {
-			ref, release := c.source.AddPluginReference(pluginID, "")
-			go c.watchPlugin(ctx, ref, release)
-		}
+		c.watchers.SetContext(ctx, true)
+		c.watchers.SyncKeys(c.pluginIDs, false)
 	})
 	return c.startErr
 }
@@ -81,39 +86,55 @@ func (c *StartupGroupCoordinator) WaitReady(ctx context.Context) error {
 	return err
 }
 
-func (c *StartupGroupCoordinator) watchPlugin(
-	ctx context.Context,
-	ref bldr_plugin.RunningPluginRef,
-	release func(),
-) {
-	if release != nil {
-		defer release()
-	}
-	if ref == nil {
-		return
-	}
+func (c *StartupGroupCoordinator) newPluginWatcher(
+	pluginID string,
+) (keyed.Routine, struct{}) {
+	return func(ctx context.Context) error {
+		ref, release := c.source.AddPluginReference(pluginID, "")
+		if release != nil {
+			defer release()
+		}
+		if ref == nil {
+			return nil
+		}
 
-	stateCtr := ref.GetPluginLoadStateCtr()
-	var current bldr_plugin.PluginLoadState
-	for {
-		next, err := stateCtr.WaitValueChange(ctx, current, nil)
-		if err != nil {
-			return
-		}
-		current = next
-		switch next.GetInitialCapabilityRegistrationState() {
-		case bldr_plugin.InitialCapabilityRegistrationComplete,
-			bldr_plugin.InitialCapabilityRegistrationFailed:
-			if c.remaining.Add(-1) == 0 {
-				c.markReady()
+		stateCtr := ref.GetPluginLoadStateCtr()
+		var current bldr_plugin.PluginLoadState
+		for {
+			next, err := stateCtr.WaitValueChange(ctx, current, nil)
+			if err != nil {
+				return nil
 			}
-			return
+			current = next
+			switch next.GetInitialCapabilityRegistrationState() {
+			case bldr_plugin.InitialCapabilityRegistrationComplete,
+				bldr_plugin.InitialCapabilityRegistrationFailed:
+				c.setPluginTerminal(pluginID)
+				return nil
+			}
 		}
-	}
+	}, struct{}{}
 }
 
-func (c *StartupGroupCoordinator) markReady() {
-	c.readyOnce.Do(func() {
-		c.readyCtr.SetValue(true)
+func (c *StartupGroupCoordinator) setPluginTerminal(pluginID string) {
+	var ready bool
+	var changed bool
+	c.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
+		if c.terminalByPluginID[pluginID] {
+			return
+		}
+		c.terminalByPluginID[pluginID] = true
+		changed = true
+		ready = true
+		for _, id := range c.pluginIDs {
+			if !c.terminalByPluginID[id] {
+				ready = false
+				break
+			}
+		}
+		broadcast()
 	})
+	if changed {
+		c.readyCtr.SetValue(ready)
+	}
 }

--- a/bldr/plugin/entrypoint/controller/startup-group-coordinator_test.go
+++ b/bldr/plugin/entrypoint/controller/startup-group-coordinator_test.go
@@ -1,0 +1,108 @@
+package plugin_entrypoint_controller
+
+import (
+	"testing"
+
+	"github.com/aperturerobotics/util/ccontainer"
+	bldr_plugin "github.com/s4wave/spacewave/bldr/plugin"
+)
+
+type testStartupPluginRef struct {
+	stateCtr *ccontainer.CContainer[bldr_plugin.PluginLoadState]
+}
+
+func newTestStartupPluginRef() *testStartupPluginRef {
+	return &testStartupPluginRef{
+		stateCtr: ccontainer.NewCContainer(bldr_plugin.NewPluginLoadState(
+			nil,
+			bldr_plugin.InitialCapabilityRegistrationPending,
+		)),
+	}
+}
+
+func (r *testStartupPluginRef) GetRunningPluginCtr() ccontainer.Watchable[bldr_plugin.RunningPlugin] {
+	return ccontainer.NewCContainer[bldr_plugin.RunningPlugin](nil)
+}
+
+func (r *testStartupPluginRef) GetPluginLoadStateCtr() ccontainer.Watchable[bldr_plugin.PluginLoadState] {
+	return r.stateCtr
+}
+
+type testStartupPluginSource struct {
+	refs       map[string]*testStartupPluginRef
+	releasedCh map[string]chan struct{}
+}
+
+func newTestStartupPluginSource(pluginIDs ...string) *testStartupPluginSource {
+	source := &testStartupPluginSource{
+		refs:       make(map[string]*testStartupPluginRef, len(pluginIDs)),
+		releasedCh: make(map[string]chan struct{}, len(pluginIDs)),
+	}
+	for _, pluginID := range pluginIDs {
+		source.refs[pluginID] = newTestStartupPluginRef()
+		source.releasedCh[pluginID] = make(chan struct{})
+	}
+	return source
+}
+
+func (s *testStartupPluginSource) AddPluginReference(
+	pluginID, _ string,
+) (bldr_plugin.RunningPluginRef, func()) {
+	return s.refs[pluginID], func() { close(s.releasedCh[pluginID]) }
+}
+
+func TestStartupGroupCoordinatorTransitionsOnceAfterAllPluginsTerminal(t *testing.T) {
+	ctx := t.Context()
+	source := newTestStartupPluginSource("plugin/a", "plugin/b")
+	coordinator := NewStartupGroupCoordinator([]string{"plugin/b", "plugin/a", "plugin/a"}, source)
+	if err := coordinator.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if coordinator.IsReady() {
+		t.Fatal("startup group was ready before any plugin completed")
+	}
+
+	source.refs["plugin/a"].stateCtr.SetValue(bldr_plugin.NewPluginLoadState(
+		nil,
+		bldr_plugin.InitialCapabilityRegistrationComplete,
+	))
+	<-source.releasedCh["plugin/a"]
+	if coordinator.IsReady() {
+		t.Fatal("startup group was ready before the last plugin completed")
+	}
+
+	source.refs["plugin/b"].stateCtr.SetValue(bldr_plugin.NewPluginLoadState(
+		nil,
+		bldr_plugin.InitialCapabilityRegistrationComplete,
+	))
+	if err := coordinator.WaitReady(ctx); err != nil {
+		t.Fatal(err)
+	}
+	<-source.releasedCh["plugin/b"]
+
+	source.refs["plugin/a"].stateCtr.SetValue(bldr_plugin.NewPluginLoadState(
+		nil,
+		bldr_plugin.InitialCapabilityRegistrationPending,
+	))
+	if !coordinator.IsReady() || !coordinator.GetReadyCtr().GetValue() {
+		t.Fatal("startup group readiness reverted after its terminal transition")
+	}
+}
+
+func TestStartupGroupCoordinatorReleasesAfterTerminalFailure(t *testing.T) {
+	ctx := t.Context()
+	source := newTestStartupPluginSource("plugin/broken")
+	coordinator := NewStartupGroupCoordinator([]string{"plugin/broken"}, source)
+	if err := coordinator.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	source.refs["plugin/broken"].stateCtr.SetValue(bldr_plugin.NewPluginLoadState(
+		nil,
+		bldr_plugin.InitialCapabilityRegistrationFailed,
+	))
+	if err := coordinator.WaitReady(ctx); err != nil {
+		t.Fatal(err)
+	}
+	<-source.releasedCh["plugin/broken"]
+}

--- a/bldr/plugin/host/scheduler/config.go
+++ b/bldr/plugin/host/scheduler/config.go
@@ -25,6 +25,7 @@ func NewConfig(
 	watchFetchManifest,
 	disableStoreManifest,
 	disableCopyManifest bool,
+	noCopyBucketIDs ...string,
 ) *Config {
 	return &Config{
 		EngineId:  engineID,
@@ -35,6 +36,7 @@ func NewConfig(
 		WatchFetchManifest:   watchFetchManifest,
 		DisableStoreManifest: disableStoreManifest,
 		DisableCopyManifest:  disableCopyManifest,
+		NoCopyBucketIds:      slices.Clone(noCopyBucketIDs),
 	}
 }
 

--- a/bldr/plugin/host/scheduler/config.pb.cc
+++ b/bldr/plugin/host/scheduler/config.pb.cc
@@ -62,6 +62,7 @@ inline constexpr Config::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
       : _cached_size_{0},
         platform_selection_policies_{},
+        no_copy_bucket_ids_{},
         engine_id_(
             &::google::protobuf::internal::fixed_address_empty_string,
             ::_pbi::ConstantInitialized()),
@@ -113,7 +114,7 @@ const ::uint32_t
         protodesc_cold) = {
         0x081, // bitmap
         PROTOBUF_FIELD_OFFSET(::plugin::host::scheduler::Config, _impl_._has_bits_),
-        15, // hasbit index offset
+        16, // hasbit index offset
         PROTOBUF_FIELD_OFFSET(::plugin::host::scheduler::Config, _impl_.engine_id_),
         PROTOBUF_FIELD_OFFSET(::plugin::host::scheduler::Config, _impl_.object_key_),
         PROTOBUF_FIELD_OFFSET(::plugin::host::scheduler::Config, _impl_.peer_id_),
@@ -121,22 +122,24 @@ const ::uint32_t
         PROTOBUF_FIELD_OFFSET(::plugin::host::scheduler::Config, _impl_.watch_fetch_manifest_),
         PROTOBUF_FIELD_OFFSET(::plugin::host::scheduler::Config, _impl_.disable_store_manifest_),
         PROTOBUF_FIELD_OFFSET(::plugin::host::scheduler::Config, _impl_.disable_copy_manifest_),
+        PROTOBUF_FIELD_OFFSET(::plugin::host::scheduler::Config, _impl_.no_copy_bucket_ids_),
         PROTOBUF_FIELD_OFFSET(::plugin::host::scheduler::Config, _impl_.fetch_concurrency_),
         PROTOBUF_FIELD_OFFSET(::plugin::host::scheduler::Config, _impl_.fetch_backoff_),
         PROTOBUF_FIELD_OFFSET(::plugin::host::scheduler::Config, _impl_.exec_backoff_),
         PROTOBUF_FIELD_OFFSET(::plugin::host::scheduler::Config, _impl_.verbose_),
         PROTOBUF_FIELD_OFFSET(::plugin::host::scheduler::Config, _impl_.platform_selection_policies_),
-        1,
         2,
         3,
         4,
-        8,
+        5,
         9,
         10,
-        7,
-        5,
-        6,
         11,
+        1,
+        8,
+        6,
+        7,
+        12,
         0,
         0x081, // bitmap
         PROTOBUF_FIELD_OFFSET(::plugin::host::scheduler::PlatformSelectionPolicy, _impl_._has_bits_),
@@ -150,7 +153,7 @@ const ::uint32_t
 static const ::_pbi::MigrationSchema
     schemas[] ABSL_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
         {0, sizeof(::plugin::host::scheduler::Config)},
-        {27, sizeof(::plugin::host::scheduler::PlatformSelectionPolicy)},
+        {29, sizeof(::plugin::host::scheduler::PlatformSelectionPolicy)},
 };
 static const ::_pb::Message* PROTOBUF_NONNULL const file_default_instances[] = {
     &::plugin::host::scheduler::_Config_default_instance_._instance,
@@ -161,19 +164,20 @@ const char descriptor_table_protodef_github_2ecom_2fs4wave_2fspacewave_2fbldr_2f
     "\nCgithub.com/s4wave/spacewave/bldr/plugi"
     "n/host/scheduler/config.proto\022\025plugin.ho"
     "st.scheduler\0326github.com/aperturerobotic"
-    "s/util/backoff/backoff.proto\"\202\003\n\006Config\022"
+    "s/util/backoff/backoff.proto\"\236\003\n\006Config\022"
     "\021\n\tengine_id\030\001 \001(\t\022\022\n\nobject_key\030\002 \001(\t\022\017"
     "\n\007peer_id\030\003 \001(\t\022\021\n\tvolume_id\030\004 \001(\t\022\034\n\024wa"
     "tch_fetch_manifest\030\005 \001(\010\022\036\n\026disable_stor"
     "e_manifest\030\006 \001(\010\022\035\n\025disable_copy_manifes"
-    "t\030\n \001(\010\022\031\n\021fetch_concurrency\030\007 \001(\r\022\'\n\rfe"
-    "tch_backoff\030\010 \001(\0132\020.backoff.Backoff\022&\n\014e"
-    "xec_backoff\030\t \001(\0132\020.backoff.Backoff\022\017\n\007v"
-    "erbose\030\013 \001(\010\022S\n\033platform_selection_polic"
-    "ies\030\014 \003(\0132..plugin.host.scheduler.Platfo"
-    "rmSelectionPolicy\"J\n\027PlatformSelectionPo"
-    "licy\022\023\n\013platform_id\030\001 \001(\t\022\032\n\022allowed_plu"
-    "gin_ids\030\002 \003(\tb\006proto3"
+    "t\030\n \001(\010\022\032\n\022no_copy_bucket_ids\030\r \003(\t\022\031\n\021f"
+    "etch_concurrency\030\007 \001(\r\022\'\n\rfetch_backoff\030"
+    "\010 \001(\0132\020.backoff.Backoff\022&\n\014exec_backoff\030"
+    "\t \001(\0132\020.backoff.Backoff\022\017\n\007verbose\030\013 \001(\010"
+    "\022S\n\033platform_selection_policies\030\014 \003(\0132.."
+    "plugin.host.scheduler.PlatformSelectionP"
+    "olicy\"J\n\027PlatformSelectionPolicy\022\023\n\013plat"
+    "form_id\030\001 \001(\t\022\032\n\022allowed_plugin_ids\030\002 \003("
+    "\tb\006proto3"
 };
 static const ::_pbi::DescriptorTable* PROTOBUF_NONNULL const
     descriptor_table_github_2ecom_2fs4wave_2fspacewave_2fbldr_2fplugin_2fhost_2fscheduler_2fconfig_2eproto_deps[1] = {
@@ -183,7 +187,7 @@ static ::absl::once_flag descriptor_table_github_2ecom_2fs4wave_2fspacewave_2fbl
 PROTOBUF_CONSTINIT const ::_pbi::DescriptorTable descriptor_table_github_2ecom_2fs4wave_2fspacewave_2fbldr_2fplugin_2fhost_2fscheduler_2fconfig_2eproto = {
     false,
     false,
-    621,
+    649,
     descriptor_table_protodef_github_2ecom_2fs4wave_2fspacewave_2fbldr_2fplugin_2fhost_2fscheduler_2fconfig_2eproto,
     "github.com/s4wave/spacewave/bldr/plugin/host/scheduler/config.proto",
     &descriptor_table_github_2ecom_2fs4wave_2fspacewave_2fbldr_2fplugin_2fhost_2fscheduler_2fconfig_2eproto_once,
@@ -213,13 +217,13 @@ void Config::clear_fetch_backoff() {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   if (_impl_.fetch_backoff_ != nullptr) _impl_.fetch_backoff_->Clear();
   ClearHasBit(_impl_._has_bits_[0],
-                  0x00000020U);
+                  0x00000040U);
 }
 void Config::clear_exec_backoff() {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   if (_impl_.exec_backoff_ != nullptr) _impl_.exec_backoff_->Clear();
   ClearHasBit(_impl_._has_bits_[0],
-                  0x00000040U);
+                  0x00000080U);
 }
 Config::Config(::google::protobuf::Arena* PROTOBUF_NULLABLE arena)
 #if defined(PROTOBUF_CUSTOM_VTABLE)
@@ -237,6 +241,7 @@ PROTOBUF_NDEBUG_INLINE Config::Impl_::Impl_(
       : _has_bits_{from._has_bits_},
         _cached_size_{0},
         platform_selection_policies_{visibility, arena, from.platform_selection_policies_},
+        no_copy_bucket_ids_{visibility, arena, from.no_copy_bucket_ids_},
         engine_id_(arena, from.engine_id_),
         object_key_(arena, from.object_key_),
         peer_id_(arena, from.peer_id_),
@@ -256,10 +261,10 @@ Config::Config(
       from._internal_metadata_);
   new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
   ::uint32_t cached_has_bits = _impl_._has_bits_[0];
-  _impl_.fetch_backoff_ = (CheckHasBit(cached_has_bits, 0x00000020U))
+  _impl_.fetch_backoff_ = (CheckHasBit(cached_has_bits, 0x00000040U))
                 ? ::google::protobuf::Message::CopyConstruct(arena, *from._impl_.fetch_backoff_)
                 : nullptr;
-  _impl_.exec_backoff_ = (CheckHasBit(cached_has_bits, 0x00000040U))
+  _impl_.exec_backoff_ = (CheckHasBit(cached_has_bits, 0x00000080U))
                 ? ::google::protobuf::Message::CopyConstruct(arena, *from._impl_.exec_backoff_)
                 : nullptr;
   ::memcpy(reinterpret_cast<char*>(&_impl_) +
@@ -277,6 +282,7 @@ PROTOBUF_NDEBUG_INLINE Config::Impl_::Impl_(
     [[maybe_unused]] ::google::protobuf::Arena* PROTOBUF_NULLABLE arena)
       : _cached_size_{0},
         platform_selection_policies_{visibility, arena},
+        no_copy_bucket_ids_{visibility, arena},
         engine_id_(arena),
         object_key_(arena),
         peer_id_(arena),
@@ -318,6 +324,10 @@ inline void* PROTOBUF_NONNULL Config::PlacementNew_(
 }
 constexpr auto Config::InternalNewImpl_() {
   constexpr auto arena_bits = ::google::protobuf::internal::EncodePlacementArenaOffsets({
+      PROTOBUF_FIELD_OFFSET(Config, _impl_.no_copy_bucket_ids_) +
+          decltype(Config::_impl_.no_copy_bucket_ids_)::
+              InternalGetArenaOffset(
+                  ::google::protobuf::Message::internal_visibility()),
       PROTOBUF_FIELD_OFFSET(Config, _impl_.platform_selection_policies_) +
           decltype(Config::_impl_.platform_selection_policies_)::
               InternalGetArenaOffset(
@@ -366,16 +376,16 @@ Config::GetClassData() const {
   return Config_class_data_.base();
 }
 PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
-const ::_pbi::TcParseTable<4, 12, 3, 80, 2>
+const ::_pbi::TcParseTable<4, 13, 3, 98, 2>
 Config::_table_ = {
   {
     PROTOBUF_FIELD_OFFSET(Config, _impl_._has_bits_),
     0, // no _extensions_
-    12, 120,  // max_field_number, fast_idx_mask
+    13, 120,  // max_field_number, fast_idx_mask
     offsetof(decltype(_table_), field_lookup_table),
-    4294963200,  // skipmap
+    4294959104,  // skipmap
     offsetof(decltype(_table_), field_entries),
-    12,  // num_field_entries
+    13,  // num_field_entries
     3,  // num_aux_entries
     offsetof(decltype(_table_), aux_entries),
     Config_class_data_.base(),
@@ -388,82 +398,87 @@ Config::_table_ = {
     {::_pbi::TcParser::MiniParse, {}},
     // string engine_id = 1;
     {::_pbi::TcParser::FastUS1,
-     {10, 1, 0,
+     {10, 2, 0,
       PROTOBUF_FIELD_OFFSET(Config, _impl_.engine_id_)}},
     // string object_key = 2;
     {::_pbi::TcParser::FastUS1,
-     {18, 2, 0,
+     {18, 3, 0,
       PROTOBUF_FIELD_OFFSET(Config, _impl_.object_key_)}},
     // string peer_id = 3;
     {::_pbi::TcParser::FastUS1,
-     {26, 3, 0,
+     {26, 4, 0,
       PROTOBUF_FIELD_OFFSET(Config, _impl_.peer_id_)}},
     // string volume_id = 4;
     {::_pbi::TcParser::FastUS1,
-     {34, 4, 0,
+     {34, 5, 0,
       PROTOBUF_FIELD_OFFSET(Config, _impl_.volume_id_)}},
     // bool watch_fetch_manifest = 5;
-    {::_pbi::TcParser::SingularVarintNoZag1<bool, offsetof(Config, _impl_.watch_fetch_manifest_), 8>(),
-     {40, 8, 0,
+    {::_pbi::TcParser::SingularVarintNoZag1<bool, offsetof(Config, _impl_.watch_fetch_manifest_), 9>(),
+     {40, 9, 0,
       PROTOBUF_FIELD_OFFSET(Config, _impl_.watch_fetch_manifest_)}},
     // bool disable_store_manifest = 6;
-    {::_pbi::TcParser::SingularVarintNoZag1<bool, offsetof(Config, _impl_.disable_store_manifest_), 9>(),
-     {48, 9, 0,
+    {::_pbi::TcParser::SingularVarintNoZag1<bool, offsetof(Config, _impl_.disable_store_manifest_), 10>(),
+     {48, 10, 0,
       PROTOBUF_FIELD_OFFSET(Config, _impl_.disable_store_manifest_)}},
     // uint32 fetch_concurrency = 7;
-    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(Config, _impl_.fetch_concurrency_), 7>(),
-     {56, 7, 0,
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(Config, _impl_.fetch_concurrency_), 8>(),
+     {56, 8, 0,
       PROTOBUF_FIELD_OFFSET(Config, _impl_.fetch_concurrency_)}},
     // .backoff.Backoff fetch_backoff = 8;
     {::_pbi::TcParser::FastMtS1,
-     {66, 5, 0,
+     {66, 6, 0,
       PROTOBUF_FIELD_OFFSET(Config, _impl_.fetch_backoff_)}},
     // .backoff.Backoff exec_backoff = 9;
     {::_pbi::TcParser::FastMtS1,
-     {74, 6, 1,
+     {74, 7, 1,
       PROTOBUF_FIELD_OFFSET(Config, _impl_.exec_backoff_)}},
     // bool disable_copy_manifest = 10;
-    {::_pbi::TcParser::SingularVarintNoZag1<bool, offsetof(Config, _impl_.disable_copy_manifest_), 10>(),
-     {80, 10, 0,
+    {::_pbi::TcParser::SingularVarintNoZag1<bool, offsetof(Config, _impl_.disable_copy_manifest_), 11>(),
+     {80, 11, 0,
       PROTOBUF_FIELD_OFFSET(Config, _impl_.disable_copy_manifest_)}},
     // bool verbose = 11;
-    {::_pbi::TcParser::SingularVarintNoZag1<bool, offsetof(Config, _impl_.verbose_), 11>(),
-     {88, 11, 0,
+    {::_pbi::TcParser::SingularVarintNoZag1<bool, offsetof(Config, _impl_.verbose_), 12>(),
+     {88, 12, 0,
       PROTOBUF_FIELD_OFFSET(Config, _impl_.verbose_)}},
     // repeated .plugin.host.scheduler.PlatformSelectionPolicy platform_selection_policies = 12;
     {::_pbi::TcParser::FastMtR1,
      {98, 0, 2,
       PROTOBUF_FIELD_OFFSET(Config, _impl_.platform_selection_policies_)}},
-    {::_pbi::TcParser::MiniParse, {}},
+    // repeated string no_copy_bucket_ids = 13;
+    {::_pbi::TcParser::FastUR1,
+     {106, 1, 0,
+      PROTOBUF_FIELD_OFFSET(Config, _impl_.no_copy_bucket_ids_)}},
     {::_pbi::TcParser::MiniParse, {}},
     {::_pbi::TcParser::MiniParse, {}},
   }}, {{
     65535, 65535
   }}, {{
     // string engine_id = 1;
-    {PROTOBUF_FIELD_OFFSET(Config, _impl_.engine_id_), _Internal::kHasBitsOffset + 1, 0, (0 | ::_fl::kFcOptional | ::_fl::kUtf8String | ::_fl::kRepAString)},
+    {PROTOBUF_FIELD_OFFSET(Config, _impl_.engine_id_), _Internal::kHasBitsOffset + 2, 0, (0 | ::_fl::kFcOptional | ::_fl::kUtf8String | ::_fl::kRepAString)},
     // string object_key = 2;
-    {PROTOBUF_FIELD_OFFSET(Config, _impl_.object_key_), _Internal::kHasBitsOffset + 2, 0, (0 | ::_fl::kFcOptional | ::_fl::kUtf8String | ::_fl::kRepAString)},
+    {PROTOBUF_FIELD_OFFSET(Config, _impl_.object_key_), _Internal::kHasBitsOffset + 3, 0, (0 | ::_fl::kFcOptional | ::_fl::kUtf8String | ::_fl::kRepAString)},
     // string peer_id = 3;
-    {PROTOBUF_FIELD_OFFSET(Config, _impl_.peer_id_), _Internal::kHasBitsOffset + 3, 0, (0 | ::_fl::kFcOptional | ::_fl::kUtf8String | ::_fl::kRepAString)},
+    {PROTOBUF_FIELD_OFFSET(Config, _impl_.peer_id_), _Internal::kHasBitsOffset + 4, 0, (0 | ::_fl::kFcOptional | ::_fl::kUtf8String | ::_fl::kRepAString)},
     // string volume_id = 4;
-    {PROTOBUF_FIELD_OFFSET(Config, _impl_.volume_id_), _Internal::kHasBitsOffset + 4, 0, (0 | ::_fl::kFcOptional | ::_fl::kUtf8String | ::_fl::kRepAString)},
+    {PROTOBUF_FIELD_OFFSET(Config, _impl_.volume_id_), _Internal::kHasBitsOffset + 5, 0, (0 | ::_fl::kFcOptional | ::_fl::kUtf8String | ::_fl::kRepAString)},
     // bool watch_fetch_manifest = 5;
-    {PROTOBUF_FIELD_OFFSET(Config, _impl_.watch_fetch_manifest_), _Internal::kHasBitsOffset + 8, 0, (0 | ::_fl::kFcOptional | ::_fl::kBool)},
+    {PROTOBUF_FIELD_OFFSET(Config, _impl_.watch_fetch_manifest_), _Internal::kHasBitsOffset + 9, 0, (0 | ::_fl::kFcOptional | ::_fl::kBool)},
     // bool disable_store_manifest = 6;
-    {PROTOBUF_FIELD_OFFSET(Config, _impl_.disable_store_manifest_), _Internal::kHasBitsOffset + 9, 0, (0 | ::_fl::kFcOptional | ::_fl::kBool)},
+    {PROTOBUF_FIELD_OFFSET(Config, _impl_.disable_store_manifest_), _Internal::kHasBitsOffset + 10, 0, (0 | ::_fl::kFcOptional | ::_fl::kBool)},
     // uint32 fetch_concurrency = 7;
-    {PROTOBUF_FIELD_OFFSET(Config, _impl_.fetch_concurrency_), _Internal::kHasBitsOffset + 7, 0, (0 | ::_fl::kFcOptional | ::_fl::kUInt32)},
+    {PROTOBUF_FIELD_OFFSET(Config, _impl_.fetch_concurrency_), _Internal::kHasBitsOffset + 8, 0, (0 | ::_fl::kFcOptional | ::_fl::kUInt32)},
     // .backoff.Backoff fetch_backoff = 8;
-    {PROTOBUF_FIELD_OFFSET(Config, _impl_.fetch_backoff_), _Internal::kHasBitsOffset + 5, 0, (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
+    {PROTOBUF_FIELD_OFFSET(Config, _impl_.fetch_backoff_), _Internal::kHasBitsOffset + 6, 0, (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
     // .backoff.Backoff exec_backoff = 9;
-    {PROTOBUF_FIELD_OFFSET(Config, _impl_.exec_backoff_), _Internal::kHasBitsOffset + 6, 1, (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
+    {PROTOBUF_FIELD_OFFSET(Config, _impl_.exec_backoff_), _Internal::kHasBitsOffset + 7, 1, (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
     // bool disable_copy_manifest = 10;
-    {PROTOBUF_FIELD_OFFSET(Config, _impl_.disable_copy_manifest_), _Internal::kHasBitsOffset + 10, 0, (0 | ::_fl::kFcOptional | ::_fl::kBool)},
+    {PROTOBUF_FIELD_OFFSET(Config, _impl_.disable_copy_manifest_), _Internal::kHasBitsOffset + 11, 0, (0 | ::_fl::kFcOptional | ::_fl::kBool)},
     // bool verbose = 11;
-    {PROTOBUF_FIELD_OFFSET(Config, _impl_.verbose_), _Internal::kHasBitsOffset + 11, 0, (0 | ::_fl::kFcOptional | ::_fl::kBool)},
+    {PROTOBUF_FIELD_OFFSET(Config, _impl_.verbose_), _Internal::kHasBitsOffset + 12, 0, (0 | ::_fl::kFcOptional | ::_fl::kBool)},
     // repeated .plugin.host.scheduler.PlatformSelectionPolicy platform_selection_policies = 12;
     {PROTOBUF_FIELD_OFFSET(Config, _impl_.platform_selection_policies_), _Internal::kHasBitsOffset + 0, 2, (0 | ::_fl::kFcRepeated | ::_fl::kMessage | ::_fl::kTvTable)},
+    // repeated string no_copy_bucket_ids = 13;
+    {PROTOBUF_FIELD_OFFSET(Config, _impl_.no_copy_bucket_ids_), _Internal::kHasBitsOffset + 1, 0, (0 | ::_fl::kFcRepeated | ::_fl::kUtf8String | ::_fl::kRepSString)},
   }},
   {{
       {::_pbi::TcParser::GetTable<::backoff::Backoff>()},
@@ -471,12 +486,13 @@ Config::_table_ = {
       {::_pbi::TcParser::GetTable<::plugin::host::scheduler::PlatformSelectionPolicy>()},
   }},
   {{
-    "\34\11\12\7\11\0\0\0\0\0\0\0\0\0\0\0"
+    "\34\11\12\7\11\0\0\0\0\0\0\0\0\22\0\0"
     "plugin.host.scheduler.Config"
     "engine_id"
     "object_key"
     "peer_id"
     "volume_id"
+    "no_copy_bucket_ids"
   }},
 };
 PROTOBUF_NOINLINE void Config::Clear() {
@@ -487,36 +503,38 @@ PROTOBUF_NOINLINE void Config::Clear() {
   (void) cached_has_bits;
 
   cached_has_bits = _impl_._has_bits_[0];
-  if (BatchCheckHasBit(cached_has_bits, 0x0000007fU)) {
+  if (BatchCheckHasBit(cached_has_bits, 0x000000ffU)) {
     if (CheckHasBitForRepeated(cached_has_bits, 0x00000001U)) {
       _impl_.platform_selection_policies_.Clear();
     }
-    if (CheckHasBit(cached_has_bits, 0x00000002U)) {
-      _impl_.engine_id_.ClearNonDefaultToEmpty();
+    if (CheckHasBitForRepeated(cached_has_bits, 0x00000002U)) {
+      _impl_.no_copy_bucket_ids_.Clear();
     }
     if (CheckHasBit(cached_has_bits, 0x00000004U)) {
-      _impl_.object_key_.ClearNonDefaultToEmpty();
+      _impl_.engine_id_.ClearNonDefaultToEmpty();
     }
     if (CheckHasBit(cached_has_bits, 0x00000008U)) {
-      _impl_.peer_id_.ClearNonDefaultToEmpty();
+      _impl_.object_key_.ClearNonDefaultToEmpty();
     }
     if (CheckHasBit(cached_has_bits, 0x00000010U)) {
-      _impl_.volume_id_.ClearNonDefaultToEmpty();
+      _impl_.peer_id_.ClearNonDefaultToEmpty();
     }
     if (CheckHasBit(cached_has_bits, 0x00000020U)) {
+      _impl_.volume_id_.ClearNonDefaultToEmpty();
+    }
+    if (CheckHasBit(cached_has_bits, 0x00000040U)) {
       ABSL_DCHECK(_impl_.fetch_backoff_ != nullptr);
       _impl_.fetch_backoff_->Clear();
     }
-    if (CheckHasBit(cached_has_bits, 0x00000040U)) {
+    if (CheckHasBit(cached_has_bits, 0x00000080U)) {
       ABSL_DCHECK(_impl_.exec_backoff_ != nullptr);
       _impl_.exec_backoff_->Clear();
     }
   }
-  _impl_.fetch_concurrency_ = 0u;
-  if (BatchCheckHasBit(cached_has_bits, 0x00000f00U)) {
-    ::memset(&_impl_.watch_fetch_manifest_, 0, static_cast<::size_t>(
+  if (BatchCheckHasBit(cached_has_bits, 0x00001f00U)) {
+    ::memset(&_impl_.fetch_concurrency_, 0, static_cast<::size_t>(
         reinterpret_cast<char*>(&_impl_.verbose_) -
-        reinterpret_cast<char*>(&_impl_.watch_fetch_manifest_)) + sizeof(_impl_.verbose_));
+        reinterpret_cast<char*>(&_impl_.fetch_concurrency_)) + sizeof(_impl_.verbose_));
   }
   _impl_._has_bits_.Clear();
   _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
@@ -542,7 +560,7 @@ PROTOBUF_NOINLINE void Config::Clear() {
 
   cached_has_bits = this_._impl_._has_bits_[0];
   // string engine_id = 1;
-  if (CheckHasBit(cached_has_bits, 0x00000002U)) {
+  if (CheckHasBit(cached_has_bits, 0x00000004U)) {
     if (!this_._internal_engine_id().empty()) {
       const ::std::string& _s = this_._internal_engine_id();
       ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
@@ -552,7 +570,7 @@ PROTOBUF_NOINLINE void Config::Clear() {
   }
 
   // string object_key = 2;
-  if (CheckHasBit(cached_has_bits, 0x00000004U)) {
+  if (CheckHasBit(cached_has_bits, 0x00000008U)) {
     if (!this_._internal_object_key().empty()) {
       const ::std::string& _s = this_._internal_object_key();
       ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
@@ -562,7 +580,7 @@ PROTOBUF_NOINLINE void Config::Clear() {
   }
 
   // string peer_id = 3;
-  if (CheckHasBit(cached_has_bits, 0x00000008U)) {
+  if (CheckHasBit(cached_has_bits, 0x00000010U)) {
     if (!this_._internal_peer_id().empty()) {
       const ::std::string& _s = this_._internal_peer_id();
       ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
@@ -572,7 +590,7 @@ PROTOBUF_NOINLINE void Config::Clear() {
   }
 
   // string volume_id = 4;
-  if (CheckHasBit(cached_has_bits, 0x00000010U)) {
+  if (CheckHasBit(cached_has_bits, 0x00000020U)) {
     if (!this_._internal_volume_id().empty()) {
       const ::std::string& _s = this_._internal_volume_id();
       ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
@@ -582,7 +600,7 @@ PROTOBUF_NOINLINE void Config::Clear() {
   }
 
   // bool watch_fetch_manifest = 5;
-  if (CheckHasBit(cached_has_bits, 0x00000100U)) {
+  if (CheckHasBit(cached_has_bits, 0x00000200U)) {
     if (this_._internal_watch_fetch_manifest() != 0) {
       target = stream->EnsureSpace(target);
       target = ::_pbi::WireFormatLite::WriteBoolToArray(
@@ -591,7 +609,7 @@ PROTOBUF_NOINLINE void Config::Clear() {
   }
 
   // bool disable_store_manifest = 6;
-  if (CheckHasBit(cached_has_bits, 0x00000200U)) {
+  if (CheckHasBit(cached_has_bits, 0x00000400U)) {
     if (this_._internal_disable_store_manifest() != 0) {
       target = stream->EnsureSpace(target);
       target = ::_pbi::WireFormatLite::WriteBoolToArray(
@@ -600,7 +618,7 @@ PROTOBUF_NOINLINE void Config::Clear() {
   }
 
   // uint32 fetch_concurrency = 7;
-  if (CheckHasBit(cached_has_bits, 0x00000080U)) {
+  if (CheckHasBit(cached_has_bits, 0x00000100U)) {
     if (this_._internal_fetch_concurrency() != 0) {
       target = stream->EnsureSpace(target);
       target = ::_pbi::WireFormatLite::WriteUInt32ToArray(
@@ -609,21 +627,21 @@ PROTOBUF_NOINLINE void Config::Clear() {
   }
 
   // .backoff.Backoff fetch_backoff = 8;
-  if (CheckHasBit(cached_has_bits, 0x00000020U)) {
+  if (CheckHasBit(cached_has_bits, 0x00000040U)) {
     target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
         8, *this_._impl_.fetch_backoff_, this_._impl_.fetch_backoff_->GetCachedSize(), target,
         stream);
   }
 
   // .backoff.Backoff exec_backoff = 9;
-  if (CheckHasBit(cached_has_bits, 0x00000040U)) {
+  if (CheckHasBit(cached_has_bits, 0x00000080U)) {
     target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
         9, *this_._impl_.exec_backoff_, this_._impl_.exec_backoff_->GetCachedSize(), target,
         stream);
   }
 
   // bool disable_copy_manifest = 10;
-  if (CheckHasBit(cached_has_bits, 0x00000400U)) {
+  if (CheckHasBit(cached_has_bits, 0x00000800U)) {
     if (this_._internal_disable_copy_manifest() != 0) {
       target = stream->EnsureSpace(target);
       target = ::_pbi::WireFormatLite::WriteBoolToArray(
@@ -632,7 +650,7 @@ PROTOBUF_NOINLINE void Config::Clear() {
   }
 
   // bool verbose = 11;
-  if (CheckHasBit(cached_has_bits, 0x00000800U)) {
+  if (CheckHasBit(cached_has_bits, 0x00001000U)) {
     if (this_._internal_verbose() != 0) {
       target = stream->EnsureSpace(target);
       target = ::_pbi::WireFormatLite::WriteBoolToArray(
@@ -650,6 +668,16 @@ PROTOBUF_NOINLINE void Config::Clear() {
           ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
               12, repfield, repfield.GetCachedSize(),
               target, stream);
+    }
+  }
+
+  // repeated string no_copy_bucket_ids = 13;
+  if (CheckHasBitForRepeated(cached_has_bits, 0x00000002U)) {
+    for (int i = 0, n = this_._internal_no_copy_bucket_ids_size(); i < n; ++i) {
+      const auto& s = this_._internal_no_copy_bucket_ids().Get(i);
+      ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          s.data(), static_cast<int>(s.length()), ::google::protobuf::internal::WireFormatLite::SERIALIZE, "plugin.host.scheduler.Config.no_copy_bucket_ids");
+      target = stream->WriteString(13, s, target);
     }
   }
 
@@ -686,73 +714,82 @@ PROTOBUF_NOINLINE void Config::Clear() {
         total_size += ::google::protobuf::internal::WireFormatLite::MessageSize(msg);
       }
     }
+    // repeated string no_copy_bucket_ids = 13;
+    if (CheckHasBitForRepeated(cached_has_bits, 0x00000002U)) {
+      total_size +=
+          1 * ::google::protobuf::internal::FromIntSize(this_._internal_no_copy_bucket_ids().size());
+      for (int i = 0, n = this_._internal_no_copy_bucket_ids().size(); i < n; ++i) {
+        total_size += ::google::protobuf::internal::WireFormatLite::StringSize(
+            this_._internal_no_copy_bucket_ids().Get(i));
+      }
+    }
     // string engine_id = 1;
-    if (CheckHasBit(cached_has_bits, 0x00000002U)) {
+    if (CheckHasBit(cached_has_bits, 0x00000004U)) {
       if (!this_._internal_engine_id().empty()) {
         total_size += 1 + ::google::protobuf::internal::WireFormatLite::StringSize(
                                         this_._internal_engine_id());
       }
     }
     // string object_key = 2;
-    if (CheckHasBit(cached_has_bits, 0x00000004U)) {
+    if (CheckHasBit(cached_has_bits, 0x00000008U)) {
       if (!this_._internal_object_key().empty()) {
         total_size += 1 + ::google::protobuf::internal::WireFormatLite::StringSize(
                                         this_._internal_object_key());
       }
     }
     // string peer_id = 3;
-    if (CheckHasBit(cached_has_bits, 0x00000008U)) {
+    if (CheckHasBit(cached_has_bits, 0x00000010U)) {
       if (!this_._internal_peer_id().empty()) {
         total_size += 1 + ::google::protobuf::internal::WireFormatLite::StringSize(
                                         this_._internal_peer_id());
       }
     }
     // string volume_id = 4;
-    if (CheckHasBit(cached_has_bits, 0x00000010U)) {
+    if (CheckHasBit(cached_has_bits, 0x00000020U)) {
       if (!this_._internal_volume_id().empty()) {
         total_size += 1 + ::google::protobuf::internal::WireFormatLite::StringSize(
                                         this_._internal_volume_id());
       }
     }
     // .backoff.Backoff fetch_backoff = 8;
-    if (CheckHasBit(cached_has_bits, 0x00000020U)) {
+    if (CheckHasBit(cached_has_bits, 0x00000040U)) {
       total_size += 1 +
                     ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.fetch_backoff_);
     }
     // .backoff.Backoff exec_backoff = 9;
-    if (CheckHasBit(cached_has_bits, 0x00000040U)) {
+    if (CheckHasBit(cached_has_bits, 0x00000080U)) {
       total_size += 1 +
                     ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.exec_backoff_);
     }
+  }
+  if (BatchCheckHasBit(cached_has_bits, 0x00001f00U)) {
     // uint32 fetch_concurrency = 7;
-    if (CheckHasBit(cached_has_bits, 0x00000080U)) {
+    if (CheckHasBit(cached_has_bits, 0x00000100U)) {
       if (this_._internal_fetch_concurrency() != 0) {
         total_size += ::_pbi::WireFormatLite::UInt32SizePlusOne(
             this_._internal_fetch_concurrency());
       }
     }
-  }
-  if (BatchCheckHasBit(cached_has_bits, 0x00000f00U)) {
     // bool watch_fetch_manifest = 5;
-    if (CheckHasBit(cached_has_bits, 0x00000100U)) {
+    if (CheckHasBit(cached_has_bits, 0x00000200U)) {
       if (this_._internal_watch_fetch_manifest() != 0) {
         total_size += 2;
       }
     }
     // bool disable_store_manifest = 6;
-    if (CheckHasBit(cached_has_bits, 0x00000200U)) {
+    if (CheckHasBit(cached_has_bits, 0x00000400U)) {
       if (this_._internal_disable_store_manifest() != 0) {
         total_size += 2;
       }
     }
     // bool disable_copy_manifest = 10;
-    if (CheckHasBit(cached_has_bits, 0x00000400U)) {
+    if (CheckHasBit(cached_has_bits, 0x00000800U)) {
       if (this_._internal_disable_copy_manifest() != 0) {
         total_size += 2;
       }
     }
     // bool verbose = 11;
-    if (CheckHasBit(cached_has_bits, 0x00000800U)) {
+    if (CheckHasBit(cached_has_bits, 0x00001000U)) {
       if (this_._internal_verbose() != 0) {
         total_size += 2;
       }
@@ -783,7 +820,12 @@ void Config::MergeImpl(::google::protobuf::MessageLite& to_msg,
           ::google::protobuf::MessageLite::internal_visibility(), arena,
           from._internal_platform_selection_policies());
     }
-    if (CheckHasBit(cached_has_bits, 0x00000002U)) {
+    if (CheckHasBitForRepeated(cached_has_bits, 0x00000002U)) {
+      _this->_internal_mutable_no_copy_bucket_ids()->InternalMergeFromWithArena(
+          ::google::protobuf::MessageLite::internal_visibility(), arena,
+          from._internal_no_copy_bucket_ids());
+    }
+    if (CheckHasBit(cached_has_bits, 0x00000004U)) {
       if (!from._internal_engine_id().empty()) {
         _this->_internal_set_engine_id(from._internal_engine_id());
       } else {
@@ -792,7 +834,7 @@ void Config::MergeImpl(::google::protobuf::MessageLite& to_msg,
         }
       }
     }
-    if (CheckHasBit(cached_has_bits, 0x00000004U)) {
+    if (CheckHasBit(cached_has_bits, 0x00000008U)) {
       if (!from._internal_object_key().empty()) {
         _this->_internal_set_object_key(from._internal_object_key());
       } else {
@@ -801,7 +843,7 @@ void Config::MergeImpl(::google::protobuf::MessageLite& to_msg,
         }
       }
     }
-    if (CheckHasBit(cached_has_bits, 0x00000008U)) {
+    if (CheckHasBit(cached_has_bits, 0x00000010U)) {
       if (!from._internal_peer_id().empty()) {
         _this->_internal_set_peer_id(from._internal_peer_id());
       } else {
@@ -810,7 +852,7 @@ void Config::MergeImpl(::google::protobuf::MessageLite& to_msg,
         }
       }
     }
-    if (CheckHasBit(cached_has_bits, 0x00000010U)) {
+    if (CheckHasBit(cached_has_bits, 0x00000020U)) {
       if (!from._internal_volume_id().empty()) {
         _this->_internal_set_volume_id(from._internal_volume_id());
       } else {
@@ -819,7 +861,7 @@ void Config::MergeImpl(::google::protobuf::MessageLite& to_msg,
         }
       }
     }
-    if (CheckHasBit(cached_has_bits, 0x00000020U)) {
+    if (CheckHasBit(cached_has_bits, 0x00000040U)) {
       ABSL_DCHECK(from._impl_.fetch_backoff_ != nullptr);
       if (_this->_impl_.fetch_backoff_ == nullptr) {
         _this->_impl_.fetch_backoff_ = ::google::protobuf::Message::CopyConstruct(arena, *from._impl_.fetch_backoff_);
@@ -827,7 +869,7 @@ void Config::MergeImpl(::google::protobuf::MessageLite& to_msg,
         _this->_impl_.fetch_backoff_->MergeFrom(*from._impl_.fetch_backoff_);
       }
     }
-    if (CheckHasBit(cached_has_bits, 0x00000040U)) {
+    if (CheckHasBit(cached_has_bits, 0x00000080U)) {
       ABSL_DCHECK(from._impl_.exec_backoff_ != nullptr);
       if (_this->_impl_.exec_backoff_ == nullptr) {
         _this->_impl_.exec_backoff_ = ::google::protobuf::Message::CopyConstruct(arena, *from._impl_.exec_backoff_);
@@ -835,29 +877,29 @@ void Config::MergeImpl(::google::protobuf::MessageLite& to_msg,
         _this->_impl_.exec_backoff_->MergeFrom(*from._impl_.exec_backoff_);
       }
     }
-    if (CheckHasBit(cached_has_bits, 0x00000080U)) {
+  }
+  if (BatchCheckHasBit(cached_has_bits, 0x00001f00U)) {
+    if (CheckHasBit(cached_has_bits, 0x00000100U)) {
       if (from._internal_fetch_concurrency() != 0) {
         _this->_impl_.fetch_concurrency_ = from._impl_.fetch_concurrency_;
       }
     }
-  }
-  if (BatchCheckHasBit(cached_has_bits, 0x00000f00U)) {
-    if (CheckHasBit(cached_has_bits, 0x00000100U)) {
+    if (CheckHasBit(cached_has_bits, 0x00000200U)) {
       if (from._internal_watch_fetch_manifest() != 0) {
         _this->_impl_.watch_fetch_manifest_ = from._impl_.watch_fetch_manifest_;
       }
     }
-    if (CheckHasBit(cached_has_bits, 0x00000200U)) {
+    if (CheckHasBit(cached_has_bits, 0x00000400U)) {
       if (from._internal_disable_store_manifest() != 0) {
         _this->_impl_.disable_store_manifest_ = from._impl_.disable_store_manifest_;
       }
     }
-    if (CheckHasBit(cached_has_bits, 0x00000400U)) {
+    if (CheckHasBit(cached_has_bits, 0x00000800U)) {
       if (from._internal_disable_copy_manifest() != 0) {
         _this->_impl_.disable_copy_manifest_ = from._impl_.disable_copy_manifest_;
       }
     }
-    if (CheckHasBit(cached_has_bits, 0x00000800U)) {
+    if (CheckHasBit(cached_has_bits, 0x00001000U)) {
       if (from._internal_verbose() != 0) {
         _this->_impl_.verbose_ = from._impl_.verbose_;
       }
@@ -883,6 +925,7 @@ void Config::InternalSwap(Config* PROTOBUF_RESTRICT PROTOBUF_NONNULL other) {
   _internal_metadata_.InternalSwap(&other->_internal_metadata_);
   swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
   _impl_.platform_selection_policies_.InternalSwap(&other->_impl_.platform_selection_policies_);
+  _impl_.no_copy_bucket_ids_.InternalSwap(&other->_impl_.no_copy_bucket_ids_);
   ::_pbi::ArenaStringPtr::InternalSwap(&_impl_.engine_id_, &other->_impl_.engine_id_, arena);
   ::_pbi::ArenaStringPtr::InternalSwap(&_impl_.object_key_, &other->_impl_.object_key_, arena);
   ::_pbi::ArenaStringPtr::InternalSwap(&_impl_.peer_id_, &other->_impl_.peer_id_, arena);

--- a/bldr/plugin/host/scheduler/config.pb.go
+++ b/bldr/plugin/host/scheduler/config.pb.go
@@ -42,6 +42,9 @@ type Config struct {
 	// This is used if the manifest bucket is always accessible and locally cached.
 	// If unset, we will copy manifests to the same bucket as the plugin host world.
 	DisableCopyManifest bool `protobuf:"varint,10,opt,name=disable_copy_manifest,json=disableCopyManifest,proto3" json:"disableCopyManifest,omitempty"`
+	// NoCopyBucketIds lists source buckets that remain authoritative without a
+	// full-DAG copy.
+	NoCopyBucketIds []string `protobuf:"bytes,13,rep,name=no_copy_bucket_ids,json=noCopyBucketIds,proto3" json:"noCopyBucketIds,omitempty"`
 	// FetchConcurrency limits the number of blocks fetched concurrently per-manifest.
 	// If zero, uses no limit to the number of concurrent fetches.
 	//
@@ -116,6 +119,13 @@ func (x *Config) GetDisableCopyManifest() bool {
 		return x.DisableCopyManifest
 	}
 	return false
+}
+
+func (x *Config) GetNoCopyBucketIds() []string {
+	if x != nil {
+		return x.NoCopyBucketIds
+	}
+	return nil
 }
 
 func (x *Config) GetFetchConcurrency() uint32 {
@@ -197,6 +207,7 @@ func (m *Config) CloneVT() *Config {
 	r.DisableCopyManifest = m.DisableCopyManifest
 	r.FetchConcurrency = m.FetchConcurrency
 	r.Verbose = m.Verbose
+	r.NoCopyBucketIds = protobuf_go_lite.CloneSlice(m.NoCopyBucketIds)
 	r.FetchBackoff = protobuf_go_lite.CloneVTValue(m.FetchBackoff)
 	r.ExecBackoff = protobuf_go_lite.CloneVTValue(m.ExecBackoff)
 	r.PlatformSelectionPolicies = protobuf_go_lite.CloneVTSlice(m.PlatformSelectionPolicies)
@@ -267,6 +278,9 @@ func (this *Config) EqualVT(that *Config) bool {
 		return false
 	}
 	if !protobuf_go_lite.EqualVTSliceImplicit(this.PlatformSelectionPolicies, that.PlatformSelectionPolicies, func() *PlatformSelectionPolicy { return &PlatformSelectionPolicy{} }) {
+		return false
+	}
+	if !protobuf_go_lite.EqualSlice(this.NoCopyBucketIds, that.NoCopyBucketIds) {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -377,6 +391,11 @@ func (x *Config) MarshalProtoJSON(s *json.MarshalState) {
 		}
 		s.WriteArrayEnd()
 	}
+	if len(x.NoCopyBucketIds) > 0 || s.HasField("noCopyBucketIds") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("noCopyBucketIds")
+		s.WriteStringArray(x.NoCopyBucketIds)
+	}
 	s.WriteObjectEnd()
 }
 
@@ -453,6 +472,13 @@ func (x *Config) UnmarshalProtoJSON(s *json.UnmarshalState) {
 				}
 				x.PlatformSelectionPolicies = append(x.PlatformSelectionPolicies, v)
 			})
+		case "no_copy_bucket_ids", "noCopyBucketIds":
+			s.AddField("no_copy_bucket_ids")
+			if s.ReadNil() {
+				x.NoCopyBucketIds = nil
+				return
+			}
+			x.NoCopyBucketIds = s.ReadStringArray()
 		}
 	})
 }
@@ -544,6 +570,13 @@ func (m *Config) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	_ = l
 	if m.unknownFields != nil {
 		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
+	}
+	if len(m.NoCopyBucketIds) > 0 {
+		for iNdEx := len(m.NoCopyBucketIds) - 1; iNdEx >= 0; iNdEx-- {
+			i = protobuf_go_lite.EncodeString(dAtA, i, m.NoCopyBucketIds[iNdEx])
+			i--
+			dAtA[i] = 0x6a
+		}
 	}
 	if len(m.PlatformSelectionPolicies) > 0 {
 		for iNdEx := len(m.PlatformSelectionPolicies) - 1; iNdEx >= 0; iNdEx-- {
@@ -696,6 +729,7 @@ func (m *Config) SizeVT() (n int) {
 		l = e.SizeVT()
 		n += protobuf_go_lite.SizeMessage(1, l)
 	}
+	n += protobuf_go_lite.SizeStringSlice(1, m.NoCopyBucketIds)
 	n += len(m.unknownFields)
 	return n
 }
@@ -768,6 +802,14 @@ func (x *Config) MarshalProtoText() string {
 			} else {
 				protobuf_go_lite.TextWriteTextMarshaler(&sb, v)
 			}
+		}
+		protobuf_go_lite.TextWriteListEnd(&sb)
+	}
+	if len(x.NoCopyBucketIds) > 0 {
+		protobuf_go_lite.TextWriteListStart(&sb, initialLen, "no_copy_bucket_ids")
+		for i, v := range x.NoCopyBucketIds {
+			protobuf_go_lite.TextWriteListSeparator(&sb, i)
+			protobuf_go_lite.TextWriteString(&sb, v)
 		}
 		protobuf_go_lite.TextWriteListEnd(&sb)
 	}
@@ -952,6 +994,16 @@ func (m *Config) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 13:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NoCopyBucketIds", wireType)
+			}
+			var v string
+			v, iNdEx, err = protobuf_go_lite.DecodeString(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.NoCopyBucketIds = append(m.NoCopyBucketIds, v)
 		default:
 			iNdEx = preIndex
 			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])

--- a/bldr/plugin/host/scheduler/config.pb.h
+++ b/bldr/plugin/host/scheduler/config.pb.h
@@ -445,6 +445,7 @@ class Config final : public ::google::protobuf::Message
   // accessors -------------------------------------------------------
   enum : int {
     kPlatformSelectionPoliciesFieldNumber = 12,
+    kNoCopyBucketIdsFieldNumber = 13,
     kEngineIdFieldNumber = 1,
     kObjectKeyFieldNumber = 2,
     kPeerIdFieldNumber = 3,
@@ -474,6 +475,28 @@ class Config final : public ::google::protobuf::Message
   const ::plugin::host::scheduler::PlatformSelectionPolicy& platform_selection_policies(int index) const;
   ::plugin::host::scheduler::PlatformSelectionPolicy* PROTOBUF_NONNULL add_platform_selection_policies();
   const ::google::protobuf::RepeatedPtrField<::plugin::host::scheduler::PlatformSelectionPolicy>& platform_selection_policies() const;
+  // repeated string no_copy_bucket_ids = 13;
+  int no_copy_bucket_ids_size() const;
+  private:
+  int _internal_no_copy_bucket_ids_size() const;
+
+  public:
+  void clear_no_copy_bucket_ids() ;
+  const ::std::string& no_copy_bucket_ids(int index) const;
+  ::std::string* PROTOBUF_NONNULL mutable_no_copy_bucket_ids(int index);
+  template <typename Arg_ = const ::std::string&, typename... Args_>
+  void set_no_copy_bucket_ids(int index, Arg_&& value, Args_... args);
+  ::std::string* PROTOBUF_NONNULL add_no_copy_bucket_ids();
+  template <typename Arg_ = const ::std::string&, typename... Args_>
+  void add_no_copy_bucket_ids(Arg_&& value, Args_... args);
+  const ::google::protobuf::RepeatedPtrField<::std::string>& no_copy_bucket_ids() const;
+  ::google::protobuf::RepeatedPtrField<::std::string>* PROTOBUF_NONNULL mutable_no_copy_bucket_ids();
+
+  private:
+  const ::google::protobuf::RepeatedPtrField<::std::string>& _internal_no_copy_bucket_ids() const;
+  ::google::protobuf::RepeatedPtrField<::std::string>* PROTOBUF_NONNULL _internal_mutable_no_copy_bucket_ids();
+
+  public:
   // string engine_id = 1;
   void clear_engine_id() ;
   const ::std::string& engine_id() const;
@@ -618,8 +641,8 @@ class Config final : public ::google::protobuf::Message
  private:
   class _Internal;
   friend class ::google::protobuf::internal::TcParser;
-  static const ::google::protobuf::internal::TcParseTable<4, 12,
-                                   3, 80,
+  static const ::google::protobuf::internal::TcParseTable<4, 13,
+                                   3, 98,
                                    2>
       _table_;
 
@@ -641,6 +664,7 @@ class Config final : public ::google::protobuf::Message
     ::google::protobuf::internal::HasBits<1> _has_bits_;
     ::google::protobuf::internal::CachedSize _cached_size_;
     ::google::protobuf::RepeatedPtrField< ::plugin::host::scheduler::PlatformSelectionPolicy > platform_selection_policies_;
+    ::google::protobuf::RepeatedPtrField<::std::string> no_copy_bucket_ids_;
     ::google::protobuf::internal::ArenaStringPtr engine_id_;
     ::google::protobuf::internal::ArenaStringPtr object_key_;
     ::google::protobuf::internal::ArenaStringPtr peer_id_;
@@ -681,7 +705,7 @@ inline void Config::clear_engine_id() {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   _impl_.engine_id_.ClearToEmpty();
   ClearHasBit(_impl_._has_bits_[0],
-                  0x00000002U);
+                  0x00000004U);
 }
 inline const ::std::string& Config::engine_id() const
     ABSL_ATTRIBUTE_LIFETIME_BOUND {
@@ -691,13 +715,13 @@ inline const ::std::string& Config::engine_id() const
 template <typename Arg_, typename... Args_>
 PROTOBUF_ALWAYS_INLINE void Config::set_engine_id(Arg_&& arg, Args_... args) {
   ::google::protobuf::internal::TSanWrite(&_impl_);
-  SetHasBit(_impl_._has_bits_[0], 0x00000002U);
+  SetHasBit(_impl_._has_bits_[0], 0x00000004U);
   _impl_.engine_id_.Set(static_cast<Arg_&&>(arg), args..., GetArena());
   // @@protoc_insertion_point(field_set:plugin.host.scheduler.Config.engine_id)
 }
 inline ::std::string* PROTOBUF_NONNULL Config::mutable_engine_id()
     ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  SetHasBit(_impl_._has_bits_[0], 0x00000002U);
+  SetHasBit(_impl_._has_bits_[0], 0x00000004U);
   ::std::string* _s = _internal_mutable_engine_id();
   // @@protoc_insertion_point(field_mutable:plugin.host.scheduler.Config.engine_id)
   return _s;
@@ -717,10 +741,10 @@ inline ::std::string* PROTOBUF_NONNULL Config::_internal_mutable_engine_id() {
 inline ::std::string* PROTOBUF_NULLABLE Config::release_engine_id() {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   // @@protoc_insertion_point(field_release:plugin.host.scheduler.Config.engine_id)
-  if (!CheckHasBit(_impl_._has_bits_[0], 0x00000002U)) {
+  if (!CheckHasBit(_impl_._has_bits_[0], 0x00000004U)) {
     return nullptr;
   }
-  ClearHasBit(_impl_._has_bits_[0], 0x00000002U);
+  ClearHasBit(_impl_._has_bits_[0], 0x00000004U);
   auto* released = _impl_.engine_id_.Release();
   if (::google::protobuf::internal::DebugHardenForceCopyDefaultString()) {
     _impl_.engine_id_.Set("", GetArena());
@@ -730,9 +754,9 @@ inline ::std::string* PROTOBUF_NULLABLE Config::release_engine_id() {
 inline void Config::set_allocated_engine_id(::std::string* PROTOBUF_NULLABLE value) {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   if (value != nullptr) {
-    SetHasBit(_impl_._has_bits_[0], 0x00000002U);
+    SetHasBit(_impl_._has_bits_[0], 0x00000004U);
   } else {
-    ClearHasBit(_impl_._has_bits_[0], 0x00000002U);
+    ClearHasBit(_impl_._has_bits_[0], 0x00000004U);
   }
   _impl_.engine_id_.SetAllocated(value, GetArena());
   if (::google::protobuf::internal::DebugHardenForceCopyDefaultString() && _impl_.engine_id_.IsDefault()) {
@@ -746,7 +770,7 @@ inline void Config::clear_object_key() {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   _impl_.object_key_.ClearToEmpty();
   ClearHasBit(_impl_._has_bits_[0],
-                  0x00000004U);
+                  0x00000008U);
 }
 inline const ::std::string& Config::object_key() const
     ABSL_ATTRIBUTE_LIFETIME_BOUND {
@@ -756,13 +780,13 @@ inline const ::std::string& Config::object_key() const
 template <typename Arg_, typename... Args_>
 PROTOBUF_ALWAYS_INLINE void Config::set_object_key(Arg_&& arg, Args_... args) {
   ::google::protobuf::internal::TSanWrite(&_impl_);
-  SetHasBit(_impl_._has_bits_[0], 0x00000004U);
+  SetHasBit(_impl_._has_bits_[0], 0x00000008U);
   _impl_.object_key_.Set(static_cast<Arg_&&>(arg), args..., GetArena());
   // @@protoc_insertion_point(field_set:plugin.host.scheduler.Config.object_key)
 }
 inline ::std::string* PROTOBUF_NONNULL Config::mutable_object_key()
     ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  SetHasBit(_impl_._has_bits_[0], 0x00000004U);
+  SetHasBit(_impl_._has_bits_[0], 0x00000008U);
   ::std::string* _s = _internal_mutable_object_key();
   // @@protoc_insertion_point(field_mutable:plugin.host.scheduler.Config.object_key)
   return _s;
@@ -782,10 +806,10 @@ inline ::std::string* PROTOBUF_NONNULL Config::_internal_mutable_object_key() {
 inline ::std::string* PROTOBUF_NULLABLE Config::release_object_key() {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   // @@protoc_insertion_point(field_release:plugin.host.scheduler.Config.object_key)
-  if (!CheckHasBit(_impl_._has_bits_[0], 0x00000004U)) {
+  if (!CheckHasBit(_impl_._has_bits_[0], 0x00000008U)) {
     return nullptr;
   }
-  ClearHasBit(_impl_._has_bits_[0], 0x00000004U);
+  ClearHasBit(_impl_._has_bits_[0], 0x00000008U);
   auto* released = _impl_.object_key_.Release();
   if (::google::protobuf::internal::DebugHardenForceCopyDefaultString()) {
     _impl_.object_key_.Set("", GetArena());
@@ -795,9 +819,9 @@ inline ::std::string* PROTOBUF_NULLABLE Config::release_object_key() {
 inline void Config::set_allocated_object_key(::std::string* PROTOBUF_NULLABLE value) {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   if (value != nullptr) {
-    SetHasBit(_impl_._has_bits_[0], 0x00000004U);
+    SetHasBit(_impl_._has_bits_[0], 0x00000008U);
   } else {
-    ClearHasBit(_impl_._has_bits_[0], 0x00000004U);
+    ClearHasBit(_impl_._has_bits_[0], 0x00000008U);
   }
   _impl_.object_key_.SetAllocated(value, GetArena());
   if (::google::protobuf::internal::DebugHardenForceCopyDefaultString() && _impl_.object_key_.IsDefault()) {
@@ -811,7 +835,7 @@ inline void Config::clear_peer_id() {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   _impl_.peer_id_.ClearToEmpty();
   ClearHasBit(_impl_._has_bits_[0],
-                  0x00000008U);
+                  0x00000010U);
 }
 inline const ::std::string& Config::peer_id() const
     ABSL_ATTRIBUTE_LIFETIME_BOUND {
@@ -821,13 +845,13 @@ inline const ::std::string& Config::peer_id() const
 template <typename Arg_, typename... Args_>
 PROTOBUF_ALWAYS_INLINE void Config::set_peer_id(Arg_&& arg, Args_... args) {
   ::google::protobuf::internal::TSanWrite(&_impl_);
-  SetHasBit(_impl_._has_bits_[0], 0x00000008U);
+  SetHasBit(_impl_._has_bits_[0], 0x00000010U);
   _impl_.peer_id_.Set(static_cast<Arg_&&>(arg), args..., GetArena());
   // @@protoc_insertion_point(field_set:plugin.host.scheduler.Config.peer_id)
 }
 inline ::std::string* PROTOBUF_NONNULL Config::mutable_peer_id()
     ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  SetHasBit(_impl_._has_bits_[0], 0x00000008U);
+  SetHasBit(_impl_._has_bits_[0], 0x00000010U);
   ::std::string* _s = _internal_mutable_peer_id();
   // @@protoc_insertion_point(field_mutable:plugin.host.scheduler.Config.peer_id)
   return _s;
@@ -847,10 +871,10 @@ inline ::std::string* PROTOBUF_NONNULL Config::_internal_mutable_peer_id() {
 inline ::std::string* PROTOBUF_NULLABLE Config::release_peer_id() {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   // @@protoc_insertion_point(field_release:plugin.host.scheduler.Config.peer_id)
-  if (!CheckHasBit(_impl_._has_bits_[0], 0x00000008U)) {
+  if (!CheckHasBit(_impl_._has_bits_[0], 0x00000010U)) {
     return nullptr;
   }
-  ClearHasBit(_impl_._has_bits_[0], 0x00000008U);
+  ClearHasBit(_impl_._has_bits_[0], 0x00000010U);
   auto* released = _impl_.peer_id_.Release();
   if (::google::protobuf::internal::DebugHardenForceCopyDefaultString()) {
     _impl_.peer_id_.Set("", GetArena());
@@ -860,9 +884,9 @@ inline ::std::string* PROTOBUF_NULLABLE Config::release_peer_id() {
 inline void Config::set_allocated_peer_id(::std::string* PROTOBUF_NULLABLE value) {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   if (value != nullptr) {
-    SetHasBit(_impl_._has_bits_[0], 0x00000008U);
+    SetHasBit(_impl_._has_bits_[0], 0x00000010U);
   } else {
-    ClearHasBit(_impl_._has_bits_[0], 0x00000008U);
+    ClearHasBit(_impl_._has_bits_[0], 0x00000010U);
   }
   _impl_.peer_id_.SetAllocated(value, GetArena());
   if (::google::protobuf::internal::DebugHardenForceCopyDefaultString() && _impl_.peer_id_.IsDefault()) {
@@ -876,7 +900,7 @@ inline void Config::clear_volume_id() {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   _impl_.volume_id_.ClearToEmpty();
   ClearHasBit(_impl_._has_bits_[0],
-                  0x00000010U);
+                  0x00000020U);
 }
 inline const ::std::string& Config::volume_id() const
     ABSL_ATTRIBUTE_LIFETIME_BOUND {
@@ -886,13 +910,13 @@ inline const ::std::string& Config::volume_id() const
 template <typename Arg_, typename... Args_>
 PROTOBUF_ALWAYS_INLINE void Config::set_volume_id(Arg_&& arg, Args_... args) {
   ::google::protobuf::internal::TSanWrite(&_impl_);
-  SetHasBit(_impl_._has_bits_[0], 0x00000010U);
+  SetHasBit(_impl_._has_bits_[0], 0x00000020U);
   _impl_.volume_id_.Set(static_cast<Arg_&&>(arg), args..., GetArena());
   // @@protoc_insertion_point(field_set:plugin.host.scheduler.Config.volume_id)
 }
 inline ::std::string* PROTOBUF_NONNULL Config::mutable_volume_id()
     ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  SetHasBit(_impl_._has_bits_[0], 0x00000010U);
+  SetHasBit(_impl_._has_bits_[0], 0x00000020U);
   ::std::string* _s = _internal_mutable_volume_id();
   // @@protoc_insertion_point(field_mutable:plugin.host.scheduler.Config.volume_id)
   return _s;
@@ -912,10 +936,10 @@ inline ::std::string* PROTOBUF_NONNULL Config::_internal_mutable_volume_id() {
 inline ::std::string* PROTOBUF_NULLABLE Config::release_volume_id() {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   // @@protoc_insertion_point(field_release:plugin.host.scheduler.Config.volume_id)
-  if (!CheckHasBit(_impl_._has_bits_[0], 0x00000010U)) {
+  if (!CheckHasBit(_impl_._has_bits_[0], 0x00000020U)) {
     return nullptr;
   }
-  ClearHasBit(_impl_._has_bits_[0], 0x00000010U);
+  ClearHasBit(_impl_._has_bits_[0], 0x00000020U);
   auto* released = _impl_.volume_id_.Release();
   if (::google::protobuf::internal::DebugHardenForceCopyDefaultString()) {
     _impl_.volume_id_.Set("", GetArena());
@@ -925,9 +949,9 @@ inline ::std::string* PROTOBUF_NULLABLE Config::release_volume_id() {
 inline void Config::set_allocated_volume_id(::std::string* PROTOBUF_NULLABLE value) {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   if (value != nullptr) {
-    SetHasBit(_impl_._has_bits_[0], 0x00000010U);
+    SetHasBit(_impl_._has_bits_[0], 0x00000020U);
   } else {
-    ClearHasBit(_impl_._has_bits_[0], 0x00000010U);
+    ClearHasBit(_impl_._has_bits_[0], 0x00000020U);
   }
   _impl_.volume_id_.SetAllocated(value, GetArena());
   if (::google::protobuf::internal::DebugHardenForceCopyDefaultString() && _impl_.volume_id_.IsDefault()) {
@@ -941,7 +965,7 @@ inline void Config::clear_watch_fetch_manifest() {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   _impl_.watch_fetch_manifest_ = false;
   ClearHasBit(_impl_._has_bits_[0],
-                  0x00000100U);
+                  0x00000200U);
 }
 inline bool Config::watch_fetch_manifest() const {
   // @@protoc_insertion_point(field_get:plugin.host.scheduler.Config.watch_fetch_manifest)
@@ -949,7 +973,7 @@ inline bool Config::watch_fetch_manifest() const {
 }
 inline void Config::set_watch_fetch_manifest(bool value) {
   _internal_set_watch_fetch_manifest(value);
-  SetHasBit(_impl_._has_bits_[0], 0x00000100U);
+  SetHasBit(_impl_._has_bits_[0], 0x00000200U);
   // @@protoc_insertion_point(field_set:plugin.host.scheduler.Config.watch_fetch_manifest)
 }
 inline bool Config::_internal_watch_fetch_manifest() const {
@@ -966,7 +990,7 @@ inline void Config::clear_disable_store_manifest() {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   _impl_.disable_store_manifest_ = false;
   ClearHasBit(_impl_._has_bits_[0],
-                  0x00000200U);
+                  0x00000400U);
 }
 inline bool Config::disable_store_manifest() const {
   // @@protoc_insertion_point(field_get:plugin.host.scheduler.Config.disable_store_manifest)
@@ -974,7 +998,7 @@ inline bool Config::disable_store_manifest() const {
 }
 inline void Config::set_disable_store_manifest(bool value) {
   _internal_set_disable_store_manifest(value);
-  SetHasBit(_impl_._has_bits_[0], 0x00000200U);
+  SetHasBit(_impl_._has_bits_[0], 0x00000400U);
   // @@protoc_insertion_point(field_set:plugin.host.scheduler.Config.disable_store_manifest)
 }
 inline bool Config::_internal_disable_store_manifest() const {
@@ -991,7 +1015,7 @@ inline void Config::clear_disable_copy_manifest() {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   _impl_.disable_copy_manifest_ = false;
   ClearHasBit(_impl_._has_bits_[0],
-                  0x00000400U);
+                  0x00000800U);
 }
 inline bool Config::disable_copy_manifest() const {
   // @@protoc_insertion_point(field_get:plugin.host.scheduler.Config.disable_copy_manifest)
@@ -999,7 +1023,7 @@ inline bool Config::disable_copy_manifest() const {
 }
 inline void Config::set_disable_copy_manifest(bool value) {
   _internal_set_disable_copy_manifest(value);
-  SetHasBit(_impl_._has_bits_[0], 0x00000400U);
+  SetHasBit(_impl_._has_bits_[0], 0x00000800U);
   // @@protoc_insertion_point(field_set:plugin.host.scheduler.Config.disable_copy_manifest)
 }
 inline bool Config::_internal_disable_copy_manifest() const {
@@ -1011,12 +1035,84 @@ inline void Config::_internal_set_disable_copy_manifest(bool value) {
   _impl_.disable_copy_manifest_ = value;
 }
 
+// repeated string no_copy_bucket_ids = 13;
+inline int Config::_internal_no_copy_bucket_ids_size() const {
+  return _internal_no_copy_bucket_ids().size();
+}
+inline int Config::no_copy_bucket_ids_size() const {
+  return _internal_no_copy_bucket_ids_size();
+}
+inline void Config::clear_no_copy_bucket_ids() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.no_copy_bucket_ids_.Clear();
+  ClearHasBitForRepeated(_impl_._has_bits_[0],
+                  0x00000002U);
+}
+inline ::std::string* PROTOBUF_NONNULL Config::add_no_copy_bucket_ids()
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::std::string* _s =
+      _internal_mutable_no_copy_bucket_ids()->InternalAddWithArena(
+          ::google::protobuf::MessageLite::internal_visibility(), GetArena());
+  SetHasBitForRepeated(_impl_._has_bits_[0], 0x00000002U);
+  // @@protoc_insertion_point(field_add_mutable:plugin.host.scheduler.Config.no_copy_bucket_ids)
+  return _s;
+}
+inline const ::std::string& Config::no_copy_bucket_ids(int index) const
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:plugin.host.scheduler.Config.no_copy_bucket_ids)
+  return _internal_no_copy_bucket_ids().Get(index);
+}
+inline ::std::string* PROTOBUF_NONNULL Config::mutable_no_copy_bucket_ids(int index)
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_mutable:plugin.host.scheduler.Config.no_copy_bucket_ids)
+  return _internal_mutable_no_copy_bucket_ids()->Mutable(index);
+}
+template <typename Arg_, typename... Args_>
+inline void Config::set_no_copy_bucket_ids(int index, Arg_&& value, Args_... args) {
+  ::google::protobuf::internal::AssignToString(*_internal_mutable_no_copy_bucket_ids()->Mutable(index), ::std::forward<Arg_>(value),
+                        args... );
+  // @@protoc_insertion_point(field_set:plugin.host.scheduler.Config.no_copy_bucket_ids)
+}
+template <typename Arg_, typename... Args_>
+inline void Config::add_no_copy_bucket_ids(Arg_&& value, Args_... args) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::google::protobuf::internal::AddToRepeatedPtrField(
+      ::google::protobuf::MessageLite::internal_visibility(), GetArena(),
+      *_internal_mutable_no_copy_bucket_ids(), ::std::forward<Arg_>(value),
+      args... );
+  SetHasBitForRepeated(_impl_._has_bits_[0], 0x00000002U);
+  // @@protoc_insertion_point(field_add:plugin.host.scheduler.Config.no_copy_bucket_ids)
+}
+inline const ::google::protobuf::RepeatedPtrField<::std::string>& Config::no_copy_bucket_ids()
+    const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_list:plugin.host.scheduler.Config.no_copy_bucket_ids)
+  return _internal_no_copy_bucket_ids();
+}
+inline ::google::protobuf::RepeatedPtrField<::std::string>* PROTOBUF_NONNULL
+Config::mutable_no_copy_bucket_ids() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  SetHasBitForRepeated(_impl_._has_bits_[0], 0x00000002U);
+  // @@protoc_insertion_point(field_mutable_list:plugin.host.scheduler.Config.no_copy_bucket_ids)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  return _internal_mutable_no_copy_bucket_ids();
+}
+inline const ::google::protobuf::RepeatedPtrField<::std::string>&
+Config::_internal_no_copy_bucket_ids() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.no_copy_bucket_ids_;
+}
+inline ::google::protobuf::RepeatedPtrField<::std::string>* PROTOBUF_NONNULL
+Config::_internal_mutable_no_copy_bucket_ids() {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return &_impl_.no_copy_bucket_ids_;
+}
+
 // uint32 fetch_concurrency = 7;
 inline void Config::clear_fetch_concurrency() {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   _impl_.fetch_concurrency_ = 0u;
   ClearHasBit(_impl_._has_bits_[0],
-                  0x00000080U);
+                  0x00000100U);
 }
 inline ::uint32_t Config::fetch_concurrency() const {
   // @@protoc_insertion_point(field_get:plugin.host.scheduler.Config.fetch_concurrency)
@@ -1024,7 +1120,7 @@ inline ::uint32_t Config::fetch_concurrency() const {
 }
 inline void Config::set_fetch_concurrency(::uint32_t value) {
   _internal_set_fetch_concurrency(value);
-  SetHasBit(_impl_._has_bits_[0], 0x00000080U);
+  SetHasBit(_impl_._has_bits_[0], 0x00000100U);
   // @@protoc_insertion_point(field_set:plugin.host.scheduler.Config.fetch_concurrency)
 }
 inline ::uint32_t Config::_internal_fetch_concurrency() const {
@@ -1038,7 +1134,7 @@ inline void Config::_internal_set_fetch_concurrency(::uint32_t value) {
 
 // .backoff.Backoff fetch_backoff = 8;
 inline bool Config::has_fetch_backoff() const {
-  bool value = CheckHasBit(_impl_._has_bits_[0], 0x00000020U);
+  bool value = CheckHasBit(_impl_._has_bits_[0], 0x00000040U);
   PROTOBUF_ASSUME(!value || _impl_.fetch_backoff_ != nullptr);
   return value;
 }
@@ -1059,16 +1155,16 @@ inline void Config::unsafe_arena_set_allocated_fetch_backoff(
   }
   _impl_.fetch_backoff_ = reinterpret_cast<::backoff::Backoff*>(value);
   if (value != nullptr) {
-    SetHasBit(_impl_._has_bits_[0], 0x00000020U);
+    SetHasBit(_impl_._has_bits_[0], 0x00000040U);
   } else {
-    ClearHasBit(_impl_._has_bits_[0], 0x00000020U);
+    ClearHasBit(_impl_._has_bits_[0], 0x00000040U);
   }
   // @@protoc_insertion_point(field_unsafe_arena_set_allocated:plugin.host.scheduler.Config.fetch_backoff)
 }
 inline ::backoff::Backoff* PROTOBUF_NULLABLE Config::release_fetch_backoff() {
   ::google::protobuf::internal::TSanWrite(&_impl_);
 
-  ClearHasBit(_impl_._has_bits_[0], 0x00000020U);
+  ClearHasBit(_impl_._has_bits_[0], 0x00000040U);
   ::backoff::Backoff* released = _impl_.fetch_backoff_;
   _impl_.fetch_backoff_ = nullptr;
   if (::google::protobuf::internal::DebugHardenForceCopyInRelease()) {
@@ -1088,7 +1184,7 @@ inline ::backoff::Backoff* PROTOBUF_NULLABLE Config::unsafe_arena_release_fetch_
   ::google::protobuf::internal::TSanWrite(&_impl_);
   // @@protoc_insertion_point(field_release:plugin.host.scheduler.Config.fetch_backoff)
 
-  ClearHasBit(_impl_._has_bits_[0], 0x00000020U);
+  ClearHasBit(_impl_._has_bits_[0], 0x00000040U);
   ::backoff::Backoff* temp = _impl_.fetch_backoff_;
   _impl_.fetch_backoff_ = nullptr;
   return temp;
@@ -1103,7 +1199,7 @@ inline ::backoff::Backoff* PROTOBUF_NONNULL Config::_internal_mutable_fetch_back
 }
 inline ::backoff::Backoff* PROTOBUF_NONNULL Config::mutable_fetch_backoff()
     ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  SetHasBit(_impl_._has_bits_[0], 0x00000020U);
+  SetHasBit(_impl_._has_bits_[0], 0x00000040U);
   ::backoff::Backoff* _msg = _internal_mutable_fetch_backoff();
   // @@protoc_insertion_point(field_mutable:plugin.host.scheduler.Config.fetch_backoff)
   return _msg;
@@ -1120,9 +1216,9 @@ inline void Config::set_allocated_fetch_backoff(::backoff::Backoff* PROTOBUF_NUL
     if (message_arena != submessage_arena) {
       value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
     }
-    SetHasBit(_impl_._has_bits_[0], 0x00000020U);
+    SetHasBit(_impl_._has_bits_[0], 0x00000040U);
   } else {
-    ClearHasBit(_impl_._has_bits_[0], 0x00000020U);
+    ClearHasBit(_impl_._has_bits_[0], 0x00000040U);
   }
 
   _impl_.fetch_backoff_ = reinterpret_cast<::backoff::Backoff*>(value);
@@ -1131,7 +1227,7 @@ inline void Config::set_allocated_fetch_backoff(::backoff::Backoff* PROTOBUF_NUL
 
 // .backoff.Backoff exec_backoff = 9;
 inline bool Config::has_exec_backoff() const {
-  bool value = CheckHasBit(_impl_._has_bits_[0], 0x00000040U);
+  bool value = CheckHasBit(_impl_._has_bits_[0], 0x00000080U);
   PROTOBUF_ASSUME(!value || _impl_.exec_backoff_ != nullptr);
   return value;
 }
@@ -1152,16 +1248,16 @@ inline void Config::unsafe_arena_set_allocated_exec_backoff(
   }
   _impl_.exec_backoff_ = reinterpret_cast<::backoff::Backoff*>(value);
   if (value != nullptr) {
-    SetHasBit(_impl_._has_bits_[0], 0x00000040U);
+    SetHasBit(_impl_._has_bits_[0], 0x00000080U);
   } else {
-    ClearHasBit(_impl_._has_bits_[0], 0x00000040U);
+    ClearHasBit(_impl_._has_bits_[0], 0x00000080U);
   }
   // @@protoc_insertion_point(field_unsafe_arena_set_allocated:plugin.host.scheduler.Config.exec_backoff)
 }
 inline ::backoff::Backoff* PROTOBUF_NULLABLE Config::release_exec_backoff() {
   ::google::protobuf::internal::TSanWrite(&_impl_);
 
-  ClearHasBit(_impl_._has_bits_[0], 0x00000040U);
+  ClearHasBit(_impl_._has_bits_[0], 0x00000080U);
   ::backoff::Backoff* released = _impl_.exec_backoff_;
   _impl_.exec_backoff_ = nullptr;
   if (::google::protobuf::internal::DebugHardenForceCopyInRelease()) {
@@ -1181,7 +1277,7 @@ inline ::backoff::Backoff* PROTOBUF_NULLABLE Config::unsafe_arena_release_exec_b
   ::google::protobuf::internal::TSanWrite(&_impl_);
   // @@protoc_insertion_point(field_release:plugin.host.scheduler.Config.exec_backoff)
 
-  ClearHasBit(_impl_._has_bits_[0], 0x00000040U);
+  ClearHasBit(_impl_._has_bits_[0], 0x00000080U);
   ::backoff::Backoff* temp = _impl_.exec_backoff_;
   _impl_.exec_backoff_ = nullptr;
   return temp;
@@ -1196,7 +1292,7 @@ inline ::backoff::Backoff* PROTOBUF_NONNULL Config::_internal_mutable_exec_backo
 }
 inline ::backoff::Backoff* PROTOBUF_NONNULL Config::mutable_exec_backoff()
     ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  SetHasBit(_impl_._has_bits_[0], 0x00000040U);
+  SetHasBit(_impl_._has_bits_[0], 0x00000080U);
   ::backoff::Backoff* _msg = _internal_mutable_exec_backoff();
   // @@protoc_insertion_point(field_mutable:plugin.host.scheduler.Config.exec_backoff)
   return _msg;
@@ -1213,9 +1309,9 @@ inline void Config::set_allocated_exec_backoff(::backoff::Backoff* PROTOBUF_NULL
     if (message_arena != submessage_arena) {
       value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
     }
-    SetHasBit(_impl_._has_bits_[0], 0x00000040U);
+    SetHasBit(_impl_._has_bits_[0], 0x00000080U);
   } else {
-    ClearHasBit(_impl_._has_bits_[0], 0x00000040U);
+    ClearHasBit(_impl_._has_bits_[0], 0x00000080U);
   }
 
   _impl_.exec_backoff_ = reinterpret_cast<::backoff::Backoff*>(value);
@@ -1227,7 +1323,7 @@ inline void Config::clear_verbose() {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   _impl_.verbose_ = false;
   ClearHasBit(_impl_._has_bits_[0],
-                  0x00000800U);
+                  0x00001000U);
 }
 inline bool Config::verbose() const {
   // @@protoc_insertion_point(field_get:plugin.host.scheduler.Config.verbose)
@@ -1235,7 +1331,7 @@ inline bool Config::verbose() const {
 }
 inline void Config::set_verbose(bool value) {
   _internal_set_verbose(value);
-  SetHasBit(_impl_._has_bits_[0], 0x00000800U);
+  SetHasBit(_impl_._has_bits_[0], 0x00001000U);
   // @@protoc_insertion_point(field_set:plugin.host.scheduler.Config.verbose)
 }
 inline bool Config::_internal_verbose() const {

--- a/bldr/plugin/host/scheduler/config.pb.rs
+++ b/bldr/plugin/host/scheduler/config.pb.rs
@@ -35,6 +35,10 @@ pub struct Config {
     /// If unset, we will copy manifests to the same bucket as the plugin host world.
     #[prost(bool, tag="10")]
     pub disable_copy_manifest: bool,
+    /// NoCopyBucketIds lists source buckets that remain authoritative without a
+    /// full-DAG copy.
+    #[prost(string, repeated, tag="13")]
+    pub no_copy_bucket_ids: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// FetchConcurrency limits the number of blocks fetched concurrently per-manifest.
     /// If zero, uses no limit to the number of concurrent fetches.
     ///

--- a/bldr/plugin/host/scheduler/config.pb.ts
+++ b/bldr/plugin/host/scheduler/config.pb.ts
@@ -107,6 +107,13 @@ export interface Config {
    */
   disableCopyManifest?: boolean
   /**
+   * NoCopyBucketIds lists source buckets that remain authoritative without a
+   * full-DAG copy.
+   *
+   * @generated from field: repeated string no_copy_bucket_ids = 13;
+   */
+  noCopyBucketIds?: string[]
+  /**
    * FetchConcurrency limits the number of blocks fetched concurrently per-manifest.
    * If zero, uses no limit to the number of concurrent fetches.
    *
@@ -166,6 +173,13 @@ export const Config: MessageType<Config> = /* @__PURE__ */ createMessageType({
       name: 'disable_copy_manifest',
       kind: 'scalar',
       T: ScalarType.BOOL,
+    },
+    {
+      no: 13,
+      name: 'no_copy_bucket_ids',
+      kind: 'scalar',
+      T: ScalarType.STRING,
+      repeated: true,
     },
     { no: 7, name: 'fetch_concurrency', kind: 'scalar', T: ScalarType.UINT32 },
     { no: 8, name: 'fetch_backoff', kind: 'message', T: () => Backoff },

--- a/bldr/plugin/host/scheduler/config.proto
+++ b/bldr/plugin/host/scheduler/config.proto
@@ -30,6 +30,9 @@ message Config {
   // This is used if the manifest bucket is always accessible and locally cached.
   // If unset, we will copy manifests to the same bucket as the plugin host world.
   bool disable_copy_manifest = 10;
+  // NoCopyBucketIds lists source buckets that remain authoritative without a
+  // full-DAG copy.
+  repeated string no_copy_bucket_ids = 13;
   // FetchConcurrency limits the number of blocks fetched concurrently per-manifest.
   // If zero, uses no limit to the number of concurrent fetches.
   //

--- a/bldr/plugin/host/scheduler/controller.go
+++ b/bldr/plugin/host/scheduler/controller.go
@@ -68,6 +68,8 @@ type Controller struct {
 	hostVolumeCtr *ccontainer.CContainer[*hostVol]
 	// pluginHostsCtr is a container with the set of available plugin hosts.
 	pluginHostsCtr *ccontainer.CContainer[*pluginHostSet]
+	// manifestCopyGate delays startup copies until runtime readiness.
+	manifestCopyGateCtr *ccontainer.CContainer[ManifestCopyGate]
 
 	// pluginInstances manages the list of running plugins by plugin ID.
 	// key: plugin ID
@@ -150,15 +152,16 @@ func NewController(
 ) *Controller {
 	peerID, _ := conf.ParsePeerID()
 	c := &Controller{
-		le:             le,
-		bus:            bus,
-		conf:           conf,
-		objKey:         conf.GetObjectKey(),
-		peerID:         peerID,
-		peerIDStr:      peerID.String(),
-		worldStateCtr:  ccontainer.NewCContainer[world.WorldState](nil),
-		hostVolumeCtr:  ccontainer.NewCContainer[*hostVol](nil),
-		pluginHostsCtr: ccontainer.NewCContainerWithEqual(nil, pluginHostSetEqual),
+		le:                  le,
+		bus:                 bus,
+		conf:                conf,
+		objKey:              conf.GetObjectKey(),
+		peerID:              peerID,
+		peerIDStr:           peerID.String(),
+		worldStateCtr:       ccontainer.NewCContainer[world.WorldState](nil),
+		hostVolumeCtr:       ccontainer.NewCContainer[*hostVol](nil),
+		pluginHostsCtr:      ccontainer.NewCContainerWithEqual(nil, pluginHostSetEqual),
+		manifestCopyGateCtr: ccontainer.NewCContainer[ManifestCopyGate](nil),
 		pluginStatusCtr: ccontainer.NewCContainerWithEqual(
 			&PluginStatusSnapshot{},
 			pluginStatusSnapshotEqual,
@@ -169,6 +172,19 @@ func NewController(
 	c.pluginInstances = keyed.NewKeyedRefCountWithLogger(c.newPluginInstance, le.WithField("tracker", "running-plugin"))
 	c.hostClient = srpc.NewClient(srpc.NewServerPipe(srpc.NewServer(bifrost_rpc.NewInvoker(bus, "plugin-host", true))))
 	return c
+}
+
+// SetManifestCopyGate sets the runtime readiness gate for startup manifest copies.
+// A nil gate preserves immediate copy behavior.
+func (c *Controller) SetManifestCopyGate(gate ManifestCopyGate) {
+	c.manifestCopyGateCtr.SetValue(gate)
+}
+
+func (c *Controller) getManifestCopyGate() ManifestCopyGate {
+	if c == nil || c.manifestCopyGateCtr == nil {
+		return nil
+	}
+	return c.manifestCopyGateCtr.GetValue()
 }
 
 // GetControllerInfo returns information about the controller.

--- a/bldr/plugin/host/scheduler/download-manifest.go
+++ b/bldr/plugin/host/scheduler/download-manifest.go
@@ -2,6 +2,7 @@ package plugin_host_scheduler
 
 import (
 	"context"
+	"slices"
 
 	"github.com/pkg/errors"
 	bldr_manifest "github.com/s4wave/spacewave/bldr/manifest"
@@ -15,16 +16,18 @@ type manifestCopyClass string
 const (
 	manifestCopyClassImmediate         manifestCopyClass = "immediate"
 	manifestCopyClassAfterExecuteReady manifestCopyClass = "after-execute-ready"
+	manifestCopyClassSuppressed        manifestCopyClass = "suppressed"
 )
 
 type manifestCopyPhase string
 
 const (
-	manifestCopyPhaseSelected manifestCopyPhase = "selected"
-	manifestCopyPhaseWaiting  manifestCopyPhase = "waiting-for-running"
-	manifestCopyPhaseCopying  manifestCopyPhase = "copying"
-	manifestCopyPhaseDone     manifestCopyPhase = "done"
-	manifestCopyPhaseFailed   manifestCopyPhase = "failed"
+	manifestCopyPhaseSelected   manifestCopyPhase = "selected"
+	manifestCopyPhaseWaiting    manifestCopyPhase = "waiting-for-running"
+	manifestCopyPhaseCopying    manifestCopyPhase = "copying"
+	manifestCopyPhaseDone       manifestCopyPhase = "done"
+	manifestCopyPhaseFailed     manifestCopyPhase = "failed"
+	manifestCopyPhaseSuppressed manifestCopyPhase = "suppressed"
 )
 
 type manifestCopyStatus struct {
@@ -39,7 +42,18 @@ type manifestCopyStatus struct {
 }
 
 func (t *pluginInstance) classifyManifestCopy(manifestSnapshot *bldr_manifest.ManifestSnapshot) manifestCopyClass {
-	if t == nil || t.executePluginRoutine == nil || t.runningPluginCtr == nil || manifestSnapshot == nil {
+	if t == nil || manifestSnapshot == nil {
+		return manifestCopyClassImmediate
+	}
+	if t.c != nil && t.c.conf != nil {
+		ref := manifestSnapshot.GetManifestRef()
+		if ref != nil &&
+			ref.GetBucketId() != "" &&
+			slices.Contains(t.c.conf.GetNoCopyBucketIds(), ref.GetBucketId()) {
+			return manifestCopyClassSuppressed
+		}
+	}
+	if t.executePluginRoutine == nil || t.runningPluginCtr == nil {
 		return manifestCopyClassImmediate
 	}
 	execState := t.executePluginRoutine.GetState()
@@ -85,6 +99,40 @@ func (t *pluginInstance) setManifestCopyStatus(
 	t.manifestCopyStatus.SetValue(status)
 }
 
+func (t *pluginInstance) setDownloadManifestState(
+	ctx context.Context,
+	manifestSnapshot *bldr_manifest.ManifestSnapshot,
+	destinationBucketID string,
+) bool {
+	if t.c.conf.GetDisableCopyManifest() {
+		return false
+	}
+	if t.classifyManifestCopy(manifestSnapshot) != manifestCopyClassSuppressed {
+		_, changed, _, _ := t.downloadManifestRoutine.SetState(manifestSnapshot)
+		return changed
+	}
+
+	_, changed, _, _ := t.downloadManifestRoutine.SetState(nil)
+	ref := manifestSnapshot.GetManifestRef()
+	accounting := t.setManifestCopySelection(
+		ctx,
+		manifestSnapshot,
+		ref.GetBucketId(),
+		destinationBucketID,
+	)
+	trace.Log(ctx, "manifest-copy-phase", string(manifestCopyPhaseSuppressed))
+	trace.Log(ctx, "manifest-copy-class", string(manifestCopyClassSuppressed))
+	t.setManifestCopyStatus(
+		manifestCopyPhaseSuppressed,
+		manifestCopyClassSuppressed,
+		manifestSnapshot,
+		accounting,
+		bucket_lookup.ObjectCopyStats{},
+	)
+	t.emitManifestCopyStartupMark(manifestCopyPhaseSuppressed, bucket_lookup.ObjectCopyStats{}, accounting)
+	return changed
+}
+
 func (t *pluginInstance) waitForStartupExecuteReady(
 	ctx context.Context,
 	class manifestCopyClass,
@@ -117,7 +165,10 @@ func (t *pluginInstance) execDownloadManifest(
 		t.c.recordPluginStatusError(t.pluginID, t.instanceKey, "download plugin manifest", rerr)
 	}()
 
-	if t.c.conf.GetDisableCopyManifest() || manifestSnapshot == nil || manifestSnapshot.GetManifestRef() == nil {
+	if t.c.conf.GetDisableCopyManifest() ||
+		manifestSnapshot == nil ||
+		manifestSnapshot.GetManifestRef() == nil ||
+		t.classifyManifestCopy(manifestSnapshot) == manifestCopyClassSuppressed {
 		return nil
 	}
 

--- a/bldr/plugin/host/scheduler/download-manifest.go
+++ b/bldr/plugin/host/scheduler/download-manifest.go
@@ -14,20 +14,22 @@ import (
 type manifestCopyClass string
 
 const (
-	manifestCopyClassImmediate         manifestCopyClass = "immediate"
-	manifestCopyClassAfterExecuteReady manifestCopyClass = "after-execute-ready"
-	manifestCopyClassSuppressed        manifestCopyClass = "suppressed"
+	manifestCopyClassImmediate              manifestCopyClass = "immediate"
+	manifestCopyClassAfterExecuteReady      manifestCopyClass = "after-execute-ready"
+	manifestCopyClassAfterStartupGroupReady manifestCopyClass = "after-startup-group-ready"
+	manifestCopyClassSuppressed             manifestCopyClass = "suppressed"
 )
 
 type manifestCopyPhase string
 
 const (
-	manifestCopyPhaseSelected   manifestCopyPhase = "selected"
-	manifestCopyPhaseWaiting    manifestCopyPhase = "waiting-for-running"
-	manifestCopyPhaseCopying    manifestCopyPhase = "copying"
-	manifestCopyPhaseDone       manifestCopyPhase = "done"
-	manifestCopyPhaseFailed     manifestCopyPhase = "failed"
-	manifestCopyPhaseSuppressed manifestCopyPhase = "suppressed"
+	manifestCopyPhaseSelected               manifestCopyPhase = "selected"
+	manifestCopyPhaseWaiting                manifestCopyPhase = "waiting-for-running"
+	manifestCopyPhaseWaitingForStartupGroup manifestCopyPhase = "waiting-for-startup-group"
+	manifestCopyPhaseCopying                manifestCopyPhase = "copying"
+	manifestCopyPhaseDone                   manifestCopyPhase = "done"
+	manifestCopyPhaseFailed                 manifestCopyPhase = "failed"
+	manifestCopyPhaseSuppressed             manifestCopyPhase = "suppressed"
 )
 
 type manifestCopyStatus struct {
@@ -52,6 +54,10 @@ func (t *pluginInstance) classifyManifestCopy(manifestSnapshot *bldr_manifest.Ma
 			slices.Contains(t.c.conf.GetNoCopyBucketIds(), ref.GetBucketId()) {
 			return manifestCopyClassSuppressed
 		}
+	}
+	gate := t.c.getManifestCopyGate()
+	if gate != nil && !gate.IsReady() {
+		return manifestCopyClassAfterStartupGroupReady
 	}
 	if t.executePluginRoutine == nil || t.runningPluginCtr == nil {
 		return manifestCopyClassImmediate
@@ -133,24 +139,41 @@ func (t *pluginInstance) setDownloadManifestState(
 	return changed
 }
 
-func (t *pluginInstance) waitForStartupExecuteReady(
+func (t *pluginInstance) waitForManifestCopyReady(
 	ctx context.Context,
 	class manifestCopyClass,
 	manifestSnapshot *bldr_manifest.ManifestSnapshot,
 	accounting *manifestCopyAccounting,
 ) error {
-	if class != manifestCopyClassAfterExecuteReady {
+	switch class {
+	case manifestCopyClassImmediate, manifestCopyClassSuppressed:
 		return nil
-	}
-	ctx, task := trace.NewTask(ctx, "bldr/plugin-host-scheduler/download-manifest/wait-for-startup-execute-ready")
-	defer task.End()
-	t.logPluginAccountingFields(ctx)
-	logManifestSnapshotAccountingFields(ctx, "download", manifestSnapshot)
+	case manifestCopyClassAfterExecuteReady:
+		ctx, task := trace.NewTask(ctx, "bldr/plugin-host-scheduler/download-manifest/wait-for-startup-execute-ready")
+		defer task.End()
+		t.logPluginAccountingFields(ctx)
+		logManifestSnapshotAccountingFields(ctx, "download", manifestSnapshot)
 
-	t.setManifestCopyStatus(manifestCopyPhaseWaiting, class, manifestSnapshot, accounting, bucket_lookup.ObjectCopyStats{})
-	t.emitManifestCopyStartupMark(manifestCopyPhaseWaiting, bucket_lookup.ObjectCopyStats{}, accounting)
-	_, err := t.runningPluginCtr.WaitValue(ctx, nil)
-	return err
+		t.setManifestCopyStatus(manifestCopyPhaseWaiting, class, manifestSnapshot, accounting, bucket_lookup.ObjectCopyStats{})
+		t.emitManifestCopyStartupMark(manifestCopyPhaseWaiting, bucket_lookup.ObjectCopyStats{}, accounting)
+		_, err := t.runningPluginCtr.WaitValue(ctx, nil)
+		return err
+	case manifestCopyClassAfterStartupGroupReady:
+		ctx, task := trace.NewTask(ctx, "bldr/plugin-host-scheduler/download-manifest/wait-for-startup-group-ready")
+		defer task.End()
+		t.logPluginAccountingFields(ctx)
+		logManifestSnapshotAccountingFields(ctx, "download", manifestSnapshot)
+
+		t.setManifestCopyStatus(manifestCopyPhaseWaitingForStartupGroup, class, manifestSnapshot, accounting, bucket_lookup.ObjectCopyStats{})
+		t.emitManifestCopyStartupMark(manifestCopyPhaseWaitingForStartupGroup, bucket_lookup.ObjectCopyStats{}, accounting)
+		gate := t.c.getManifestCopyGate()
+		if gate == nil {
+			return nil
+		}
+		return gate.WaitReady(ctx)
+	default:
+		return errors.Errorf("unknown manifest copy class: %q", class)
+	}
 }
 
 // execDownloadManifest copies manifest blocks from the source bucket to the world bucket.
@@ -202,7 +225,7 @@ func (t *pluginInstance) execDownloadManifest(
 	trace.Log(ctx, "startup-fetch-kind", "background-manifest-dag-copy")
 	trace.Log(ctx, "manifest-copy-class", string(class))
 
-	if err := t.waitForStartupExecuteReady(ctx, class, manifestSnapshot, accounting); err != nil {
+	if err := t.waitForManifestCopyReady(ctx, class, manifestSnapshot, accounting); err != nil {
 		return err
 	}
 	materializerCtx, materializerTask := trace.NewTask(ctx, "bldr/plugin-host-scheduler/materializer")

--- a/bldr/plugin/host/scheduler/fetch-world-manifest.go
+++ b/bldr/plugin/host/scheduler/fetch-world-manifest.go
@@ -244,9 +244,7 @@ func (t *pluginInstance) newDirectFetchHandler(ctx context.Context, hosts *plugi
 				manifestSnapshot: snapshot,
 				pluginHost:       best.host,
 			})
-			if !t.c.conf.GetDisableCopyManifest() {
-				t.downloadManifestRoutine.SetState(snapshot)
-			}
+			t.setDownloadManifestState(ctx, snapshot, "")
 			t.loggedNotFound.Store(false)
 			return
 		}
@@ -258,9 +256,7 @@ func (t *pluginInstance) newDirectFetchHandler(ctx context.Context, hosts *plugi
 		}
 
 		t.executePluginRoutine.SetState(nil)
-		if !t.c.conf.GetDisableCopyManifest() {
-			t.downloadManifestRoutine.SetState(nil)
-		}
+		t.setDownloadManifestState(ctx, nil, "")
 	}
 
 	return directive.NewTypedCallbackHandler(

--- a/bldr/plugin/host/scheduler/fetch-world-manifest.go
+++ b/bldr/plugin/host/scheduler/fetch-world-manifest.go
@@ -244,7 +244,7 @@ func (t *pluginInstance) newDirectFetchHandler(ctx context.Context, hosts *plugi
 				manifestSnapshot: snapshot,
 				pluginHost:       best.host,
 			})
-			t.setDownloadManifestState(ctx, snapshot, "")
+			t.setDownloadManifestState(ctx, snapshot, t.c.conf.GetEngineId())
 			t.loggedNotFound.Store(false)
 			return
 		}
@@ -256,7 +256,7 @@ func (t *pluginInstance) newDirectFetchHandler(ctx context.Context, hosts *plugi
 		}
 
 		t.executePluginRoutine.SetState(nil)
-		t.setDownloadManifestState(ctx, nil, "")
+		t.setDownloadManifestState(ctx, nil, t.c.conf.GetEngineId())
 	}
 
 	return directive.NewTypedCallbackHandler(

--- a/bldr/plugin/host/scheduler/fetch-world-manifest_test.go
+++ b/bldr/plugin/host/scheduler/fetch-world-manifest_test.go
@@ -105,6 +105,55 @@ func TestDirectFetchHandlerPreservesCurrentStateAcrossEmptyGap(t *testing.T) {
 	}
 }
 
+func TestDirectFetchHandlerSuppressesConfiguredBucketOnly(t *testing.T) {
+	ctx := context.Background()
+	le := logrus.NewEntry(logrus.New())
+	const noCopyBucketID = "dist/project"
+	host := &testPluginHost{id: "desktop/linux/amd64"}
+	pi := &pluginInstance{
+		c: &Controller{
+			conf: &Config{NoCopyBucketIds: []string{noCopyBucketID}},
+		},
+		le:                      le,
+		manifestCopyStatus:      ccontainer.NewCContainer[*manifestCopyStatus](nil),
+		downloadManifestRoutine: routine.NewStateRoutineContainerWithLoggerVT[*bldr_manifest.ManifestSnapshot](le),
+		executePluginRoutine:    routine.NewStateRoutineContainerWithLogger(executePluginArgsEqual, le),
+	}
+	handler := pi.newDirectFetchHandler(ctx, &pluginHostSet{
+		pluginHosts: []bldr_plugin_host.PluginHost{host},
+	})
+
+	suppressed := bldr_manifest.NewFetchManifestValue([]*bldr_manifest.ManifestRef{
+		newTestManifestRef("spacewave-app", "desktop/linux/amd64", 1, noCopyBucketID),
+	})
+	handler.HandleValueAdded(nil, directive.NewAttachedValue(1, suppressed))
+
+	execState := pi.executePluginRoutine.GetState()
+	if execState == nil || execState.manifestSnapshot == nil {
+		t.Fatal("expected configured no-copy manifest to remain executable")
+	}
+	if pi.downloadManifestRoutine.GetState() != nil {
+		t.Fatal("configured no-copy manifest set download state")
+	}
+	status := pi.manifestCopyStatus.GetValue()
+	if status == nil ||
+		status.phase != manifestCopyPhaseSuppressed ||
+		status.class != manifestCopyClassSuppressed ||
+		status.sourceBucketID != noCopyBucketID {
+		t.Fatalf("suppressed copy status = %#v", status)
+	}
+
+	dynamic := bldr_manifest.NewFetchManifestValue([]*bldr_manifest.ManifestRef{
+		newTestManifestRef("spacewave-app", "desktop/linux/amd64", 2, "dynamic-provider"),
+	})
+	handler.HandleValueAdded(nil, directive.NewAttachedValue(2, dynamic))
+
+	downloadState := pi.downloadManifestRoutine.GetState()
+	if downloadState == nil || downloadState.GetManifestRef().GetBucketId() != "dynamic-provider" {
+		t.Fatalf("dynamic download state = %#v, want dynamic provider", downloadState)
+	}
+}
+
 func TestDirectFetchHandlerPrefersCurrentStateAcrossEqualRevOverlap(t *testing.T) {
 	le := logrus.NewEntry(logrus.New())
 	host := &testPluginHost{id: "desktop/linux/amd64"}
@@ -1752,6 +1801,210 @@ func TestProcessManifestWorldStateRunsDownloadAndExecuteForRemoteManifest(t *tes
 	if execState.manifestSnapshot.GetManifest() == nil ||
 		!execState.manifestSnapshot.GetManifest().GetMeta().EqualVT(ref.GetMeta()) {
 		t.Fatal("execute manifest metadata changed")
+	}
+}
+
+func TestProcessManifestWorldStateSuppressesNoCopyBucketWhileDynamicManifestCopies(t *testing.T) {
+	ctx := context.Background()
+	le := logrus.NewEntry(logrus.New())
+
+	tb, err := testbed.NewTestbed(ctx, le)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	t.Cleanup(tb.Release)
+
+	ocs, err := tb.BuildEmptyCursor(ctx)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	t.Cleanup(ocs.Release)
+
+	ws, err := world_block.BuildMockWorldState(ctx, le, true, ocs, false)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	const (
+		objKey          = "plugin-host"
+		noCopyBucketID  = "dist/project"
+		dynamicBucketID = "dynamic-provider"
+		platformID      = "desktop/darwin/arm64"
+		suppressedID    = "embedded-plugin"
+		dynamicID       = "dynamic-plugin"
+	)
+	if _, err := bldr_manifest_world.CreateManifestStore(ctx, ws, objKey); err != nil {
+		t.Fatal(err.Error())
+	}
+	for _, bucketID := range []string{noCopyBucketID, dynamicBucketID} {
+		if _, _, _, err := tb.Volume.ApplyBucketConfig(ctx, &bucket.Config{
+			Id:  bucketID,
+			Rev: 1,
+		}); err != nil {
+			t.Fatal(err.Error())
+		}
+	}
+
+	suppressedRef := newTestStoredManifestRefWithDistInBucket(
+		t,
+		ctx,
+		tb,
+		noCopyBucketID,
+		suppressedID,
+		platformID,
+		2,
+	)
+	dynamicRef := newTestStoredManifestRefWithDistInBucket(
+		t,
+		ctx,
+		tb,
+		dynamicBucketID,
+		dynamicID,
+		platformID,
+		2,
+	)
+	for _, ref := range []*bldr_manifest.ManifestRef{suppressedRef, dynamicRef} {
+		manifestKey := bldr_manifest.NewManifestKey(objKey, ref.GetMeta())
+		if err := bldr_manifest_world.ExStoreManifestOp(
+			ctx,
+			ws,
+			peer.ID("test"),
+			manifestKey,
+			[]string{objKey},
+			ref,
+		); err != nil {
+			t.Fatal(err.Error())
+		}
+	}
+
+	obj, ok, err := ws.GetObject(ctx, objKey)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if !ok {
+		t.Fatal("expected plugin host manifest store object")
+	}
+	var worldBucketID string
+	if err := ws.AccessWorldState(ctx, nil, func(cursor *bucket_lookup.Cursor) error {
+		worldBucketID = cursor.GetOpArgs().GetBucketId()
+		return nil
+	}); err != nil {
+		t.Fatal(err.Error())
+	}
+
+	var wsv world.WorldState = ws
+	c := &Controller{
+		conf: &Config{
+			NoCopyBucketIds: []string{noCopyBucketID},
+		},
+		objKey:          objKey,
+		peerID:          peer.ID("test"),
+		worldStateCtr:   ccontainer.NewCContainer(wsv),
+		pluginStatus:    make(map[string]*bldr_plugin.PluginStatus),
+		pluginStatusCtr: ccontainer.NewCContainer(&PluginStatusSnapshot{}),
+	}
+	host := &testPluginHost{id: platformID}
+	newInstance := func(pluginID string) *pluginInstance {
+		return &pluginInstance{
+			c:                       c,
+			le:                      le,
+			pluginID:                pluginID,
+			instanceKey:             pluginID,
+			runningPluginCtr:        ccontainer.NewCContainer(bldr_plugin.NewRunningPlugin(nil)),
+			manifestCopyStatus:      ccontainer.NewCContainer[*manifestCopyStatus](nil),
+			downloadManifestRoutine: routine.NewStateRoutineContainerWithLoggerVT[*bldr_manifest.ManifestSnapshot](le),
+			executePluginRoutine:    routine.NewStateRoutineContainerWithLogger(executePluginArgsEqual, le),
+		}
+	}
+	process := func(pi *pluginInstance) {
+		t.Helper()
+		wait, err := pi.processManifestWorldState(ctx, le, &pluginHostSet{
+			pluginHosts: []bldr_plugin_host.PluginHost{host},
+		}, ws, obj)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		if !wait {
+			t.Fatal("expected world manifest watch to continue")
+		}
+	}
+
+	suppressed := newInstance(suppressedID)
+	process(suppressed)
+	if suppressed.downloadManifestRoutine.GetState() != nil {
+		t.Fatal("configured no-copy manifest set download state")
+	}
+	suppressedExec := suppressed.executePluginRoutine.GetState()
+	if suppressedExec == nil || suppressedExec.manifestSnapshot == nil {
+		t.Fatal("configured no-copy manifest was not executable")
+	}
+	status := suppressed.manifestCopyStatus.GetValue()
+	if status == nil ||
+		status.phase != manifestCopyPhaseSuppressed ||
+		status.class != manifestCopyClassSuppressed ||
+		status.sourceBucketID != noCopyBucketID ||
+		status.destinationBucketID != worldBucketID {
+		t.Fatalf("suppressed copy status = %#v", status)
+	}
+	if err := suppressed.execDownloadManifest(ctx, suppressedExec.manifestSnapshot); err != nil {
+		t.Fatal(err.Error())
+	}
+
+	dynamic := newInstance(dynamicID)
+	process(dynamic)
+	dynamicDownload := dynamic.downloadManifestRoutine.GetState()
+	if dynamicDownload == nil {
+		t.Fatal("dynamic manifest did not set download state")
+	}
+	if dynamicDownload.GetManifestRef().GetBucketId() != dynamicBucketID {
+		t.Fatalf("dynamic source bucket = %q, want %q", dynamicDownload.GetManifestRef().GetBucketId(), dynamicBucketID)
+	}
+	if err := dynamic.execDownloadManifest(ctx, dynamicDownload); err != nil {
+		t.Fatal(err.Error())
+	}
+	dynamicStatus := dynamic.manifestCopyStatus.GetValue()
+	if dynamicStatus == nil || dynamicStatus.phase != manifestCopyPhaseDone {
+		t.Fatalf("dynamic copy status = %#v, want done", dynamicStatus)
+	}
+
+	suppressedManifests, suppressedErrs, err := bldr_manifest_world.CollectManifestsForManifestID(
+		ctx,
+		ws,
+		suppressedID,
+		[]string{platformID},
+		objKey,
+	)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if len(suppressedErrs) != 0 {
+		t.Fatalf("suppressed manifest errors = %v", suppressedErrs)
+	}
+	if len(suppressedManifests) != 1 {
+		t.Fatalf("suppressed manifest count = %d, want 1", len(suppressedManifests))
+	}
+	if got := suppressedManifests[0].ManifestRef.GetBucketId(); got != noCopyBucketID {
+		t.Fatalf("suppressed manifest bucket = %q, want authoritative external bucket %q", got, noCopyBucketID)
+	}
+
+	dynamicManifests, dynamicErrs, err := bldr_manifest_world.CollectManifestsForManifestID(
+		ctx,
+		ws,
+		dynamicID,
+		[]string{platformID},
+		objKey,
+	)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if len(dynamicErrs) != 0 {
+		t.Fatalf("dynamic manifest errors = %v", dynamicErrs)
+	}
+	if len(dynamicManifests) != 1 {
+		t.Fatalf("dynamic manifest count = %d, want 1", len(dynamicManifests))
+	}
+	if got := dynamicManifests[0].ManifestRef.GetBucketId(); got != worldBucketID {
+		t.Fatalf("dynamic manifest bucket = %q, want local world bucket %q", got, worldBucketID)
 	}
 }
 

--- a/bldr/plugin/host/scheduler/fetch-world-manifest_test.go
+++ b/bldr/plugin/host/scheduler/fetch-world-manifest_test.go
@@ -109,10 +109,11 @@ func TestDirectFetchHandlerSuppressesConfiguredBucketOnly(t *testing.T) {
 	ctx := context.Background()
 	le := logrus.NewEntry(logrus.New())
 	const noCopyBucketID = "dist/project"
+	const worldBucketID = "plugin-host-world"
 	host := &testPluginHost{id: "desktop/linux/amd64"}
 	pi := &pluginInstance{
 		c: &Controller{
-			conf: &Config{NoCopyBucketIds: []string{noCopyBucketID}},
+			conf: &Config{EngineId: worldBucketID, NoCopyBucketIds: []string{noCopyBucketID}},
 		},
 		le:                      le,
 		manifestCopyStatus:      ccontainer.NewCContainer[*manifestCopyStatus](nil),
@@ -139,7 +140,8 @@ func TestDirectFetchHandlerSuppressesConfiguredBucketOnly(t *testing.T) {
 	if status == nil ||
 		status.phase != manifestCopyPhaseSuppressed ||
 		status.class != manifestCopyClassSuppressed ||
-		status.sourceBucketID != noCopyBucketID {
+		status.sourceBucketID != noCopyBucketID ||
+		status.destinationBucketID != worldBucketID {
 		t.Fatalf("suppressed copy status = %#v", status)
 	}
 
@@ -2741,7 +2743,7 @@ func TestDownloadManifestCopiesExternalVolumeDAGAndCachesSourceReads(t *testing.
 	}
 }
 
-func TestDownloadManifestYieldsColdStartCopyUntilPluginRunning(t *testing.T) {
+func TestDownloadManifestYieldsColdStartCopyUntilStartupGroupReady(t *testing.T) {
 	ctx := context.Background()
 	le := logrus.NewEntry(logrus.New())
 
@@ -2796,14 +2798,16 @@ func TestDownloadManifestYieldsColdStartCopyUntilPluginRunning(t *testing.T) {
 	}
 
 	var wsv world.WorldState = ws
+	gate := newTestManifestCopyGate(false)
 	pi := &pluginInstance{
 		c: &Controller{
-			conf:            &Config{},
-			objKey:          objKey,
-			peerID:          peer.ID("test"),
-			worldStateCtr:   ccontainer.NewCContainer(wsv),
-			pluginStatus:    make(map[string]*bldr_plugin.PluginStatus),
-			pluginStatusCtr: ccontainer.NewCContainer(&PluginStatusSnapshot{}),
+			conf:                &Config{},
+			objKey:              objKey,
+			peerID:              peer.ID("test"),
+			worldStateCtr:       ccontainer.NewCContainer(wsv),
+			manifestCopyGateCtr: ccontainer.NewCContainer[ManifestCopyGate](gate),
+			pluginStatus:        make(map[string]*bldr_plugin.PluginStatus),
+			pluginStatusCtr:     ccontainer.NewCContainer(&PluginStatusSnapshot{}),
 		},
 		le:                      le,
 		pluginID:                "spacewave-core",
@@ -2827,17 +2831,17 @@ func TestDownloadManifestYieldsColdStartCopyUntilPluginRunning(t *testing.T) {
 	waitCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	status, err := pi.manifestCopyStatus.WaitValueWithValidator(waitCtx, func(status *manifestCopyStatus) (bool, error) {
-		return status != nil && status.phase == manifestCopyPhaseWaiting, nil
+		return status != nil && status.phase == manifestCopyPhaseWaitingForStartupGroup, nil
 	}, nil)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	if status.class != manifestCopyClassAfterExecuteReady {
-		t.Fatalf("copy class = %q, want %q", status.class, manifestCopyClassAfterExecuteReady)
+	if status.class != manifestCopyClassAfterStartupGroupReady {
+		t.Fatalf("copy class = %q, want %q", status.class, manifestCopyClassAfterStartupGroupReady)
 	}
 	select {
 	case err := <-copyErrCh:
-		t.Fatalf("copy completed before plugin was running: %v", err)
+		t.Fatalf("copy completed before startup group readiness: %v", err)
 	default:
 	}
 
@@ -2855,10 +2859,10 @@ func TestDownloadManifestYieldsColdStartCopyUntilPluginRunning(t *testing.T) {
 		t.Fatalf("manifest errors = %v", errs)
 	}
 	if len(got) != 0 {
-		t.Fatalf("manifest count before running = %d, want 0", len(got))
+		t.Fatalf("manifest count before startup group readiness = %d, want 0", len(got))
 	}
 
-	pi.runningPluginCtr.SetValue(bldr_plugin.NewRunningPlugin(nil))
+	gate.readyCtr.SetValue(true)
 	select {
 	case err := <-copyErrCh:
 		if err != nil {

--- a/bldr/plugin/host/scheduler/fetch-world-manifest_test.go
+++ b/bldr/plugin/host/scheduler/fetch-world-manifest_test.go
@@ -1514,111 +1514,58 @@ func TestWatchWorldManifestRecordsCompactSkippedRefStatusWhenNoCandidate(t *test
 	}
 }
 
-func TestWatchWorldManifestPrefersLocalExecutableOverNewerDownload(t *testing.T) {
-	ctx := context.Background()
-	le := logrus.NewEntry(logrus.New())
-
-	tb, err := testbed.NewTestbed(ctx, le)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-	defer tb.Release()
-
-	ocs, err := tb.BuildEmptyCursor(ctx)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-	defer ocs.Release()
-
-	ws, err := world_block.BuildMockWorldState(ctx, le, true, ocs, false)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-
-	const objKey = "plugin-host"
-	if _, err := bldr_manifest_world.CreateManifestStore(ctx, ws, objKey); err != nil {
-		t.Fatal(err.Error())
-	}
-
-	remoteRef := newTestStoredManifestRefInBucket(t, ctx, tb, "remote-bucket", "spacewave-core", "desktop/darwin/arm64", 9)
-	const remoteRefKey = "plugin-host/ref/remote-newer"
-	storeTestManifestRefObject(t, ctx, ws, remoteRefKey, remoteRef)
-	if err := ws.SetGraphQuad(ctx, bldr_manifest_world.NewManifestQuad(objKey, remoteRefKey, "spacewave-core")); err != nil {
-		t.Fatal(err.Error())
-	}
-
-	localRef, localRefKey := storeTestWorldManifest(t, ctx, ws, "spacewave-core", "desktop/darwin/arm64", 7)
-	if err := ws.SetGraphQuad(ctx, bldr_manifest_world.NewManifestQuad(objKey, localRefKey, "spacewave-core")); err != nil {
-		t.Fatal(err.Error())
-	}
-
-	host := &testPluginHost{id: "desktop/darwin/arm64"}
-	pi := &pluginInstance{
-		c: &Controller{
-			conf:   &Config{},
-			objKey: objKey,
-		},
-		le:                      le,
-		pluginID:                "spacewave-core",
-		downloadManifestRoutine: routine.NewStateRoutineContainerWithLoggerVT[*bldr_manifest.ManifestSnapshot](le),
-		executePluginRoutine:    routine.NewStateRoutineContainerWithLogger(executePluginArgsEqual, le),
-	}
-
-	obj, ok, err := ws.GetObject(ctx, objKey)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-	if !ok {
-		t.Fatal("expected plugin host object")
-	}
-
-	wait, err := pi.processManifestWorldState(ctx, le, &pluginHostSet{
-		pluginHosts: []bldr_plugin_host.PluginHost{host},
-	}, ws, obj)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-	if !wait {
-		t.Fatal("expected watch loop to wait for changes")
-	}
-
-	downloadState := pi.downloadManifestRoutine.GetState()
-	if downloadState == nil {
-		t.Fatal("expected newer remote manifest to be queued for download")
-	}
-	if !downloadState.GetManifestRef().EqualVT(remoteRef.GetManifestRef()) {
-		t.Fatal("expected download state to use newest remote manifest")
-	}
-
-	execState := pi.executePluginRoutine.GetState()
-	if execState == nil || execState.manifestSnapshot == nil {
-		t.Fatal("expected execute state from local manifest")
-	}
-	if execState.pluginHost != host {
-		t.Fatal("expected execute state to use matching plugin host")
-	}
-	if !execState.manifestSnapshot.GetManifestRef().EqualVT(localRef.GetManifestRef()) {
-		t.Fatal("expected local executable manifest to remain selected while newer remote downloads")
-	}
-}
-
-func TestWatchWorldManifestSelectsBestNoCopyOrLocalExecutable(t *testing.T) {
+func TestWatchWorldManifestSelectsManifestClassPairsByRevision(t *testing.T) {
+	const (
+		manifestClassLocal   = "local"
+		manifestClassNoCopy  = "no-copy"
+		manifestClassDynamic = "dynamic-external"
+	)
 	tests := []struct {
-		name       string
-		localRev   uint64
-		noCopyRev  uint64
-		wantNoCopy bool
+		name              string
+		newerClass        string
+		olderClass        string
+		wantExecuteClass  string
+		wantDownloadClass string
 	}{
 		{
-			name:       "newer no-copy wins",
-			localRev:   7,
-			noCopyRev:  9,
-			wantNoCopy: true,
+			name:             "newer local over older no-copy",
+			newerClass:       manifestClassLocal,
+			olderClass:       manifestClassNoCopy,
+			wantExecuteClass: manifestClassLocal,
 		},
 		{
-			name:      "newer local wins",
-			localRev:  9,
-			noCopyRev: 7,
+			name:              "newer no-copy over older local",
+			newerClass:        manifestClassNoCopy,
+			olderClass:        manifestClassLocal,
+			wantExecuteClass:  manifestClassNoCopy,
+			wantDownloadClass: manifestClassNoCopy,
+		},
+		{
+			name:             "newer local over older dynamic",
+			newerClass:       manifestClassLocal,
+			olderClass:       manifestClassDynamic,
+			wantExecuteClass: manifestClassLocal,
+		},
+		{
+			name:              "newer dynamic over older local",
+			newerClass:        manifestClassDynamic,
+			olderClass:        manifestClassLocal,
+			wantExecuteClass:  manifestClassLocal,
+			wantDownloadClass: manifestClassDynamic,
+		},
+		{
+			name:              "newer no-copy over older dynamic",
+			newerClass:        manifestClassNoCopy,
+			olderClass:        manifestClassDynamic,
+			wantExecuteClass:  manifestClassNoCopy,
+			wantDownloadClass: manifestClassNoCopy,
+		},
+		{
+			name:              "newer dynamic over older no-copy",
+			newerClass:        manifestClassDynamic,
+			olderClass:        manifestClassNoCopy,
+			wantExecuteClass:  manifestClassNoCopy,
+			wantDownloadClass: manifestClassDynamic,
 		},
 	}
 
@@ -1645,56 +1592,72 @@ func TestWatchWorldManifestSelectsBestNoCopyOrLocalExecutable(t *testing.T) {
 			}
 
 			const (
-				objKey         = "plugin-host"
-				noCopyBucketID = "dist/project"
+				objKey          = "plugin-host"
+				noCopyBucketID  = "dist/project"
+				dynamicBucketID = "dynamic-provider"
+				manifestID      = "spacewave-core"
+				platformID      = "desktop/darwin/arm64"
 			)
 			if _, err := bldr_manifest_world.CreateManifestStore(ctx, ws, objKey); err != nil {
 				t.Fatal(err.Error())
 			}
 
-			noCopyRef := newTestStoredManifestRefInBucket(
-				t,
-				ctx,
-				tb,
-				noCopyBucketID,
-				"spacewave-core",
-				"desktop/darwin/arm64",
-				tt.noCopyRev,
-			)
-			const noCopyRefKey = "plugin-host/ref/no-copy"
-			storeTestManifestRefObject(t, ctx, ws, noCopyRefKey, noCopyRef)
-			if err := ws.SetGraphQuad(
-				ctx,
-				bldr_manifest_world.NewManifestQuad(objKey, noCopyRefKey, "spacewave-core"),
-			); err != nil {
-				t.Fatal(err.Error())
+			storeCandidate := func(class string, rev uint64) *bldr_manifest.ManifestRef {
+				var ref *bldr_manifest.ManifestRef
+				var refKey string
+				switch class {
+				case manifestClassLocal:
+					ref, refKey = storeTestWorldManifest(
+						t,
+						ctx,
+						ws,
+						manifestID,
+						platformID,
+						rev,
+					)
+				case manifestClassNoCopy, manifestClassDynamic:
+					bucketID := dynamicBucketID
+					if class == manifestClassNoCopy {
+						bucketID = noCopyBucketID
+					}
+					ref = newTestStoredManifestRefInBucket(
+						t,
+						ctx,
+						tb,
+						bucketID,
+						manifestID,
+						platformID,
+						rev,
+					)
+					refKey = "plugin-host/ref/" + class
+					storeTestManifestRefObject(t, ctx, ws, refKey, ref)
+				default:
+					t.Fatalf("unknown manifest class %q", class)
+				}
+				if err := ws.SetGraphQuad(
+					ctx,
+					bldr_manifest_world.NewManifestQuad(objKey, refKey, manifestID),
+				); err != nil {
+					t.Fatal(err.Error())
+				}
+				return ref
 			}
 
-			localRef, localRefKey := storeTestWorldManifest(
-				t,
-				ctx,
-				ws,
-				"spacewave-core",
-				"desktop/darwin/arm64",
-				tt.localRev,
-			)
-			if err := ws.SetGraphQuad(
-				ctx,
-				bldr_manifest_world.NewManifestQuad(objKey, localRefKey, "spacewave-core"),
-			); err != nil {
-				t.Fatal(err.Error())
+			refs := map[string]*bldr_manifest.ManifestRef{
+				tt.newerClass: storeCandidate(tt.newerClass, 9),
+				tt.olderClass: storeCandidate(tt.olderClass, 7),
 			}
-
-			host := &testPluginHost{id: "desktop/darwin/arm64"}
-			pi := &pluginInstance{
-				c: &Controller{
-					conf: &Config{
-						NoCopyBucketIds: []string{noCopyBucketID},
-					},
-					objKey: objKey,
+			host := &testPluginHost{id: platformID}
+			ctrl := &Controller{
+				conf: &Config{
+					NoCopyBucketIds: []string{noCopyBucketID},
 				},
+				objKey: objKey,
+			}
+			pi := &pluginInstance{
+				c:                       ctrl,
 				le:                      le,
-				pluginID:                "spacewave-core",
+				pluginID:                manifestID,
 				manifestCopyStatus:      ccontainer.NewCContainer[*manifestCopyStatus](nil),
 				downloadManifestRoutine: routine.NewStateRoutineContainerWithLoggerVT[*bldr_manifest.ManifestSnapshot](le),
 				executePluginRoutine:    routine.NewStateRoutineContainerWithLogger(executePluginArgsEqual, le),
@@ -1707,7 +1670,6 @@ func TestWatchWorldManifestSelectsBestNoCopyOrLocalExecutable(t *testing.T) {
 			if !ok {
 				t.Fatal("expected plugin host object")
 			}
-
 			wait, err := pi.processManifestWorldState(ctx, le, &pluginHostSet{
 				pluginHosts: []bldr_plugin_host.PluginHost{host},
 			}, ws, obj)
@@ -1722,22 +1684,45 @@ func TestWatchWorldManifestSelectsBestNoCopyOrLocalExecutable(t *testing.T) {
 			if execState == nil || execState.manifestSnapshot == nil {
 				t.Fatal("expected executable manifest selection")
 			}
-			wantRef := localRef.GetManifestRef()
-			if tt.wantNoCopy {
-				wantRef = noCopyRef.GetManifestRef()
-			}
-			if !execState.manifestSnapshot.GetManifestRef().EqualVT(wantRef) {
+			wantExecuteRef := refs[tt.wantExecuteClass].GetManifestRef()
+			if !execState.manifestSnapshot.GetManifestRef().EqualVT(wantExecuteRef) {
 				t.Fatalf(
-					"execute ref = %s, want %s",
+					"execute ref = %s, want %s class ref %s",
 					execState.manifestSnapshot.GetManifestRef().MarshalString(),
-					wantRef.MarshalString(),
+					tt.wantExecuteClass,
+					wantExecuteRef.MarshalString(),
 				)
 			}
-			if pi.downloadManifestRoutine.GetState() != nil {
-				t.Fatal("execute-eligible manifest unexpectedly scheduled a copy")
+
+			recovery := ctrl.pluginManifestRecoveryStatus[pluginInstanceKey(manifestID, "")]
+			if recovery == nil {
+				t.Fatal("expected retained manifest selection status")
+			}
+			wantDownloadRef := ""
+			if tt.wantDownloadClass != "" {
+				wantDownloadRef = refs[tt.wantDownloadClass].GetManifestRef().MarshalB58()
+			}
+			if recovery.DownloadManifestRef != wantDownloadRef {
+				t.Fatalf(
+					"download candidate = %q, want %s class ref %q",
+					recovery.DownloadManifestRef,
+					tt.wantDownloadClass,
+					wantDownloadRef,
+				)
 			}
 
-			if tt.wantNoCopy {
+			downloadState := pi.downloadManifestRoutine.GetState()
+			if tt.wantDownloadClass == manifestClassDynamic {
+				wantDynamicRef := refs[manifestClassDynamic].GetManifestRef()
+				if downloadState == nil ||
+					!downloadState.GetManifestRef().EqualVT(wantDynamicRef) {
+					t.Fatalf("download state = %#v, want dynamic manifest", downloadState)
+				}
+			} else if downloadState != nil {
+				t.Fatalf("non-dynamic candidate unexpectedly scheduled a copy: %#v", downloadState)
+			}
+
+			if tt.wantDownloadClass == manifestClassNoCopy {
 				status := pi.manifestCopyStatus.GetValue()
 				if status == nil ||
 					status.phase != manifestCopyPhaseSuppressed ||

--- a/bldr/plugin/host/scheduler/fetch-world-manifest_test.go
+++ b/bldr/plugin/host/scheduler/fetch-world-manifest_test.go
@@ -1602,6 +1602,154 @@ func TestWatchWorldManifestPrefersLocalExecutableOverNewerDownload(t *testing.T)
 	}
 }
 
+func TestWatchWorldManifestSelectsBestNoCopyOrLocalExecutable(t *testing.T) {
+	tests := []struct {
+		name       string
+		localRev   uint64
+		noCopyRev  uint64
+		wantNoCopy bool
+	}{
+		{
+			name:       "newer no-copy wins",
+			localRev:   7,
+			noCopyRev:  9,
+			wantNoCopy: true,
+		},
+		{
+			name:      "newer local wins",
+			localRev:  9,
+			noCopyRev: 7,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			le := logrus.NewEntry(logrus.New())
+
+			tb, err := testbed.NewTestbed(ctx, le)
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			defer tb.Release()
+
+			ocs, err := tb.BuildEmptyCursor(ctx)
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			defer ocs.Release()
+
+			ws, err := world_block.BuildMockWorldState(ctx, le, true, ocs, false)
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+
+			const (
+				objKey         = "plugin-host"
+				noCopyBucketID = "dist/project"
+			)
+			if _, err := bldr_manifest_world.CreateManifestStore(ctx, ws, objKey); err != nil {
+				t.Fatal(err.Error())
+			}
+
+			noCopyRef := newTestStoredManifestRefInBucket(
+				t,
+				ctx,
+				tb,
+				noCopyBucketID,
+				"spacewave-core",
+				"desktop/darwin/arm64",
+				tt.noCopyRev,
+			)
+			const noCopyRefKey = "plugin-host/ref/no-copy"
+			storeTestManifestRefObject(t, ctx, ws, noCopyRefKey, noCopyRef)
+			if err := ws.SetGraphQuad(
+				ctx,
+				bldr_manifest_world.NewManifestQuad(objKey, noCopyRefKey, "spacewave-core"),
+			); err != nil {
+				t.Fatal(err.Error())
+			}
+
+			localRef, localRefKey := storeTestWorldManifest(
+				t,
+				ctx,
+				ws,
+				"spacewave-core",
+				"desktop/darwin/arm64",
+				tt.localRev,
+			)
+			if err := ws.SetGraphQuad(
+				ctx,
+				bldr_manifest_world.NewManifestQuad(objKey, localRefKey, "spacewave-core"),
+			); err != nil {
+				t.Fatal(err.Error())
+			}
+
+			host := &testPluginHost{id: "desktop/darwin/arm64"}
+			pi := &pluginInstance{
+				c: &Controller{
+					conf: &Config{
+						NoCopyBucketIds: []string{noCopyBucketID},
+					},
+					objKey: objKey,
+				},
+				le:                      le,
+				pluginID:                "spacewave-core",
+				manifestCopyStatus:      ccontainer.NewCContainer[*manifestCopyStatus](nil),
+				downloadManifestRoutine: routine.NewStateRoutineContainerWithLoggerVT[*bldr_manifest.ManifestSnapshot](le),
+				executePluginRoutine:    routine.NewStateRoutineContainerWithLogger(executePluginArgsEqual, le),
+			}
+
+			obj, ok, err := ws.GetObject(ctx, objKey)
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			if !ok {
+				t.Fatal("expected plugin host object")
+			}
+
+			wait, err := pi.processManifestWorldState(ctx, le, &pluginHostSet{
+				pluginHosts: []bldr_plugin_host.PluginHost{host},
+			}, ws, obj)
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			if !wait {
+				t.Fatal("expected watch loop to wait for changes")
+			}
+
+			execState := pi.executePluginRoutine.GetState()
+			if execState == nil || execState.manifestSnapshot == nil {
+				t.Fatal("expected executable manifest selection")
+			}
+			wantRef := localRef.GetManifestRef()
+			if tt.wantNoCopy {
+				wantRef = noCopyRef.GetManifestRef()
+			}
+			if !execState.manifestSnapshot.GetManifestRef().EqualVT(wantRef) {
+				t.Fatalf(
+					"execute ref = %s, want %s",
+					execState.manifestSnapshot.GetManifestRef().MarshalString(),
+					wantRef.MarshalString(),
+				)
+			}
+			if pi.downloadManifestRoutine.GetState() != nil {
+				t.Fatal("execute-eligible manifest unexpectedly scheduled a copy")
+			}
+
+			if tt.wantNoCopy {
+				status := pi.manifestCopyStatus.GetValue()
+				if status == nil ||
+					status.phase != manifestCopyPhaseSuppressed ||
+					status.class != manifestCopyClassSuppressed ||
+					status.sourceBucketID != noCopyBucketID {
+					t.Fatalf("suppressed copy status = %#v", status)
+				}
+			}
+		})
+	}
+}
+
 func TestWatchWorldManifestFallsBackToBestDownloadWhenNoLocalExecutable(t *testing.T) {
 	ctx := context.Background()
 	le := logrus.NewEntry(logrus.New())

--- a/bldr/plugin/host/scheduler/manifest-copy-gate.go
+++ b/bldr/plugin/host/scheduler/manifest-copy-gate.go
@@ -1,0 +1,11 @@
+package plugin_host_scheduler
+
+import "context"
+
+// ManifestCopyGate delays startup manifest copies until its readiness boundary.
+type ManifestCopyGate interface {
+	// IsReady reports whether new copies can start without waiting.
+	IsReady() bool
+	// WaitReady waits until copies can start or the context is canceled.
+	WaitReady(ctx context.Context) error
+}

--- a/bldr/plugin/host/scheduler/manifest-copy-gate_test.go
+++ b/bldr/plugin/host/scheduler/manifest-copy-gate_test.go
@@ -1,0 +1,86 @@
+package plugin_host_scheduler
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/aperturerobotics/util/ccontainer"
+	bldr_manifest "github.com/s4wave/spacewave/bldr/manifest"
+	"github.com/s4wave/spacewave/db/bucket"
+)
+
+type testManifestCopyGate struct {
+	readyCtr    *ccontainer.CContainer[bool]
+	waitOnce    sync.Once
+	waitStarted chan struct{}
+	waitCount   atomic.Int32
+}
+
+func newTestManifestCopyGate(ready bool) *testManifestCopyGate {
+	return &testManifestCopyGate{
+		readyCtr:    ccontainer.NewCContainer(ready),
+		waitStarted: make(chan struct{}),
+	}
+}
+
+func (g *testManifestCopyGate) IsReady() bool {
+	return g.readyCtr.GetValue()
+}
+
+func (g *testManifestCopyGate) WaitReady(ctx context.Context) error {
+	g.waitCount.Add(1)
+	g.waitOnce.Do(func() { close(g.waitStarted) })
+	_, err := g.readyCtr.WaitValue(ctx, nil)
+	return err
+}
+
+func TestManifestCopyGateDefersOnlyPreReadyDynamicCopies(t *testing.T) {
+	gate := newTestManifestCopyGate(false)
+	controller := &Controller{
+		conf:                &Config{NoCopyBucketIds: []string{"dist/project"}},
+		manifestCopyGateCtr: ccontainer.NewCContainer[ManifestCopyGate](gate),
+	}
+	instance := &pluginInstance{c: controller}
+	suppressed := &bldr_manifest.ManifestSnapshot{
+		ManifestRef: &bucket.ObjectRef{BucketId: "dist/project"},
+	}
+	dynamic := &bldr_manifest.ManifestSnapshot{
+		ManifestRef: &bucket.ObjectRef{BucketId: "dynamic-provider"},
+	}
+
+	if class := instance.classifyManifestCopy(suppressed); class != manifestCopyClassSuppressed {
+		t.Fatalf("suppressed copy class = %q, want %q", class, manifestCopyClassSuppressed)
+	}
+	if class := instance.classifyManifestCopy(dynamic); class != manifestCopyClassAfterStartupGroupReady {
+		t.Fatalf("pre-ready dynamic copy class = %q, want %q", class, manifestCopyClassAfterStartupGroupReady)
+	}
+
+	waitErrCh := make(chan error, 1)
+	go func() {
+		waitErrCh <- instance.waitForManifestCopyReady(
+			t.Context(),
+			manifestCopyClassAfterStartupGroupReady,
+			dynamic,
+			nil,
+		)
+	}()
+	<-gate.waitStarted
+	select {
+	case err := <-waitErrCh:
+		t.Fatalf("dynamic copy gate returned before readiness: %v", err)
+	default:
+	}
+
+	gate.readyCtr.SetValue(true)
+	if err := <-waitErrCh; err != nil {
+		t.Fatal(err)
+	}
+	if class := instance.classifyManifestCopy(dynamic); class != manifestCopyClassImmediate {
+		t.Fatalf("post-startup dynamic copy class = %q, want %q", class, manifestCopyClassImmediate)
+	}
+	if got := gate.waitCount.Load(); got != 1 {
+		t.Fatalf("gate wait count = %d, want 1", got)
+	}
+}

--- a/bldr/plugin/host/scheduler/watch-world-manifest.go
+++ b/bldr/plugin/host/scheduler/watch-world-manifest.go
@@ -207,8 +207,9 @@ func (t *pluginInstance) processManifestWorldState(
 				if !needsDownload || noCopy {
 					executeManifest = manifestSnapshot
 					executeManifestHost = manifestPluginHost
-					if noCopy {
+					if noCopy && downloadManifest == nil {
 						downloadManifest = manifestSnapshot
+						downloadManifestHost = manifestPluginHost
 					}
 					break
 				}

--- a/bldr/plugin/host/scheduler/watch-world-manifest.go
+++ b/bldr/plugin/host/scheduler/watch-world-manifest.go
@@ -166,14 +166,14 @@ func (t *pluginInstance) processManifestWorldState(
 			worldBucketID := bls.GetOpArgs().GetBucketId()
 			trace.Log(ctx, "world-bucket-id", worldBucketID)
 
-			// decide the "download manifest" and the "execute manifest" based on which is fully downloaded
-			// we consider a manifest to be fully downloaded if its ref bucket matches the world bucket
-			// this way we will fully download the manifest(s) before swapping in a new version
+			// Select an execute manifest that is local or backed by an
+			// authoritative no-copy bucket. Other external manifests must be
+			// copied into the world bucket before execution switches to them.
 			var downloadManifest, executeManifest *bldr_manifest.ManifestSnapshot
 			var downloadManifestHost, executeManifestHost plugin_host.PluginHost
 
-			// Prefer candidates in descending revision order, but keep looking
-			// for an already-local manifest after recording the best download.
+			// Prefer candidates in sorted order, but keep looking past external
+			// copy candidates for an execute-eligible manifest.
 			for _, manifest := range manifests {
 				// find the corresponding plugin host
 				manifestPlatformID := manifest.Manifest.GetMeta().GetPlatformId()
@@ -193,7 +193,9 @@ func (t *pluginInstance) processManifestWorldState(
 					manifest.ManifestRef.BucketId = worldBucketID
 				}
 
-				// needs download if bucket id differs
+				// Configured no-copy buckets remain authoritative without a
+				// local DAG copy and are therefore execute-eligible.
+				noCopy := slices.Contains(t.c.conf.GetNoCopyBucketIds(), manifestBucketID)
 				needsDownload := manifestBucketID != worldBucketID
 
 				// create the snapshot
@@ -202,10 +204,12 @@ func (t *pluginInstance) processManifestWorldState(
 					Manifest:    manifest.Manifest,
 				}
 
-				if !needsDownload {
-					// we have our downloaded manifest to execute.
+				if !needsDownload || noCopy {
 					executeManifest = manifestSnapshot
 					executeManifestHost = manifestPluginHost
+					if noCopy {
+						downloadManifest = manifestSnapshot
+					}
 					break
 				}
 

--- a/bldr/plugin/host/scheduler/watch-world-manifest.go
+++ b/bldr/plugin/host/scheduler/watch-world-manifest.go
@@ -269,11 +269,9 @@ func (t *pluginInstance) processManifestWorldState(
 
 			// Schedule the full-DAG local copy after the execute path so startup
 			// demand fetches get the first chance at worker and shell blocks.
-			// If downloadManifest is nil this stops that routine.
-			if !t.c.conf.GetDisableCopyManifest() {
-				_, changed, _, _ := t.downloadManifestRoutine.SetState(downloadManifest)
-				anyChanged = anyChanged || changed
-			}
+			// A nil or source-suppressed manifest clears the copy routine.
+			changed := t.setDownloadManifestState(ctx, downloadManifest, worldBucketID)
+			anyChanged = anyChanged || changed
 
 			if anyChanged {
 				fields := logrus.Fields{}


### PR DESCRIPTION
Browser startup pays for full-DAG manifest materialization it does not need. The distribution's embedded dist/<project> bucket stays mounted for the entrypoint lifetime and already serves blocks on demand through its range-backed static store, but the plugin scheduler still copied those manifests into the plugin-host world bucket and republished a local ref, adding storage work while startup was resolving content. Dynamic provider manifests also began complete copies as soon as their own plugin executed, so early copies competed with later plugins' manifest publication on the same storage path.

The scheduler config gains a repeated no_copy_bucket_ids field naming source buckets that remain authoritative without a copy. The distribution entrypoint lists its dist bucket; candidates from listed buckets classify as suppressed, set no download state, and keep executing from their external ref, with the suppressed phase visible in copy status and startup marks. A new StartupGroupCoordinator in the plugin entrypoint watches each configured startup plugin's existing load-state container and publishes one aggregate ready transition, counting each plugin at registration complete or terminal registration failure; the scheduler defers non-suppressed dynamic copies through an injected runtime gate until that transition, and later selections use the existing copy classes. A nil gate and an empty bucket list preserve current behavior, so existing configurations are unaffected, and there are no schema or storage changes beyond the additive config field.

Verified with focused scheduler, coordinator, and entrypoint package tests covering mixed suppression alongside a dynamic copy, once-only and failure-release coordinator transitions, pre-ready deferral, and the existing remote-copy contract, plus scoped vet, gofmt, go fix, and a wasm compile of the devtool controller. One known gap: the scheduler exposes no retry-exhaustion event, so a startup plugin that never reaches execution keeps the group pending on that boot; execution is never gated, only background copies defer.