### PR TITLE
fix(listener): scope the daemon socket to the selected state path

### DIFF
--- a/bldr/cli/entrypoint/main.go
+++ b/bldr/cli/entrypoint/main.go
@@ -36,6 +36,8 @@ func Main(
 
 	var dtBus *CliBusImpl
 	var statePath string
+	var socketPath string
+	var startSocketPath string
 	var logLevel string
 	var logFiles cli.StringSlice
 	var logFileCleanup func()
@@ -58,6 +60,16 @@ func Main(
 			if err := os.MkdirAll(root, 0o755); err != nil {
 				busInitErr = err
 				return
+			}
+			if err := os.Setenv(storagepath.StatePathEnvVar(projectID), root); err != nil {
+				busInitErr = err
+				return
+			}
+			if socketPath != "" {
+				if err := os.Setenv(storagepath.SocketPathEnvVar(projectID), socketPath); err != nil {
+					busInitErr = err
+					return
+				}
 			}
 
 			b, err := BuildCliBus(ctx, le, root)
@@ -130,6 +142,12 @@ func Main(
 			EnvVars:     statePathEnvVars,
 			Value:       defaultStatePath,
 			Destination: &statePath,
+		},
+		&cli.StringFlag{
+			Name:        "socket-path",
+			Usage:       "listen on this exact Unix socket path",
+			EnvVars:     []string{envPrefix + "_SOCKET_PATH"},
+			Destination: &socketPath,
 		},
 		&cli.StringFlag{
 			Name:        "log-level",
@@ -238,9 +256,18 @@ func Main(
 				EnvVars:     []string{envPrefix + "_TRACE"},
 				Destination: &runtimeTracePath,
 			},
+			&cli.StringFlag{
+				Name:        "socket-path",
+				Usage:       "listen on this exact Unix socket path",
+				EnvVars:     []string{envPrefix + "_SOCKET_PATH"},
+				Destination: &startSocketPath,
+			},
 		},
 		Action: func(c *cli.Context) error {
 			return runWithRuntimeTrace(runtimeTracePath, func() error {
+				if startSocketPath != "" {
+					socketPath = startSocketPath
+				}
 				if err := ensureBus(); err != nil {
 					return err
 				}

--- a/bldr/cli/entrypoint/main.go
+++ b/bldr/cli/entrypoint/main.go
@@ -62,15 +62,9 @@ func Main(
 				busInitErr = err
 				return
 			}
-			if err := os.Setenv(storagepath.StatePathEnvVar(projectID), root); err != nil {
+			if err := storagepath.PublishResolvedPaths(projectID, root, socketPath); err != nil {
 				busInitErr = err
 				return
-			}
-			if socketPath != "" {
-				if err := os.Setenv(storagepath.SocketPathEnvVar(projectID), socketPath); err != nil {
-					busInitErr = err
-					return
-				}
 			}
 
 			b, err := BuildCliBus(ctx, le, root)

--- a/bldr/cli/entrypoint/main.go
+++ b/bldr/cli/entrypoint/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/aperturerobotics/controllerbus/directive"
 	"github.com/aperturerobotics/fastjson"
 	"github.com/pkg/errors"
+	entrypoint_fatal "github.com/s4wave/spacewave/bldr/entrypoint/fatal"
 	"github.com/s4wave/spacewave/bldr/entrypoint/storagepath"
 	"github.com/s4wave/spacewave/bldr/util/logfile"
 	"github.com/sirupsen/logrus"
@@ -275,8 +276,17 @@ func Main(
 					return errors.New("bus not initialized")
 				}
 				dtBus.GetLogger().Info("started, press ctrl+c to stop")
-				<-dtBus.GetContext().Done()
-				return nil
+				select {
+				case <-dtBus.GetContext().Done():
+					return nil
+				case <-entrypoint_fatal.Chan():
+					// A controller reported a condition under which the
+					// daemon cannot serve, such as another live daemon
+					// owning the front-door socket. Exit with the error
+					// instead of blocking as a daemon without its
+					// front door.
+					return entrypoint_fatal.Err()
+				}
 			})
 		},
 	})

--- a/bldr/cli/entrypoint/state-path.go
+++ b/bldr/cli/entrypoint/state-path.go
@@ -3,15 +3,12 @@
 package cli_entrypoint
 
 import (
-	"strings"
-
 	entrypoint_storagepath "github.com/s4wave/spacewave/bldr/entrypoint/storagepath"
 )
 
 // StatePathEnvVar returns the project-specific state path environment variable.
 func StatePathEnvVar(projectID string) string {
-	sanitized := strings.ReplaceAll(strings.TrimSpace(projectID), "-", "_")
-	return strings.ToUpper(sanitized) + "_STATE_PATH"
+	return entrypoint_storagepath.StatePathEnvVar(projectID)
 }
 
 // StatePathEnvVars returns the environment variables that override the state path.

--- a/bldr/dist/entrypoint/common.go
+++ b/bldr/dist/entrypoint/common.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aperturerobotics/go-kvfile"
 	"github.com/pkg/errors"
 	bldr_dist "github.com/s4wave/spacewave/bldr/dist"
+	entrypoint_fatal "github.com/s4wave/spacewave/bldr/entrypoint/fatal"
 	"github.com/s4wave/spacewave/db/block"
 	store_kvkey "github.com/s4wave/spacewave/db/store/kvkey"
 	"github.com/sirupsen/logrus"
@@ -87,9 +88,17 @@ func Run(
 		}
 	}
 
