### PR TITLE
docs: state when DistSources may grow for downstream apps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,6 +252,35 @@ a subdirectory.
   404.
 - When adding TypeScript that must be bundled for Electron or browser
   entrypoints, update the relevant `//go:embed` `DistSources` in `dist.go`.
+- `DistSources` may also grow so a downstream Bldr app can resolve a Spacewave
+  TypeScript subpath from `.bldr/src` instead of a sibling checkout. This serves
+  the `web/` plugin-importable surface named under Package Boundaries; it does
+  not widen that surface. Embed only the subpaths that app imports plus their
+  transitive TypeScript imports.
+  Downstream apps consume leaf modules, so the transitive set is usually larger
+  than the import list and must be walked, not guessed. Never embed a whole
+  domain tree or the app surface to save that walk.
+- Match the existing entry style and prefer the narrowest form that covers the
+  need: an exact file list (`sdk/resource/client.ts sdk/resource/resource.ts`)
+  or a single-directory extension glob (`web/fetch/*.ts`). Whole-directory
+  entries such as `web/electron` exist for entrypoint trees and are not the
+  default for new downstream additions.
+- Embed TypeScript and TSX only. Go reaches downstream projects through
+  `vendor/`, so domain `.go` never belongs in `DistSources`. The handful of
+  embedded `deps.go` and `web.go` entries are `deps_only` build-tag stubs that
+  let the dist module resolve packages referenced by `.proto` files; they are
+  not precedent for embedding Go logic.
+- `//go:embed` patterns cannot contain `..`, so `bldr/dist.go` reaches only
+  paths under `bldr/`. A downstream `@s4wave/web/...` import resolves against
+  the repository-root `web/` tree, which `bldr/dist.go` cannot embed. Exporting
+  that tree needs an embed rooted inside it, not a wider pattern in
+  `bldr/dist.go`. Note also that `.bldr/src/web` is `bldr/web`, a different tree
+  from `web/`, so mapping a downstream alias at `.bldr/src/web` silently
+  resolves the wrong sources.
+- `go mod vendor` keeps a directory's full contents once any Go file makes it a
+  package, so a TypeScript-only directory under `web/` vendors as empty while a
+  sibling with generated Go vendors completely. Do not infer downstream
+  TypeScript availability from a populated `vendor/` path.
 - Treat Bldr config as the build graph. Change it only when the task truly
   changes build inputs, manifests, platform targets, or generated exports.
 


### PR DESCRIPTION
`AGENTS.md` said to update `DistSources` when adding TypeScript for Electron or browser entrypoints, but said nothing about the other reason it grows: a downstream Bldr app resolving a `web/` subpath from `.bldr/src` instead of a sibling checkout.

Four facts make that decision hard to reach from the file alone, and all four cost real time to rediscover:

- Downstream apps import leaf modules, so the **transitive** TypeScript set is larger than the import list and has to be walked.
- `go mod vendor` keeps a directory's full contents once any Go file makes it a package. A TypeScript-only directory under `web/` vendors as **empty**, while a sibling carrying generated Go vendors completely — so a populated `vendor/` path is misleading evidence.
- `go:embed` patterns cannot contain `..`, so `bldr/dist.go` reaches only paths under `bldr/`.
- `.bldr/src/web` is `bldr/web`, not `web/`. A downstream alias pointed there resolves the wrong tree **without erroring**.

The rule keeps additions narrow and TypeScript-only, and notes that the embedded `deps.go` entries are `deps_only` build-tag stubs rather than precedent for embedding Go logic. It ties the allowance to the existing Package Boundaries statement that `web/` is the plugin-importable surface, so this records how that surface reaches downstream rather than widening it.

Docs only; no build or code change.