### PR TITLE
feat(web): distribute downstream source closure

### DIFF
--- a/dist.go
+++ b/dist.go
@@ -1,0 +1,69 @@
+package spacewave
+
+import "embed"
+
+// DistSources contains the TypeScript source closure that downstream apps use
+// to resolve Spacewave package imports without a sibling checkout.
+//
+//go:embed app/canvas/GraphLinkPill.tsx app/canvas/type.ts app/canvas/types.ts app/creator-visibility.ts
+//go:embed app/device/add-device-wizard.ts app/quickstart/create.ts app/quickstart/options.ts
+//go:embed app/quickstart/perf-test.ts app/quickstart/startup-boundary.ts app/space/create-op-builders.ts
+//go:embed app/space/space-settings.ts app/space/space.ts app/urls.ts app/vm/v86-wizard-config.ts
+//go:embed app/wizard/intro.ts core/account/settings/settings.pb.ts core/changelog/changelog.pb.ts
+//go:embed core/forge/dashboard/dashboard.pb.ts core/forge/job/job.pb.ts core/forge/task/task.pb.ts
+//go:embed core/git/git.pb.ts core/provider/provider.pb.ts core/provider/spacewave/api/api.pb.ts
+//go:embed core/provider/spacewave/cacheseed/cacheseed.pb.ts
+//go:embed core/provider/spacewave/cacheseed/cacheseed_srpc.pb.ts
+//go:embed core/provider/spacewave/launcher/launcher.pb.ts
+//go:embed core/provider/spacewave/launcher/launcher_srpc.pb.ts core/provider/transfer/transfer.pb.ts
+//go:embed core/session/handoff/handoff.pb.ts core/session/session.pb.ts core/sobject/sobject.pb.ts
+//go:embed core/space/space.pb.ts core/space/world/ops/init-canvas-demo.ts
+//go:embed core/space/world/ops/init-object-layout.ts core/space/world/ops/init-unixfs.ts
+//go:embed core/space/world/ops/ops.pb.ts core/space/world/ops/set-space-settings.ts
+//go:embed core/space/world/world.pb.ts core/space/world/world.ts db/block/blob/blob.pb.ts
+//go:embed db/block/block.pb.ts db/block/quad/quad.pb.ts db/block/transform/transform.pb.ts
+//go:embed db/bucket/bucket.pb.ts db/git/block/git.pb.ts db/kvtx/block/iavl/iavl.pb.ts
+//go:embed db/kvtx/block/kvtx.pb.ts db/kvtx/block/okra/okra.pb.ts db/kvtx/rpc/kvtx.pb.ts
+//go:embed db/kvtx/rpc/kvtx_srpc.pb.ts net/hash/hash.pb.ts net/peer/peer.pb.ts sdk/account/account.pb.ts
+//go:embed sdk/account/account.ts sdk/account/account_srpc.pb.ts sdk/block/cursor/cursor.pb.ts
+//go:embed sdk/block/cursor/cursor.ts sdk/block/cursor/cursor_srpc.pb.ts
+//go:embed sdk/block/transaction/transaction.pb.ts sdk/block/transaction/transaction.ts
+//go:embed sdk/block/transaction/transaction_srpc.pb.ts sdk/bucket/lookup/lookup.pb.ts
+//go:embed sdk/bucket/lookup/lookup.ts sdk/bucket/lookup/lookup_srpc.pb.ts sdk/canvas/canvas.pb.ts
+//go:embed sdk/cdn/cdn-resource.pb.ts sdk/cdn/cdn-resource_srpc.pb.ts sdk/cdn/cdn.ts sdk/chat/chat.pb.ts
+//go:embed sdk/chat/create-channel.ts sdk/chat/init-chat-demo.ts sdk/command/command.pb.ts
+//go:embed sdk/command/registry/registry.pb.ts sdk/command/registry/registry_srpc.pb.ts
+//go:embed sdk/configtype/registry/registry.pb.ts sdk/configtype/registry/registry_srpc.pb.ts
+//go:embed sdk/debug/context.ts sdk/debug/debug-service.ts sdk/debug/debug.pb.ts sdk/debug/debug_srpc.pb.ts
+//go:embed sdk/debugdb/benchmark.ts sdk/debugdb/debugdb.pb.ts sdk/debugdb/debugdb.ts
+//go:embed sdk/debugdb/debugdb_srpc.pb.ts sdk/deploy/deploy.pb.ts
+//go:embed sdk/device/computers/create-computers-dashboard.ts sdk/device/device.pb.ts sdk/device/device.ts
+//go:embed sdk/device/device_srpc.pb.ts sdk/forge/dashboard/create-forge-dashboard.ts
+//go:embed sdk/forge/dashboard/init-forge-quickstart.ts sdk/kv/index.ts sdk/kv/kv.ts sdk/layout/layout-host.ts
+//go:embed sdk/layout/layout.pb.ts sdk/layout/layout.ts sdk/layout/layout_srpc.pb.ts
+//go:embed sdk/layout/world/object-layout.ts sdk/layout/world/world.pb.ts
+//go:embed sdk/objecttype/registry/registry.pb.ts sdk/objecttype/registry/registry_srpc.pb.ts
+//go:embed sdk/provider/index.ts sdk/provider/local/local.pb.ts sdk/provider/local/local.ts
+//go:embed sdk/provider/local/local_srpc.pb.ts sdk/provider/provider.pb.ts sdk/provider/provider.ts
+//go:embed sdk/provider/provider_srpc.pb.ts sdk/provider/spacewave/spacewave.pb.ts
+//go:embed sdk/provider/spacewave/spacewave.ts sdk/provider/spacewave/spacewave_srpc.pb.ts
+//go:embed sdk/quickstart/registry/registry.pb.ts sdk/quickstart/registry/registry_srpc.pb.ts
+//go:embed sdk/root/index.ts sdk/root/root.pb.ts sdk/root/root.ts sdk/root/root_srpc.pb.ts
+//go:embed sdk/secret/secret.pb.ts sdk/session/index.ts sdk/session/local-session.pb.ts
+//go:embed sdk/session/local-session.ts sdk/session/local-session_srpc.pb.ts sdk/session/session.pb.ts
+//go:embed sdk/session/session.ts sdk/session/session_srpc.pb.ts
+//go:embed sdk/session/shared-object-self-enrollment.pb.ts sdk/session/shared-object-self-enrollment.ts
+//go:embed sdk/session/shared-object-self-enrollment_srpc.pb.ts sdk/session/spacewave-session.pb.ts
+//go:embed sdk/session/spacewave-session.ts sdk/session/spacewave-session_srpc.pb.ts sdk/sobject/sobject.pb.ts
+//go:embed sdk/sobject/sobject.ts sdk/sobject/sobject_srpc.pb.ts sdk/space/contents.ts sdk/space/object-uri.ts
+//go:embed sdk/space/space.pb.ts sdk/space/space.ts sdk/space/space_srpc.pb.ts sdk/status/status.pb.ts
+//go:embed sdk/status/status.ts sdk/status/status_srpc.pb.ts sdk/unixfs/file-kind.ts sdk/unixfs/fs-cursor.ts
+//go:embed sdk/unixfs/handle.pb.ts sdk/unixfs/handle.ts sdk/unixfs/handle_srpc.pb.ts sdk/unixfs/index.ts
+//go:embed sdk/unixfs/path.ts sdk/unixfs/type.ts sdk/viewer/registry/registry.pb.ts
+//go:embed sdk/viewer/registry/registry_srpc.pb.ts sdk/vm/v86-wizard.pb.ts sdk/vm/v86.pb.ts
+//go:embed sdk/world/engine-state.ts sdk/world/engine.ts sdk/world/graph-utils.ts sdk/world/object-ref.ts
+//go:embed sdk/world/object-state.ts sdk/world/object_iterator.ts sdk/world/tx.ts sdk/world/types/errors.ts
+//go:embed sdk/world/types/types.ts sdk/world/utils.ts sdk/world/wizard/create-wizard.ts
+//go:embed sdk/world/wizard/wizard.pb.ts sdk/world/wizard/wizard_srpc.pb.ts sdk/world/world-state.ts
+//go:embed sdk/world/world.pb.ts sdk/world/world_srpc.pb.ts
+var DistSources embed.FS