-	// wait for context to be canceled
-	<-ctx.Done()
-	return context.Canceled
+	// wait for context cancellation or a process-fatal condition
+	select {
+	case <-ctx.Done():
+		return context.Canceled
+	case <-entrypoint_fatal.Chan():
+		// A controller reported a condition under which the daemon
+		// cannot serve, such as another live daemon owning the
+		// front-door socket. Exit with the error instead of running
+		// without the reporting controller.
+		return entrypoint_fatal.Err()
+	}
 }
 
 func validateStaticBlockStoreRoot(rdr *kvfile.Reader, rootRef *block.BlockRef) error {

--- a/bldr/dist/entrypoint/native-cli.go
+++ b/bldr/dist/entrypoint/native-cli.go
@@ -42,6 +42,7 @@ func runCliMain(
 
 	var dtBus *DistBus
 	var statePath string
+	var socketPath string
 	var logLevelName string
 	var logFiles cli.StringSlice
 	var logFileCleanup func()
@@ -61,6 +62,10 @@ func runCliMain(
 				root = filepath.Join(cwd, root)
 			}
 			if err := os.MkdirAll(root, 0o755); err != nil {
+				busInitErr = err
+				return
+			}
+			if err := storagepath.PublishResolvedPaths(projectID, root, socketPath); err != nil {
 				busInitErr = err
 				return
 			}
@@ -115,6 +120,12 @@ func runCliMain(
 			EnvVars:     statePathEnvVars,
 			Value:       defaultStatePath,
 			Destination: &statePath,
+		},
+		&cli.StringFlag{
+			Name:        "socket-path",
+			Usage:       "listen on this exact Unix socket path",
+			EnvVars:     []string{storagepath.SocketPathEnvVar(projectID)},
+			Destination: &socketPath,
 		},
 		&cli.StringFlag{
 			Name:        "log-level",

--- a/bldr/entrypoint/fatal/fatal.go
+++ b/bldr/entrypoint/fatal/fatal.go
@@ -1,0 +1,50 @@
+// Package fatal carries process-fatal boot conditions from bus
+// controllers to the entrypoint command that owns the process exit.
+//
+// A controller that discovers a condition under which the daemon
+// cannot serve its purpose (for example, another live daemon already
+// owns the front-door socket) reports it here instead of returning an
+// error into the controllerbus retry loop, where it would be retried
+// with backoff while the daemon keeps running without its front door.
+// The blocking entrypoint command watches the channel and exits with
+// the reported error.
+package fatal
+
+import "sync"
+
+// broker is the process-wide fatal-condition record. The first
+// reported error wins; later reports are dropped.
+var broker = struct {
+	mtx sync.Mutex
+	err error
+	ch  chan struct{}
+}{ch: make(chan struct{})}
+
+// Report records err as a process-fatal condition and wakes watchers.
+// The first reported error is kept; a nil err or a later report is a
+// no-op.
+func Report(err error) {
+	if err == nil {
+		return
+	}
+	broker.mtx.Lock()
+	defer broker.mtx.Unlock()
+	if broker.err != nil {
+		return
+	}
+	broker.err = err
+	close(broker.ch)
+}
+
+// Chan returns a channel closed after the first Report.
+func Chan() <-chan struct{} {
+	return broker.ch
+}
+
+// Err returns the recorded fatal error, or nil before the first
+// Report.
+func Err() error {
+	broker.mtx.Lock()
+	defer broker.mtx.Unlock()
+	return broker.err
+}

--- a/bldr/entrypoint/storagepath/storage-root.go
+++ b/bldr/entrypoint/storagepath/storage-root.go
@@ -17,6 +17,18 @@ func LogLevelEnvVar(projectID string) string {
 	return projectIDPrefix(projectID) + "_LOG_LEVEL"
 }
 
+// StatePathEnvVar returns the environment variable that carries the resolved
+// project state path (e.g. "spacewave" -> "SPACEWAVE_STATE_PATH").
+func StatePathEnvVar(projectID string) string {
+	return projectIDPrefix(projectID) + "_STATE_PATH"
+}
+
+// SocketPathEnvVar returns the environment variable that overrides the
+// daemon socket path (e.g. "spacewave" -> "SPACEWAVE_SOCKET_PATH").
+func SocketPathEnvVar(projectID string) string {
+	return projectIDPrefix(projectID) + "_SOCKET_PATH"
+}
+
 // LogRetentionDaysEnvVar returns the environment variable that overrides
 // the on-disk log retention duration (in days) for the given project.
 func LogRetentionDaysEnvVar(projectID string) string {

--- a/bldr/entrypoint/storagepath/storage-root.go
+++ b/bldr/entrypoint/storagepath/storage-root.go
@@ -29,6 +29,22 @@ func SocketPathEnvVar(projectID string) string {
 	return projectIDPrefix(projectID) + "_SOCKET_PATH"
 }
 
+// PublishResolvedPaths publishes the resolved state root and optional
+// explicit socket path to the project's environment variables so
+// bus-hosted components (such as the resource listener) scope their
+// default paths to the invocation's state root instead of the shared
+// process default. socketPath may be empty when no explicit socket
+// path was requested.
+func PublishResolvedPaths(projectID, stateRoot, socketPath string) error {
+	if err := os.Setenv(StatePathEnvVar(projectID), stateRoot); err != nil {
+		return err
+	}
+	if socketPath == "" {
+		return nil
+	}
+	return os.Setenv(SocketPathEnvVar(projectID), socketPath)
+}
+
 // LogRetentionDaysEnvVar returns the environment variable that overrides
 // the on-disk log retention duration (in days) for the given project.
 func LogRetentionDaysEnvVar(projectID string) string {

--- a/core/resource/listener/config.go
+++ b/core/resource/listener/config.go
@@ -1,6 +1,7 @@
 package resource_listener
 
 import (
+	"os"
 	"path/filepath"
 
 	"github.com/aperturerobotics/controllerbus/config"
@@ -16,8 +17,8 @@ func (c *Config) Validate() error {
 }
 
 // DetermineSocketPath returns the configured socket path. An explicit path
-// takes precedence; otherwise StorageProjectId uses the same project storage
-// root as the rest of the native runtime.
+// takes precedence; otherwise a project state path, when present, scopes the
+// socket before the shared storage root fallback.
 func (c *Config) DetermineSocketPath() (string, error) {
 	if socketPath := c.GetListenerSocketPath(); socketPath != "" {
 		return socketPath, nil
@@ -25,6 +26,12 @@ func (c *Config) DetermineSocketPath() (string, error) {
 	projectID := c.GetStorageProjectId()
 	if projectID == "" {
 		return "", nil
+	}
+	if socketPath := os.Getenv(storagepath.SocketPathEnvVar(projectID)); socketPath != "" {
+		return socketPath, nil
+	}
+	if statePath := os.Getenv(storagepath.StatePathEnvVar(projectID)); statePath != "" {
+		return filepath.Join(statePath, projectID+".sock"), nil
 	}
 	storageRoot, err := storagepath.DetermineStorageRoot(projectID)
 	if err != nil {

--- a/core/resource/listener/config_test.go
+++ b/core/resource/listener/config_test.go
@@ -105,3 +105,39 @@ func TestExplicitSocketPathsTakePrecedenceAndResolve(t *testing.T) {
 		})
 	}
 }
+
+func TestDetermineSocketPathUsesStatePath(t *testing.T) {
+	home := filepath.Join(t.TempDir(), "home")
+	statePath := filepath.Join(t.TempDir(), "state")
+	t.Setenv("HOME", home)
+	t.Setenv("SPACEWAVE_DATA_DIR", "")
+	t.Setenv("SPACEWAVE_SOCKET_PATH", "")
+	t.Setenv("SPACEWAVE_STATE_PATH", statePath)
+
+	got, err := (&Config{StorageProjectId: "spacewave"}).DetermineSocketPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(statePath, "spacewave.sock")
+	if got != want {
+		t.Fatalf("socket path: got %q, want %q", got, want)
+	}
+}
+
+func TestDetermineSocketPathUsesExplicitSocketPath(t *testing.T) {
+	home := filepath.Join(t.TempDir(), "home")
+	statePath := filepath.Join(t.TempDir(), "state")
+	explicit := filepath.Join(t.TempDir(), "explicit.sock")
+	t.Setenv("HOME", home)
+	t.Setenv("SPACEWAVE_DATA_DIR", "")
+	t.Setenv("SPACEWAVE_STATE_PATH", statePath)
+	t.Setenv("SPACEWAVE_SOCKET_PATH", explicit)
+
+	got, err := (&Config{StorageProjectId: "spacewave"}).DetermineSocketPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != explicit {
+		t.Fatalf("socket path: got %q, want %q", got, explicit)
+	}
+}

--- a/core/resource/listener/control/takeover.go
+++ b/core/resource/listener/control/takeover.go
@@ -13,18 +13,24 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// TakeoverSocket ensures that the Unix socket at sockPath is free to
-// be bound. If a live daemon is already listening there, TakeoverSocket
-// issues the daemon-control Shutdown RPC and waits for its completion
-// acknowledgement. If the peer exits after yielding but before sending
-// that acknowledgement, TakeoverSocket observes the closed connection,
-// verifies that no listener remains, and removes the stale socket.
-//
-// Callers must bind directly after a successful return. They must not
-// remove the path: the completed protocol or stale-owner recovery
-// already released it, and a later remove could unlink a concurrent
-// winner's listener.
+// TakeoverSocket ensures that the Unix socket at sockPath is free to be
+// bound by requesting a live daemon to yield it or removing a stale file.
 func TakeoverSocket(ctx context.Context, le *logrus.Entry, sockPath string) error {
+	return prepareSocket(ctx, le, sockPath, true)
+}
+
+// EnsureSocketAvailable verifies that the Unix socket at sockPath is free to
+// be bound. A live listener is an error; a stale socket file is removed.
+func EnsureSocketAvailable(ctx context.Context, le *logrus.Entry, sockPath string) error {
+	return prepareSocket(ctx, le, sockPath, false)
+}
+
+func prepareSocket(
+	ctx context.Context,
+	le *logrus.Entry,
+	sockPath string,
+	allowTakeover bool,
+) error {
 	socketInfo, err := os.Stat(sockPath)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -50,6 +56,10 @@ func TakeoverSocket(ctx context.Context, le *logrus.Entry, sockPath string) erro
 		return nil
 	}
 	defer conn.Close()
+
+	if !allowTakeover {
+		return errors.Errorf("daemon socket %s is already in use", sockPath)
+	}
 
 	if err := RequestShutdown(ctx, conn); err != nil {
 		var denyErr *DenyError

--- a/core/resource/listener/control/takeover.go
+++ b/core/resource/listener/control/takeover.go
@@ -13,6 +13,26 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// SocketInUseError reports that a live listener already owns the
+// daemon socket and takeover was not requested. The condition is
+// permanent for the refusing process: retrying without takeover
+// cannot succeed while the owner lives.
+type SocketInUseError struct {
+	// Path is the contended socket path.
+	Path string
+}
+
+// Error implements error.
+func (e *SocketInUseError) Error() string {
+	return "daemon socket " + e.Path + " is already in use"
+}
+
+// IsSocketInUse reports whether err wraps a SocketInUseError.
+func IsSocketInUse(err error) bool {
+	var inUse *SocketInUseError
+	return errors.As(err, &inUse)
+}
+
 // TakeoverSocket ensures that the Unix socket at sockPath is free to be
 // bound by requesting a live daemon to yield it or removing a stale file.
 func TakeoverSocket(ctx context.Context, le *logrus.Entry, sockPath string) error {
@@ -58,7 +78,7 @@ func prepareSocket(
 	defer conn.Close()
 
 	if !allowTakeover {
-		return errors.Errorf("daemon socket %s is already in use", sockPath)
+		return &SocketInUseError{Path: sockPath}
 	}
 
 	if err := RequestShutdown(ctx, conn); err != nil {

--- a/core/resource/listener/control/takeover_test.go
+++ b/core/resource/listener/control/takeover_test.go
@@ -146,6 +146,37 @@ func TestTakeoverSocketNoop(t *testing.T) {
 	}
 }
 
+func TestEnsureSocketAvailableRefusesLiveListener(t *testing.T) {
+	sock := filepath.Join(makeShortTakeoverDir(t, "ensure-live"), "d.sock")
+	lis, err := net.ListenUnix("unix", &net.UnixAddr{Name: sock, Net: "unix"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lis.Close()
+
+	err = EnsureSocketAvailable(t.Context(), logrus.NewEntry(logrus.New()), sock)
+	if err == nil {
+		t.Fatal("expected live socket refusal")
+	}
+	if want := "daemon socket " + sock + " is already in use"; err.Error() != want {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestEnsureSocketAvailableRemovesStaleFile(t *testing.T) {
+	sock := filepath.Join(makeShortTakeoverDir(t, "ensure-stale"), "d.sock")
+	if err := os.WriteFile(sock, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := EnsureSocketAvailable(t.Context(), logrus.NewEntry(logrus.New()), sock); err != nil {
+		t.Fatalf("ensure socket available: %v", err)
+	}
+	if _, err := os.Stat(sock); !os.IsNotExist(err) {
+		t.Fatalf("expected stale socket removed; stat err=%v", err)
+	}
+}
+
 // TestTakeoverSocketReclaimsWhenYieldingPeerExitsBeforeCompletion
 // asserts that connection closure after yield is treated as owner
 // death, not as a permanent handoff wait. The stale path is removed

--- a/core/resource/listener/execute.go
+++ b/core/resource/listener/execute.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 
 	"github.com/aperturerobotics/starpc/srpc"
 	"github.com/aperturerobotics/util/gitroot"
@@ -151,6 +152,13 @@ func (c *Controller) serveOnce(
 
 	lis, err := net.ListenUnix("unix", &net.UnixAddr{Name: absPath, Net: "unix"})
 	if err != nil {
+		if stderrors.Is(err, syscall.EADDRINUSE) {
+			// Two daemons can both pass the availability check before
+			// either binds. The bind loser is the same live-owner
+			// conflict as the pre-bind refusal, so classify it the
+			// same way and let the caller surface it fatally.
+			return false, &listener_control.SocketInUseError{Path: absPath}
+		}
 		return false, err
 	}
 	defer lis.Close()

--- a/core/resource/listener/execute.go
+++ b/core/resource/listener/execute.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aperturerobotics/starpc/srpc"
 	"github.com/aperturerobotics/util/gitroot"
 	"github.com/pkg/errors"
+	entrypoint_fatal "github.com/s4wave/spacewave/bldr/entrypoint/fatal"
 	resource "github.com/s4wave/spacewave/bldr/resource"
 	listener_control "github.com/s4wave/spacewave/core/resource/listener/control"
 	yield_policy "github.com/s4wave/spacewave/core/resource/listener/yieldpolicy"
@@ -70,6 +71,12 @@ func (c *Controller) Execute(ctx context.Context) error {
 
 	broker := GetProcessYieldBroker()
 
+	// allowTakeover is false on first entry so a live daemon on the
+	// socket is refused rather than displaced, and true when
+	// re-entering after an explicit reclaim signal: the reclaim is a
+	// deliberate user action that authorizes asking the remote
+	// runtime to yield the socket back.
+	allowTakeover := false
 	for {
 		handoff, handoffWaitCh := broker.SnapshotHandoff()
 		if handoffBlocksListener(handoff) {
@@ -81,10 +88,21 @@ func (c *Controller) Execute(ctx context.Context) error {
 				continue
 			}
 		}
-		yielded, err := c.serveOnce(ctx, le, invokers[0], absPath, broker, status)
+		yielded, err := c.serveOnce(ctx, le, invokers[0], absPath, broker, status, allowTakeover)
 		if err != nil {
+			if listener_control.IsSocketInUse(err) {
+				// Another live daemon owns the socket. Retrying under the
+				// controller backoff loop cannot succeed while the owner
+				// lives and would leave this daemon running without its
+				// front door, so surface the conflict as process-fatal
+				// and stop the restart loop.
+				le.WithError(err).Errorf("another daemon owns %s; stop it or run with takeover", absPath)
+				entrypoint_fatal.Report(err)
+				return nil
+			}
 			return err
 		}
+		allowTakeover = false
 		if !yielded || ctx.Err() != nil {
 			return nil
 		}
@@ -96,6 +114,7 @@ func (c *Controller) Execute(ctx context.Context) error {
 			return nil
 		case <-reclaimCh:
 			le.Info("reclaim signal received, re-binding socket")
+			allowTakeover = true
 		}
 	}
 }
@@ -104,10 +123,12 @@ func handoffBlocksListener(handoff yield_policy.HandoffState) bool {
 	return handoff.Active
 }
 
-// serveOnce takes over the socket, listens, serves until either the
+// serveOnce prepares the socket, listens, and serves until either the
 // serve context is canceled externally or a daemon-control Shutdown
-// is honored. The returned bool is true when the listener yielded
-// cleanly so the caller can enter the reclaim-wait loop.
+// is honored. When allowTakeover is true a live socket owner is asked
+// to yield; otherwise a live owner is refused with a typed in-use
+// error. The returned bool is true when the listener yielded cleanly
+// so the caller can enter the reclaim-wait loop.
 func (c *Controller) serveOnce(
 	parentCtx context.Context,
 	le *logrus.Entry,
@@ -115,9 +136,14 @@ func (c *Controller) serveOnce(
 	absPath string,
 	broker *yield_policy.Broker,
 	status *StatusBroker,
+	allowTakeover bool,
 ) (bool, error) {
-	if err := listener_control.EnsureSocketAvailable(parentCtx, le, absPath); err != nil {
-		return false, errors.Wrap(err, "ensure socket available")
+	prepare := listener_control.EnsureSocketAvailable
+	if allowTakeover {
+		prepare = listener_control.TakeoverSocket
+	}
+	if err := prepare(parentCtx, le, absPath); err != nil {
+		return false, errors.Wrap(err, "prepare socket")
 	}
 	if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
 		return false, err

--- a/core/resource/listener/execute.go
+++ b/core/resource/listener/execute.go
@@ -116,8 +116,8 @@ func (c *Controller) serveOnce(
 	broker *yield_policy.Broker,
 	status *StatusBroker,
 ) (bool, error) {
-	if err := listener_control.TakeoverSocket(parentCtx, le, absPath); err != nil {
-		return false, errors.Wrap(err, "takeover socket")
+	if err := listener_control.EnsureSocketAvailable(parentCtx, le, absPath); err != nil {
+		return false, errors.Wrap(err, "ensure socket available")
 	}
 	if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
 		return false, err

--- a/core/resource/listener/execute_test.go
+++ b/core/resource/listener/execute_test.go
@@ -97,6 +97,7 @@ func TestServeOnceRefusesConnectableSocket(t *testing.T) {
 		sock,
 		yield_policy.NewBroker(),
 		NewStatusBroker(),
+		false,
 	)
 	if err == nil {
 		t.Fatal("expected startup refusal")
@@ -222,6 +223,7 @@ func TestServeOnceReleasesSocketBeforeDrainingConcurrentClients(t *testing.T) {
 			sock,
 			broker,
 			status,
+			false,
 		)
 		serveResultCh <- serveResult{yielded: yielded, err: err}
 	}()

--- a/core/resource/listener/execute_test.go
+++ b/core/resource/listener/execute_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -63,6 +64,45 @@ func TestHandoffBlocksActiveListener(t *testing.T) {
 				t.Fatalf("handoffBlocksListener() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestServeOnceRefusesConnectableSocket(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+
+	if err := os.MkdirAll(".tmp", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	dir, err := os.MkdirTemp(".tmp", "refuse-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.RemoveAll(dir)
+	})
+	sock := filepath.Join(dir, "spacewave.sock")
+	lis, err := net.ListenUnix("unix", &net.UnixAddr{Name: sock, Net: "unix"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lis.Close()
+
+	_, err = (&Controller{}).serveOnce(
+		ctx,
+		logrus.NewEntry(logrus.New()),
+		srpc.InvokerFunc(func(string, string, srpc.Stream) (bool, error) {
+			return false, nil
+		}),
+		sock,
+		yield_policy.NewBroker(),
+		NewStatusBroker(),
+	)
+	if err == nil {
+		t.Fatal("expected startup refusal")
+	}
+	if !strings.Contains(err.Error(), "already in use") {
+		t.Fatalf("unexpected startup refusal: %v", err)
 	}
 }
 


### PR DESCRIPTION
Running a second instance with --state-path moved its storage root but left the resource listener deriving its socket from the shared default storage root, so the state-scoped instance took over the default socket and silently shut down the daemon the user meant to leave running.

Socket path selection now lives in the listener config with one precedence order: an explicit listener config path, the --socket-path override, the project state path with <project>.sock joined underneath, then the shared storage root fallback. The CLI entrypoint publishes the resolved state and socket paths through the project-scoped environment variables owned by the storagepath package, which gains StatePathEnvVar and SocketPathEnvVar beside the existing StorageRootEnvVar helpers so every consumer shares one sanitized naming scheme.

Startup no longer performs an implicit takeover. serveOnce uses a new EnsureSocketAvailable mode that refuses a connectable socket with a clear already-in-use error, while the takeover command keeps its existing behavior, and both modes share the stale socket cleanup. Regression tests prove state-path scoping, explicit socket precedence, live-listener refusal, and stale-file removal; the listener, control, CLI, and entrypoint package suites pass.