### PR TITLE
feat(web): distribute downstream type sources

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,5 +1,5 @@
 import 'csstype'
-import 'react'
+import './web/react-css.d.ts'
 
 // CSS
 declare module '*.css'
@@ -35,15 +35,6 @@ declare module '*.svg' {
 declare module 'csstype' {
   interface StandardLonghandProperties<TLength = (string & {}) | 0, TTime = string & {}> {
     WebkitAppRegion?: 'drag' | 'no-drag' | string
-  }
-}
-
-// React's CSSProperties uses closed csstype typing with no index signature, so
-// inline CSS custom properties (--foo) are rejected. Re-admit only --prefixed
-// keys; standard property typos still fail.
-declare module 'react' {
-  interface CSSProperties {
-    [customProperty: `--${string}`]: string | number | undefined
   }
 }
 

--- a/web/dist.go
+++ b/web/dist.go
@@ -1,0 +1,76 @@
+package app_web
+
+import "embed"
+
+// DistSources contains the source closure that downstream Bldr apps use to
+// resolve @s4wave/web during typechecking. The closure is wider than the
+// spacewave-web manifest entrypoint list because public entrypoints import
+// internal source directories and assets.
+//
+//go:embed command/CommandContext.tsx command/CommandPalette.tsx command/FocusContext.tsx
+//go:embed command/KeyDispatcher.tsx command/KeybindingBindingList.tsx command/KeybindingCaptureInput.tsx
+//go:embed command/KeybindingCommandDetails.tsx command/KeybindingCommandList.tsx
+//go:embed command/KeybindingConflictList.tsx command/KeybindingDiscoverySettings.tsx
+//go:embed command/KeybindingEditor.tsx command/KeybindingEditorActions.tsx command/KeybindingEditorContext.ts
+//go:embed command/KeybindingResolver.ts command/KeyboardManager.tsx command/KeyboardShortcutsDialog.tsx
+//go:embed command/WhichKeyPanel.tsx command/component.ts command/index.ts command/keybinding-editor-helpers.ts
+//go:embed command/keybinding-overrides.ts command/sub-item-navigation.ts
+//go:embed command/useAccountKeybindingOverrides.ts command/useCommand.ts command/useKeybindingEditorLayers.ts
+//go:embed command/useKeybindingEditorModel.ts command/useKeybindingGraph.ts command/useKeybindingRecorder.ts
+//go:embed command/useLocalKeybindingOverrides.ts command/useSpaceKeybindingOverrides.ts
+//go:embed configtype/ConfigTypeRegistryContext.tsx configtype/configtype.ts configtype/useConfigEditor.tsx
+//go:embed contexts/SessionContext.tsx contexts/SessionIndexContext.tsx contexts/SpaceContainerContext.tsx
+//go:embed contexts/SpacewaveOnboardingContext.tsx contexts/SpacewaveOrgListContext.tsx
+//go:embed contexts/TabActiveContext.tsx contexts/contexts.tsx contexts/index.ts debug/CanvasGraphLinksDebug.tsx
+//go:embed debug/DebugBridgeProvider.tsx debug/DebugDbBench.tsx debug/ForgeViewerDebug.tsx debug/HDRDebug.tsx
+//go:embed debug/LayoutColorsDebug.tsx debug/LayoutDebug.tsx debug/LoadingDebug.tsx
+//go:embed debug/SessionSettingsDebug.tsx debug/UnixFSBrowserDebug.tsx devtools/CacheSeedTab.tsx
+//go:embed devtools/ResourceDetailsPanel.tsx devtools/ResourceDevTools.tsx devtools/ResourceErrorsTab.tsx
+//go:embed devtools/ResourceTreeTab.tsx devtools/StateDetailsPanel.tsx devtools/StateDevTools.tsx
+//go:embed devtools/StateDevToolsContext.tsx devtools/StateTreeTab.tsx devtools/index.ts
+//go:embed devtools/useStateInspectorEntries.ts dnd/app-drag.ts dnd/download-url-drag.ts download.ts
+//go:embed editors/file-browser/FileList.tsx editors/file-browser/FileListEntry.tsx
+//go:embed editors/file-browser/FileListState.tsx editors/file-browser/PathBar.tsx
+//go:embed editors/file-browser/Toolbar.tsx editors/file-browser/types.ts forge/ForgeEntityLink.tsx
+//go:embed forge/ForgeEntityList.tsx forge/ForgeViewerShell.tsx forge/StateBadge.tsx forge/predicates.ts
+//go:embed forge/useForgeBlockData.ts forge/useForgeLinkedEntities.ts frame/ViewerFrame.tsx frame/bar.tsx
+//go:embed frame/bottom-bar-context.tsx frame/bottom-bar-item.tsx frame/bottom-bar-level.tsx
+//go:embed frame/bottom-bar-root.tsx frame/bottom-icon-props.tsx frame/breadcrumb-separator.tsx frame/frame.tsx
+//go:embed hooks/useAccessTypedHandle.ts hooks/useContainerDensity.ts hooks/useDynamicRegistrations.ts
+//go:embed hooks/useEmailManagement.ts hooks/useMobile.ts hooks/useMountAccount.ts
+//go:embed hooks/useObjectTypeMetadata.ts hooks/usePromise.tsx hooks/useRootResource.tsx hooks/useSessionInfo.ts
+//go:embed hooks/useTypedObjectState.ts hooks/useUnixFSHandle.tsx hooks/useViewerRegistry.tsx images/AppLogo.tsx
+//go:embed images/spacewave-icon.png launcher/UpdateNotifier.tsx layout/BaseLayout.tsx
+//go:embed layout/BaseLayoutContext.tsx layout/FlexTabContextMenu.tsx layout/LocalStorageLayout.tsx
+//go:embed layout/layout.ts object/ComponentSelector.tsx object/DebugObjectViewer.tsx
+//go:embed object/LayoutObjectViewer.tsx object/ObjectLink.tsx object/ObjectViewer.tsx
+//go:embed object/ObjectViewerContent.tsx object/ObjectViewerContext.tsx object/ObjectViewerDetails.tsx
+//go:embed object/ObjectViewerLoadingState.tsx object/ObjectViewerNotFoundState.tsx object/TabContent.tsx
+//go:embed object/TabContext.tsx object/ViewerStatusShell.tsx object/layout-object-app-drag.ts
+//go:embed object/object-viewer-space-actions.ts object/object.pb.ts object/object.ts object/useObjectViewer.tsx
+//go:embed object/useObjectViewerSetup.ts platform/detect-platform.ts router/HashRouter.tsx
+//go:embed router/HistoryRouter.tsx router/NavigatePath.tsx router/Redirect.tsx router/app-path.ts
+//go:embed router/hash.tsx router/router.tsx router/static-routes.ts sdk/app/SpacewaveRuntimeProviders.tsx
+//go:embed sdk/app/base-viewers.ts sdk/app/index.ts sdk/app/lifecycle.tsx sdk/app/viewer-catalog.ts
+//go:embed space/object-tree.tsx space/space-object-navigation-actions.ts state/StateAtomRegistry.tsx
+//go:embed state/global.ts state/index.tsx state/interaction.ts state/persist.tsx state/useBackendStateAtom.tsx
+//go:embed state/useStateAtomResource.tsx style/app.css style/flexlayout/base.css
+//go:embed style/flexlayout/flexlayout.css style/shadcn.css style/utils.ts title/DocumentTitleContext.tsx
+//go:embed title/DocumentTitleFocusContext.ts transform/TransformConfigDisplay.tsx ui/BackButton.tsx
+//go:embed ui/CollapsibleSection.tsx ui/CopyButton.tsx ui/CopyableField.tsx ui/DashboardButton.tsx
+//go:embed ui/DropdownMenu.tsx ui/DropdownMenuGhostAnchor.tsx ui/DropdownTriggerButton.tsx ui/EmptyState.tsx
+//go:embed ui/ErrorState.tsx ui/ExperimentalBadge.tsx ui/FloatingWindow.tsx ui/InfoCard.tsx ui/MenuButton.tsx
+//go:embed ui/MenuButtonGroup.tsx ui/Menubar.tsx ui/ObjectKeySelector.tsx ui/OutputPanel.tsx ui/PanelHeader.tsx
+//go:embed ui/PanelSizeGate.tsx ui/Popover.tsx ui/RadioOption.tsx ui/SearchBox.tsx ui/StatCard.tsx
+//go:embed ui/StatsBar.tsx ui/StatusList.tsx ui/Window.tsx ui/badge.tsx ui/button-group.tsx ui/button.tsx
+//go:embed ui/card.tsx ui/command.tsx ui/credential/AuthProgressCard.tsx ui/credential/CredentialProofInput.tsx
+//go:embed ui/credential/auth-utils.ts ui/credential/useCredentialProof.ts ui/dialog.tsx ui/input.tsx
+//go:embed ui/label.tsx ui/list/List.tsx ui/list/ListItem.tsx ui/list/ListRow.tsx ui/list/ListState.tsx
+//go:embed ui/list/index.ts ui/loading/LoadingCard.tsx ui/loading/LoadingInline.tsx ui/loading/LoadingScreen.tsx
+//go:embed ui/loading/ProgressBar.tsx ui/loading/Spinner.tsx ui/loading/index.ts ui/loading/types.ts
+//go:embed ui/loading/useReducedMotion.ts ui/login-form.tsx ui/path/PathInput.tsx ui/path/index.ts
+//go:embed ui/range-slider.tsx ui/separator.tsx ui/sheet.tsx ui/shine-border.tsx ui/tabs.tsx ui/toaster.tsx
+//go:embed ui/tooltip.tsx ui/tree/Tree.tsx ui/tree/TreeNode.tsx ui/tree/TreeRow.tsx ui/tree/TreeState.tsx
+//go:embed ui/tree/index.ts ui/turnstile.tsx util/isEqual.ts
+//go:embed react-css.d.ts
+var DistSources embed.FS

--- a/web/dist_test.go
+++ b/web/dist_test.go
@@ -1,0 +1,191 @@
+package app_web
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestDistSourcesCoverManifestEntrypoints(t *testing.T) {
+	manifest, err := os.ReadFile("../bldr.star")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const marker = `web_pkg("@s4wave/web", entrypoints=[`
+	start := strings.Index(string(manifest), marker)
+	if start == -1 {
+		t.Fatalf("bldr.star does not contain %q", marker)
+	}
+	surface := string(manifest)[start+len(marker):]
+	before, _, ok := strings.Cut(surface, "])")
+	if !ok {
+		t.Fatal("@s4wave/web entrypoint list is not terminated")
+	}
+
+	entrypoints := strings.FieldsFunc(before, func(r rune) bool {
+		switch r {
+		case '"', ',', ' ', '\n', '\r', '\t':
+			return true
+		default:
+			return false
+		}
+	})
+	if len(entrypoints) == 0 {
+		t.Fatal("@s4wave/web has no entrypoints")
+	}
+
+	for _, entrypoint := range entrypoints {
+		entrypoint = strings.TrimPrefix(entrypoint, "./")
+		exists, err := embeddedEntrypointSource(entrypoint)
+		if err != nil {
+			t.Fatalf("inspect embedded entrypoint %s: %v", entrypoint, err)
+		}
+		if !exists {
+			t.Errorf("DistSources has no source for @s4wave/web/%s", entrypoint)
+		}
+	}
+
+	err = fs.WalkDir(DistSources, ".", func(name string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if !entry.IsDir() && isWebTestSource(name) {
+			t.Errorf("DistSources includes test source %s", name)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDistSourcesAreClosed(t *testing.T) {
+	importPattern, err := regexp.Compile(`(?m)(?:\bfrom\s*|\bimport\s*(?:\(\s*)?|@import\s*)["']([^"']+)["']`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = fs.WalkDir(DistSources, ".", func(name string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			if name == "test" {
+				t.Error("DistSources includes the web/test helper directory")
+			}
+			return nil
+		}
+		if !isWebSource(name) {
+			return nil
+		}
+
+		source, err := fs.ReadFile(DistSources, name)
+		if err != nil {
+			return err
+		}
+		for _, match := range importPattern.FindAllSubmatch(source, -1) {
+			target, local := embeddedImportTarget(name, string(match[1]))
+			if !local {
+				continue
+			}
+
+			exists, err := embeddedSourceExists(target)
+			if err != nil {
+				return err
+			}
+			if !exists {
+				t.Errorf("%s imports source %s, which is not embedded", name, match[1])
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func embeddedImportTarget(source, importPath string) (string, bool) {
+	const webPrefix = "@s4wave/web/"
+
+	switch {
+	case importPath == "@s4wave/web":
+		return ".", true
+	case strings.HasPrefix(importPath, webPrefix):
+		return strings.TrimPrefix(importPath, webPrefix), true
+	case strings.HasPrefix(importPath, "."):
+		return path.Clean(path.Join(path.Dir(source), importPath)), true
+	default:
+		return "", false
+	}
+}
+
+func embeddedSourceExists(target string) (bool, error) {
+	var candidates []string
+	switch path.Ext(target) {
+	case ".js":
+		base := strings.TrimSuffix(target, ".js")
+		candidates = []string{base + ".ts", base + ".tsx"}
+	case ".ts", ".tsx", ".css":
+		candidates = []string{target}
+	case "":
+		candidates = []string{
+			target + ".ts",
+			target + ".tsx",
+			path.Join(target, "index.ts"),
+			path.Join(target, "index.tsx"),
+		}
+	default:
+		candidates = []string{target}
+	}
+
+	for _, candidate := range candidates {
+		entry, err := fs.Stat(DistSources, candidate)
+		if err == nil {
+			return !entry.IsDir(), nil
+		}
+		if !errors.Is(err, fs.ErrNotExist) {
+			return false, err
+		}
+	}
+	return false, nil
+}
+
+func embeddedEntrypointSource(entrypoint string) (bool, error) {
+	for _, ext := range []string{".ts", ".tsx", ".css"} {
+		_, err := fs.Stat(DistSources, entrypoint+ext)
+		if err == nil {
+			return true, nil
+		}
+		if !errors.Is(err, fs.ErrNotExist) {
+			return false, err
+		}
+	}
+
+	entries, err := fs.ReadDir(DistSources, entrypoint)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if !entry.IsDir() && isWebSource(name) && !isWebTestSource(name) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func isWebSource(name string) bool {
+	return strings.HasSuffix(name, ".ts") || strings.HasSuffix(name, ".tsx") || strings.HasSuffix(name, ".css")
+}
+
+func isWebTestSource(name string) bool {
+	return strings.HasSuffix(name, ".test.ts") || strings.HasSuffix(name, ".test.tsx")
+}

--- a/web/react-css.d.ts
+++ b/web/react-css.d.ts
@@ -1,0 +1,7 @@
+import 'react'
+
+declare module 'react' {
+  interface CSSProperties {
+    [customProperty: `--${string}`]: string | number | undefined
+  }
+}


### PR DESCRIPTION
Downstream Bldr apps can now typecheck the shared web package without relying on a sibling Spacewave checkout. The runtime package surface remains the 27 entrypoints declared by the spacewave-web manifest.

The web package embeds the complete 228-file source closure required by those entrypoints, including imported assets and the React style type environment. A closure check resolves every relative and @s4wave/web import from embedded sources so a missing transitive source fails in the owning package.

Focused verification passed with go build ./web/... and go test ./web/....