--- a/web/dist_test.go
+++ b/web/dist_test.go
@@ -8,6 +8,8 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+
+	spacewave "github.com/s4wave/spacewave"
 )
 
 func TestDistSourcesCoverManifestEntrypoints(t *testing.T) {
@@ -50,18 +52,6 @@ func TestDistSourcesCoverManifestEntrypoints(t *testing.T) {
 		}
 	}
 
-	err = fs.WalkDir(DistSources, ".", func(name string, entry fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if !entry.IsDir() && isWebTestSource(name) {
-			t.Errorf("DistSources includes test source %s", name)
-		}
-		return nil
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
 }
 
 func TestDistSourcesAreClosed(t *testing.T) {
@@ -70,53 +60,61 @@ func TestDistSourcesAreClosed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = fs.WalkDir(DistSources, ".", func(name string, entry fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if entry.IsDir() {
-			if name == "test" {
-				t.Error("DistSources includes the web/test helper directory")
+	sources := []struct {
+		prefix string
+		fsys   fs.FS
+	}{
+		{fsys: spacewave.DistSources},
+		{prefix: "web", fsys: DistSources},
+	}
+	for _, sourceFS := range sources {
+		err = fs.WalkDir(sourceFS.fsys, ".", func(name string, entry fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
 			}
-			return nil
-		}
-		if !isWebSource(name) {
-			return nil
-		}
-
-		source, err := fs.ReadFile(DistSources, name)
-		if err != nil {
-			return err
-		}
-		for _, match := range importPattern.FindAllSubmatch(source, -1) {
-			target, local := embeddedImportTarget(name, string(match[1]))
-			if !local {
-				continue
+			if entry.IsDir() {
+				return nil
+			}
+			if isDistTestSource(name) {
+				t.Errorf("DistSources includes test source %s", name)
+			}
+			if !isDistSource(name) {
+				return nil
 			}
 
-			exists, err := embeddedSourceExists(target)
+			source, err := fs.ReadFile(sourceFS.fsys, name)
 			if err != nil {
 				return err
 			}
-			if !exists {
-				t.Errorf("%s imports source %s, which is not embedded", name, match[1])
+			sourceName := path.Join(sourceFS.prefix, name)
+			for _, match := range importPattern.FindAllSubmatch(source, -1) {
+				target, local := embeddedImportTarget(sourceName, string(match[1]))
+				if !local {
+					continue
+				}
+
+				exists, err := embeddedSourceExists(target)
+				if err != nil {
+					return err
+				}
+				if !exists {
+					t.Errorf("%s imports source %s, which is not embedded", sourceName, match[1])
+				}
 			}
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
 		}
-		return nil
-	})
-	if err != nil {
-		t.Fatal(err)
 	}
 }
 
 func embeddedImportTarget(source, importPath string) (string, bool) {
-	const webPrefix = "@s4wave/web/"
+	const prefix = "@s4wave/"
 
 	switch {
-	case importPath == "@s4wave/web":
-		return ".", true
-	case strings.HasPrefix(importPath, webPrefix):
-		return strings.TrimPrefix(importPath, webPrefix), true
+	case strings.HasPrefix(importPath, prefix):
+		return strings.TrimPrefix(importPath, prefix), true
 	case strings.HasPrefix(importPath, "."):
 		return path.Clean(path.Join(path.Dir(source), importPath)), true
 	default:
@@ -125,6 +123,15 @@ func embeddedImportTarget(source, importPath string) (string, bool) {
 }
 
 func embeddedSourceExists(target string) (bool, error) {
+	fsys := spacewave.DistSources
+	if target == "web" {
+		fsys = DistSources
+		target = "."
+	} else if strings.HasPrefix(target, "web/") {
+		fsys = DistSources
+		target = strings.TrimPrefix(target, "web/")
+	}
+
 	var candidates []string
 	switch path.Ext(target) {
 	case ".js":
@@ -144,7 +151,7 @@ func embeddedSourceExists(target string) (bool, error) {
 	}
 
 	for _, candidate := range candidates {
-		entry, err := fs.Stat(DistSources, candidate)
+		entry, err := fs.Stat(fsys, candidate)
 		if err == nil {
 			return !entry.IsDir(), nil
 		}
@@ -175,17 +182,17 @@ func embeddedEntrypointSource(entrypoint string) (bool, error) {
 	}
 	for _, entry := range entries {
 		name := entry.Name()
-		if !entry.IsDir() && isWebSource(name) && !isWebTestSource(name) {
+		if !entry.IsDir() && isDistSource(name) && !isDistTestSource(name) {
 			return true, nil
 		}
 	}
 	return false, nil
 }
 
-func isWebSource(name string) bool {
+func isDistSource(name string) bool {
 	return strings.HasSuffix(name, ".ts") || strings.HasSuffix(name, ".tsx") || strings.HasSuffix(name, ".css")
 }
 
-func isWebTestSource(name string) bool {
+func isDistTestSource(name string) bool {
 	return strings.HasSuffix(name, ".test.ts") || strings.HasSuffix(name, ".test.tsx")
 }


### PR DESCRIPTION
Downstream apps can now resolve Spacewave TypeScript packages from the Go vendor tree without a sibling checkout. The previous web distribution embedded only @s4wave/web, while those sources and downstream entrypoints also import SDK, app, core, and generated net and database source.

The module root now explicitly embeds the measured cross-package closure at its canonical paths. The closure check walks both root and web distributions and rejects unresolved relative or @s4wave imports, including bare package imports. Runtime APIs and source paths remain unchanged.

Focused Go package checks pass. Removing a required SDK registry source makes the closure check fail at both importing web files, and restoring it returns the check to green.