### PR TITLE
feat(world): add batched object body reads to the World state seam

### DIFF
--- a/.protoc-manifest.json
+++ b/.protoc-manifest.json
@@ -4438,7 +4438,7 @@
       "protoFiles": ["sdk/vm/v86-wizard.proto", "sdk/vm/v86.proto"]
     },
     "github.com/s4wave/spacewave/sdk/world": {
-      "hash": "220ed53dc2a89a0d9ecbda302d14c50507584b332d24cd99a4604e7b26c9ec1c",
+      "hash": "dfb78c1ae6a353a4405cca41bbcf54a57020baa35a69490f8b7393c3e6e45d3b",
       "generatedFiles": [
         "sdk/world/world.pb.cc",
         "sdk/world/world.pb.go",

--- a/core/resource/world/world-state.go
+++ b/core/resource/world/world-state.go
@@ -467,6 +467,85 @@ func (r *WorldStateResource) GetObjectMetadataBatch(ctx context.Context, req *s4
 	return &s4wave_world.GetObjectMetadataBatchResponse{Metadata: out}, nil
 }
 
+// GetObjectBodiesBatch returns serialized object bodies for object keys.
+func (r *WorldStateResource) GetObjectBodiesBatch(ctx context.Context, req *s4wave_world.GetObjectBodiesBatchRequest) (*s4wave_world.GetObjectBodiesBatchResponse, error) {
+	started := time.Now()
+	record := WorldStateOperationRecord{
+		Name:              "GetObjectBodiesBatch",
+		StartKeyCount:     len(req.GetObjectKeys()),
+		ResultObjectCount: 0,
+	}
+	var retErr error
+	ctx, readCounter := block.WithReadCounter(ctx)
+	defer func() {
+		recordBlockReadSnapshot(&record, readCounter)
+		r.observeOperation(record, started, retErr)
+	}()
+
+	keys := req.GetObjectKeys()
+	var bodies []*world.ObjectBody
+	var nextKeyIndex uint32
+	var worldSeqno uint64
+	startKeyIndex := req.GetStartKeyIndex()
+	if uint64(startKeyIndex) < uint64(len(keys)) {
+		bodies, nextKeyIndex, worldSeqno, retErr = getObjectBodiesBatchPage(
+			ctx,
+			r.ws,
+			keys,
+			startKeyIndex,
+			objectBodiesBatchBudget,
+		)
+		if retErr != nil {
+			return nil, retErr
+		}
+	}
+
+	out := make([]*s4wave_world.ObjectBody, len(bodies))
+	for i, body := range bodies {
+		if body.Exists {
+			record.ResultObjectCount++
+		}
+		out[i] = &s4wave_world.ObjectBody{
+			ObjectKey: body.ObjectKey,
+			Body:      body.Body,
+			Exists:    body.Exists,
+		}
+	}
+
+	return &s4wave_world.GetObjectBodiesBatchResponse{
+		Bodies:       out,
+		NextKeyIndex: nextKeyIndex,
+		WorldSeqno:   worldSeqno,
+	}, nil
+}
+
+// The reserve covers the SRPC envelope and transport framing around body
+// entries. The budget remains positive and the owner always returns one body.
+const objectBodiesBatchEnvelopeReserve = 64 * 1024
+
+const objectBodiesBatchBudget = block.MaxBlockSize - objectBodiesBatchEnvelopeReserve
+
+func getObjectBodiesBatchPage(
+	ctx context.Context,
+	ws world.WorldState,
+	keys []string,
+	startKeyIndex uint32,
+	bodyBudget int,
+) ([]*world.ObjectBody, uint32, uint64, error) {
+	if uint64(startKeyIndex) >= uint64(len(keys)) {
+		return nil, 0, 0, nil
+	}
+	start := int(startKeyIndex)
+	bodies, consumed, worldSeqno, err := world.GetObjectBodiesBatchPageWithSeqno(ctx, ws, keys[start:], bodyBudget)
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	if consumed == 0 || uint64(consumed) >= uint64(len(keys)-start) {
+		return bodies, 0, worldSeqno, nil
+	}
+	return bodies, startKeyIndex + consumed, worldSeqno, nil
+}
+
 // QueryGraphPath creates a resource for a bounded graph path query.
 func (r *WorldStateResource) QueryGraphPath(ctx context.Context, req *s4wave_world.QueryGraphPathRequest) (*s4wave_world.QueryGraphPathResponse, error) {
 	started := time.Now()

--- a/core/resource/world/world-state_paging_test.go
+++ b/core/resource/world/world-state_paging_test.go
@@ -1,0 +1,197 @@
+//go:build !js
+
+package resource_world
+
+import (
+	"context"
+	"testing"
+
+	"github.com/s4wave/spacewave/db/world"
+	s4wave_world "github.com/s4wave/spacewave/sdk/world"
+)
+
+type objectBodyPageWorld struct {
+	world.WorldState
+	bodies    []*world.ObjectBody
+	readSizes []int
+	pageSizes []int
+	seqnos    []uint64
+}
+
+func (w *objectBodyPageWorld) GetObjectBodiesBatchPage(
+	_ context.Context,
+	keys []string,
+	byteBudget int,
+) ([]*world.ObjectBody, uint32, error) {
+	byKey := make(map[string]*world.ObjectBody, len(w.bodies))
+	for _, body := range w.bodies {
+		byKey[body.ObjectKey] = body
+	}
+	page := make([]*world.ObjectBody, 0, len(keys))
+	readCount := 0
+	for i, key := range keys {
+		readCount++
+		body := byKey[key]
+		candidate := append(append([]*world.ObjectBody(nil), page...), body)
+		if len(page) > 0 && encodedBodyResponseSize(candidate) > byteBudget {
+			w.pageSizes = append(w.pageSizes, len(page))
+			w.readSizes = append(w.readSizes, readCount)
+			return page, uint32(i), nil
+		}
+		page = append(page, body)
+	}
+	w.pageSizes = append(w.pageSizes, len(page))
+	w.readSizes = append(w.readSizes, readCount)
+	return page, 0, nil
+}
+
+func (w *objectBodyPageWorld) GetObjectBodiesBatchPageWithSeqno(
+	ctx context.Context,
+	keys []string,
+	byteBudget int,
+) ([]*world.ObjectBody, uint32, uint64, error) {
+	bodies, next, err := w.GetObjectBodiesBatchPage(ctx, keys, byteBudget)
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	var seqno uint64
+	if page := len(w.readSizes) - 1; page >= 0 && page < len(w.seqnos) {
+		seqno = w.seqnos[page]
+	}
+	return bodies, next, seqno, nil
+}
+
+func encodedBodyResponseSize(bodies []*world.ObjectBody, nextKeyIndex ...uint32) int {
+	out := make([]*s4wave_world.ObjectBody, len(bodies))
+	for i, body := range bodies {
+		out[i] = &s4wave_world.ObjectBody{
+			ObjectKey: body.ObjectKey,
+			Body:      body.Body,
+			Exists:    body.Exists,
+		}
+	}
+	var next uint32
+	if len(nextKeyIndex) > 0 {
+		next = nextKeyIndex[0]
+	}
+	return (&s4wave_world.GetObjectBodiesBatchResponse{
+		Bodies:       out,
+		NextKeyIndex: next,
+	}).SizeVT()
+}
+
+func TestGetObjectBodiesBatchPageBudgetsEncodedResponseSize(t *testing.T) {
+	ctx := context.Background()
+	ws := &objectBodyPageWorld{}
+	keys := make([]string, 32)
+	for i := range keys {
+		keys[i] = "body/tiny"
+		ws.bodies = append(ws.bodies, &world.ObjectBody{
+			ObjectKey: keys[i],
+			Body:      []byte("x"),
+			Exists:    true,
+		})
+	}
+
+	page, next, _, err := getObjectBodiesBatchPage(ctx, ws, keys, 0, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if next == 0 {
+		t.Fatal("expected a continuation for many tiny bodies")
+	}
+	if len(page) < 2 {
+		t.Fatalf("page length = %d, want multiple tiny bodies", len(page))
+	}
+	if size := encodedBodyResponseSize(page, next); size > 100 {
+		t.Fatalf("encoded page size = %d, want <= 100", size)
+	}
+}
+
+func TestGetObjectBodiesBatchPageReadsOnlyOneBoundedPageAtATime(t *testing.T) {
+	ctx := context.Background()
+	ws := &objectBodyPageWorld{}
+	keys := make([]string, 32)
+	for i := range keys {
+		keys[i] = "body/" + string(rune('a'+i))
+		ws.bodies = append(ws.bodies, &world.ObjectBody{
+			ObjectKey: keys[i],
+			Body:      []byte("x"),
+			Exists:    true,
+		})
+	}
+
+	var all []*world.ObjectBody
+	for start := uint32(0); ; {
+		page, next, _, err := getObjectBodiesBatchPage(ctx, ws, keys, start, 100)
+		if err != nil {
+			t.Fatal(err)
+		}
+		all = append(all, page...)
+		if next == 0 {
+			break
+		}
+		start = next
+	}
+	if len(all) != len(keys) {
+		t.Fatalf("read %d bodies, want %d", len(all), len(keys))
+	}
+	if len(ws.readSizes) < 2 {
+		t.Fatalf("read sizes = %v, want multiple owner reads", ws.readSizes)
+	}
+	remaining := len(keys)
+	for i, read := range ws.readSizes {
+		if i < len(ws.readSizes)-1 && read >= remaining {
+			t.Fatalf("owner read %d read %d keys from suffix of %d", i, read, remaining)
+		}
+		remaining -= ws.pageSizes[i]
+		if remaining < 0 {
+			t.Fatalf("owner page sizes = %v exceed key count", ws.pageSizes)
+		}
+	}
+}
+
+func TestGetObjectBodiesBatchPageRejectsUint32IndexOverflow(t *testing.T) {
+	ctx := context.Background()
+	ws := &objectBodyPageWorld{
+		bodies: []*world.ObjectBody{{ObjectKey: "body/only", Body: []byte("x"), Exists: true}},
+	}
+	resource := &WorldStateResource{ws: ws}
+
+	resp, err := resource.GetObjectBodiesBatch(ctx, &s4wave_world.GetObjectBodiesBatchRequest{
+		ObjectKeys:    []string{"body/only"},
+		StartKeyIndex: ^uint32(0),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.GetBodies()) != 0 || resp.GetNextKeyIndex() != 0 {
+		t.Fatalf("out-of-range response = %+v, want empty terminal page", resp)
+	}
+	if len(ws.readSizes) != 0 {
+		t.Fatalf("out-of-range request performed reads: %v", ws.readSizes)
+	}
+}
+
+func TestGetObjectBodiesBatchCarriesWorldSeqno(t *testing.T) {
+	ws := &objectBodyPageWorld{
+		bodies: []*world.ObjectBody{
+			{ObjectKey: "body/one", Body: []byte("x"), Exists: true},
+		},
+		seqnos: []uint64{42},
+	}
+	resource := &WorldStateResource{ws: ws}
+
+	resp, err := resource.GetObjectBodiesBatch(context.Background(), &s4wave_world.GetObjectBodiesBatchRequest{
+		ObjectKeys: []string{"body/one"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.GetWorldSeqno() != 42 {
+		t.Fatalf("world seqno = %d, want 42", resp.GetWorldSeqno())
+	}
+}
+
+var _ world.ObjectBodyPageBatcher = (*objectBodyPageWorld)(nil)
+var _ world.ObjectBodyPageSeqnoBatcher = (*objectBodyPageWorld)(nil)

--- a/core/resource/world/world-state_test.go
+++ b/core/resource/world/world-state_test.go
@@ -15,6 +15,8 @@ import (
 	resource_server "github.com/s4wave/spacewave/bldr/resource/server"
 	resource_testbed "github.com/s4wave/spacewave/core/resource/testbed"
 	resource_world "github.com/s4wave/spacewave/core/resource/world"
+	"github.com/s4wave/spacewave/db/block"
+	block_mock "github.com/s4wave/spacewave/db/block/mock"
 	"github.com/s4wave/spacewave/db/block/quad"
 	"github.com/s4wave/spacewave/db/bucket"
 	"github.com/s4wave/spacewave/db/world"
@@ -420,6 +422,81 @@ func TestWorldStateResourceGetObjectRootRefsBatch(t *testing.T) {
 	}
 	if record.Duration <= 0 {
 		t.Fatalf("expected positive duration, got %s", record.Duration)
+	}
+}
+
+func TestWorldStateResourceGetObjectBodiesBatch(t *testing.T) {
+	ctx := context.Background()
+
+	tb, tbCleanup := setupWorldTestbed(ctx, t)
+	defer tbCleanup()
+
+	for _, entry := range []struct {
+		key string
+		msg string
+	}{
+		{key: "body/alpha", msg: "alpha"},
+		{key: "body/beta", msg: "beta"},
+		{key: "body/gamma", msg: "gamma"},
+	} {
+		_, _, err := world.CreateWorldObject(ctx, tb.WorldState, entry.key, func(bcs *block.Cursor) error {
+			bcs.SetBlock(block_mock.NewExample(entry.msg), true)
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var records []resource_world.WorldStateOperationRecord
+	resource := resource_world.NewWorldStateResource(nil, nil, tb.WorldState, nil, resource_world.WithWorldStateOperationObserver(func(record resource_world.WorldStateOperationRecord) {
+		records = append(records, record)
+	}))
+	resp, err := resource.GetObjectBodiesBatch(ctx, &s4wave_world.GetObjectBodiesBatchRequest{
+		ObjectKeys: []string{"body/gamma", "body/missing", "body/alpha", "body/alpha"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bodies := resp.GetBodies()
+	if len(bodies) != 4 {
+		t.Fatalf("expected 4 bodies, got %d", len(bodies))
+	}
+	checkBody := func(index int, key string, msg string, exists bool) {
+		t.Helper()
+		body := bodies[index]
+		if body.GetObjectKey() != key || body.GetExists() != exists {
+			t.Fatalf("body %d = key %q exists %v, want key %q exists %v", index, body.GetObjectKey(), body.GetExists(), key, exists)
+		}
+		if !exists {
+			if body.GetBody() != nil {
+				t.Fatalf("body %d has data for missing key", index)
+			}
+			return
+		}
+		decoded := block_mock.NewExample("")
+		if err := decoded.UnmarshalBlock(body.GetBody()); err != nil {
+			t.Fatalf("decode body %d: %v", index, err)
+		}
+		if decoded.GetMsg() != msg {
+			t.Fatalf("body %d message = %q, want %q", index, decoded.GetMsg(), msg)
+		}
+	}
+	checkBody(0, "body/gamma", "gamma", true)
+	checkBody(1, "body/missing", "", false)
+	checkBody(2, "body/alpha", "alpha", true)
+	checkBody(3, "body/alpha", "alpha", true)
+
+	if len(records) != 1 {
+		t.Fatalf("expected one operation record, got %d", len(records))
+	}
+	record := records[0]
+	if record.Name != "GetObjectBodiesBatch" {
+		t.Fatalf("record name = %q", record.Name)
+	}
+	if record.StartKeyCount != 4 || record.ResultObjectCount != 3 {
+		t.Fatalf("unexpected object counts: %+v", record)
 	}
 }
 

--- a/db/world/engine-state-object-body.go
+++ b/db/world/engine-state-object-body.go
@@ -1,0 +1,47 @@
+package world
+
+import "context"
+
+// GetObjectBodiesBatch returns object bodies from one read transaction.
+func (e *engineWorldState) GetObjectBodiesBatch(ctx context.Context, keys []string) ([]*ObjectBody, error) {
+	var bodies []*ObjectBody
+	err := e.performOp(ctx, false, func(tx Tx) error {
+		var berr error
+		bodies, berr = GetObjectBodiesBatch(ctx, tx, keys)
+		return berr
+	})
+	return bodies, err
+}
+
+// GetObjectBodiesBatchPage returns one encoded-size-bounded page from one read
+// transaction.
+func (e *engineWorldState) GetObjectBodiesBatchPage(
+	ctx context.Context,
+	keys []string,
+	byteBudget int,
+) ([]*ObjectBody, uint32, error) {
+	bodies, consumed, _, err := e.GetObjectBodiesBatchPageWithSeqno(ctx, keys, byteBudget)
+	return bodies, consumed, err
+}
+
+// GetObjectBodiesBatchPageWithSeqno returns one page and the sequence number
+// observed by the read transaction.
+func (e *engineWorldState) GetObjectBodiesBatchPageWithSeqno(
+	ctx context.Context,
+	keys []string,
+	byteBudget int,
+) ([]*ObjectBody, uint32, uint64, error) {
+	var bodies []*ObjectBody
+	var consumed uint32
+	var seqno uint64
+	err := e.performOp(ctx, false, func(tx Tx) error {
+		var berr error
+		seqno, berr = tx.GetSeqno(ctx)
+		if berr != nil {
+			return berr
+		}
+		bodies, consumed, berr = GetObjectBodiesBatchPage(ctx, tx, keys, byteBudget)
+		return berr
+	})
+	return bodies, consumed, seqno, err
+}

--- a/db/world/object-body.go
+++ b/db/world/object-body.go
@@ -1,0 +1,230 @@
+package world
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/s4wave/spacewave/db/block"
+)
+
+// ObjectBody contains the serialized root body for one object key.
+type ObjectBody struct {
+	// ObjectKey is the requested object key.
+	ObjectKey string
+	// Body is the transformed root block data when the object exists.
+	Body []byte
+	// Exists reports whether the object key exists.
+	Exists bool
+}
+
+// ObjectBodyBatcher returns serialized object bodies for object keys.
+type ObjectBodyBatcher interface {
+	// GetObjectBodiesBatch returns object bodies for object keys.
+	GetObjectBodiesBatch(ctx context.Context, keys []string) ([]*ObjectBody, error)
+}
+
+// ObjectBodyPageBatcher returns one budgeted page of serialized object bodies.
+type ObjectBodyPageBatcher interface {
+	// GetObjectBodiesBatchPage returns bodies and the number of keys consumed.
+	GetObjectBodiesBatchPage(ctx context.Context, keys []string, byteBudget int) ([]*ObjectBody, uint32, error)
+}
+
+// ObjectBodyPageSeqnoBatcher returns one budgeted page and its World sequence number.
+type ObjectBodyPageSeqnoBatcher interface {
+	// GetObjectBodiesBatchPageWithSeqno returns bodies, consumed keys, and the
+	// World sequence number observed by the read transaction.
+	GetObjectBodiesBatchPageWithSeqno(ctx context.Context, keys []string, byteBudget int) ([]*ObjectBody, uint32, uint64, error)
+}
+
+// ObjectBodyTooLargeError reports a body that cannot fit in one response page.
+type ObjectBodyTooLargeError struct {
+	// ObjectKey is the key whose encoded entry exceeds the page budget.
+	ObjectKey string
+	// EncodedSize is the serialized size of the object body response entry.
+	EncodedSize int
+	// ByteBudget is the maximum encoded size allowed for one page.
+	ByteBudget int
+}
+
+// Error returns the oversized object body details.
+func (e *ObjectBodyTooLargeError) Error() string {
+	return errors.Errorf(
+		"object body %q encoded size %d exceeds page budget %d",
+		e.ObjectKey,
+		e.EncodedSize,
+		e.ByteBudget,
+	).Error()
+}
+
+// GetObjectBodiesBatch returns serialized object bodies for object keys.
+// Results preserve the requested key order and include one missing marker per
+// key that does not exist.
+func GetObjectBodiesBatch(ctx context.Context, ws WorldState, keys []string) ([]*ObjectBody, error) {
+	if len(keys) == 0 {
+		return nil, nil
+	}
+	if batcher, ok := ws.(ObjectBodyBatcher); ok {
+		return batcher.GetObjectBodiesBatch(ctx, keys)
+	}
+
+	out := make([]*ObjectBody, len(keys))
+	for i, key := range keys {
+		body, exists, err := LookupObjectBodyBytes(ctx, ws, key)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = &ObjectBody{
+			ObjectKey: key,
+			Body:      body,
+			Exists:    exists,
+		}
+	}
+	return out, nil
+}
+
+// GetObjectBodiesBatchPage returns one encoded-size-bounded page of bodies.
+func GetObjectBodiesBatchPage(
+	ctx context.Context,
+	ws WorldState,
+	keys []string,
+	byteBudget int,
+) ([]*ObjectBody, uint32, error) {
+	if len(keys) == 0 {
+		return nil, 0, nil
+	}
+	if pager, ok := ws.(ObjectBodyPageBatcher); ok {
+		return pager.GetObjectBodiesBatchPage(ctx, keys, byteBudget)
+	}
+
+	return getObjectBodiesBatchPage(ctx, keys, byteBudget, func(ctx context.Context, key string) ([]byte, bool, error) {
+		return LookupObjectBodyBytes(ctx, ws, key)
+	})
+}
+
+func getObjectBodiesBatchPage(
+	ctx context.Context,
+	keys []string,
+	byteBudget int,
+	lookup func(context.Context, string) ([]byte, bool, error),
+) ([]*ObjectBody, uint32, error) {
+	out := make([]*ObjectBody, 0, len(keys))
+	encodedSize := 0
+	for i, key := range keys {
+		if len(out) > 0 && encodedSize >= byteBudget {
+			return out, uint32(i), nil
+		}
+		body, exists, err := lookup(ctx, key)
+		if err != nil {
+			return nil, 0, err
+		}
+		result := &ObjectBody{
+			ObjectKey: key,
+			Body:      body,
+			Exists:    exists,
+		}
+		resultSize := objectBodyEncodedSize(result)
+		if resultSize > byteBudget {
+			return nil, 0, &ObjectBodyTooLargeError{
+				ObjectKey:   key,
+				EncodedSize: resultSize,
+				ByteBudget:  byteBudget,
+			}
+		}
+		if len(out) > 0 && encodedSize+resultSize > byteBudget {
+			return out, uint32(i), nil
+		}
+		out = append(out, result)
+		encodedSize += resultSize
+	}
+	return out, 0, nil
+}
+
+// GetObjectBodiesBatchPageWithSeqno returns one page and its World sequence number.
+func GetObjectBodiesBatchPageWithSeqno(
+	ctx context.Context,
+	ws WorldState,
+	keys []string,
+	byteBudget int,
+) ([]*ObjectBody, uint32, uint64, error) {
+	if pager, ok := ws.(ObjectBodyPageSeqnoBatcher); ok {
+		return pager.GetObjectBodiesBatchPageWithSeqno(ctx, keys, byteBudget)
+	}
+	bodies, consumed, err := GetObjectBodiesBatchPage(ctx, ws, keys, byteBudget)
+	return bodies, consumed, 0, err
+}
+
+// objectBodyEncodedSize matches the generated protobuf size of one repeated
+// ObjectBody response entry, including its key, body, exists flag, and the
+// enclosing repeated-message tag and length.
+func objectBodyEncodedSize(body *ObjectBody) int {
+	if body == nil {
+		return 0
+	}
+	bodySize := 0
+	if len(body.ObjectKey) > 0 {
+		bodySize += 1 + protoVarintSize(len(body.ObjectKey)) + len(body.ObjectKey)
+	}
+	if len(body.Body) > 0 {
+		bodySize += 1 + protoVarintSize(len(body.Body)) + len(body.Body)
+	}
+	if body.Exists {
+		bodySize += 2
+	}
+	return 1 + protoVarintSize(bodySize) + bodySize
+}
+
+func protoVarintSize(value int) int {
+	size := 1
+	for value >= 128 {
+		value >>= 7
+		size++
+	}
+	return size
+}
+
+// ObjectBodyResult contains a typed body or a missing marker for one object
+// key.
+type ObjectBodyResult[T block.Block] struct {
+	// ObjectKey is the requested object key.
+	ObjectKey string
+	// Body is the decoded object body when the object exists.
+	Body T
+	// Exists reports whether the object key exists.
+	Exists bool
+}
+
+// LookupObjectBodies looks up and unmarshals object bodies for the given keys.
+// Results preserve the requested key order and include a zero Body with
+// Exists=false for missing objects.
+func LookupObjectBodies[T block.Block](
+	ctx context.Context,
+	ws WorldState,
+	objKeys []string,
+	ctor func() block.Block,
+) ([]*ObjectBodyResult[T], error) {
+	bodies, err := GetObjectBodiesBatch(ctx, ws, objKeys)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]*ObjectBodyResult[T], len(bodies))
+	for i, body := range bodies {
+		result := &ObjectBodyResult[T]{
+			ObjectKey: body.ObjectKey,
+			Exists:    body.Exists,
+		}
+		if body.Exists {
+			result.Body, err = decodeObjectBody[T](body.Body, ctor)
+			if err != nil {
+				return nil, err
+			}
+		}
+		results[i] = result
+	}
+	return results, nil
+}
+
+// _ is a type assertion.
+var _ ObjectBodyBatcher = ((*engineWorldState)(nil))
+var _ ObjectBodyPageBatcher = ((*engineWorldState)(nil))
+var _ ObjectBodyPageSeqnoBatcher = ((*engineWorldState)(nil))

--- a/db/world/object-body_test.go
+++ b/db/world/object-body_test.go
@@ -1,0 +1,32 @@
+package world
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestGetObjectBodiesBatchPageRejectsOversizedFirstBody(t *testing.T) {
+	const byteBudget = 100
+	key := "body/oversized"
+	body := make([]byte, byteBudget)
+
+	page, consumed, err := getObjectBodiesBatchPage(
+		context.Background(),
+		[]string{key},
+		byteBudget,
+		func(context.Context, string) ([]byte, bool, error) {
+			return body, true, nil
+		},
+	)
+	var tooLargeErr *ObjectBodyTooLargeError
+	if !errors.As(err, &tooLargeErr) {
+		t.Fatalf("error = %v, want ObjectBodyTooLargeError", err)
+	}
+	if tooLargeErr.ObjectKey != key {
+		t.Fatalf("oversized key = %q, want %q", tooLargeErr.ObjectKey, key)
+	}
+	if page != nil || consumed != 0 {
+		t.Fatalf("page = %v, consumed = %d, want no response page", page, consumed)
+	}
+}

--- a/db/world/util.go
+++ b/db/world/util.go
@@ -79,7 +79,6 @@ func LookupObject[T block.Block](
 		return out, nil, err
 	}
 	_, _, err = AccessObjectState(ctx, obj, false, func(bcs *block.Cursor) error {
-		var err error
 		out, err = block.UnmarshalBlock[T](ctx, bcs, ctor)
 		return err
 	})
@@ -118,6 +117,56 @@ func LookupObjectBody[T block.Block](
 	return out, err
 }
 
+// LookupObjectBodyBytes looks up the transformed root body for an object.
+// It returns nil, false, nil when the object does not exist.
+func LookupObjectBodyBytes(
+	ctx context.Context,
+	ws WorldState,
+	objKey string,
+) ([]byte, bool, error) {
+	obj, found, err := ws.GetObject(ctx, objKey)
+	if err != nil {
+		ReleaseObjectState(obj)
+		return nil, false, err
+	}
+	if !found {
+		return nil, false, nil
+	}
+	defer ReleaseObjectState(obj)
+
+	var body []byte
+	_, _, err = AccessObjectState(ctx, obj, false, func(bcs *block.Cursor) error {
+		var found bool
+		body, found, err = bcs.Fetch(ctx)
+		if err == nil && !found {
+			body = nil
+		}
+		return err
+	})
+	return body, true, err
+}
+
+func decodeObjectBody[T block.Block](data []byte, ctor func() block.Block) (out T, err error) {
+	if ctor == nil {
+		return out, nil
+	}
+	blk := ctor()
+	if blk == nil {
+		return out, nil
+	}
+	if data != nil {
+		if err := blk.UnmarshalBlock(data); err != nil {
+			return out, err
+		}
+	}
+	var ok bool
+	out, ok = blk.(T)
+	if !ok {
+		return out, block.ErrUnexpectedType
+	}
+	return out, nil
+}
+
 // LookupObjectRef looks up & unmarshals an object ref from the world.
 func LookupObjectRef[T block.Block](
 	ctx context.Context,
@@ -126,7 +175,6 @@ func LookupObjectRef[T block.Block](
 	ctor func() block.Block,
 ) (out T, err error) {
 	_, err = AccessObject(ctx, access, ref, func(bcs *block.Cursor) error {
-		var err error
 		out, err = block.UnmarshalBlock[T](ctx, bcs, ctor)
 		return err
 	})

--- a/db/world/world-state_test.go
+++ b/db/world/world-state_test.go
@@ -83,6 +83,71 @@ func TestLookupObjectBodyReleasesObjectState(t *testing.T) {
 		t.Fatalf("expected lookup to release object state once, got %d", wrapped.releases)
 	}
 }
+func TestLookupObjectBodiesPreservesKeysAndMissingMarkers(t *testing.T) {
+	ctx := context.Background()
+	wtb, err := world_testbed.Default(ctx, world_testbed.WithWorldVerbose(false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer wtb.Release()
+
+	ws := world.NewEngineWorldState(wtb.Engine, true)
+	for _, entry := range []struct {
+		key string
+		msg string
+	}{
+		{key: "example/batch-alpha", msg: "alpha"},
+		{key: "example/batch-beta", msg: "beta"},
+		{key: "example/batch-gamma", msg: "gamma"},
+	} {
+		_, _, err = world.CreateWorldObject(ctx, ws, entry.key, func(bcs *block.Cursor) error {
+			bcs.SetBlock(block_mock.NewExample(entry.msg), true)
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	results, err := world.LookupObjectBodies[*block_mock.Example](
+		ctx,
+		ws,
+		[]string{
+			"example/batch-gamma",
+			"example/batch-missing",
+			"example/batch-alpha",
+			"example/batch-alpha",
+		},
+		block_mock.NewExampleBlock,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 4 {
+		t.Fatalf("expected 4 results, got %d", len(results))
+	}
+
+	check := func(index int, key string, msg string, exists bool) {
+		t.Helper()
+		result := results[index]
+		if result.ObjectKey != key || result.Exists != exists {
+			t.Fatalf("result %d = key %q exists %v, want key %q exists %v", index, result.ObjectKey, result.Exists, key, exists)
+		}
+		if !exists {
+			if result.Body != nil {
+				t.Fatalf("result %d has body for missing key", index)
+			}
+			return
+		}
+		if result.Body == nil || result.Body.GetMsg() != msg {
+			t.Fatalf("result %d body = %v, want %q", index, result.Body, msg)
+		}
+	}
+	check(0, "example/batch-gamma", "gamma", true)
+	check(1, "example/batch-missing", "", false)
+	check(2, "example/batch-alpha", "alpha", true)
+	check(3, "example/batch-alpha", "alpha", true)
+}
 
 func TestAccessWorldObjectReleasesObjectState(t *testing.T) {
 	ctx := context.Background()

--- a/sdk/world/engine/world-state.go
+++ b/sdk/world/engine/world-state.go
@@ -3,6 +3,7 @@ package sdk_world_engine
 import (
 	"context"
 
+	"github.com/pkg/errors"
 	resource_client "github.com/s4wave/spacewave/bldr/resource/client"
 	"github.com/s4wave/spacewave/db/block/quad"
 	"github.com/s4wave/spacewave/db/bucket"
@@ -354,6 +355,63 @@ func (ws *SDKWorldState) GetObjectMetadataBatch(ctx context.Context, keys []stri
 		}
 	}
 	return metadata, nil
+}
+
+// GetObjectBodiesBatch returns serialized object bodies for object keys.
+func (ws *SDKWorldState) GetObjectBodiesBatch(ctx context.Context, keys []string) ([]*world.ObjectBody, error) {
+	const maxObjectBodiesBatchRevisionRetries = 3
+
+	for retry := 0; retry <= maxObjectBodiesBatchRevisionRetries; retry++ {
+		bodies := make([]*world.ObjectBody, 0, len(keys))
+		var worldSeqno uint64
+		var haveWorldSeqno bool
+		consistent := true
+		for startKeyIndex := uint32(0); ; {
+			resp, err := ws.service.GetObjectBodiesBatch(ctx, &s4wave_world.GetObjectBodiesBatchRequest{
+				ObjectKeys:    keys,
+				StartKeyIndex: startKeyIndex,
+			})
+			if err != nil {
+				return nil, err
+			}
+
+			pageSeqno := resp.GetWorldSeqno()
+			if !haveWorldSeqno {
+				worldSeqno = pageSeqno
+				haveWorldSeqno = true
+			} else if pageSeqno != worldSeqno {
+				consistent = false
+				if retry == maxObjectBodiesBatchRevisionRetries {
+					return nil, &s4wave_world.ObjectBodiesBatchRevisionError{
+						Expected: worldSeqno,
+						Got:      pageSeqno,
+						Retries:  retry,
+					}
+				}
+				break
+			}
+
+			for _, body := range resp.GetBodies() {
+				bodies = append(bodies, &world.ObjectBody{
+					ObjectKey: body.GetObjectKey(),
+					Body:      append([]byte(nil), body.GetBody()...),
+					Exists:    body.GetExists(),
+				})
+			}
+			nextKeyIndex := resp.GetNextKeyIndex()
+			if nextKeyIndex == 0 {
+				break
+			}
+			if nextKeyIndex <= startKeyIndex {
+				return nil, errors.Errorf("object bodies batch page did not advance: next key index %d after %d", nextKeyIndex, startKeyIndex)
+			}
+			startKeyIndex = nextKeyIndex
+		}
+		if consistent {
+			return bodies, nil
+		}
+	}
+	return nil, &s4wave_world.ObjectBodiesBatchRevisionError{}
 }
 
 // QueryGraphPath executes a bounded server-side graph path query.

--- a/sdk/world/engine/world-state_paging_test.go
+++ b/sdk/world/engine/world-state_paging_test.go
@@ -1,0 +1,88 @@
+package sdk_world_engine
+
+import (
+	"context"
+	"testing"
+
+	s4wave_world "github.com/s4wave/spacewave/sdk/world"
+)
+
+type objectBodiesBatchService struct {
+	s4wave_world.SRPCWorldStateResourceServiceClient
+	responses []*s4wave_world.GetObjectBodiesBatchResponse
+	requests  []*s4wave_world.GetObjectBodiesBatchRequest
+}
+
+func (s *objectBodiesBatchService) GetObjectBodiesBatch(_ context.Context, req *s4wave_world.GetObjectBodiesBatchRequest) (*s4wave_world.GetObjectBodiesBatchResponse, error) {
+	s.requests = append(s.requests, req)
+	return s.responses[len(s.requests)-1], nil
+}
+
+func TestSDKWorldStateGetObjectBodiesBatchPagesResults(t *testing.T) {
+	service := &objectBodiesBatchService{
+		responses: []*s4wave_world.GetObjectBodiesBatchResponse{
+			{
+				Bodies:       []*s4wave_world.ObjectBody{{ObjectKey: "body/large", Body: []byte("12345"), Exists: true}},
+				NextKeyIndex: 1,
+			},
+			{
+				Bodies: []*s4wave_world.ObjectBody{
+					{ObjectKey: "body/missing", Exists: false},
+					{ObjectKey: "body/large", Body: []byte("12345"), Exists: true},
+				},
+			},
+		},
+	}
+	ws := &SDKWorldState{service: service}
+	keys := []string{"body/large", "body/missing", "body/large"}
+
+	bodies, err := ws.GetObjectBodiesBatch(context.Background(), keys)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(service.requests) != 2 {
+		t.Fatalf("request count = %d, want 2", len(service.requests))
+	}
+	if service.requests[0].GetStartKeyIndex() != 0 || service.requests[1].GetStartKeyIndex() != 1 {
+		t.Fatalf("request start indexes = %d, %d, want 0, 1", service.requests[0].GetStartKeyIndex(), service.requests[1].GetStartKeyIndex())
+	}
+	if len(bodies) != len(keys) {
+		t.Fatalf("body count = %d, want %d", len(bodies), len(keys))
+	}
+	for i, want := range keys {
+		if bodies[i].ObjectKey != want {
+			t.Fatalf("body %d key = %q, want %q", i, bodies[i].ObjectKey, want)
+		}
+	}
+	if bodies[1].Exists || bodies[1].Body != nil {
+		t.Fatalf("missing body = %+v, want an empty missing marker", bodies[1])
+	}
+}
+
+func TestSDKWorldStateGetObjectBodiesBatchRestartsOnWorldSeqnoChange(t *testing.T) {
+	service := &objectBodiesBatchService{
+		responses: []*s4wave_world.GetObjectBodiesBatchResponse{
+			{Bodies: []*s4wave_world.ObjectBody{{ObjectKey: "body/one"}}, NextKeyIndex: 1, WorldSeqno: 1},
+			{Bodies: []*s4wave_world.ObjectBody{{ObjectKey: "body/two"}}, WorldSeqno: 2},
+			{Bodies: []*s4wave_world.ObjectBody{{ObjectKey: "body/one"}}, NextKeyIndex: 1, WorldSeqno: 2},
+			{Bodies: []*s4wave_world.ObjectBody{{ObjectKey: "body/two"}}, WorldSeqno: 2},
+		},
+	}
+	ws := &SDKWorldState{service: service}
+
+	bodies, err := ws.GetObjectBodiesBatch(context.Background(), []string{"body/one", "body/two"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(service.requests) != 4 {
+		t.Fatalf("request count = %d, want 4", len(service.requests))
+	}
+	for i, want := range []uint32{0, 1, 0, 1} {
+		if got := service.requests[i].GetStartKeyIndex(); got != want {
+			t.Fatalf("request %d start index = %d, want %d", i, got, want)
+		}
+	}
+	if len(bodies) != 2 || bodies[0].ObjectKey != "body/one" || bodies[1].ObjectKey != "body/two" {
+		t.Fatalf("bodies = %+v, want both consistent pages", bodies)
+	}
+}

--- a/sdk/world/errors.go
+++ b/sdk/world/errors.go
@@ -14,3 +14,24 @@ func ErrorFromCode(code WorldErrorCode) error {
 		return nil
 	}
 }
+
+// ObjectBodiesBatchRevisionError reports that paginated reads crossed World
+// sequence numbers too many times to form one consistent result.
+type ObjectBodiesBatchRevisionError struct {
+	// Expected is the sequence number recorded from the first page.
+	Expected uint64
+	// Got is the sequence number observed on the mismatching page.
+	Got uint64
+	// Retries is the number of pagination restarts attempted.
+	Retries int
+}
+
+// Error returns the inconsistent World sequence details.
+func (e *ObjectBodiesBatchRevisionError) Error() string {
+	return errors.Errorf(
+		"object bodies batch World sequence changed from %d to %d after %d retries",
+		e.Expected,
+		e.Got,
+		e.Retries,
+	).Error()
+}

--- a/sdk/world/world-state.go
+++ b/sdk/world/world-state.go
@@ -3,6 +3,7 @@ package s4wave_world
 import (
 	"context"
 
+	"github.com/pkg/errors"
 	resource_client "github.com/s4wave/spacewave/bldr/resource/client"
 	"github.com/s4wave/spacewave/db/block/quad"
 	"github.com/s4wave/spacewave/db/bucket"
@@ -352,6 +353,63 @@ func (ws *WorldState) GetObjectMetadataBatch(ctx context.Context, keys []string)
 		}
 	}
 	return metadata, nil
+}
+
+// GetObjectBodiesBatch returns serialized object bodies for object keys.
+func (ws *WorldState) GetObjectBodiesBatch(ctx context.Context, keys []string) ([]*world.ObjectBody, error) {
+	const maxObjectBodiesBatchRevisionRetries = 3
+
+	for retry := 0; retry <= maxObjectBodiesBatchRevisionRetries; retry++ {
+		bodies := make([]*world.ObjectBody, 0, len(keys))
+		var worldSeqno uint64
+		var haveWorldSeqno bool
+		consistent := true
+		for startKeyIndex := uint32(0); ; {
+			resp, err := ws.service.GetObjectBodiesBatch(ctx, &GetObjectBodiesBatchRequest{
+				ObjectKeys:    keys,
+				StartKeyIndex: startKeyIndex,
+			})
+			if err != nil {
+				return nil, err
+			}
+
+			pageSeqno := resp.GetWorldSeqno()
+			if !haveWorldSeqno {
+				worldSeqno = pageSeqno
+				haveWorldSeqno = true
+			} else if pageSeqno != worldSeqno {
+				consistent = false
+				if retry == maxObjectBodiesBatchRevisionRetries {
+					return nil, &ObjectBodiesBatchRevisionError{
+						Expected: worldSeqno,
+						Got:      pageSeqno,
+						Retries:  retry,
+					}
+				}
+				break
+			}
+
+			for _, body := range resp.GetBodies() {
+				bodies = append(bodies, &world.ObjectBody{
+					ObjectKey: body.GetObjectKey(),
+					Body:      append([]byte(nil), body.GetBody()...),
+					Exists:    body.GetExists(),
+				})
+			}
+			nextKeyIndex := resp.GetNextKeyIndex()
+			if nextKeyIndex == 0 {
+				break
+			}
+			if nextKeyIndex <= startKeyIndex {
+				return nil, errors.Errorf("object bodies batch page did not advance: next key index %d after %d", nextKeyIndex, startKeyIndex)
+			}
+			startKeyIndex = nextKeyIndex
+		}
+		if consistent {
+			return bodies, nil
+		}
+	}
+	return nil, &ObjectBodiesBatchRevisionError{}
 }
 
 // QueryGraphPath executes a bounded server-side graph path query.

--- a/sdk/world/world-state_paging_test.go
+++ b/sdk/world/world-state_paging_test.go
@@ -1,0 +1,112 @@
+package s4wave_world
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type objectBodiesBatchService struct {
+	SRPCWorldStateResourceServiceClient
+	responses []*GetObjectBodiesBatchResponse
+	requests  []*GetObjectBodiesBatchRequest
+}
+
+func (s *objectBodiesBatchService) GetObjectBodiesBatch(_ context.Context, req *GetObjectBodiesBatchRequest) (*GetObjectBodiesBatchResponse, error) {
+	s.requests = append(s.requests, req)
+	return s.responses[len(s.requests)-1], nil
+}
+
+func TestWorldStateGetObjectBodiesBatchPagesResults(t *testing.T) {
+	service := &objectBodiesBatchService{
+		responses: []*GetObjectBodiesBatchResponse{
+			{
+				Bodies:       []*ObjectBody{{ObjectKey: "body/large", Body: []byte("12345"), Exists: true}},
+				NextKeyIndex: 1,
+			},
+			{
+				Bodies: []*ObjectBody{
+					{ObjectKey: "body/missing", Exists: false},
+					{ObjectKey: "body/large", Body: []byte("12345"), Exists: true},
+				},
+			},
+		},
+	}
+	ws := &WorldState{service: service}
+	keys := []string{"body/large", "body/missing", "body/large"}
+
+	bodies, err := ws.GetObjectBodiesBatch(context.Background(), keys)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(service.requests) != 2 {
+		t.Fatalf("request count = %d, want 2", len(service.requests))
+	}
+	if service.requests[0].GetStartKeyIndex() != 0 || service.requests[1].GetStartKeyIndex() != 1 {
+		t.Fatalf("request start indexes = %d, %d, want 0, 1", service.requests[0].GetStartKeyIndex(), service.requests[1].GetStartKeyIndex())
+	}
+	if len(bodies) != len(keys) {
+		t.Fatalf("body count = %d, want %d", len(bodies), len(keys))
+	}
+	for i, want := range keys {
+		if bodies[i].ObjectKey != want {
+			t.Fatalf("body %d key = %q, want %q", i, bodies[i].ObjectKey, want)
+		}
+	}
+	if bodies[1].Exists || bodies[1].Body != nil {
+		t.Fatalf("missing body = %+v, want an empty missing marker", bodies[1])
+	}
+}
+
+func TestWorldStateGetObjectBodiesBatchRestartsOnWorldSeqnoChange(t *testing.T) {
+	service := &objectBodiesBatchService{
+		responses: []*GetObjectBodiesBatchResponse{
+			{Bodies: []*ObjectBody{{ObjectKey: "body/one"}}, NextKeyIndex: 1, WorldSeqno: 1},
+			{Bodies: []*ObjectBody{{ObjectKey: "body/two"}}, WorldSeqno: 2},
+			{Bodies: []*ObjectBody{{ObjectKey: "body/one"}}, NextKeyIndex: 1, WorldSeqno: 2},
+			{Bodies: []*ObjectBody{{ObjectKey: "body/two"}}, WorldSeqno: 2},
+		},
+	}
+	ws := &WorldState{service: service}
+
+	bodies, err := ws.GetObjectBodiesBatch(context.Background(), []string{"body/one", "body/two"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(service.requests) != 4 {
+		t.Fatalf("request count = %d, want 4", len(service.requests))
+	}
+	for i, want := range []uint32{0, 1, 0, 1} {
+		if got := service.requests[i].GetStartKeyIndex(); got != want {
+			t.Fatalf("request %d start index = %d, want %d", i, got, want)
+		}
+	}
+	if len(bodies) != 2 || bodies[0].ObjectKey != "body/one" || bodies[1].ObjectKey != "body/two" {
+		t.Fatalf("bodies = %+v, want both consistent pages", bodies)
+	}
+}
+
+func TestWorldStateGetObjectBodiesBatchReturnsTypedRevisionError(t *testing.T) {
+	service := &objectBodiesBatchService{
+		responses: []*GetObjectBodiesBatchResponse{
+			{Bodies: []*ObjectBody{{ObjectKey: "body/one"}}, NextKeyIndex: 1, WorldSeqno: 1},
+			{Bodies: []*ObjectBody{{ObjectKey: "body/two"}}, NextKeyIndex: 1, WorldSeqno: 2},
+			{Bodies: []*ObjectBody{{ObjectKey: "body/one"}}, NextKeyIndex: 1, WorldSeqno: 3},
+			{Bodies: []*ObjectBody{{ObjectKey: "body/two"}}, NextKeyIndex: 1, WorldSeqno: 4},
+			{Bodies: []*ObjectBody{{ObjectKey: "body/one"}}, NextKeyIndex: 1, WorldSeqno: 5},
+			{Bodies: []*ObjectBody{{ObjectKey: "body/two"}}, NextKeyIndex: 1, WorldSeqno: 6},
+			{Bodies: []*ObjectBody{{ObjectKey: "body/one"}}, NextKeyIndex: 1, WorldSeqno: 7},
+			{Bodies: []*ObjectBody{{ObjectKey: "body/two"}}, WorldSeqno: 8},
+		},
+	}
+	ws := &WorldState{service: service}
+
+	_, err := ws.GetObjectBodiesBatch(context.Background(), []string{"body/one", "body/two"})
+	var revisionErr *ObjectBodiesBatchRevisionError
+	if !errors.As(err, &revisionErr) {
+		t.Fatalf("error = %v, want ObjectBodiesBatchRevisionError", err)
+	}
+	if revisionErr.Retries != 3 {
+		t.Fatalf("retries = %d, want 3", revisionErr.Retries)
+	}
+}

--- a/sdk/world/world.pb.cc
+++ b/sdk/world/world.pb.cc
@@ -510,6 +510,37 @@ struct ObjectMetadataDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 ObjectMetadataDefaultTypeInternal _ObjectMetadata_default_instance_;
 
+inline constexpr ObjectBody::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : _cached_size_{0},
+        object_key_(
+            &::google::protobuf::internal::fixed_address_empty_string,
+            ::_pbi::ConstantInitialized()),
+        body_(
+            &::google::protobuf::internal::fixed_address_empty_string,
+            ::_pbi::ConstantInitialized()),
+        exists_{false} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR ObjectBody::ObjectBody(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(ObjectBody_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct ObjectBodyDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR ObjectBodyDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~ObjectBodyDefaultTypeInternal() {}
+  union {
+    ObjectBody _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 ObjectBodyDefaultTypeInternal _ObjectBody_default_instance_;
+
 inline constexpr NextResponse::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
       : _cached_size_{0},
@@ -1101,6 +1132,32 @@ struct GetObjectMetadataBatchRequestDefaultTypeInternal {
 
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 GetObjectMetadataBatchRequestDefaultTypeInternal _GetObjectMetadataBatchRequest_default_instance_;
+
+inline constexpr GetObjectBodiesBatchRequest::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : _cached_size_{0},
+        object_keys_{},
+        start_key_index_{0u} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR GetObjectBodiesBatchRequest::GetObjectBodiesBatchRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(GetObjectBodiesBatchRequest_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct GetObjectBodiesBatchRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR GetObjectBodiesBatchRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~GetObjectBodiesBatchRequestDefaultTypeInternal() {}
+  union {
+    GetObjectBodiesBatchRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 GetObjectBodiesBatchRequestDefaultTypeInternal _GetObjectBodiesBatchRequest_default_instance_;
 
 inline constexpr GetKeyResponse::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
@@ -2036,6 +2093,33 @@ struct GetObjectMetadataBatchResponseDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 GetObjectMetadataBatchResponseDefaultTypeInternal _GetObjectMetadataBatchResponse_default_instance_;
 
+inline constexpr GetObjectBodiesBatchResponse::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : _cached_size_{0},
+        bodies_{},
+        world_seqno_{::uint64_t{0u}},
+        next_key_index_{0u} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR GetObjectBodiesBatchResponse::GetObjectBodiesBatchResponse(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(GetObjectBodiesBatchResponse_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct GetObjectBodiesBatchResponseDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR GetObjectBodiesBatchResponseDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~GetObjectBodiesBatchResponseDefaultTypeInternal() {}
+  union {
+    GetObjectBodiesBatchResponse _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 GetObjectBodiesBatchResponseDefaultTypeInternal _GetObjectBodiesBatchResponse_default_instance_;
+
 inline constexpr GetEngineInfoResponse::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
       : _cached_size_{0},
@@ -2606,6 +2690,31 @@ const ::uint32_t
         PROTOBUF_FIELD_OFFSET(::s4wave::world::GetObjectMetadataBatchResponse, _impl_.metadata_),
         0,
         0x081, // bitmap
+        PROTOBUF_FIELD_OFFSET(::s4wave::world::ObjectBody, _impl_._has_bits_),
+        6, // hasbit index offset
+        PROTOBUF_FIELD_OFFSET(::s4wave::world::ObjectBody, _impl_.object_key_),
+        PROTOBUF_FIELD_OFFSET(::s4wave::world::ObjectBody, _impl_.body_),
+        PROTOBUF_FIELD_OFFSET(::s4wave::world::ObjectBody, _impl_.exists_),
+        0,
+        1,
+        2,
+        0x081, // bitmap
+        PROTOBUF_FIELD_OFFSET(::s4wave::world::GetObjectBodiesBatchRequest, _impl_._has_bits_),
+        5, // hasbit index offset
+        PROTOBUF_FIELD_OFFSET(::s4wave::world::GetObjectBodiesBatchRequest, _impl_.object_keys_),
+        PROTOBUF_FIELD_OFFSET(::s4wave::world::GetObjectBodiesBatchRequest, _impl_.start_key_index_),
+        0,
+        1,
+        0x081, // bitmap
+        PROTOBUF_FIELD_OFFSET(::s4wave::world::GetObjectBodiesBatchResponse, _impl_._has_bits_),
+        6, // hasbit index offset
+        PROTOBUF_FIELD_OFFSET(::s4wave::world::GetObjectBodiesBatchResponse, _impl_.bodies_),
+        PROTOBUF_FIELD_OFFSET(::s4wave::world::GetObjectBodiesBatchResponse, _impl_.next_key_index_),
+        PROTOBUF_FIELD_OFFSET(::s4wave::world::GetObjectBodiesBatchResponse, _impl_.world_seqno_),
+        0,
+        2,
+        1,
+        0x081, // bitmap
         PROTOBUF_FIELD_OFFSET(::s4wave::world::GraphPathStep, _impl_._has_bits_),
         6, // hasbit index offset
         PROTOBUF_FIELD_OFFSET(::s4wave::world::GraphPathStep, _impl_.direction_),
@@ -2852,47 +2961,50 @@ static const ::_pbi::MigrationSchema
         {253, sizeof(::s4wave::world::ObjectMetadata)},
         {262, sizeof(::s4wave::world::GetObjectMetadataBatchRequest)},
         {267, sizeof(::s4wave::world::GetObjectMetadataBatchResponse)},
-        {272, sizeof(::s4wave::world::GraphPathStep)},
-        {281, sizeof(::s4wave::world::QueryGraphPathRequest)},
-        {294, sizeof(::s4wave::world::QueryGraphPathResponse)},
-        {299, sizeof(::s4wave::world::DeleteGraphObjectRequest)},
-        {304, sizeof(::s4wave::world::DeleteGraphObjectResponse)},
-        {305, sizeof(::s4wave::world::ApplyWorldOpRequest)},
-        {314, sizeof(::s4wave::world::ApplyWorldOpResponse)},
-        {323, sizeof(::s4wave::world::WatchWorldStateRequest)},
-        {324, sizeof(::s4wave::world::WatchWorldStateResponse)},
-        {329, sizeof(::s4wave::world::TrackedWorldStateSnapshot_ObjectAccess)},
-        {336, sizeof(::s4wave::world::TrackedWorldStateSnapshot)},
-        {345, sizeof(::s4wave::world::ErrRequest)},
-        {346, sizeof(::s4wave::world::ErrResponse)},
-        {351, sizeof(::s4wave::world::ValidRequest)},
-        {352, sizeof(::s4wave::world::ValidResponse)},
-        {357, sizeof(::s4wave::world::KeyRequest)},
-        {358, sizeof(::s4wave::world::KeyResponse)},
-        {363, sizeof(::s4wave::world::NextRequest)},
-        {364, sizeof(::s4wave::world::NextResponse)},
-        {369, sizeof(::s4wave::world::SeekRequest)},
-        {374, sizeof(::s4wave::world::SeekResponse)},
-        {375, sizeof(::s4wave::world::CloseRequest)},
-        {376, sizeof(::s4wave::world::CloseResponse)},
-        {377, sizeof(::s4wave::world::NextGraphPathQueryRequest)},
-        {378, sizeof(::s4wave::world::NextGraphPathQueryResponse)},
-        {387, sizeof(::s4wave::world::CloseGraphPathQueryRequest)},
-        {388, sizeof(::s4wave::world::CloseGraphPathQueryResponse)},
-        {389, sizeof(::s4wave::world::GetKeyRequest)},
-        {390, sizeof(::s4wave::world::GetKeyResponse)},
-        {395, sizeof(::s4wave::world::GetRootRefRequest)},
-        {396, sizeof(::s4wave::world::GetRootRefResponse)},
-        {403, sizeof(::s4wave::world::SetRootRefRequest)},
-        {408, sizeof(::s4wave::world::SetRootRefResponse)},
-        {413, sizeof(::s4wave::world::ApplyObjectOpRequest)},
-        {422, sizeof(::s4wave::world::ApplyObjectOpResponse)},
-        {431, sizeof(::s4wave::world::IncrementRevRequest)},
-        {432, sizeof(::s4wave::world::IncrementRevResponse)},
-        {437, sizeof(::s4wave::world::WaitRevRequest)},
-        {444, sizeof(::s4wave::world::WaitRevResponse)},
-        {449, sizeof(::s4wave::world::AccessTypedObjectRequest)},
-        {454, sizeof(::s4wave::world::AccessTypedObjectResponse)},
+        {272, sizeof(::s4wave::world::ObjectBody)},
+        {281, sizeof(::s4wave::world::GetObjectBodiesBatchRequest)},
+        {288, sizeof(::s4wave::world::GetObjectBodiesBatchResponse)},
+        {297, sizeof(::s4wave::world::GraphPathStep)},
+        {306, sizeof(::s4wave::world::QueryGraphPathRequest)},
+        {319, sizeof(::s4wave::world::QueryGraphPathResponse)},
+        {324, sizeof(::s4wave::world::DeleteGraphObjectRequest)},
+        {329, sizeof(::s4wave::world::DeleteGraphObjectResponse)},
+        {330, sizeof(::s4wave::world::ApplyWorldOpRequest)},
+        {339, sizeof(::s4wave::world::ApplyWorldOpResponse)},
+        {348, sizeof(::s4wave::world::WatchWorldStateRequest)},
+        {349, sizeof(::s4wave::world::WatchWorldStateResponse)},
+        {354, sizeof(::s4wave::world::TrackedWorldStateSnapshot_ObjectAccess)},
+        {361, sizeof(::s4wave::world::TrackedWorldStateSnapshot)},
+        {370, sizeof(::s4wave::world::ErrRequest)},
+        {371, sizeof(::s4wave::world::ErrResponse)},
+        {376, sizeof(::s4wave::world::ValidRequest)},
+        {377, sizeof(::s4wave::world::ValidResponse)},
+        {382, sizeof(::s4wave::world::KeyRequest)},
+        {383, sizeof(::s4wave::world::KeyResponse)},
+        {388, sizeof(::s4wave::world::NextRequest)},
+        {389, sizeof(::s4wave::world::NextResponse)},
+        {394, sizeof(::s4wave::world::SeekRequest)},
+        {399, sizeof(::s4wave::world::SeekResponse)},
+        {400, sizeof(::s4wave::world::CloseRequest)},
+        {401, sizeof(::s4wave::world::CloseResponse)},
+        {402, sizeof(::s4wave::world::NextGraphPathQueryRequest)},
+        {403, sizeof(::s4wave::world::NextGraphPathQueryResponse)},
+        {412, sizeof(::s4wave::world::CloseGraphPathQueryRequest)},
+        {413, sizeof(::s4wave::world::CloseGraphPathQueryResponse)},
+        {414, sizeof(::s4wave::world::GetKeyRequest)},
+        {415, sizeof(::s4wave::world::GetKeyResponse)},
+        {420, sizeof(::s4wave::world::GetRootRefRequest)},
+        {421, sizeof(::s4wave::world::GetRootRefResponse)},
+        {428, sizeof(::s4wave::world::SetRootRefRequest)},
+        {433, sizeof(::s4wave::world::SetRootRefResponse)},
+        {438, sizeof(::s4wave::world::ApplyObjectOpRequest)},
+        {447, sizeof(::s4wave::world::ApplyObjectOpResponse)},
+        {456, sizeof(::s4wave::world::IncrementRevRequest)},
+        {457, sizeof(::s4wave::world::IncrementRevResponse)},
+        {462, sizeof(::s4wave::world::WaitRevRequest)},
+        {469, sizeof(::s4wave::world::WaitRevResponse)},
+        {474, sizeof(::s4wave::world::AccessTypedObjectRequest)},
+        {479, sizeof(::s4wave::world::AccessTypedObjectResponse)},
 };
 static const ::_pb::Message* PROTOBUF_NONNULL const file_default_instances[] = {
     &::s4wave::world::_SyncRequest_default_instance_._instance,
@@ -2949,6 +3061,9 @@ static const ::_pb::Message* PROTOBUF_NONNULL const file_default_instances[] = {
     &::s4wave::world::_ObjectMetadata_default_instance_._instance,
     &::s4wave::world::_GetObjectMetadataBatchRequest_default_instance_._instance,
     &::s4wave::world::_GetObjectMetadataBatchResponse_default_instance_._instance,
+    &::s4wave::world::_ObjectBody_default_instance_._instance,
+    &::s4wave::world::_GetObjectBodiesBatchRequest_default_instance_._instance,
+    &::s4wave::world::_GetObjectBodiesBatchResponse_default_instance_._instance,
     &::s4wave::world::_GraphPathStep_default_instance_._instance,
     &::s4wave::world::_QueryGraphPathRequest_default_instance_._instance,
     &::s4wave::world::_QueryGraphPathResponse_default_instance_._instance,
@@ -3073,182 +3188,192 @@ const char descriptor_table_protodef_github_2ecom_2fs4wave_2fspacewave_2fsdk_2fw
     "\003 \001(\t\"4\n\035GetObjectMetadataBatchRequest\022\023"
     "\n\013object_keys\030\001 \003(\t\"P\n\036GetObjectMetadata"
     "BatchResponse\022.\n\010metadata\030\001 \003(\0132\034.s4wave"
-    ".world.ObjectMetadata\"f\n\rGraphPathStep\0223"
-    "\n\tdirection\030\001 \001(\0162 .s4wave.world.GraphPa"
-    "thDirection\022\021\n\tpredicate\030\002 \001(\t\022\r\n\005limit\030"
-    "\003 \001(\r\"\227\001\n\025QueryGraphPathRequest\022\022\n\nstart"
-    "_keys\030\001 \003(\t\022*\n\005steps\030\002 \003(\0132\033.s4wave.worl"
-    "d.GraphPathStep\022\024\n\014result_limit\030\003 \001(\r\022\025\n"
-    "\rinclude_quads\030\004 \001(\010\022\021\n\tpage_size\030\005 \001(\r\""
-    "-\n\026QueryGraphPathResponse\022\023\n\013resource_id"
-    "\030\001 \001(\r\".\n\030DeleteGraphObjectRequest\022\022\n\nob"
-    "ject_key\030\001 \001(\t\"\033\n\031DeleteGraphObjectRespo"
-    "nse\"M\n\023ApplyWorldOpRequest\022\022\n\nop_type_id"
-    "\030\001 \001(\t\022\017\n\007op_data\030\002 \001(\014\022\021\n\top_sender\030\003 \001"
-    "(\t\"h\n\024ApplyWorldOpResponse\022\r\n\005seqno\030\001 \001("
-    "\004\022\017\n\007sys_err\030\002 \001(\010\0220\n\nerror_code\030\003 \001(\0162\034"
-    ".s4wave.world.WorldErrorCode\"\030\n\026WatchWor"
-    "ldStateRequest\".\n\027WatchWorldStateRespons"
-    "e\022\023\n\013resource_id\030\001 \001(\r\"\304\001\n\031TrackedWorldS"
-    "tateSnapshot\022M\n\017object_accesses\030\001 \003(\01324."
-    "s4wave.world.TrackedWorldStateSnapshot.O"
-    "bjectAccess\022\027\n\017has_quad_access\030\002 \001(\010\022\025\n\r"
-    "initial_seqno\030\003 \001(\004\032(\n\014ObjectAccess\022\013\n\003k"
-    "ey\030\001 \001(\t\022\013\n\003rev\030\002 \001(\004\"\014\n\nErrRequest\"\034\n\013E"
-    "rrResponse\022\r\n\005error\030\001 \001(\t\"\016\n\014ValidReques"
-    "t\"\036\n\rValidResponse\022\r\n\005valid\030\001 \001(\010\"\014\n\nKey"
-    "Request\"!\n\013KeyResponse\022\022\n\nobject_key\030\001 \001"
-    "(\t\"\r\n\013NextRequest\"\035\n\014NextResponse\022\r\n\005val"
-    "id\030\001 \001(\010\"!\n\013SeekRequest\022\022\n\nobject_key\030\001 "
-    "\001(\t\"\016\n\014SeekResponse\"\016\n\014CloseRequest\"\017\n\rC"
-    "loseResponse\"\033\n\031NextGraphPathQueryReques"
-    "t\"Z\n\032NextGraphPathQueryResponse\022\023\n\013objec"
-    "t_keys\030\001 \003(\t\022\031\n\005quads\030\002 \003(\0132\n.quad.Quad\022"
-    "\014\n\004done\030\003 \001(\010\"\034\n\032CloseGraphPathQueryRequ"
-    "est\"\035\n\033CloseGraphPathQueryResponse\"\017\n\rGe"
-    "tKeyRequest\"$\n\016GetKeyResponse\022\022\n\nobject_"
-    "key\030\001 \001(\t\"\023\n\021GetRootRefRequest\"F\n\022GetRoo"
-    "tRefResponse\022#\n\010root_ref\030\001 \001(\0132\021.bucket."
-    "ObjectRef\022\013\n\003rev\030\002 \001(\004\"8\n\021SetRootRefRequ"
-    "est\022#\n\010root_ref\030\001 \001(\0132\021.bucket.ObjectRef"
-    "\"!\n\022SetRootRefResponse\022\013\n\003rev\030\001 \001(\004\"N\n\024A"
-    "pplyObjectOpRequest\022\022\n\nop_type_id\030\001 \001(\t\022"
-    "\017\n\007op_data\030\002 \001(\014\022\021\n\top_sender\030\003 \001(\t\"g\n\025A"
-    "pplyObjectOpResponse\022\013\n\003rev\030\001 \001(\004\022\017\n\007sys"
-    "_err\030\002 \001(\010\0220\n\nerror_code\030\003 \001(\0162\034.s4wave."
-    "world.WorldErrorCode\"\025\n\023IncrementRevRequ"
-    "est\"#\n\024IncrementRevResponse\022\013\n\003rev\030\001 \001(\004"
-    "\"7\n\016WaitRevRequest\022\013\n\003rev\030\001 \001(\004\022\030\n\020ignor"
-    "e_not_found\030\002 \001(\010\"\036\n\017WaitRevResponse\022\013\n\003"
-    "rev\030\001 \001(\004\".\n\030AccessTypedObjectRequest\022\022\n"
-    "\nobject_key\030\001 \001(\t\"A\n\031AccessTypedObjectRe"
-    "sponse\022\023\n\013resource_id\030\001 \001(\r\022\017\n\007type_id\030\002"
-    " \001(\t*\266\001\n\030GraphEdgeBucketDirection\022+\n\'GRA"
-    "PH_EDGE_BUCKET_DIRECTION_UNSPECIFIED\020\000\022#"
-    "\n\037GRAPH_EDGE_BUCKET_DIRECTION_OUT\020\001\022\"\n\036G"
-    "RAPH_EDGE_BUCKET_DIRECTION_IN\020\002\022$\n GRAPH"
-    "_EDGE_BUCKET_DIRECTION_BOTH\020\003*\224\001\n\022GraphP"
-    "athDirection\022$\n GRAPH_PATH_DIRECTION_UNS"
-    "PECIFIED\020\000\022\034\n\030GRAPH_PATH_DIRECTION_OUT\020\001"
-    "\022\033\n\027GRAPH_PATH_DIRECTION_IN\020\002\022\035\n\031GRAPH_P"
-    "ATH_DIRECTION_BOTH\020\003*U\n\016WorldErrorCode\022 "
-    "\n\034WORLD_ERROR_CODE_UNSPECIFIED\020\000\022!\n\035WORL"
-    "D_ERROR_CODE_UNHANDLED_OP\020\0012\302\006\n\025EngineRe"
-    "sourceService\022X\n\rGetEngineInfo\022\".s4wave."
-    "world.GetEngineInfoRequest\032#.s4wave.worl"
-    "d.GetEngineInfoResponse\022b\n\024GetWorldRootS"
-    "napshot\022).s4wave.world.GetWorldRootSnaps"
-    "hotRequest\032\037.s4wave.world.WorldRootSnaps"
-    "hot\022j\n\027WatchWorldRootSnapshots\022,.s4wave."
-    "world.WatchWorldRootSnapshotsRequest\032\037.s"
-    "4wave.world.WorldRootSnapshot0\001\022[\n\016NewTr"
-    "ansaction\022#.s4wave.world.NewTransactionR"
-    "equest\032$.s4wave.world.NewTransactionResp"
-    "onse\022=\n\004Sync\022\031.s4wave.world.SyncRequest\032"
-    "\032.s4wave.world.SyncResponse\022I\n\010GetSeqno\022"
-    "\035.s4wave.world.GetSeqnoRequest\032\036.s4wave."
-    "world.GetSeqnoResponse\022L\n\tWaitSeqno\022\036.s4"
-    "wave.world.WaitSeqnoRequest\032\037.s4wave.wor"
-    "ld.WaitSeqnoResponse\022g\n\022BuildStorageCurs"
-    "or\022\'.s4wave.world.BuildStorageCursorRequ"
-    "est\032(.s4wave.world.BuildStorageCursorRes"
-    "ponse\022a\n\020AccessWorldState\022%.s4wave.world"
-    ".AccessWorldStateRequest\032&.s4wave.world."
-    "AccessWorldStateResponse2\256\020\n\031WorldStateR"
-    "esourceService\022R\n\013GetReadOnly\022 .s4wave.w"
-    "orld.GetReadOnlyRequest\032!.s4wave.world.G"
-    "etReadOnlyResponse\022=\n\004Sync\022\031.s4wave.worl"
-    "d.SyncRequest\032\032.s4wave.world.SyncRespons"
-    "e\022I\n\010GetSeqno\022\035.s4wave.world.GetSeqnoReq"
-    "uest\032\036.s4wave.world.GetSeqnoResponse\022L\n\t"
-    "WaitSeqno\022\036.s4wave.world.WaitSeqnoReques"
-    "t\032\037.s4wave.world.WaitSeqnoResponse\022g\n\022Bu"
-    "ildStorageCursor\022\'.s4wave.world.BuildSto"
-    "rageCursorRequest\032(.s4wave.world.BuildSt"
-    "orageCursorResponse\022a\n\020AccessWorldState\022"
-    "%.s4wave.world.AccessWorldStateRequest\032&"
-    ".s4wave.world.AccessWorldStateResponse\022U"
-    "\n\014CreateObject\022!.s4wave.world.CreateObje"
-    "ctRequest\032\".s4wave.world.CreateObjectRes"
-    "ponse\022L\n\tGetObject\022\036.s4wave.world.GetObj"
-    "ectRequest\032\037.s4wave.world.GetObjectRespo"
-    "nse\022[\n\016IterateObjects\022#.s4wave.world.Ite"
-    "rateObjectsRequest\032$.s4wave.world.Iterat"
-    "eObjectsResponse\022U\n\014RenameObject\022!.s4wav"
-    "e.world.RenameObjectRequest\032\".s4wave.wor"
-    "ld.RenameObjectResponse\022U\n\014DeleteObject\022"
-    "!.s4wave.world.DeleteObjectRequest\032\".s4w"
-    "ave.world.DeleteObjectResponse\022U\n\014SetGra"
-    "phQuad\022!.s4wave.world.SetGraphQuadReques"
-    "t\032\".s4wave.world.SetGraphQuadResponse\022^\n"
-    "\017DeleteGraphQuad\022$.s4wave.world.DeleteGr"
-    "aphQuadRequest\032%.s4wave.world.DeleteGrap"
-    "hQuadResponse\022a\n\020LookupGraphQuads\022%.s4wa"
-    "ve.world.LookupGraphQuadsRequest\032&.s4wav"
-    "e.world.LookupGraphQuadsResponse\022p\n\025Look"
-    "upGraphQuadsBatch\022*.s4wave.world.LookupG"
-    "raphQuadsBatchRequest\032+.s4wave.world.Loo"
-    "kupGraphQuadsBatchResponse\022m\n\024ListGraphE"
-    "dgeBuckets\022).s4wave.world.ListGraphEdgeB"
-    "ucketsRequest\032*.s4wave.world.ListGraphEd"
-    "geBucketsResponse\022j\n\023ListObjectsWithType"
-    "\022(.s4wave.world.ListObjectsWithTypeReque"
-    "st\032).s4wave.world.ListObjectsWithTypeRes"
-    "ponse\022s\n\026GetObjectRootRefsBatch\022+.s4wave"
-    ".world.GetObjectRootRefsBatchRequest\032,.s"
-    "4wave.world.GetObjectRootRefsBatchRespon"
-    "se\022s\n\026GetObjectMetadataBatch\022+.s4wave.wo"
-    "rld.GetObjectMetadataBatchRequest\032,.s4wa"
-    "ve.world.GetObjectMetadataBatchResponse\022"
-    "[\n\016QueryGraphPath\022#.s4wave.world.QueryGr"
-    "aphPathRequest\032$.s4wave.world.QueryGraph"
-    "PathResponse\022d\n\021DeleteGraphObject\022&.s4wa"
-    "ve.world.DeleteGraphObjectRequest\032\'.s4wa"
-    "ve.world.DeleteGraphObjectResponse\022U\n\014Ap"
-    "plyWorldOp\022!.s4wave.world.ApplyWorldOpRe"
-    "quest\032\".s4wave.world.ApplyWorldOpRespons"
-    "e2\202\001\n\036WatchWorldStateResourceService\022`\n\017"
-    "WatchWorldState\022$.s4wave.world.WatchWorl"
-    "dStateRequest\032%.s4wave.world.WatchWorldS"
-    "tateResponse0\0012\240\001\n\021TxResourceService\022C\n\006"
-    "Commit\022\033.s4wave.world.CommitRequest\032\034.s4"
-    "wave.world.CommitResponse\022F\n\007Discard\022\034.s"
-    "4wave.world.DiscardRequest\032\035.s4wave.worl"
-    "d.DiscardResponse2\231\003\n\035ObjectIteratorReso"
-    "urceService\022:\n\003Err\022\030.s4wave.world.ErrReq"
-    "uest\032\031.s4wave.world.ErrResponse\022@\n\005Valid"
-    "\022\032.s4wave.world.ValidRequest\032\033.s4wave.wo"
-    "rld.ValidResponse\022:\n\003Key\022\030.s4wave.world."
-    "KeyRequest\032\031.s4wave.world.KeyResponse\022=\n"
-    "\004Next\022\031.s4wave.world.NextRequest\032\032.s4wav"
-    "e.world.NextResponse\022=\n\004Seek\022\031.s4wave.wo"
-    "rld.SeekRequest\032\032.s4wave.world.SeekRespo"
-    "nse\022@\n\005Close\022\032.s4wave.world.CloseRequest"
-    "\032\033.s4wave.world.CloseResponse2\330\001\n\035GraphP"
-    "athQueryResourceService\022Y\n\004Next\022\'.s4wave"
-    ".world.NextGraphPathQueryRequest\032(.s4wav"
-    "e.world.NextGraphPathQueryResponse\022\\\n\005Cl"
-    "ose\022(.s4wave.world.CloseGraphPathQueryRe"
-    "quest\032).s4wave.world.CloseGraphPathQuery"
-    "Response2\337\004\n\032ObjectStateResourceService\022"
-    "C\n\006GetKey\022\033.s4wave.world.GetKeyRequest\032\034"
-    ".s4wave.world.GetKeyResponse\022O\n\nGetRootR"
-    "ef\022\037.s4wave.world.GetRootRefRequest\032 .s4"
-    "wave.world.GetRootRefResponse\022O\n\nSetRoot"
-    "Ref\022\037.s4wave.world.SetRootRefRequest\032 .s"
-    "4wave.world.SetRootRefResponse\022a\n\020Access"
-    "WorldState\022%.s4wave.world.AccessWorldSta"
-    "teRequest\032&.s4wave.world.AccessWorldStat"
-    "eResponse\022X\n\rApplyObjectOp\022\".s4wave.worl"
-    "d.ApplyObjectOpRequest\032#.s4wave.world.Ap"
-    "plyObjectOpResponse\022U\n\014IncrementRev\022!.s4"
-    "wave.world.IncrementRevRequest\032\".s4wave."
-    "world.IncrementRevResponse\022F\n\007WaitRev\022\034."
-    "s4wave.world.WaitRevRequest\032\035.s4wave.wor"
-    "ld.WaitRevResponse2\202\001\n\032TypedObjectResour"
-    "ceService\022d\n\021AccessTypedObject\022&.s4wave."
-    "world.AccessTypedObjectRequest\032\'.s4wave."
-    "world.AccessTypedObjectResponseb\006proto3"
+    ".world.ObjectMetadata\">\n\nObjectBody\022\022\n\no"
+    "bject_key\030\001 \001(\t\022\014\n\004body\030\002 \001(\014\022\016\n\006exists\030"
+    "\003 \001(\010\"K\n\033GetObjectBodiesBatchRequest\022\023\n\013"
+    "object_keys\030\001 \003(\t\022\027\n\017start_key_index\030\002 \001"
+    "(\r\"u\n\034GetObjectBodiesBatchResponse\022(\n\006bo"
+    "dies\030\001 \003(\0132\030.s4wave.world.ObjectBody\022\026\n\016"
+    "next_key_index\030\002 \001(\r\022\023\n\013world_seqno\030\003 \001("
+    "\004\"f\n\rGraphPathStep\0223\n\tdirection\030\001 \001(\0162 ."
+    "s4wave.world.GraphPathDirection\022\021\n\tpredi"
+    "cate\030\002 \001(\t\022\r\n\005limit\030\003 \001(\r\"\227\001\n\025QueryGraph"
+    "PathRequest\022\022\n\nstart_keys\030\001 \003(\t\022*\n\005steps"
+    "\030\002 \003(\0132\033.s4wave.world.GraphPathStep\022\024\n\014r"
+    "esult_limit\030\003 \001(\r\022\025\n\rinclude_quads\030\004 \001(\010"
+    "\022\021\n\tpage_size\030\005 \001(\r\"-\n\026QueryGraphPathRes"
+    "ponse\022\023\n\013resource_id\030\001 \001(\r\".\n\030DeleteGrap"
+    "hObjectRequest\022\022\n\nobject_key\030\001 \001(\t\"\033\n\031De"
+    "leteGraphObjectResponse\"M\n\023ApplyWorldOpR"
+    "equest\022\022\n\nop_type_id\030\001 \001(\t\022\017\n\007op_data\030\002 "
+    "\001(\014\022\021\n\top_sender\030\003 \001(\t\"h\n\024ApplyWorldOpRe"
+    "sponse\022\r\n\005seqno\030\001 \001(\004\022\017\n\007sys_err\030\002 \001(\010\0220"
+    "\n\nerror_code\030\003 \001(\0162\034.s4wave.world.WorldE"
+    "rrorCode\"\030\n\026WatchWorldStateRequest\".\n\027Wa"
+    "tchWorldStateResponse\022\023\n\013resource_id\030\001 \001"
+    "(\r\"\304\001\n\031TrackedWorldStateSnapshot\022M\n\017obje"
+    "ct_accesses\030\001 \003(\01324.s4wave.world.Tracked"
+    "WorldStateSnapshot.ObjectAccess\022\027\n\017has_q"
+    "uad_access\030\002 \001(\010\022\025\n\rinitial_seqno\030\003 \001(\004\032"
+    "(\n\014ObjectAccess\022\013\n\003key\030\001 \001(\t\022\013\n\003rev\030\002 \001("
+    "\004\"\014\n\nErrRequest\"\034\n\013ErrResponse\022\r\n\005error\030"
+    "\001 \001(\t\"\016\n\014ValidRequest\"\036\n\rValidResponse\022\r"
+    "\n\005valid\030\001 \001(\010\"\014\n\nKeyRequest\"!\n\013KeyRespon"
+    "se\022\022\n\nobject_key\030\001 \001(\t\"\r\n\013NextRequest\"\035\n"
+    "\014NextResponse\022\r\n\005valid\030\001 \001(\010\"!\n\013SeekRequ"
+    "est\022\022\n\nobject_key\030\001 \001(\t\"\016\n\014SeekResponse\""
+    "\016\n\014CloseRequest\"\017\n\rCloseResponse\"\033\n\031Next"
+    "GraphPathQueryRequest\"Z\n\032NextGraphPathQu"
+    "eryResponse\022\023\n\013object_keys\030\001 \003(\t\022\031\n\005quad"
+    "s\030\002 \003(\0132\n.quad.Quad\022\014\n\004done\030\003 \001(\010\"\034\n\032Clo"
+    "seGraphPathQueryRequest\"\035\n\033CloseGraphPat"
+    "hQueryResponse\"\017\n\rGetKeyRequest\"$\n\016GetKe"
+    "yResponse\022\022\n\nobject_key\030\001 \001(\t\"\023\n\021GetRoot"
+    "RefRequest\"F\n\022GetRootRefResponse\022#\n\010root"
+    "_ref\030\001 \001(\0132\021.bucket.ObjectRef\022\013\n\003rev\030\002 \001"
+    "(\004\"8\n\021SetRootRefRequest\022#\n\010root_ref\030\001 \001("
+    "\0132\021.bucket.ObjectRef\"!\n\022SetRootRefRespon"
+    "se\022\013\n\003rev\030\001 \001(\004\"N\n\024ApplyObjectOpRequest\022"
+    "\022\n\nop_type_id\030\001 \001(\t\022\017\n\007op_data\030\002 \001(\014\022\021\n\t"
+    "op_sender\030\003 \001(\t\"g\n\025ApplyObjectOpResponse"
+    "\022\013\n\003rev\030\001 \001(\004\022\017\n\007sys_err\030\002 \001(\010\0220\n\nerror_"
+    "code\030\003 \001(\0162\034.s4wave.world.WorldErrorCode"
+    "\"\025\n\023IncrementRevRequest\"#\n\024IncrementRevR"
+    "esponse\022\013\n\003rev\030\001 \001(\004\"7\n\016WaitRevRequest\022\013"
+    "\n\003rev\030\001 \001(\004\022\030\n\020ignore_not_found\030\002 \001(\010\"\036\n"
+    "\017WaitRevResponse\022\013\n\003rev\030\001 \001(\004\".\n\030AccessT"
+    "ypedObjectRequest\022\022\n\nobject_key\030\001 \001(\t\"A\n"
+    "\031AccessTypedObjectResponse\022\023\n\013resource_i"
+    "d\030\001 \001(\r\022\017\n\007type_id\030\002 \001(\t*\266\001\n\030GraphEdgeBu"
+    "cketDirection\022+\n\'GRAPH_EDGE_BUCKET_DIREC"
+    "TION_UNSPECIFIED\020\000\022#\n\037GRAPH_EDGE_BUCKET_"
+    "DIRECTION_OUT\020\001\022\"\n\036GRAPH_EDGE_BUCKET_DIR"
+    "ECTION_IN\020\002\022$\n GRAPH_EDGE_BUCKET_DIRECTI"
+    "ON_BOTH\020\003*\224\001\n\022GraphPathDirection\022$\n GRAP"
+    "H_PATH_DIRECTION_UNSPECIFIED\020\000\022\034\n\030GRAPH_"
+    "PATH_DIRECTION_OUT\020\001\022\033\n\027GRAPH_PATH_DIREC"
+    "TION_IN\020\002\022\035\n\031GRAPH_PATH_DIRECTION_BOTH\020\003"
+    "*U\n\016WorldErrorCode\022 \n\034WORLD_ERROR_CODE_U"
+    "NSPECIFIED\020\000\022!\n\035WORLD_ERROR_CODE_UNHANDL"
+    "ED_OP\020\0012\302\006\n\025EngineResourceService\022X\n\rGet"
+    "EngineInfo\022\".s4wave.world.GetEngineInfoR"
+    "equest\032#.s4wave.world.GetEngineInfoRespo"
+    "nse\022b\n\024GetWorldRootSnapshot\022).s4wave.wor"
+    "ld.GetWorldRootSnapshotRequest\032\037.s4wave."
+    "world.WorldRootSnapshot\022j\n\027WatchWorldRoo"
+    "tSnapshots\022,.s4wave.world.WatchWorldRoot"
+    "SnapshotsRequest\032\037.s4wave.world.WorldRoo"
+    "tSnapshot0\001\022[\n\016NewTransaction\022#.s4wave.w"
+    "orld.NewTransactionRequest\032$.s4wave.worl"
+    "d.NewTransactionResponse\022=\n\004Sync\022\031.s4wav"
+    "e.world.SyncRequest\032\032.s4wave.world.SyncR"
+    "esponse\022I\n\010GetSeqno\022\035.s4wave.world.GetSe"
+    "qnoRequest\032\036.s4wave.world.GetSeqnoRespon"
+    "se\022L\n\tWaitSeqno\022\036.s4wave.world.WaitSeqno"
+    "Request\032\037.s4wave.world.WaitSeqnoResponse"
+    "\022g\n\022BuildStorageCursor\022\'.s4wave.world.Bu"
+    "ildStorageCursorRequest\032(.s4wave.world.B"
+    "uildStorageCursorResponse\022a\n\020AccessWorld"
+    "State\022%.s4wave.world.AccessWorldStateReq"
+    "uest\032&.s4wave.world.AccessWorldStateResp"
+    "onse2\235\021\n\031WorldStateResourceService\022R\n\013Ge"
+    "tReadOnly\022 .s4wave.world.GetReadOnlyRequ"
+    "est\032!.s4wave.world.GetReadOnlyResponse\022="
+    "\n\004Sync\022\031.s4wave.world.SyncRequest\032\032.s4wa"
+    "ve.world.SyncResponse\022I\n\010GetSeqno\022\035.s4wa"
+    "ve.world.GetSeqnoRequest\032\036.s4wave.world."
+    "GetSeqnoResponse\022L\n\tWaitSeqno\022\036.s4wave.w"
+    "orld.WaitSeqnoRequest\032\037.s4wave.world.Wai"
+    "tSeqnoResponse\022g\n\022BuildStorageCursor\022\'.s"
+    "4wave.world.BuildStorageCursorRequest\032(."
+    "s4wave.world.BuildStorageCursorResponse\022"
+    "a\n\020AccessWorldState\022%.s4wave.world.Acces"
+    "sWorldStateRequest\032&.s4wave.world.Access"
+    "WorldStateResponse\022U\n\014CreateObject\022!.s4w"
+    "ave.world.CreateObjectRequest\032\".s4wave.w"
+    "orld.CreateObjectResponse\022L\n\tGetObject\022\036"
+    ".s4wave.world.GetObjectRequest\032\037.s4wave."
+    "world.GetObjectResponse\022[\n\016IterateObject"
+    "s\022#.s4wave.world.IterateObjectsRequest\032$"
+    ".s4wave.world.IterateObjectsResponse\022U\n\014"
+    "RenameObject\022!.s4wave.world.RenameObject"
+    "Request\032\".s4wave.world.RenameObjectRespo"
+    "nse\022U\n\014DeleteObject\022!.s4wave.world.Delet"
+    "eObjectRequest\032\".s4wave.world.DeleteObje"
+    "ctResponse\022U\n\014SetGraphQuad\022!.s4wave.worl"
+    "d.SetGraphQuadRequest\032\".s4wave.world.Set"
+    "GraphQuadResponse\022^\n\017DeleteGraphQuad\022$.s"
+    "4wave.world.DeleteGraphQuadRequest\032%.s4w"
+    "ave.world.DeleteGraphQuadResponse\022a\n\020Loo"
+    "kupGraphQuads\022%.s4wave.world.LookupGraph"
+    "QuadsRequest\032&.s4wave.world.LookupGraphQ"
+    "uadsResponse\022p\n\025LookupGraphQuadsBatch\022*."
+    "s4wave.world.LookupGraphQuadsBatchReques"
+    "t\032+.s4wave.world.LookupGraphQuadsBatchRe"
+    "sponse\022m\n\024ListGraphEdgeBuckets\022).s4wave."
+    "world.ListGraphEdgeBucketsRequest\032*.s4wa"
+    "ve.world.ListGraphEdgeBucketsResponse\022j\n"
+    "\023ListObjectsWithType\022(.s4wave.world.List"
+    "ObjectsWithTypeRequest\032).s4wave.world.Li"
+    "stObjectsWithTypeResponse\022s\n\026GetObjectRo"
+    "otRefsBatch\022+.s4wave.world.GetObjectRoot"
+    "RefsBatchRequest\032,.s4wave.world.GetObjec"
+    "tRootRefsBatchResponse\022s\n\026GetObjectMetad"
+    "ataBatch\022+.s4wave.world.GetObjectMetadat"
+    "aBatchRequest\032,.s4wave.world.GetObjectMe"
+    "tadataBatchResponse\022m\n\024GetObjectBodiesBa"
+    "tch\022).s4wave.world.GetObjectBodiesBatchR"
+    "equest\032*.s4wave.world.GetObjectBodiesBat"
+    "chResponse\022[\n\016QueryGraphPath\022#.s4wave.wo"
+    "rld.QueryGraphPathRequest\032$.s4wave.world"
+    ".QueryGraphPathResponse\022d\n\021DeleteGraphOb"
+    "ject\022&.s4wave.world.DeleteGraphObjectReq"
+    "uest\032\'.s4wave.world.DeleteGraphObjectRes"
+    "ponse\022U\n\014ApplyWorldOp\022!.s4wave.world.App"
+    "lyWorldOpRequest\032\".s4wave.world.ApplyWor"
+    "ldOpResponse2\202\001\n\036WatchWorldStateResource"
+    "Service\022`\n\017WatchWorldState\022$.s4wave.worl"
+    "d.WatchWorldStateRequest\032%.s4wave.world."
+    "WatchWorldStateResponse0\0012\240\001\n\021TxResource"
+    "Service\022C\n\006Commit\022\033.s4wave.world.CommitR"
+    "equest\032\034.s4wave.world.CommitResponse\022F\n\007"
+    "Discard\022\034.s4wave.world.DiscardRequest\032\035."
+    "s4wave.world.DiscardResponse2\231\003\n\035ObjectI"
+    "teratorResourceService\022:\n\003Err\022\030.s4wave.w"
+    "orld.ErrRequest\032\031.s4wave.world.ErrRespon"
+    "se\022@\n\005Valid\022\032.s4wave.world.ValidRequest\032"
+    "\033.s4wave.world.ValidResponse\022:\n\003Key\022\030.s4"
+    "wave.world.KeyRequest\032\031.s4wave.world.Key"
+    "Response\022=\n\004Next\022\031.s4wave.world.NextRequ"
+    "est\032\032.s4wave.world.NextResponse\022=\n\004Seek\022"
+    "\031.s4wave.world.SeekRequest\032\032.s4wave.worl"
+    "d.SeekResponse\022@\n\005Close\022\032.s4wave.world.C"
+    "loseRequest\032\033.s4wave.world.CloseResponse"
+    "2\330\001\n\035GraphPathQueryResourceService\022Y\n\004Ne"
+    "xt\022\'.s4wave.world.NextGraphPathQueryRequ"
+    "est\032(.s4wave.world.NextGraphPathQueryRes"
+    "ponse\022\\\n\005Close\022(.s4wave.world.CloseGraph"
+    "PathQueryRequest\032).s4wave.world.CloseGra"
+    "phPathQueryResponse2\337\004\n\032ObjectStateResou"
+    "rceService\022C\n\006GetKey\022\033.s4wave.world.GetK"
+    "eyRequest\032\034.s4wave.world.GetKeyResponse\022"
+    "O\n\nGetRootRef\022\037.s4wave.world.GetRootRefR"
+    "equest\032 .s4wave.world.GetRootRefResponse"
+    "\022O\n\nSetRootRef\022\037.s4wave.world.SetRootRef"
+    "Request\032 .s4wave.world.SetRootRefRespons"
+    "e\022a\n\020AccessWorldState\022%.s4wave.world.Acc"
+    "essWorldStateRequest\032&.s4wave.world.Acce"
+    "ssWorldStateResponse\022X\n\rApplyObjectOp\022\"."
+    "s4wave.world.ApplyObjectOpRequest\032#.s4wa"
+    "ve.world.ApplyObjectOpResponse\022U\n\014Increm"
+    "entRev\022!.s4wave.world.IncrementRevReques"
+    "t\032\".s4wave.world.IncrementRevResponse\022F\n"
+    "\007WaitRev\022\034.s4wave.world.WaitRevRequest\032\035"
+    ".s4wave.world.WaitRevResponse2\202\001\n\032TypedO"
+    "bjectResourceService\022d\n\021AccessTypedObjec"
+    "t\022&.s4wave.world.AccessTypedObjectReques"
+    "t\032\'.s4wave.world.AccessTypedObjectRespon"
+    "seb\006proto3"
 };
 static const ::_pbi::DescriptorTable* PROTOBUF_NONNULL const
     descriptor_table_github_2ecom_2fs4wave_2fspacewave_2fsdk_2fworld_2fworld_2eproto_deps[2] = {
@@ -3259,13 +3384,13 @@ static ::absl::once_flag descriptor_table_github_2ecom_2fs4wave_2fspacewave_2fsd
 PROTOBUF_CONSTINIT const ::_pbi::DescriptorTable descriptor_table_github_2ecom_2fs4wave_2fspacewave_2fsdk_2fworld_2fworld_2eproto = {
     false,
     false,
-    10239,
+    10610,
     descriptor_table_protodef_github_2ecom_2fs4wave_2fspacewave_2fsdk_2fworld_2fworld_2eproto,
     "github.com/s4wave/spacewave/sdk/world/world.proto",
     &descriptor_table_github_2ecom_2fs4wave_2fspacewave_2fsdk_2fworld_2fworld_2eproto_once,
     descriptor_table_github_2ecom_2fs4wave_2fspacewave_2fsdk_2fworld_2fworld_2eproto_deps,
     2,
-    95,
+    98,
     schemas,
     file_default_instances,
     TableStruct_github_2ecom_2fs4wave_2fspacewave_2fsdk_2fworld_2fworld_2eproto::offsets,
@@ -16924,6 +17049,1036 @@ void GetObjectMetadataBatchResponse::InternalSwap(GetObjectMetadataBatchResponse
 }
 
 ::google::protobuf::Metadata GetObjectMetadataBatchResponse::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class ObjectBody::_Internal {
+ public:
+  using HasBits =
+      decltype(::std::declval<ObjectBody>()._impl_._has_bits_);
+  static constexpr ::int32_t kHasBitsOffset =
+      8 * PROTOBUF_FIELD_OFFSET(ObjectBody, _impl_._has_bits_);
+};
+
+ObjectBody::ObjectBody(::google::protobuf::Arena* PROTOBUF_NULLABLE arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, ObjectBody_class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:s4wave.world.ObjectBody)
+}
+PROTOBUF_NDEBUG_INLINE ObjectBody::Impl_::Impl_(
+    [[maybe_unused]] ::google::protobuf::internal::InternalVisibility visibility,
+    [[maybe_unused]] ::google::protobuf::Arena* PROTOBUF_NULLABLE arena, const Impl_& from,
+    [[maybe_unused]] const ::s4wave::world::ObjectBody& from_msg)
+      : _has_bits_{from._has_bits_},
+        _cached_size_{0},
+        object_key_(arena, from.object_key_),
+        body_(arena, from.body_) {}
+
+ObjectBody::ObjectBody(
+    ::google::protobuf::Arena* PROTOBUF_NULLABLE arena,
+    const ObjectBody& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, ObjectBody_class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  ObjectBody* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  _impl_.exists_ = from._impl_.exists_;
+
+  // @@protoc_insertion_point(copy_constructor:s4wave.world.ObjectBody)
+}
+PROTOBUF_NDEBUG_INLINE ObjectBody::Impl_::Impl_(
+    [[maybe_unused]] ::google::protobuf::internal::InternalVisibility visibility,
+    [[maybe_unused]] ::google::protobuf::Arena* PROTOBUF_NULLABLE arena)
+      : _cached_size_{0},
+        object_key_(arena),
+        body_(arena) {}
+
+inline void ObjectBody::SharedCtor(::_pb::Arena* PROTOBUF_NULLABLE arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.exists_ = {};
+}
+ObjectBody::~ObjectBody() {
+  // @@protoc_insertion_point(destructor:s4wave.world.ObjectBody)
+  SharedDtor(*this);
+}
+inline void ObjectBody::SharedDtor(MessageLite& self) {
+  ObjectBody& this_ = static_cast<ObjectBody&>(self);
+  if constexpr (::_pbi::DebugHardenCheckHasBitConsistency()) {
+    this_.CheckHasBitConsistency();
+  }
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.object_key_.Destroy();
+  this_._impl_.body_.Destroy();
+  this_._impl_.~Impl_();
+}
+
+inline void* PROTOBUF_NONNULL ObjectBody::PlacementNew_(
+    const void* PROTOBUF_NONNULL, void* PROTOBUF_NONNULL mem,
+    ::google::protobuf::Arena* PROTOBUF_NULLABLE arena) {
+  return ::new (mem) ObjectBody(arena);
+}
+constexpr auto ObjectBody::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::CopyInit(sizeof(ObjectBody),
+                                            alignof(ObjectBody));
+}
+constexpr auto ObjectBody::InternalGenerateClassData_() {
+  return ::google::protobuf::internal::ClassDataFull{
+      ::google::protobuf::internal::ClassData{
+          &_ObjectBody_default_instance_._instance,
+          &_table_.header,
+          nullptr,  // OnDemandRegisterArenaDtor
+          nullptr,  // IsInitialized
+          &ObjectBody::MergeImpl,
+          ::google::protobuf::Message::GetNewImpl<ObjectBody>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+          &ObjectBody::SharedDtor,
+          ::google::protobuf::Message::GetClearImpl<ObjectBody>(), &ObjectBody::ByteSizeLong,
+              &ObjectBody::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          PROTOBUF_FIELD_OFFSET(ObjectBody, _impl_._cached_size_),
+          false,
+      },
+      &ObjectBody::kDescriptorMethods,
+      &descriptor_table_github_2ecom_2fs4wave_2fspacewave_2fsdk_2fworld_2fworld_2eproto,
+      nullptr,  // tracker
+  };
+}
+
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 const
+    ::google::protobuf::internal::ClassDataFull ObjectBody_class_data_ =
+        ObjectBody::InternalGenerateClassData_();
+
+PROTOBUF_ATTRIBUTE_WEAK const ::google::protobuf::internal::ClassData* PROTOBUF_NONNULL
+ObjectBody::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&ObjectBody_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(ObjectBody_class_data_.tc_table);
+  return ObjectBody_class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<2, 3, 0, 42, 2>
+ObjectBody::_table_ = {
+  {
+    PROTOBUF_FIELD_OFFSET(ObjectBody, _impl_._has_bits_),
+    0, // no _extensions_
+    3, 24,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967288,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    3,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    ObjectBody_class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::s4wave::world::ObjectBody>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    {::_pbi::TcParser::MiniParse, {}},
+    // string object_key = 1;
+    {::_pbi::TcParser::FastUS1,
+     {10, 0, 0,
+      PROTOBUF_FIELD_OFFSET(ObjectBody, _impl_.object_key_)}},
+    // bytes body = 2;
+    {::_pbi::TcParser::FastBS1,
+     {18, 1, 0,
+      PROTOBUF_FIELD_OFFSET(ObjectBody, _impl_.body_)}},
+    // bool exists = 3;
+    {::_pbi::TcParser::SingularVarintNoZag1<bool, offsetof(ObjectBody, _impl_.exists_), 2>(),
+     {24, 2, 0,
+      PROTOBUF_FIELD_OFFSET(ObjectBody, _impl_.exists_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // string object_key = 1;
+    {PROTOBUF_FIELD_OFFSET(ObjectBody, _impl_.object_key_), _Internal::kHasBitsOffset + 0, 0, (0 | ::_fl::kFcOptional | ::_fl::kUtf8String | ::_fl::kRepAString)},
+    // bytes body = 2;
+    {PROTOBUF_FIELD_OFFSET(ObjectBody, _impl_.body_), _Internal::kHasBitsOffset + 1, 0, (0 | ::_fl::kFcOptional | ::_fl::kBytes | ::_fl::kRepAString)},
+    // bool exists = 3;
+    {PROTOBUF_FIELD_OFFSET(ObjectBody, _impl_.exists_), _Internal::kHasBitsOffset + 2, 0, (0 | ::_fl::kFcOptional | ::_fl::kBool)},
+  }},
+  // no aux_entries
+  {{
+    "\27\12\0\0\0\0\0\0"
+    "s4wave.world.ObjectBody"
+    "object_key"
+  }},
+};
+PROTOBUF_NOINLINE void ObjectBody::Clear() {
+// @@protoc_insertion_point(message_clear_start:s4wave.world.ObjectBody)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (BatchCheckHasBit(cached_has_bits, 0x00000003U)) {
+    if (CheckHasBit(cached_has_bits, 0x00000001U)) {
+      _impl_.object_key_.ClearNonDefaultToEmpty();
+    }
+    if (CheckHasBit(cached_has_bits, 0x00000002U)) {
+      _impl_.body_.ClearNonDefaultToEmpty();
+    }
+  }
+  _impl_.exists_ = false;
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+::uint8_t* PROTOBUF_NONNULL ObjectBody::_InternalSerialize(
+    const ::google::protobuf::MessageLite& base, ::uint8_t* PROTOBUF_NONNULL target,
+    ::google::protobuf::io::EpsCopyOutputStream* PROTOBUF_NONNULL stream) {
+  const ObjectBody& this_ = static_cast<const ObjectBody&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+::uint8_t* PROTOBUF_NONNULL ObjectBody::_InternalSerialize(
+    ::uint8_t* PROTOBUF_NONNULL target,
+    ::google::protobuf::io::EpsCopyOutputStream* PROTOBUF_NONNULL stream) const {
+  const ObjectBody& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  if constexpr (::_pbi::DebugHardenCheckHasBitConsistency()) {
+    this_.CheckHasBitConsistency();
+  }
+  // @@protoc_insertion_point(serialize_to_array_start:s4wave.world.ObjectBody)
+  ::uint32_t cached_has_bits = 0;
+  (void)cached_has_bits;
+
+  cached_has_bits = this_._impl_._has_bits_[0];
+  // string object_key = 1;
+  if (CheckHasBit(cached_has_bits, 0x00000001U)) {
+    if (!this_._internal_object_key().empty()) {
+      const ::std::string& _s = this_._internal_object_key();
+      ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          _s.data(), static_cast<int>(_s.length()), ::google::protobuf::internal::WireFormatLite::SERIALIZE, "s4wave.world.ObjectBody.object_key");
+      target = stream->WriteStringMaybeAliased(1, _s, target);
+    }
+  }
+
+  // bytes body = 2;
+  if (CheckHasBit(cached_has_bits, 0x00000002U)) {
+    if (!this_._internal_body().empty()) {
+      const ::std::string& _s = this_._internal_body();
+      target = stream->WriteBytesMaybeAliased(2, _s, target);
+    }
+  }
+
+  // bool exists = 3;
+  if (CheckHasBit(cached_has_bits, 0x00000004U)) {
+    if (this_._internal_exists() != 0) {
+      target = stream->EnsureSpace(target);
+      target = ::_pbi::WireFormatLite::WriteBoolToArray(
+          3, this_._internal_exists(), target);
+    }
+  }
+
+  if (ABSL_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+    target =
+        ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+            this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:s4wave.world.ObjectBody)
+  return target;
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+::size_t ObjectBody::ByteSizeLong(const MessageLite& base) {
+  const ObjectBody& this_ = static_cast<const ObjectBody&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+::size_t ObjectBody::ByteSizeLong() const {
+  const ObjectBody& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  // @@protoc_insertion_point(message_byte_size_start:s4wave.world.ObjectBody)
+  ::size_t total_size = 0;
+
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void)cached_has_bits;
+
+  ::_pbi::Prefetch5LinesFrom7Lines(&this_);
+  cached_has_bits = this_._impl_._has_bits_[0];
+  if (BatchCheckHasBit(cached_has_bits, 0x00000007U)) {
+    // string object_key = 1;
+    if (CheckHasBit(cached_has_bits, 0x00000001U)) {
+      if (!this_._internal_object_key().empty()) {
+        total_size += 1 + ::google::protobuf::internal::WireFormatLite::StringSize(
+                                        this_._internal_object_key());
+      }
+    }
+    // bytes body = 2;
+    if (CheckHasBit(cached_has_bits, 0x00000002U)) {
+      if (!this_._internal_body().empty()) {
+        total_size += 1 + ::google::protobuf::internal::WireFormatLite::BytesSize(
+                                        this_._internal_body());
+      }
+    }
+    // bool exists = 3;
+    if (CheckHasBit(cached_has_bits, 0x00000004U)) {
+      if (this_._internal_exists() != 0) {
+        total_size += 2;
+      }
+    }
+  }
+  return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                             &this_._impl_._cached_size_);
+}
+
+void ObjectBody::MergeImpl(::google::protobuf::MessageLite& to_msg,
+                            const ::google::protobuf::MessageLite& from_msg) {
+   auto* const _this =
+      static_cast<ObjectBody*>(&to_msg);
+  auto& from = static_cast<const ObjectBody&>(from_msg);
+  if constexpr (::_pbi::DebugHardenCheckHasBitConsistency()) {
+    from.CheckHasBitConsistency();
+  }
+  // @@protoc_insertion_point(class_specific_merge_from_start:s4wave.world.ObjectBody)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void)cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (BatchCheckHasBit(cached_has_bits, 0x00000007U)) {
+    if (CheckHasBit(cached_has_bits, 0x00000001U)) {
+      if (!from._internal_object_key().empty()) {
+        _this->_internal_set_object_key(from._internal_object_key());
+      } else {
+        if (_this->_impl_.object_key_.IsDefault()) {
+          _this->_internal_set_object_key("");
+        }
+      }
+    }
+    if (CheckHasBit(cached_has_bits, 0x00000002U)) {
+      if (!from._internal_body().empty()) {
+        _this->_internal_set_body(from._internal_body());
+      } else {
+        if (_this->_impl_.body_.IsDefault()) {
+          _this->_internal_set_body("");
+        }
+      }
+    }
+    if (CheckHasBit(cached_has_bits, 0x00000004U)) {
+      if (from._internal_exists() != 0) {
+        _this->_impl_.exists_ = from._impl_.exists_;
+      }
+    }
+  }
+  _this->_impl_._has_bits_[0] |= cached_has_bits;
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+}
+
+void ObjectBody::CopyFrom(const ObjectBody& from) {
+  // @@protoc_insertion_point(class_specific_copy_from_start:s4wave.world.ObjectBody)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void ObjectBody::InternalSwap(ObjectBody* PROTOBUF_RESTRICT PROTOBUF_NONNULL other) {
+  using ::std::swap;
+  auto* arena = GetArena();
+  ABSL_DCHECK_EQ(arena, other->GetArena());
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  ::_pbi::ArenaStringPtr::InternalSwap(&_impl_.object_key_, &other->_impl_.object_key_, arena);
+  ::_pbi::ArenaStringPtr::InternalSwap(&_impl_.body_, &other->_impl_.body_, arena);
+  swap(_impl_.exists_, other->_impl_.exists_);
+}
+
+::google::protobuf::Metadata ObjectBody::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class GetObjectBodiesBatchRequest::_Internal {
+ public:
+  using HasBits =
+      decltype(::std::declval<GetObjectBodiesBatchRequest>()._impl_._has_bits_);
+  static constexpr ::int32_t kHasBitsOffset =
+      8 * PROTOBUF_FIELD_OFFSET(GetObjectBodiesBatchRequest, _impl_._has_bits_);
+};
+
+GetObjectBodiesBatchRequest::GetObjectBodiesBatchRequest(::google::protobuf::Arena* PROTOBUF_NULLABLE arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, GetObjectBodiesBatchRequest_class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:s4wave.world.GetObjectBodiesBatchRequest)
+}
+PROTOBUF_NDEBUG_INLINE GetObjectBodiesBatchRequest::Impl_::Impl_(
+    [[maybe_unused]] ::google::protobuf::internal::InternalVisibility visibility,
+    [[maybe_unused]] ::google::protobuf::Arena* PROTOBUF_NULLABLE arena, const Impl_& from,
+    [[maybe_unused]] const ::s4wave::world::GetObjectBodiesBatchRequest& from_msg)
+      : _has_bits_{from._has_bits_},
+        _cached_size_{0},
+        object_keys_{visibility, arena, from.object_keys_} {}
+
+GetObjectBodiesBatchRequest::GetObjectBodiesBatchRequest(
+    ::google::protobuf::Arena* PROTOBUF_NULLABLE arena,
+    const GetObjectBodiesBatchRequest& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, GetObjectBodiesBatchRequest_class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  GetObjectBodiesBatchRequest* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  _impl_.start_key_index_ = from._impl_.start_key_index_;
+
+  // @@protoc_insertion_point(copy_constructor:s4wave.world.GetObjectBodiesBatchRequest)
+}
+PROTOBUF_NDEBUG_INLINE GetObjectBodiesBatchRequest::Impl_::Impl_(
+    [[maybe_unused]] ::google::protobuf::internal::InternalVisibility visibility,
+    [[maybe_unused]] ::google::protobuf::Arena* PROTOBUF_NULLABLE arena)
+      : _cached_size_{0},
+        object_keys_{visibility, arena} {}
+
+inline void GetObjectBodiesBatchRequest::SharedCtor(::_pb::Arena* PROTOBUF_NULLABLE arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.start_key_index_ = {};
+}
+GetObjectBodiesBatchRequest::~GetObjectBodiesBatchRequest() {
+  // @@protoc_insertion_point(destructor:s4wave.world.GetObjectBodiesBatchRequest)
+  SharedDtor(*this);
+}
+inline void GetObjectBodiesBatchRequest::SharedDtor(MessageLite& self) {
+  GetObjectBodiesBatchRequest& this_ = static_cast<GetObjectBodiesBatchRequest&>(self);
+  if constexpr (::_pbi::DebugHardenCheckHasBitConsistency()) {
+    this_.CheckHasBitConsistency();
+  }
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.~Impl_();
+}
+
+inline void* PROTOBUF_NONNULL GetObjectBodiesBatchRequest::PlacementNew_(
+    const void* PROTOBUF_NONNULL, void* PROTOBUF_NONNULL mem,
+    ::google::protobuf::Arena* PROTOBUF_NULLABLE arena) {
+  return ::new (mem) GetObjectBodiesBatchRequest(arena);
+}
+constexpr auto GetObjectBodiesBatchRequest::InternalNewImpl_() {
+  constexpr auto arena_bits = ::google::protobuf::internal::EncodePlacementArenaOffsets({
+      PROTOBUF_FIELD_OFFSET(GetObjectBodiesBatchRequest, _impl_.object_keys_) +
+          decltype(GetObjectBodiesBatchRequest::_impl_.object_keys_)::
+              InternalGetArenaOffset(
+                  ::google::protobuf::Message::internal_visibility()),
+  });
+  if (arena_bits.has_value()) {
+    return ::google::protobuf::internal::MessageCreator::ZeroInit(
+        sizeof(GetObjectBodiesBatchRequest), alignof(GetObjectBodiesBatchRequest), *arena_bits);
+  } else {
+    return ::google::protobuf::internal::MessageCreator(&GetObjectBodiesBatchRequest::PlacementNew_,
+                                 sizeof(GetObjectBodiesBatchRequest),
+                                 alignof(GetObjectBodiesBatchRequest));
+  }
+}
+constexpr auto GetObjectBodiesBatchRequest::InternalGenerateClassData_() {
+  return ::google::protobuf::internal::ClassDataFull{
+      ::google::protobuf::internal::ClassData{
+          &_GetObjectBodiesBatchRequest_default_instance_._instance,
+          &_table_.header,
+          nullptr,  // OnDemandRegisterArenaDtor
+          nullptr,  // IsInitialized
+          &GetObjectBodiesBatchRequest::MergeImpl,
+          ::google::protobuf::Message::GetNewImpl<GetObjectBodiesBatchRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+          &GetObjectBodiesBatchRequest::SharedDtor,
+          ::google::protobuf::Message::GetClearImpl<GetObjectBodiesBatchRequest>(), &GetObjectBodiesBatchRequest::ByteSizeLong,
+              &GetObjectBodiesBatchRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          PROTOBUF_FIELD_OFFSET(GetObjectBodiesBatchRequest, _impl_._cached_size_),
+          false,
+      },
+      &GetObjectBodiesBatchRequest::kDescriptorMethods,
+      &descriptor_table_github_2ecom_2fs4wave_2fspacewave_2fsdk_2fworld_2fworld_2eproto,
+      nullptr,  // tracker
+  };
+}
+
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 const
+    ::google::protobuf::internal::ClassDataFull GetObjectBodiesBatchRequest_class_data_ =
+        GetObjectBodiesBatchRequest::InternalGenerateClassData_();
+
+PROTOBUF_ATTRIBUTE_WEAK const ::google::protobuf::internal::ClassData* PROTOBUF_NONNULL
+GetObjectBodiesBatchRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&GetObjectBodiesBatchRequest_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(GetObjectBodiesBatchRequest_class_data_.tc_table);
+  return GetObjectBodiesBatchRequest_class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<1, 2, 0, 60, 2>
+GetObjectBodiesBatchRequest::_table_ = {
+  {
+    PROTOBUF_FIELD_OFFSET(GetObjectBodiesBatchRequest, _impl_._has_bits_),
+    0, // no _extensions_
+    2, 8,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967292,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    2,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    GetObjectBodiesBatchRequest_class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::s4wave::world::GetObjectBodiesBatchRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // uint32 start_key_index = 2;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(GetObjectBodiesBatchRequest, _impl_.start_key_index_), 1>(),
+     {16, 1, 0,
+      PROTOBUF_FIELD_OFFSET(GetObjectBodiesBatchRequest, _impl_.start_key_index_)}},
+    // repeated string object_keys = 1;
+    {::_pbi::TcParser::FastUR1,
+     {10, 0, 0,
+      PROTOBUF_FIELD_OFFSET(GetObjectBodiesBatchRequest, _impl_.object_keys_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // repeated string object_keys = 1;
+    {PROTOBUF_FIELD_OFFSET(GetObjectBodiesBatchRequest, _impl_.object_keys_), _Internal::kHasBitsOffset + 0, 0, (0 | ::_fl::kFcRepeated | ::_fl::kUtf8String | ::_fl::kRepSString)},
+    // uint32 start_key_index = 2;
+    {PROTOBUF_FIELD_OFFSET(GetObjectBodiesBatchRequest, _impl_.start_key_index_), _Internal::kHasBitsOffset + 1, 0, (0 | ::_fl::kFcOptional | ::_fl::kUInt32)},
+  }},
+  // no aux_entries
+  {{
+    "\50\13\0\0\0\0\0\0"
+    "s4wave.world.GetObjectBodiesBatchRequest"
+    "object_keys"
+  }},
+};
+PROTOBUF_NOINLINE void GetObjectBodiesBatchRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:s4wave.world.GetObjectBodiesBatchRequest)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (CheckHasBitForRepeated(cached_has_bits, 0x00000001U)) {
+    _impl_.object_keys_.Clear();
+  }
+  _impl_.start_key_index_ = 0u;
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+::uint8_t* PROTOBUF_NONNULL GetObjectBodiesBatchRequest::_InternalSerialize(
+    const ::google::protobuf::MessageLite& base, ::uint8_t* PROTOBUF_NONNULL target,
+    ::google::protobuf::io::EpsCopyOutputStream* PROTOBUF_NONNULL stream) {
+  const GetObjectBodiesBatchRequest& this_ = static_cast<const GetObjectBodiesBatchRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+::uint8_t* PROTOBUF_NONNULL GetObjectBodiesBatchRequest::_InternalSerialize(
+    ::uint8_t* PROTOBUF_NONNULL target,
+    ::google::protobuf::io::EpsCopyOutputStream* PROTOBUF_NONNULL stream) const {
+  const GetObjectBodiesBatchRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  if constexpr (::_pbi::DebugHardenCheckHasBitConsistency()) {
+    this_.CheckHasBitConsistency();
+  }
+  // @@protoc_insertion_point(serialize_to_array_start:s4wave.world.GetObjectBodiesBatchRequest)
+  ::uint32_t cached_has_bits = 0;
+  (void)cached_has_bits;
+
+  cached_has_bits = this_._impl_._has_bits_[0];
+  // repeated string object_keys = 1;
+  if (CheckHasBitForRepeated(cached_has_bits, 0x00000001U)) {
+    for (int i = 0, n = this_._internal_object_keys_size(); i < n; ++i) {
+      const auto& s = this_._internal_object_keys().Get(i);
+      ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+          s.data(), static_cast<int>(s.length()), ::google::protobuf::internal::WireFormatLite::SERIALIZE, "s4wave.world.GetObjectBodiesBatchRequest.object_keys");
+      target = stream->WriteString(1, s, target);
+    }
+  }
+
+  // uint32 start_key_index = 2;
+  if (CheckHasBit(cached_has_bits, 0x00000002U)) {
+    if (this_._internal_start_key_index() != 0) {
+      target = stream->EnsureSpace(target);
+      target = ::_pbi::WireFormatLite::WriteUInt32ToArray(
+          2, this_._internal_start_key_index(), target);
+    }
+  }
+
+  if (ABSL_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+    target =
+        ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+            this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:s4wave.world.GetObjectBodiesBatchRequest)
+  return target;
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+::size_t GetObjectBodiesBatchRequest::ByteSizeLong(const MessageLite& base) {
+  const GetObjectBodiesBatchRequest& this_ = static_cast<const GetObjectBodiesBatchRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+::size_t GetObjectBodiesBatchRequest::ByteSizeLong() const {
+  const GetObjectBodiesBatchRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  // @@protoc_insertion_point(message_byte_size_start:s4wave.world.GetObjectBodiesBatchRequest)
+  ::size_t total_size = 0;
+
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void)cached_has_bits;
+
+  ::_pbi::Prefetch5LinesFrom7Lines(&this_);
+  cached_has_bits = this_._impl_._has_bits_[0];
+  if (BatchCheckHasBit(cached_has_bits, 0x00000003U)) {
+    // repeated string object_keys = 1;
+    if (CheckHasBitForRepeated(cached_has_bits, 0x00000001U)) {
+      total_size +=
+          1 * ::google::protobuf::internal::FromIntSize(this_._internal_object_keys().size());
+      for (int i = 0, n = this_._internal_object_keys().size(); i < n; ++i) {
+        total_size += ::google::protobuf::internal::WireFormatLite::StringSize(
+            this_._internal_object_keys().Get(i));
+      }
+    }
+    // uint32 start_key_index = 2;
+    if (CheckHasBit(cached_has_bits, 0x00000002U)) {
+      if (this_._internal_start_key_index() != 0) {
+        total_size += ::_pbi::WireFormatLite::UInt32SizePlusOne(
+            this_._internal_start_key_index());
+      }
+    }
+  }
+  return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                             &this_._impl_._cached_size_);
+}
+
+void GetObjectBodiesBatchRequest::MergeImpl(::google::protobuf::MessageLite& to_msg,
+                            const ::google::protobuf::MessageLite& from_msg) {
+   auto* const _this =
+      static_cast<GetObjectBodiesBatchRequest*>(&to_msg);
+  auto& from = static_cast<const GetObjectBodiesBatchRequest&>(from_msg);
+  if constexpr (::_pbi::DebugHardenCheckHasBitConsistency()) {
+    from.CheckHasBitConsistency();
+  }
+  ::google::protobuf::Arena* arena = _this->GetArena();
+  // @@protoc_insertion_point(class_specific_merge_from_start:s4wave.world.GetObjectBodiesBatchRequest)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void)cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (BatchCheckHasBit(cached_has_bits, 0x00000003U)) {
+    if (CheckHasBitForRepeated(cached_has_bits, 0x00000001U)) {
+      _this->_internal_mutable_object_keys()->InternalMergeFromWithArena(
+          ::google::protobuf::MessageLite::internal_visibility(), arena,
+          from._internal_object_keys());
+    }
+    if (CheckHasBit(cached_has_bits, 0x00000002U)) {
+      if (from._internal_start_key_index() != 0) {
+        _this->_impl_.start_key_index_ = from._impl_.start_key_index_;
+      }
+    }
+  }
+  _this->_impl_._has_bits_[0] |= cached_has_bits;
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+}
+
+void GetObjectBodiesBatchRequest::CopyFrom(const GetObjectBodiesBatchRequest& from) {
+  // @@protoc_insertion_point(class_specific_copy_from_start:s4wave.world.GetObjectBodiesBatchRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void GetObjectBodiesBatchRequest::InternalSwap(GetObjectBodiesBatchRequest* PROTOBUF_RESTRICT PROTOBUF_NONNULL other) {
+  using ::std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  _impl_.object_keys_.InternalSwap(&other->_impl_.object_keys_);
+  swap(_impl_.start_key_index_, other->_impl_.start_key_index_);
+}
+
+::google::protobuf::Metadata GetObjectBodiesBatchRequest::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class GetObjectBodiesBatchResponse::_Internal {
+ public:
+  using HasBits =
+      decltype(::std::declval<GetObjectBodiesBatchResponse>()._impl_._has_bits_);
+  static constexpr ::int32_t kHasBitsOffset =
+      8 * PROTOBUF_FIELD_OFFSET(GetObjectBodiesBatchResponse, _impl_._has_bits_);
+};
+
+GetObjectBodiesBatchResponse::GetObjectBodiesBatchResponse(::google::protobuf::Arena* PROTOBUF_NULLABLE arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, GetObjectBodiesBatchResponse_class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:s4wave.world.GetObjectBodiesBatchResponse)
+}
+PROTOBUF_NDEBUG_INLINE GetObjectBodiesBatchResponse::Impl_::Impl_(
+    [[maybe_unused]] ::google::protobuf::internal::InternalVisibility visibility,
+    [[maybe_unused]] ::google::protobuf::Arena* PROTOBUF_NULLABLE arena, const Impl_& from,
+    [[maybe_unused]] const ::s4wave::world::GetObjectBodiesBatchResponse& from_msg)
+      : _has_bits_{from._has_bits_},
+        _cached_size_{0},
+        bodies_{visibility, arena, from.bodies_} {}
+
+GetObjectBodiesBatchResponse::GetObjectBodiesBatchResponse(
+    ::google::protobuf::Arena* PROTOBUF_NULLABLE arena,
+    const GetObjectBodiesBatchResponse& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, GetObjectBodiesBatchResponse_class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  GetObjectBodiesBatchResponse* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  ::memcpy(reinterpret_cast<char*>(&_impl_) +
+               offsetof(Impl_, world_seqno_),
+           reinterpret_cast<const char*>(&from._impl_) +
+               offsetof(Impl_, world_seqno_),
+           offsetof(Impl_, next_key_index_) -
+               offsetof(Impl_, world_seqno_) +
+               sizeof(Impl_::next_key_index_));
+
+  // @@protoc_insertion_point(copy_constructor:s4wave.world.GetObjectBodiesBatchResponse)
+}
+PROTOBUF_NDEBUG_INLINE GetObjectBodiesBatchResponse::Impl_::Impl_(
+    [[maybe_unused]] ::google::protobuf::internal::InternalVisibility visibility,
+    [[maybe_unused]] ::google::protobuf::Arena* PROTOBUF_NULLABLE arena)
+      : _cached_size_{0},
+        bodies_{visibility, arena} {}
+
+inline void GetObjectBodiesBatchResponse::SharedCtor(::_pb::Arena* PROTOBUF_NULLABLE arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  ::memset(reinterpret_cast<char*>(&_impl_) +
+               offsetof(Impl_, world_seqno_),
+           0,
+           offsetof(Impl_, next_key_index_) -
+               offsetof(Impl_, world_seqno_) +
+               sizeof(Impl_::next_key_index_));
+}
+GetObjectBodiesBatchResponse::~GetObjectBodiesBatchResponse() {
+  // @@protoc_insertion_point(destructor:s4wave.world.GetObjectBodiesBatchResponse)
+  SharedDtor(*this);
+}
+inline void GetObjectBodiesBatchResponse::SharedDtor(MessageLite& self) {
+  GetObjectBodiesBatchResponse& this_ = static_cast<GetObjectBodiesBatchResponse&>(self);
+  if constexpr (::_pbi::DebugHardenCheckHasBitConsistency()) {
+    this_.CheckHasBitConsistency();
+  }
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.~Impl_();
+}
+
+inline void* PROTOBUF_NONNULL GetObjectBodiesBatchResponse::PlacementNew_(
+    const void* PROTOBUF_NONNULL, void* PROTOBUF_NONNULL mem,
+    ::google::protobuf::Arena* PROTOBUF_NULLABLE arena) {
+  return ::new (mem) GetObjectBodiesBatchResponse(arena);
+}
+constexpr auto GetObjectBodiesBatchResponse::InternalNewImpl_() {
+  constexpr auto arena_bits = ::google::protobuf::internal::EncodePlacementArenaOffsets({
+      PROTOBUF_FIELD_OFFSET(GetObjectBodiesBatchResponse, _impl_.bodies_) +
+          decltype(GetObjectBodiesBatchResponse::_impl_.bodies_)::
+              InternalGetArenaOffset(
+                  ::google::protobuf::Message::internal_visibility()),
+  });
+  if (arena_bits.has_value()) {
+    return ::google::protobuf::internal::MessageCreator::ZeroInit(
+        sizeof(GetObjectBodiesBatchResponse), alignof(GetObjectBodiesBatchResponse), *arena_bits);
+  } else {
+    return ::google::protobuf::internal::MessageCreator(&GetObjectBodiesBatchResponse::PlacementNew_,
+                                 sizeof(GetObjectBodiesBatchResponse),
+                                 alignof(GetObjectBodiesBatchResponse));
+  }
+}
+constexpr auto GetObjectBodiesBatchResponse::InternalGenerateClassData_() {
+  return ::google::protobuf::internal::ClassDataFull{
+      ::google::protobuf::internal::ClassData{
+          &_GetObjectBodiesBatchResponse_default_instance_._instance,
+          &_table_.header,
+          nullptr,  // OnDemandRegisterArenaDtor
+          nullptr,  // IsInitialized
+          &GetObjectBodiesBatchResponse::MergeImpl,
+          ::google::protobuf::Message::GetNewImpl<GetObjectBodiesBatchResponse>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+          &GetObjectBodiesBatchResponse::SharedDtor,
+          ::google::protobuf::Message::GetClearImpl<GetObjectBodiesBatchResponse>(), &GetObjectBodiesBatchResponse::ByteSizeLong,
+              &GetObjectBodiesBatchResponse::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          PROTOBUF_FIELD_OFFSET(GetObjectBodiesBatchResponse, _impl_._cached_size_),
+          false,
+      },
+      &GetObjectBodiesBatchResponse::kDescriptorMethods,
+      &descriptor_table_github_2ecom_2fs4wave_2fspacewave_2fsdk_2fworld_2fworld_2eproto,
+      nullptr,  // tracker
+  };
+}
+
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 const
+    ::google::protobuf::internal::ClassDataFull GetObjectBodiesBatchResponse_class_data_ =
+        GetObjectBodiesBatchResponse::InternalGenerateClassData_();
+
+PROTOBUF_ATTRIBUTE_WEAK const ::google::protobuf::internal::ClassData* PROTOBUF_NONNULL
+GetObjectBodiesBatchResponse::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&GetObjectBodiesBatchResponse_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(GetObjectBodiesBatchResponse_class_data_.tc_table);
+  return GetObjectBodiesBatchResponse_class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<2, 3, 1, 0, 2>
+GetObjectBodiesBatchResponse::_table_ = {
+  {
+    PROTOBUF_FIELD_OFFSET(GetObjectBodiesBatchResponse, _impl_._has_bits_),
+    0, // no _extensions_
+    3, 24,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967288,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    3,  // num_field_entries
+    1,  // num_aux_entries
+    offsetof(decltype(_table_), aux_entries),
+    GetObjectBodiesBatchResponse_class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::s4wave::world::GetObjectBodiesBatchResponse>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    {::_pbi::TcParser::MiniParse, {}},
+    // repeated .s4wave.world.ObjectBody bodies = 1;
+    {::_pbi::TcParser::FastMtR1,
+     {10, 0, 0,
+      PROTOBUF_FIELD_OFFSET(GetObjectBodiesBatchResponse, _impl_.bodies_)}},
+    // uint32 next_key_index = 2;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(GetObjectBodiesBatchResponse, _impl_.next_key_index_), 2>(),
+     {16, 2, 0,
+      PROTOBUF_FIELD_OFFSET(GetObjectBodiesBatchResponse, _impl_.next_key_index_)}},
+    // uint64 world_seqno = 3;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint64_t, offsetof(GetObjectBodiesBatchResponse, _impl_.world_seqno_), 1>(),
+     {24, 1, 0,
+      PROTOBUF_FIELD_OFFSET(GetObjectBodiesBatchResponse, _impl_.world_seqno_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // repeated .s4wave.world.ObjectBody bodies = 1;
+    {PROTOBUF_FIELD_OFFSET(GetObjectBodiesBatchResponse, _impl_.bodies_), _Internal::kHasBitsOffset + 0, 0, (0 | ::_fl::kFcRepeated | ::_fl::kMessage | ::_fl::kTvTable)},
+    // uint32 next_key_index = 2;
+    {PROTOBUF_FIELD_OFFSET(GetObjectBodiesBatchResponse, _impl_.next_key_index_), _Internal::kHasBitsOffset + 2, 0, (0 | ::_fl::kFcOptional | ::_fl::kUInt32)},
+    // uint64 world_seqno = 3;
+    {PROTOBUF_FIELD_OFFSET(GetObjectBodiesBatchResponse, _impl_.world_seqno_), _Internal::kHasBitsOffset + 1, 0, (0 | ::_fl::kFcOptional | ::_fl::kUInt64)},
+  }},
+  {{
+      {::_pbi::TcParser::GetTable<::s4wave::world::ObjectBody>()},
+  }},
+  {{
+  }},
+};
+PROTOBUF_NOINLINE void GetObjectBodiesBatchResponse::Clear() {
+// @@protoc_insertion_point(message_clear_start:s4wave.world.GetObjectBodiesBatchResponse)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (CheckHasBitForRepeated(cached_has_bits, 0x00000001U)) {
+    _impl_.bodies_.Clear();
+  }
+  if (BatchCheckHasBit(cached_has_bits, 0x00000006U)) {
+    ::memset(&_impl_.world_seqno_, 0, static_cast<::size_t>(
+        reinterpret_cast<char*>(&_impl_.next_key_index_) -
+        reinterpret_cast<char*>(&_impl_.world_seqno_)) + sizeof(_impl_.next_key_index_));
+  }
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+::uint8_t* PROTOBUF_NONNULL GetObjectBodiesBatchResponse::_InternalSerialize(
+    const ::google::protobuf::MessageLite& base, ::uint8_t* PROTOBUF_NONNULL target,
+    ::google::protobuf::io::EpsCopyOutputStream* PROTOBUF_NONNULL stream) {
+  const GetObjectBodiesBatchResponse& this_ = static_cast<const GetObjectBodiesBatchResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+::uint8_t* PROTOBUF_NONNULL GetObjectBodiesBatchResponse::_InternalSerialize(
+    ::uint8_t* PROTOBUF_NONNULL target,
+    ::google::protobuf::io::EpsCopyOutputStream* PROTOBUF_NONNULL stream) const {
+  const GetObjectBodiesBatchResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  if constexpr (::_pbi::DebugHardenCheckHasBitConsistency()) {
+    this_.CheckHasBitConsistency();
+  }
+  // @@protoc_insertion_point(serialize_to_array_start:s4wave.world.GetObjectBodiesBatchResponse)
+  ::uint32_t cached_has_bits = 0;
+  (void)cached_has_bits;
+
+  cached_has_bits = this_._impl_._has_bits_[0];
+  // repeated .s4wave.world.ObjectBody bodies = 1;
+  if (CheckHasBitForRepeated(cached_has_bits, 0x00000001U)) {
+    for (unsigned i = 0, n = static_cast<unsigned>(
+                             this_._internal_bodies_size());
+         i < n; i++) {
+      const auto& repfield = this_._internal_bodies().Get(i);
+      target =
+          ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+              1, repfield, repfield.GetCachedSize(),
+              target, stream);
+    }
+  }
+
+  // uint32 next_key_index = 2;
+  if (CheckHasBit(cached_has_bits, 0x00000004U)) {
+    if (this_._internal_next_key_index() != 0) {
+      target = stream->EnsureSpace(target);
+      target = ::_pbi::WireFormatLite::WriteUInt32ToArray(
+          2, this_._internal_next_key_index(), target);
+    }
+  }
+
+  // uint64 world_seqno = 3;
+  if (CheckHasBit(cached_has_bits, 0x00000002U)) {
+    if (this_._internal_world_seqno() != 0) {
+      target = stream->EnsureSpace(target);
+      target = ::_pbi::WireFormatLite::WriteUInt64ToArray(
+          3, this_._internal_world_seqno(), target);
+    }
+  }
+
+  if (ABSL_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+    target =
+        ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+            this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:s4wave.world.GetObjectBodiesBatchResponse)
+  return target;
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+::size_t GetObjectBodiesBatchResponse::ByteSizeLong(const MessageLite& base) {
+  const GetObjectBodiesBatchResponse& this_ = static_cast<const GetObjectBodiesBatchResponse&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+::size_t GetObjectBodiesBatchResponse::ByteSizeLong() const {
+  const GetObjectBodiesBatchResponse& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  // @@protoc_insertion_point(message_byte_size_start:s4wave.world.GetObjectBodiesBatchResponse)
+  ::size_t total_size = 0;
+
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void)cached_has_bits;
+
+  ::_pbi::Prefetch5LinesFrom7Lines(&this_);
+  cached_has_bits = this_._impl_._has_bits_[0];
+  if (BatchCheckHasBit(cached_has_bits, 0x00000007U)) {
+    // repeated .s4wave.world.ObjectBody bodies = 1;
+    if (CheckHasBitForRepeated(cached_has_bits, 0x00000001U)) {
+      total_size += 1UL * this_._internal_bodies_size();
+      for (const auto& msg : this_._internal_bodies()) {
+        total_size += ::google::protobuf::internal::WireFormatLite::MessageSize(msg);
+      }
+    }
+    // uint64 world_seqno = 3;
+    if (CheckHasBit(cached_has_bits, 0x00000002U)) {
+      if (this_._internal_world_seqno() != 0) {
+        total_size += ::_pbi::WireFormatLite::UInt64SizePlusOne(
+            this_._internal_world_seqno());
+      }
+    }
+    // uint32 next_key_index = 2;
+    if (CheckHasBit(cached_has_bits, 0x00000004U)) {
+      if (this_._internal_next_key_index() != 0) {
+        total_size += ::_pbi::WireFormatLite::UInt32SizePlusOne(
+            this_._internal_next_key_index());
+      }
+    }
+  }
+  return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                             &this_._impl_._cached_size_);
+}
+
+void GetObjectBodiesBatchResponse::MergeImpl(::google::protobuf::MessageLite& to_msg,
+                            const ::google::protobuf::MessageLite& from_msg) {
+   auto* const _this =
+      static_cast<GetObjectBodiesBatchResponse*>(&to_msg);
+  auto& from = static_cast<const GetObjectBodiesBatchResponse&>(from_msg);
+  if constexpr (::_pbi::DebugHardenCheckHasBitConsistency()) {
+    from.CheckHasBitConsistency();
+  }
+  ::google::protobuf::Arena* arena = _this->GetArena();
+  // @@protoc_insertion_point(class_specific_merge_from_start:s4wave.world.GetObjectBodiesBatchResponse)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void)cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (BatchCheckHasBit(cached_has_bits, 0x00000007U)) {
+    if (CheckHasBitForRepeated(cached_has_bits, 0x00000001U)) {
+      _this->_internal_mutable_bodies()->InternalMergeFromWithArena(
+          ::google::protobuf::MessageLite::internal_visibility(), arena,
+          from._internal_bodies());
+    }
+    if (CheckHasBit(cached_has_bits, 0x00000002U)) {
+      if (from._internal_world_seqno() != 0) {
+        _this->_impl_.world_seqno_ = from._impl_.world_seqno_;
+      }
+    }
+    if (CheckHasBit(cached_has_bits, 0x00000004U)) {
+      if (from._internal_next_key_index() != 0) {
+        _this->_impl_.next_key_index_ = from._impl_.next_key_index_;
+      }
+    }
+  }
+  _this->_impl_._has_bits_[0] |= cached_has_bits;
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+}
+
+void GetObjectBodiesBatchResponse::CopyFrom(const GetObjectBodiesBatchResponse& from) {
+  // @@protoc_insertion_point(class_specific_copy_from_start:s4wave.world.GetObjectBodiesBatchResponse)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void GetObjectBodiesBatchResponse::InternalSwap(GetObjectBodiesBatchResponse* PROTOBUF_RESTRICT PROTOBUF_NONNULL other) {
+  using ::std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  _impl_.bodies_.InternalSwap(&other->_impl_.bodies_);
+  ::google::protobuf::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(GetObjectBodiesBatchResponse, _impl_.next_key_index_)
+      + sizeof(GetObjectBodiesBatchResponse::_impl_.next_key_index_)
+      - PROTOBUF_FIELD_OFFSET(GetObjectBodiesBatchResponse, _impl_.world_seqno_)>(
+          reinterpret_cast<char*>(&_impl_.world_seqno_),
+          reinterpret_cast<char*>(&other->_impl_.world_seqno_));
+}
+
+::google::protobuf::Metadata GetObjectBodiesBatchResponse::GetMetadata() const {
   return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
 }
 // ===================================================================

--- a/sdk/world/world.pb.go
+++ b/sdk/world/world.pb.go
@@ -1359,6 +1359,113 @@ func (x *GetObjectMetadataBatchResponse) GetMetadata() []*ObjectMetadata {
 	return nil
 }
 
+// ObjectBody contains the serialized root body for one object key.
+type ObjectBody struct {
+	unknownFields []byte
+	// ObjectKey is the requested object key.
+	ObjectKey string `protobuf:"bytes,1,opt,name=object_key,json=objectKey,proto3" json:"objectKey,omitempty"`
+	// Body is the transformed root block data when the object exists.
+	Body []byte `protobuf:"bytes,2,opt,name=body,proto3" json:"body,omitempty"`
+	// Exists indicates whether the object key exists.
+	Exists bool `protobuf:"varint,3,opt,name=exists,proto3" json:"exists,omitempty"`
+}
+
+func (x *ObjectBody) Reset() {
+	*x = ObjectBody{}
+}
+
+func (*ObjectBody) ProtoMessage() {}
+
+func (x *ObjectBody) GetObjectKey() string {
+	if x != nil {
+		return x.ObjectKey
+	}
+	return ""
+}
+
+func (x *ObjectBody) GetBody() []byte {
+	if x != nil {
+		return x.Body
+	}
+	return nil
+}
+
+func (x *ObjectBody) GetExists() bool {
+	if x != nil {
+		return x.Exists
+	}
+	return false
+}
+
+// GetObjectBodiesBatchRequest is the request type for
+// GetObjectBodiesBatch.
+type GetObjectBodiesBatchRequest struct {
+	unknownFields []byte
+	// ObjectKeys is the list of object keys to inspect.
+	ObjectKeys []string `protobuf:"bytes,1,rep,name=object_keys,json=objectKeys,proto3" json:"objectKeys,omitempty"`
+	// StartKeyIndex is the first object key index to include in this page.
+	StartKeyIndex uint32 `protobuf:"varint,2,opt,name=start_key_index,json=startKeyIndex,proto3" json:"startKeyIndex,omitempty"`
+}
+
+func (x *GetObjectBodiesBatchRequest) Reset() {
+	*x = GetObjectBodiesBatchRequest{}
+}
+
+func (*GetObjectBodiesBatchRequest) ProtoMessage() {}
+
+func (x *GetObjectBodiesBatchRequest) GetObjectKeys() []string {
+	if x != nil {
+		return x.ObjectKeys
+	}
+	return nil
+}
+
+func (x *GetObjectBodiesBatchRequest) GetStartKeyIndex() uint32 {
+	if x != nil {
+		return x.StartKeyIndex
+	}
+	return 0
+}
+
+// GetObjectBodiesBatchResponse is the response type for
+// GetObjectBodiesBatch.
+type GetObjectBodiesBatchResponse struct {
+	unknownFields []byte
+	// Bodies preserves the request object key order.
+	Bodies []*ObjectBody `protobuf:"bytes,1,rep,name=bodies,proto3" json:"bodies,omitempty"`
+	// NextKeyIndex is the next key index to request. Zero means complete.
+	NextKeyIndex uint32 `protobuf:"varint,2,opt,name=next_key_index,json=nextKeyIndex,proto3" json:"nextKeyIndex,omitempty"`
+	// WorldSeqno is the World sequence number observed for this page.
+	WorldSeqno uint64 `protobuf:"varint,3,opt,name=world_seqno,json=worldSeqno,proto3" json:"worldSeqno,omitempty"`
+}
+
+func (x *GetObjectBodiesBatchResponse) Reset() {
+	*x = GetObjectBodiesBatchResponse{}
+}
+
+func (*GetObjectBodiesBatchResponse) ProtoMessage() {}
+
+func (x *GetObjectBodiesBatchResponse) GetBodies() []*ObjectBody {
+	if x != nil {
+		return x.Bodies
+	}
+	return nil
+}
+
+func (x *GetObjectBodiesBatchResponse) GetNextKeyIndex() uint32 {
+	if x != nil {
+		return x.NextKeyIndex
+	}
+	return 0
+}
+
+func (x *GetObjectBodiesBatchResponse) GetWorldSeqno() uint64 {
+	if x != nil {
+		return x.WorldSeqno
+	}
+	return 0
+}
+
 // GraphPathStep is one bounded predicate traversal step.
 type GraphPathStep struct {
 	unknownFields []byte
@@ -3122,6 +3229,59 @@ func (m *GetObjectMetadataBatchResponse) CloneVT() *GetObjectMetadataBatchRespon
 }
 
 func (m *GetObjectMetadataBatchResponse) CloneMessageVT() protobuf_go_lite.CloneMessage {
+	return m.CloneVT()
+}
+
+func (m *ObjectBody) CloneVT() *ObjectBody {
+	if m == nil {
+		return (*ObjectBody)(nil)
+	}
+	r := new(ObjectBody)
+	r.ObjectKey = m.ObjectKey
+	r.Exists = m.Exists
+	r.Body = protobuf_go_lite.CloneBytes(m.Body)
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = slices.Clone(m.unknownFields)
+	}
+	return r
+}
+
+func (m *ObjectBody) CloneMessageVT() protobuf_go_lite.CloneMessage {
+	return m.CloneVT()
+}
+
+func (m *GetObjectBodiesBatchRequest) CloneVT() *GetObjectBodiesBatchRequest {
+	if m == nil {
+		return (*GetObjectBodiesBatchRequest)(nil)
+	}
+	r := new(GetObjectBodiesBatchRequest)
+	r.StartKeyIndex = m.StartKeyIndex
+	r.ObjectKeys = protobuf_go_lite.CloneSlice(m.ObjectKeys)
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = slices.Clone(m.unknownFields)
+	}
+	return r
+}
+
+func (m *GetObjectBodiesBatchRequest) CloneMessageVT() protobuf_go_lite.CloneMessage {
+	return m.CloneVT()
+}
+
+func (m *GetObjectBodiesBatchResponse) CloneVT() *GetObjectBodiesBatchResponse {
+	if m == nil {
+		return (*GetObjectBodiesBatchResponse)(nil)
+	}
+	r := new(GetObjectBodiesBatchResponse)
+	r.NextKeyIndex = m.NextKeyIndex
+	r.WorldSeqno = m.WorldSeqno
+	r.Bodies = protobuf_go_lite.CloneVTSlice(m.Bodies)
+	if len(m.unknownFields) > 0 {
+		r.unknownFields = slices.Clone(m.unknownFields)
+	}
+	return r
+}
+
+func (m *GetObjectBodiesBatchResponse) CloneMessageVT() protobuf_go_lite.CloneMessage {
 	return m.CloneVT()
 }
 
@@ -4904,6 +5064,81 @@ func (this *GetObjectMetadataBatchResponse) EqualVT(that *GetObjectMetadataBatch
 
 func (this *GetObjectMetadataBatchResponse) EqualMessageVT(thatMsg any) bool {
 	that, ok := thatMsg.(*GetObjectMetadataBatchResponse)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+
+func (this *ObjectBody) EqualVT(that *ObjectBody) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if this.ObjectKey != that.ObjectKey {
+		return false
+	}
+	if !protobuf_go_lite.EqualBytes(this.Body, that.Body) {
+		return false
+	}
+	if this.Exists != that.Exists {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *ObjectBody) EqualMessageVT(thatMsg any) bool {
+	that, ok := thatMsg.(*ObjectBody)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+
+func (this *GetObjectBodiesBatchRequest) EqualVT(that *GetObjectBodiesBatchRequest) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if !protobuf_go_lite.EqualSlice(this.ObjectKeys, that.ObjectKeys) {
+		return false
+	}
+	if this.StartKeyIndex != that.StartKeyIndex {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *GetObjectBodiesBatchRequest) EqualMessageVT(thatMsg any) bool {
+	that, ok := thatMsg.(*GetObjectBodiesBatchRequest)
+	if !ok {
+		return false
+	}
+	return this.EqualVT(that)
+}
+
+func (this *GetObjectBodiesBatchResponse) EqualVT(that *GetObjectBodiesBatchResponse) bool {
+	if this == that {
+		return true
+	} else if this == nil || that == nil {
+		return false
+	}
+	if !protobuf_go_lite.EqualVTSliceImplicit(this.Bodies, that.Bodies, func() *ObjectBody { return &ObjectBody{} }) {
+		return false
+	}
+	if this.NextKeyIndex != that.NextKeyIndex {
+		return false
+	}
+	if this.WorldSeqno != that.WorldSeqno {
+		return false
+	}
+	return string(this.unknownFields) == string(that.unknownFields)
+}
+
+func (this *GetObjectBodiesBatchResponse) EqualMessageVT(thatMsg any) bool {
+	that, ok := thatMsg.(*GetObjectBodiesBatchResponse)
 	if !ok {
 		return false
 	}
@@ -8437,6 +8672,197 @@ func (x *GetObjectMetadataBatchResponse) UnmarshalProtoJSON(s *json.UnmarshalSta
 
 // UnmarshalJSON unmarshals the GetObjectMetadataBatchResponse from JSON.
 func (x *GetObjectMetadataBatchResponse) UnmarshalJSON(b []byte) error {
+	return json.DefaultUnmarshalerConfig.Unmarshal(b, x)
+}
+
+// MarshalProtoJSON marshals the ObjectBody message to JSON.
+func (x *ObjectBody) MarshalProtoJSON(s *json.MarshalState) {
+	if x == nil {
+		s.WriteNil()
+		return
+	}
+	s.WriteObjectStart()
+	var wroteField bool
+	if x.ObjectKey != "" || s.HasField("objectKey") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("objectKey")
+		s.WriteString(x.ObjectKey)
+	}
+	if len(x.Body) > 0 || s.HasField("body") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("body")
+		s.WriteBytes(x.Body)
+	}
+	if x.Exists || s.HasField("exists") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("exists")
+		s.WriteBool(x.Exists)
+	}
+	s.WriteObjectEnd()
+}
+
+// MarshalJSON marshals the ObjectBody to JSON.
+func (x *ObjectBody) MarshalJSON() ([]byte, error) {
+	return json.DefaultMarshalerConfig.Marshal(x)
+}
+
+// UnmarshalProtoJSON unmarshals the ObjectBody message from JSON.
+func (x *ObjectBody) UnmarshalProtoJSON(s *json.UnmarshalState) {
+	if s.ReadNil() {
+		return
+	}
+	s.ReadObject(func(key string) {
+		switch key {
+		default:
+			s.Skip() // ignore unknown field
+		case "object_key", "objectKey":
+			s.AddField("object_key")
+			x.ObjectKey = s.ReadString()
+		case "body":
+			s.AddField("body")
+			x.Body = s.ReadBytes()
+		case "exists":
+			s.AddField("exists")
+			x.Exists = s.ReadBool()
+		}
+	})
+}
+
+// UnmarshalJSON unmarshals the ObjectBody from JSON.
+func (x *ObjectBody) UnmarshalJSON(b []byte) error {
+	return json.DefaultUnmarshalerConfig.Unmarshal(b, x)
+}
+
+// MarshalProtoJSON marshals the GetObjectBodiesBatchRequest message to JSON.
+func (x *GetObjectBodiesBatchRequest) MarshalProtoJSON(s *json.MarshalState) {
+	if x == nil {
+		s.WriteNil()
+		return
+	}
+	s.WriteObjectStart()
+	var wroteField bool
+	if len(x.ObjectKeys) > 0 || s.HasField("objectKeys") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("objectKeys")
+		s.WriteStringArray(x.ObjectKeys)
+	}
+	if x.StartKeyIndex != 0 || s.HasField("startKeyIndex") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("startKeyIndex")
+		s.WriteUint32(x.StartKeyIndex)
+	}
+	s.WriteObjectEnd()
+}
+
+// MarshalJSON marshals the GetObjectBodiesBatchRequest to JSON.
+func (x *GetObjectBodiesBatchRequest) MarshalJSON() ([]byte, error) {
+	return json.DefaultMarshalerConfig.Marshal(x)
+}
+
+// UnmarshalProtoJSON unmarshals the GetObjectBodiesBatchRequest message from JSON.
+func (x *GetObjectBodiesBatchRequest) UnmarshalProtoJSON(s *json.UnmarshalState) {
+	if s.ReadNil() {
+		return
+	}
+	s.ReadObject(func(key string) {
+		switch key {
+		default:
+			s.Skip() // ignore unknown field
+		case "object_keys", "objectKeys":
+			s.AddField("object_keys")
+			if s.ReadNil() {
+				x.ObjectKeys = nil
+				return
+			}
+			x.ObjectKeys = s.ReadStringArray()
+		case "start_key_index", "startKeyIndex":
+			s.AddField("start_key_index")
+			x.StartKeyIndex = s.ReadUint32()
+		}
+	})
+}
+
+// UnmarshalJSON unmarshals the GetObjectBodiesBatchRequest from JSON.
+func (x *GetObjectBodiesBatchRequest) UnmarshalJSON(b []byte) error {
+	return json.DefaultUnmarshalerConfig.Unmarshal(b, x)
+}
+
+// MarshalProtoJSON marshals the GetObjectBodiesBatchResponse message to JSON.
+func (x *GetObjectBodiesBatchResponse) MarshalProtoJSON(s *json.MarshalState) {
+	if x == nil {
+		s.WriteNil()
+		return
+	}
+	s.WriteObjectStart()
+	var wroteField bool
+	if len(x.Bodies) > 0 || s.HasField("bodies") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("bodies")
+		s.WriteArrayStart()
+		var wroteElement bool
+		for _, element := range x.Bodies {
+			s.WriteMoreIf(&wroteElement)
+			element.MarshalProtoJSON(s.WithField("bodies"))
+		}
+		s.WriteArrayEnd()
+	}
+	if x.NextKeyIndex != 0 || s.HasField("nextKeyIndex") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("nextKeyIndex")
+		s.WriteUint32(x.NextKeyIndex)
+	}
+	if x.WorldSeqno != 0 || s.HasField("worldSeqno") {
+		s.WriteMoreIf(&wroteField)
+		s.WriteObjectField("worldSeqno")
+		s.WriteUint64(x.WorldSeqno)
+	}
+	s.WriteObjectEnd()
+}
+
+// MarshalJSON marshals the GetObjectBodiesBatchResponse to JSON.
+func (x *GetObjectBodiesBatchResponse) MarshalJSON() ([]byte, error) {
+	return json.DefaultMarshalerConfig.Marshal(x)
+}
+
+// UnmarshalProtoJSON unmarshals the GetObjectBodiesBatchResponse message from JSON.
+func (x *GetObjectBodiesBatchResponse) UnmarshalProtoJSON(s *json.UnmarshalState) {
+	if s.ReadNil() {
+		return
+	}
+	s.ReadObject(func(key string) {
+		switch key {
+		default:
+			s.Skip() // ignore unknown field
+		case "bodies":
+			s.AddField("bodies")
+			if s.ReadNil() {
+				x.Bodies = nil
+				return
+			}
+			s.ReadArray(func() {
+				if s.ReadNil() {
+					x.Bodies = append(x.Bodies, nil)
+					return
+				}
+				v := &ObjectBody{}
+				v.UnmarshalProtoJSON(s.WithField("bodies", false))
+				if s.Err() != nil {
+					return
+				}
+				x.Bodies = append(x.Bodies, v)
+			})
+		case "next_key_index", "nextKeyIndex":
+			s.AddField("next_key_index")
+			x.NextKeyIndex = s.ReadUint32()
+		case "world_seqno", "worldSeqno":
+			s.AddField("world_seqno")
+			x.WorldSeqno = s.ReadUint64()
+		}
+	})
+}
+
+// UnmarshalJSON unmarshals the GetObjectBodiesBatchResponse from JSON.
+func (x *GetObjectBodiesBatchResponse) UnmarshalJSON(b []byte) error {
 	return json.DefaultUnmarshalerConfig.Unmarshal(b, x)
 }
 
@@ -12421,6 +12847,151 @@ func (m *GetObjectMetadataBatchResponse) MarshalToSizedBufferVT(dAtA []byte) (in
 	return len(dAtA) - i, nil
 }
 
+func (m *ObjectBody) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *ObjectBody) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *ObjectBody) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
+	}
+	if m.Exists {
+		i = protobuf_go_lite.EncodeBool(dAtA, i, m.Exists)
+		i--
+		dAtA[i] = 0x18
+	}
+	if len(m.Body) > 0 {
+		i = protobuf_go_lite.EncodeBytes(dAtA, i, m.Body)
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.ObjectKey) > 0 {
+		i = protobuf_go_lite.EncodeString(dAtA, i, m.ObjectKey)
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *GetObjectBodiesBatchRequest) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GetObjectBodiesBatchRequest) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *GetObjectBodiesBatchRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
+	}
+	if m.StartKeyIndex != 0 {
+		i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(m.StartKeyIndex))
+		i--
+		dAtA[i] = 0x10
+	}
+	if len(m.ObjectKeys) > 0 {
+		for iNdEx := len(m.ObjectKeys) - 1; iNdEx >= 0; iNdEx-- {
+			i = protobuf_go_lite.EncodeString(dAtA, i, m.ObjectKeys[iNdEx])
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *GetObjectBodiesBatchResponse) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *GetObjectBodiesBatchResponse) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *GetObjectBodiesBatchResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i = protobuf_go_lite.EncodeRawBytes(dAtA, i, m.unknownFields)
+	}
+	if m.WorldSeqno != 0 {
+		i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(m.WorldSeqno))
+		i--
+		dAtA[i] = 0x18
+	}
+	if m.NextKeyIndex != 0 {
+		i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(m.NextKeyIndex))
+		i--
+		dAtA[i] = 0x10
+	}
+	if len(m.Bodies) > 0 {
+		for iNdEx := len(m.Bodies) - 1; iNdEx >= 0; iNdEx-- {
+			size, err := m.Bodies[iNdEx].MarshalToSizedBufferVT(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = protobuf_go_lite.EncodeVarint(dAtA, i, uint64(size))
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
+}
+
 func (m *GraphPathStep) MarshalVT() (dAtA []byte, err error) {
 	if m == nil {
 		return nil, nil
@@ -14670,6 +15241,47 @@ func (m *GetObjectMetadataBatchResponse) SizeVT() (n int) {
 	return n
 }
 
+func (m *ObjectBody) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	n += protobuf_go_lite.SizeStringNonEmpty(1, m.ObjectKey)
+	n += protobuf_go_lite.SizeBytesNonEmpty(1, m.Body)
+	n += protobuf_go_lite.SizeBoolNonZero(1, m.Exists)
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *GetObjectBodiesBatchRequest) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	n += protobuf_go_lite.SizeStringSlice(1, m.ObjectKeys)
+	n += protobuf_go_lite.SizeVarintNonZero(1, m.StartKeyIndex)
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *GetObjectBodiesBatchResponse) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	for _, e := range m.Bodies {
+		l = e.SizeVT()
+		n += protobuf_go_lite.SizeMessage(1, l)
+	}
+	n += protobuf_go_lite.SizeVarintNonZero(1, m.NextKeyIndex)
+	n += protobuf_go_lite.SizeVarintNonZero(1, m.WorldSeqno)
+	n += len(m.unknownFields)
+	return n
+}
+
 func (m *GraphPathStep) SizeVT() (n int) {
 	if m == nil {
 		return 0
@@ -16052,6 +16664,80 @@ func (x *GetObjectMetadataBatchResponse) MarshalProtoText() string {
 }
 
 func (x *GetObjectMetadataBatchResponse) String() string {
+	return x.MarshalProtoText()
+}
+
+func (x *ObjectBody) MarshalProtoText() string {
+	var sb protobuf_go_lite.TextBuilder
+	initialLen := protobuf_go_lite.TextStartMessage(&sb, "ObjectBody")
+	if x.ObjectKey != "" {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "object_key")
+		protobuf_go_lite.TextWriteString(&sb, x.ObjectKey)
+	}
+	if len(x.Body) != 0 {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "body")
+		protobuf_go_lite.TextWriteBytes(&sb, x.Body)
+	}
+	if x.Exists != false {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "exists")
+		protobuf_go_lite.TextWriteBool(&sb, x.Exists)
+	}
+	return protobuf_go_lite.TextFinishMessage(&sb)
+}
+
+func (x *ObjectBody) String() string {
+	return x.MarshalProtoText()
+}
+
+func (x *GetObjectBodiesBatchRequest) MarshalProtoText() string {
+	var sb protobuf_go_lite.TextBuilder
+	initialLen := protobuf_go_lite.TextStartMessage(&sb, "GetObjectBodiesBatchRequest")
+	if len(x.ObjectKeys) > 0 {
+		protobuf_go_lite.TextWriteListStart(&sb, initialLen, "object_keys")
+		for i, v := range x.ObjectKeys {
+			protobuf_go_lite.TextWriteListSeparator(&sb, i)
+			protobuf_go_lite.TextWriteString(&sb, v)
+		}
+		protobuf_go_lite.TextWriteListEnd(&sb)
+	}
+	if x.StartKeyIndex != 0 {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "start_key_index")
+		protobuf_go_lite.TextWriteUint(&sb, x.StartKeyIndex)
+	}
+	return protobuf_go_lite.TextFinishMessage(&sb)
+}
+
+func (x *GetObjectBodiesBatchRequest) String() string {
+	return x.MarshalProtoText()
+}
+
+func (x *GetObjectBodiesBatchResponse) MarshalProtoText() string {
+	var sb protobuf_go_lite.TextBuilder
+	initialLen := protobuf_go_lite.TextStartMessage(&sb, "GetObjectBodiesBatchResponse")
+	if len(x.Bodies) > 0 {
+		protobuf_go_lite.TextWriteListStart(&sb, initialLen, "bodies")
+		for i, v := range x.Bodies {
+			protobuf_go_lite.TextWriteListSeparator(&sb, i)
+			if v == nil {
+				protobuf_go_lite.TextWriteTextMarshaler(&sb, &ObjectBody{})
+			} else {
+				protobuf_go_lite.TextWriteTextMarshaler(&sb, v)
+			}
+		}
+		protobuf_go_lite.TextWriteListEnd(&sb)
+	}
+	if x.NextKeyIndex != 0 {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "next_key_index")
+		protobuf_go_lite.TextWriteUint(&sb, x.NextKeyIndex)
+	}
+	if x.WorldSeqno != 0 {
+		protobuf_go_lite.TextWriteFieldPrefix(&sb, initialLen, "world_seqno")
+		protobuf_go_lite.TextWriteUint(&sb, x.WorldSeqno)
+	}
+	return protobuf_go_lite.TextFinishMessage(&sb)
+}
+
+func (x *GetObjectBodiesBatchResponse) String() string {
 	return x.MarshalProtoText()
 }
 
@@ -19726,6 +20412,213 @@ func (m *GetObjectMetadataBatchResponse) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protobuf_go_lite.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+
+func (m *ObjectBody) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	var err error
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		wire, iNdEx, err = protobuf_go_lite.DecodeVarint(dAtA, iNdEx)
+		if err != nil {
+			return err
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: ObjectBody: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: ObjectBody: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ObjectKey", wireType)
+			}
+			var v string
+			v, iNdEx, err = protobuf_go_lite.DecodeString(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.ObjectKey = v
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Body", wireType)
+			}
+			m.Body, iNdEx, err = protobuf_go_lite.DecodeBytesAppend(m.Body, dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Exists", wireType)
+			}
+			var v bool
+			v, iNdEx, err = protobuf_go_lite.DecodeVarintBool(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.Exists = bool(v)
+		default:
+			iNdEx = preIndex
+			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protobuf_go_lite.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+
+func (m *GetObjectBodiesBatchRequest) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	var err error
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		wire, iNdEx, err = protobuf_go_lite.DecodeVarint(dAtA, iNdEx)
+		if err != nil {
+			return err
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetObjectBodiesBatchRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetObjectBodiesBatchRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ObjectKeys", wireType)
+			}
+			var v string
+			v, iNdEx, err = protobuf_go_lite.DecodeString(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.ObjectKeys = append(m.ObjectKeys, v)
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field StartKeyIndex", wireType)
+			}
+			m.StartKeyIndex = 0
+			m.StartKeyIndex, iNdEx, err = protobuf_go_lite.DecodeVarintUint32(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+		default:
+			iNdEx = preIndex
+			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return protobuf_go_lite.ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+
+func (m *GetObjectBodiesBatchResponse) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	var err error
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		wire, iNdEx, err = protobuf_go_lite.DecodeVarint(dAtA, iNdEx)
+		if err != nil {
+			return err
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: GetObjectBodiesBatchResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: GetObjectBodiesBatchResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Bodies", wireType)
+			}
+			msgStart, postIndex, err := protobuf_go_lite.DecodeLengthDelimited(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+			m.Bodies = append(m.Bodies, &ObjectBody{})
+			if err := m.Bodies[len(m.Bodies)-1].UnmarshalVT(dAtA[msgStart:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field NextKeyIndex", wireType)
+			}
+			m.NextKeyIndex = 0
+			m.NextKeyIndex, iNdEx, err = protobuf_go_lite.DecodeVarintUint32(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field WorldSeqno", wireType)
+			}
+			m.WorldSeqno = 0
+			m.WorldSeqno, iNdEx, err = protobuf_go_lite.DecodeVarint(dAtA, iNdEx)
+			if err != nil {
+				return err
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := protobuf_go_lite.Skip(dAtA[iNdEx:])

--- a/sdk/world/world.pb.h
+++ b/sdk/world/world.pb.h
@@ -198,6 +198,14 @@ class GetKeyResponse;
 struct GetKeyResponseDefaultTypeInternal;
 extern GetKeyResponseDefaultTypeInternal _GetKeyResponse_default_instance_;
 extern const ::google::protobuf::internal::ClassDataFull GetKeyResponse_class_data_;
+class GetObjectBodiesBatchRequest;
+struct GetObjectBodiesBatchRequestDefaultTypeInternal;
+extern GetObjectBodiesBatchRequestDefaultTypeInternal _GetObjectBodiesBatchRequest_default_instance_;
+extern const ::google::protobuf::internal::ClassDataFull GetObjectBodiesBatchRequest_class_data_;
+class GetObjectBodiesBatchResponse;
+struct GetObjectBodiesBatchResponseDefaultTypeInternal;
+extern GetObjectBodiesBatchResponseDefaultTypeInternal _GetObjectBodiesBatchResponse_default_instance_;
+extern const ::google::protobuf::internal::ClassDataFull GetObjectBodiesBatchResponse_class_data_;
 class GetObjectMetadataBatchRequest;
 struct GetObjectMetadataBatchRequestDefaultTypeInternal;
 extern GetObjectMetadataBatchRequestDefaultTypeInternal _GetObjectMetadataBatchRequest_default_instance_;
@@ -342,6 +350,10 @@ class NextResponse;
 struct NextResponseDefaultTypeInternal;
 extern NextResponseDefaultTypeInternal _NextResponse_default_instance_;
 extern const ::google::protobuf::internal::ClassDataFull NextResponse_class_data_;
+class ObjectBody;
+struct ObjectBodyDefaultTypeInternal;
+extern ObjectBodyDefaultTypeInternal _ObjectBody_default_instance_;
+extern const ::google::protobuf::internal::ClassDataFull ObjectBody_class_data_;
 class ObjectMetadata;
 struct ObjectMetadataDefaultTypeInternal;
 extern ObjectMetadataDefaultTypeInternal _ObjectMetadata_default_instance_;
@@ -637,7 +649,7 @@ class WatchWorldStateResponse final : public ::google::protobuf::Message
     return *reinterpret_cast<const WatchWorldStateResponse*>(
         &_WatchWorldStateResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 62;
+  static constexpr int kIndexInFileMessages = 65;
   friend void swap(WatchWorldStateResponse& a, WatchWorldStateResponse& b) { a.Swap(&b); }
   inline void Swap(WatchWorldStateResponse* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -826,7 +838,7 @@ class WatchWorldStateRequest final : public ::google::protobuf::internal::ZeroFi
     return *reinterpret_cast<const WatchWorldStateRequest*>(
         &_WatchWorldStateRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 61;
+  static constexpr int kIndexInFileMessages = 64;
   friend void swap(WatchWorldStateRequest& a, WatchWorldStateRequest& b) { a.Swap(&b); }
   inline void Swap(WatchWorldStateRequest* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -1475,7 +1487,7 @@ class WaitRevResponse final : public ::google::protobuf::Message
     return *reinterpret_cast<const WaitRevResponse*>(
         &_WaitRevResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 92;
+  static constexpr int kIndexInFileMessages = 95;
   friend void swap(WaitRevResponse& a, WaitRevResponse& b) { a.Swap(&b); }
   inline void Swap(WaitRevResponse* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -1665,7 +1677,7 @@ class WaitRevRequest final : public ::google::protobuf::Message
     return *reinterpret_cast<const WaitRevRequest*>(
         &_WaitRevRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 91;
+  static constexpr int kIndexInFileMessages = 94;
   friend void swap(WaitRevRequest& a, WaitRevRequest& b) { a.Swap(&b); }
   inline void Swap(WaitRevRequest* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -1867,7 +1879,7 @@ class ValidResponse final : public ::google::protobuf::Message
     return *reinterpret_cast<const ValidResponse*>(
         &_ValidResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 68;
+  static constexpr int kIndexInFileMessages = 71;
   friend void swap(ValidResponse& a, ValidResponse& b) { a.Swap(&b); }
   inline void Swap(ValidResponse* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -2056,7 +2068,7 @@ class ValidRequest final : public ::google::protobuf::internal::ZeroFieldsBase
     return *reinterpret_cast<const ValidRequest*>(
         &_ValidRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 67;
+  static constexpr int kIndexInFileMessages = 70;
   friend void swap(ValidRequest& a, ValidRequest& b) { a.Swap(&b); }
   inline void Swap(ValidRequest* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -2191,7 +2203,7 @@ class TrackedWorldStateSnapshot_ObjectAccess final : public ::google::protobuf::
     return *reinterpret_cast<const TrackedWorldStateSnapshot_ObjectAccess*>(
         &_TrackedWorldStateSnapshot_ObjectAccess_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 63;
+  static constexpr int kIndexInFileMessages = 66;
   friend void swap(TrackedWorldStateSnapshot_ObjectAccess& a, TrackedWorldStateSnapshot_ObjectAccess& b) { a.Swap(&b); }
   inline void Swap(TrackedWorldStateSnapshot_ObjectAccess* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -2722,7 +2734,7 @@ class SetRootRefResponse final : public ::google::protobuf::Message
     return *reinterpret_cast<const SetRootRefResponse*>(
         &_SetRootRefResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 86;
+  static constexpr int kIndexInFileMessages = 89;
   friend void swap(SetRootRefResponse& a, SetRootRefResponse& b) { a.Swap(&b); }
   inline void Swap(SetRootRefResponse* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -3045,7 +3057,7 @@ class SeekResponse final : public ::google::protobuf::internal::ZeroFieldsBase
     return *reinterpret_cast<const SeekResponse*>(
         &_SeekResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 74;
+  static constexpr int kIndexInFileMessages = 77;
   friend void swap(SeekResponse& a, SeekResponse& b) { a.Swap(&b); }
   inline void Swap(SeekResponse* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -3180,7 +3192,7 @@ class SeekRequest final : public ::google::protobuf::Message
     return *reinterpret_cast<const SeekRequest*>(
         &_SeekRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 73;
+  static constexpr int kIndexInFileMessages = 76;
   friend void swap(SeekRequest& a, SeekRequest& b) { a.Swap(&b); }
   inline void Swap(SeekRequest* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -3806,7 +3818,7 @@ class QueryGraphPathResponse final : public ::google::protobuf::Message
     return *reinterpret_cast<const QueryGraphPathResponse*>(
         &_QueryGraphPathResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 56;
+  static constexpr int kIndexInFileMessages = 59;
   friend void swap(QueryGraphPathResponse& a, QueryGraphPathResponse& b) { a.Swap(&b); }
   inline void Swap(QueryGraphPathResponse* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -4170,6 +4182,230 @@ class ObjectMetadata final : public ::google::protobuf::Message
 extern const ::google::protobuf::internal::ClassDataFull ObjectMetadata_class_data_;
 // -------------------------------------------------------------------
 
+class ObjectBody final : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:s4wave.world.ObjectBody) */ {
+ public:
+  inline ObjectBody() : ObjectBody(nullptr) {}
+  ~ObjectBody() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(ObjectBody* PROTOBUF_NONNULL msg, ::std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(ObjectBody));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR ObjectBody(::google::protobuf::internal::ConstantInitialized);
+
+  inline ObjectBody(const ObjectBody& from) : ObjectBody(nullptr, from) {}
+  inline ObjectBody(ObjectBody&& from) noexcept
+      : ObjectBody(nullptr, ::std::move(from)) {}
+  inline ObjectBody& operator=(const ObjectBody& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline ObjectBody& operator=(ObjectBody&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* PROTOBUF_NONNULL mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* PROTOBUF_NONNULL descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* PROTOBUF_NONNULL GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* PROTOBUF_NONNULL GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const ObjectBody& default_instance() {
+    return *reinterpret_cast<const ObjectBody*>(
+        &_ObjectBody_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 54;
+  friend void swap(ObjectBody& a, ObjectBody& b) { a.Swap(&b); }
+  inline void Swap(ObjectBody* PROTOBUF_NONNULL other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(ObjectBody* PROTOBUF_NONNULL other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  ObjectBody* PROTOBUF_NONNULL New(::google::protobuf::Arena* PROTOBUF_NULLABLE arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<ObjectBody>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const ObjectBody& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const ObjectBody& from) { ObjectBody::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(::google::protobuf::MessageLite& to_msg,
+                        const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* PROTOBUF_NONNULL _InternalSerialize(
+      const ::google::protobuf::MessageLite& msg, ::uint8_t* PROTOBUF_NONNULL target,
+      ::google::protobuf::io::EpsCopyOutputStream* PROTOBUF_NONNULL stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* PROTOBUF_NONNULL _InternalSerialize(
+      ::uint8_t* PROTOBUF_NONNULL target,
+      ::google::protobuf::io::EpsCopyOutputStream* PROTOBUF_NONNULL stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* PROTOBUF_NONNULL _InternalSerialize(
+      ::uint8_t* PROTOBUF_NONNULL target,
+      ::google::protobuf::io::EpsCopyOutputStream* PROTOBUF_NONNULL stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* PROTOBUF_NULLABLE arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(ObjectBody* PROTOBUF_NONNULL other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "s4wave.world.ObjectBody"; }
+
+  explicit ObjectBody(::google::protobuf::Arena* PROTOBUF_NULLABLE arena);
+  ObjectBody(::google::protobuf::Arena* PROTOBUF_NULLABLE arena, const ObjectBody& from);
+  ObjectBody(
+      ::google::protobuf::Arena* PROTOBUF_NULLABLE arena, ObjectBody&& from) noexcept
+      : ObjectBody(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* PROTOBUF_NONNULL GetClassData() const PROTOBUF_FINAL;
+  static void* PROTOBUF_NONNULL PlacementNew_(
+      const void* PROTOBUF_NONNULL, void* PROTOBUF_NONNULL mem,
+      ::google::protobuf::Arena* PROTOBUF_NULLABLE arena);
+  static constexpr auto InternalNewImpl_();
+
+ public:
+  static constexpr auto InternalGenerateClassData_();
+
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kObjectKeyFieldNumber = 1,
+    kBodyFieldNumber = 2,
+    kExistsFieldNumber = 3,
+  };
+  // string object_key = 1;
+  void clear_object_key() ;
+  const ::std::string& object_key() const;
+  template <typename Arg_ = const ::std::string&, typename... Args_>
+  void set_object_key(Arg_&& arg, Args_... args);
+  ::std::string* PROTOBUF_NONNULL mutable_object_key();
+  [[nodiscard]] ::std::string* PROTOBUF_NULLABLE release_object_key();
+  void set_allocated_object_key(::std::string* PROTOBUF_NULLABLE value);
+
+  private:
+  const ::std::string& _internal_object_key() const;
+  PROTOBUF_ALWAYS_INLINE void _internal_set_object_key(const ::std::string& value);
+  ::std::string* PROTOBUF_NONNULL _internal_mutable_object_key();
+
+  public:
+  // bytes body = 2;
+  void clear_body() ;
+  const ::std::string& body() const;
+  template <typename Arg_ = const ::std::string&, typename... Args_>
+  void set_body(Arg_&& arg, Args_... args);
+  ::std::string* PROTOBUF_NONNULL mutable_body();
+  [[nodiscard]] ::std::string* PROTOBUF_NULLABLE release_body();
+  void set_allocated_body(::std::string* PROTOBUF_NULLABLE value);
+
+  private:
+  const ::std::string& _internal_body() const;
+  PROTOBUF_ALWAYS_INLINE void _internal_set_body(const ::std::string& value);
+  ::std::string* PROTOBUF_NONNULL _internal_mutable_body();
+
+  public:
+  // bool exists = 3;
+  void clear_exists() ;
+  bool exists() const;
+  void set_exists(bool value);
+
+  private:
+  bool _internal_exists() const;
+  void _internal_set_exists(bool value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:s4wave.world.ObjectBody)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<2, 3,
+                                   0, 42,
+                                   2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(
+        ::google::protobuf::internal::InternalVisibility visibility,
+        ::google::protobuf::Arena* PROTOBUF_NULLABLE arena);
+    inline explicit Impl_(
+        ::google::protobuf::internal::InternalVisibility visibility,
+        ::google::protobuf::Arena* PROTOBUF_NULLABLE arena, const Impl_& from,
+        const ObjectBody& from_msg);
+    ::google::protobuf::internal::HasBits<1> _has_bits_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    ::google::protobuf::internal::ArenaStringPtr object_key_;
+    ::google::protobuf::internal::ArenaStringPtr body_;
+    bool exists_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_github_2ecom_2fs4wave_2fspacewave_2fsdk_2fworld_2fworld_2eproto;
+};
+
+extern const ::google::protobuf::internal::ClassDataFull ObjectBody_class_data_;
+// -------------------------------------------------------------------
+
 class NextResponse final : public ::google::protobuf::Message
 /* @@protoc_insertion_point(class_definition:s4wave.world.NextResponse) */ {
  public:
@@ -4225,7 +4461,7 @@ class NextResponse final : public ::google::protobuf::Message
     return *reinterpret_cast<const NextResponse*>(
         &_NextResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 72;
+  static constexpr int kIndexInFileMessages = 75;
   friend void swap(NextResponse& a, NextResponse& b) { a.Swap(&b); }
   inline void Swap(NextResponse* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -4414,7 +4650,7 @@ class NextRequest final : public ::google::protobuf::internal::ZeroFieldsBase
     return *reinterpret_cast<const NextRequest*>(
         &_NextRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 71;
+  static constexpr int kIndexInFileMessages = 74;
   friend void swap(NextRequest& a, NextRequest& b) { a.Swap(&b); }
   inline void Swap(NextRequest* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -4548,7 +4784,7 @@ class NextGraphPathQueryRequest final : public ::google::protobuf::internal::Zer
     return *reinterpret_cast<const NextGraphPathQueryRequest*>(
         &_NextGraphPathQueryRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 77;
+  static constexpr int kIndexInFileMessages = 80;
   friend void swap(NextGraphPathQueryRequest& a, NextGraphPathQueryRequest& b) { a.Swap(&b); }
   inline void Swap(NextGraphPathQueryRequest* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -5715,7 +5951,7 @@ class KeyResponse final : public ::google::protobuf::Message
     return *reinterpret_cast<const KeyResponse*>(
         &_KeyResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 70;
+  static constexpr int kIndexInFileMessages = 73;
   friend void swap(KeyResponse& a, KeyResponse& b) { a.Swap(&b); }
   inline void Swap(KeyResponse* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -5909,7 +6145,7 @@ class KeyRequest final : public ::google::protobuf::internal::ZeroFieldsBase
     return *reinterpret_cast<const KeyRequest*>(
         &_KeyRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 69;
+  static constexpr int kIndexInFileMessages = 72;
   friend void swap(KeyRequest& a, KeyRequest& b) { a.Swap(&b); }
   inline void Swap(KeyRequest* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -6441,7 +6677,7 @@ class IncrementRevResponse final : public ::google::protobuf::Message
     return *reinterpret_cast<const IncrementRevResponse*>(
         &_IncrementRevResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 90;
+  static constexpr int kIndexInFileMessages = 93;
   friend void swap(IncrementRevResponse& a, IncrementRevResponse& b) { a.Swap(&b); }
   inline void Swap(IncrementRevResponse* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -6630,7 +6866,7 @@ class IncrementRevRequest final : public ::google::protobuf::internal::ZeroField
     return *reinterpret_cast<const IncrementRevRequest*>(
         &_IncrementRevRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 89;
+  static constexpr int kIndexInFileMessages = 92;
   friend void swap(IncrementRevRequest& a, IncrementRevRequest& b) { a.Swap(&b); }
   inline void Swap(IncrementRevRequest* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -6765,7 +7001,7 @@ class GraphPathStep final : public ::google::protobuf::Message
     return *reinterpret_cast<const GraphPathStep*>(
         &_GraphPathStep_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 54;
+  static constexpr int kIndexInFileMessages = 57;
   friend void swap(GraphPathStep& a, GraphPathStep& b) { a.Swap(&b); }
   inline void Swap(GraphPathStep* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -7441,7 +7677,7 @@ class GetRootRefRequest final : public ::google::protobuf::internal::ZeroFieldsB
     return *reinterpret_cast<const GetRootRefRequest*>(
         &_GetRootRefRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 83;
+  static constexpr int kIndexInFileMessages = 86;
   friend void swap(GetRootRefRequest& a, GetRootRefRequest& b) { a.Swap(&b); }
   inline void Swap(GetRootRefRequest* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -8663,6 +8899,220 @@ class GetObjectMetadataBatchRequest final : public ::google::protobuf::Message
 extern const ::google::protobuf::internal::ClassDataFull GetObjectMetadataBatchRequest_class_data_;
 // -------------------------------------------------------------------
 
+class GetObjectBodiesBatchRequest final : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:s4wave.world.GetObjectBodiesBatchRequest) */ {
+ public:
+  inline GetObjectBodiesBatchRequest() : GetObjectBodiesBatchRequest(nullptr) {}
+  ~GetObjectBodiesBatchRequest() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(GetObjectBodiesBatchRequest* PROTOBUF_NONNULL msg, ::std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(GetObjectBodiesBatchRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR GetObjectBodiesBatchRequest(::google::protobuf::internal::ConstantInitialized);
+
+  inline GetObjectBodiesBatchRequest(const GetObjectBodiesBatchRequest& from) : GetObjectBodiesBatchRequest(nullptr, from) {}
+  inline GetObjectBodiesBatchRequest(GetObjectBodiesBatchRequest&& from) noexcept
+      : GetObjectBodiesBatchRequest(nullptr, ::std::move(from)) {}
+  inline GetObjectBodiesBatchRequest& operator=(const GetObjectBodiesBatchRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline GetObjectBodiesBatchRequest& operator=(GetObjectBodiesBatchRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* PROTOBUF_NONNULL mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* PROTOBUF_NONNULL descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* PROTOBUF_NONNULL GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* PROTOBUF_NONNULL GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const GetObjectBodiesBatchRequest& default_instance() {
+    return *reinterpret_cast<const GetObjectBodiesBatchRequest*>(
+        &_GetObjectBodiesBatchRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 55;
+  friend void swap(GetObjectBodiesBatchRequest& a, GetObjectBodiesBatchRequest& b) { a.Swap(&b); }
+  inline void Swap(GetObjectBodiesBatchRequest* PROTOBUF_NONNULL other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(GetObjectBodiesBatchRequest* PROTOBUF_NONNULL other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  GetObjectBodiesBatchRequest* PROTOBUF_NONNULL New(::google::protobuf::Arena* PROTOBUF_NULLABLE arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<GetObjectBodiesBatchRequest>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const GetObjectBodiesBatchRequest& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const GetObjectBodiesBatchRequest& from) { GetObjectBodiesBatchRequest::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(::google::protobuf::MessageLite& to_msg,
+                        const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* PROTOBUF_NONNULL _InternalSerialize(
+      const ::google::protobuf::MessageLite& msg, ::uint8_t* PROTOBUF_NONNULL target,
+      ::google::protobuf::io::EpsCopyOutputStream* PROTOBUF_NONNULL stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* PROTOBUF_NONNULL _InternalSerialize(
+      ::uint8_t* PROTOBUF_NONNULL target,
+      ::google::protobuf::io::EpsCopyOutputStream* PROTOBUF_NONNULL stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* PROTOBUF_NONNULL _InternalSerialize(
+      ::uint8_t* PROTOBUF_NONNULL target,
+      ::google::protobuf::io::EpsCopyOutputStream* PROTOBUF_NONNULL stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* PROTOBUF_NULLABLE arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(GetObjectBodiesBatchRequest* PROTOBUF_NONNULL other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "s4wave.world.GetObjectBodiesBatchRequest"; }
+
+  explicit GetObjectBodiesBatchRequest(::google::protobuf::Arena* PROTOBUF_NULLABLE arena);
+  GetObjectBodiesBatchRequest(::google::protobuf::Arena* PROTOBUF_NULLABLE arena, const GetObjectBodiesBatchRequest& from);
+  GetObjectBodiesBatchRequest(
+      ::google::protobuf::Arena* PROTOBUF_NULLABLE arena, GetObjectBodiesBatchRequest&& from) noexcept
+      : GetObjectBodiesBatchRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* PROTOBUF_NONNULL GetClassData() const PROTOBUF_FINAL;
+  static void* PROTOBUF_NONNULL PlacementNew_(
+      const void* PROTOBUF_NONNULL, void* PROTOBUF_NONNULL mem,
+      ::google::protobuf::Arena* PROTOBUF_NULLABLE arena);
+  static constexpr auto InternalNewImpl_();
+
+ public:
+  static constexpr auto InternalGenerateClassData_();
+
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kObjectKeysFieldNumber = 1,
+    kStartKeyIndexFieldNumber = 2,
+  };
+  // repeated string object_keys = 1;
+  int object_keys_size() const;
+  private:
+  int _internal_object_keys_size() const;
+
+  public:
+  void clear_object_keys() ;
+  const ::std::string& object_keys(int index) const;
+  ::std::string* PROTOBUF_NONNULL mutable_object_keys(int index);
+  template <typename Arg_ = const ::std::string&, typename... Args_>
+  void set_object_keys(int index, Arg_&& value, Args_... args);
+  ::std::string* PROTOBUF_NONNULL add_object_keys();
+  template <typename Arg_ = const ::std::string&, typename... Args_>
+  void add_object_keys(Arg_&& value, Args_... args);
+  const ::google::protobuf::RepeatedPtrField<::std::string>& object_keys() const;
+  ::google::protobuf::RepeatedPtrField<::std::string>* PROTOBUF_NONNULL mutable_object_keys();
+
+  private:
+  const ::google::protobuf::RepeatedPtrField<::std::string>& _internal_object_keys() const;
+  ::google::protobuf::RepeatedPtrField<::std::string>* PROTOBUF_NONNULL _internal_mutable_object_keys();
+
+  public:
+  // uint32 start_key_index = 2;
+  void clear_start_key_index() ;
+  ::uint32_t start_key_index() const;
+  void set_start_key_index(::uint32_t value);
+
+  private:
+  ::uint32_t _internal_start_key_index() const;
+  void _internal_set_start_key_index(::uint32_t value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:s4wave.world.GetObjectBodiesBatchRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<1, 2,
+                                   0, 60,
+                                   2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(
+        ::google::protobuf::internal::InternalVisibility visibility,
+        ::google::protobuf::Arena* PROTOBUF_NULLABLE arena);
+    inline explicit Impl_(
+        ::google::protobuf::internal::InternalVisibility visibility,
+        ::google::protobuf::Arena* PROTOBUF_NULLABLE arena, const Impl_& from,
+        const GetObjectBodiesBatchRequest& from_msg);
+    ::google::protobuf::internal::HasBits<1> _has_bits_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    ::google::protobuf::RepeatedPtrField<::std::string> object_keys_;
+    ::uint32_t start_key_index_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_github_2ecom_2fs4wave_2fspacewave_2fsdk_2fworld_2fworld_2eproto;
+};
+
+extern const ::google::protobuf::internal::ClassDataFull GetObjectBodiesBatchRequest_class_data_;
+// -------------------------------------------------------------------
+
 class GetKeyResponse final : public ::google::protobuf::Message
 /* @@protoc_insertion_point(class_definition:s4wave.world.GetKeyResponse) */ {
  public:
@@ -8718,7 +9168,7 @@ class GetKeyResponse final : public ::google::protobuf::Message
     return *reinterpret_cast<const GetKeyResponse*>(
         &_GetKeyResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 82;
+  static constexpr int kIndexInFileMessages = 85;
   friend void swap(GetKeyResponse& a, GetKeyResponse& b) { a.Swap(&b); }
   inline void Swap(GetKeyResponse* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -8912,7 +9362,7 @@ class GetKeyRequest final : public ::google::protobuf::internal::ZeroFieldsBase
     return *reinterpret_cast<const GetKeyRequest*>(
         &_GetKeyRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 81;
+  static constexpr int kIndexInFileMessages = 84;
   friend void swap(GetKeyRequest& a, GetKeyRequest& b) { a.Swap(&b); }
   inline void Swap(GetKeyRequest* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -9181,7 +9631,7 @@ class ErrResponse final : public ::google::protobuf::Message
     return *reinterpret_cast<const ErrResponse*>(
         &_ErrResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 66;
+  static constexpr int kIndexInFileMessages = 69;
   friend void swap(ErrResponse& a, ErrResponse& b) { a.Swap(&b); }
   inline void Swap(ErrResponse* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -9375,7 +9825,7 @@ class ErrRequest final : public ::google::protobuf::internal::ZeroFieldsBase
     return *reinterpret_cast<const ErrRequest*>(
         &_ErrRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 65;
+  static constexpr int kIndexInFileMessages = 68;
   friend void swap(ErrRequest& a, ErrRequest& b) { a.Swap(&b); }
   inline void Swap(ErrRequest* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -10508,7 +10958,7 @@ class DeleteGraphObjectResponse final : public ::google::protobuf::internal::Zer
     return *reinterpret_cast<const DeleteGraphObjectResponse*>(
         &_DeleteGraphObjectResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 58;
+  static constexpr int kIndexInFileMessages = 61;
   friend void swap(DeleteGraphObjectResponse& a, DeleteGraphObjectResponse& b) { a.Swap(&b); }
   inline void Swap(DeleteGraphObjectResponse* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -10643,7 +11093,7 @@ class DeleteGraphObjectRequest final : public ::google::protobuf::Message
     return *reinterpret_cast<const DeleteGraphObjectRequest*>(
         &_DeleteGraphObjectRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 57;
+  static constexpr int kIndexInFileMessages = 60;
   friend void swap(DeleteGraphObjectRequest& a, DeleteGraphObjectRequest& b) { a.Swap(&b); }
   inline void Swap(DeleteGraphObjectRequest* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -11312,7 +11762,7 @@ class CloseResponse final : public ::google::protobuf::internal::ZeroFieldsBase
     return *reinterpret_cast<const CloseResponse*>(
         &_CloseResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 76;
+  static constexpr int kIndexInFileMessages = 79;
   friend void swap(CloseResponse& a, CloseResponse& b) { a.Swap(&b); }
   inline void Swap(CloseResponse* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -11446,7 +11896,7 @@ class CloseRequest final : public ::google::protobuf::internal::ZeroFieldsBase
     return *reinterpret_cast<const CloseRequest*>(
         &_CloseRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 75;
+  static constexpr int kIndexInFileMessages = 78;
   friend void swap(CloseRequest& a, CloseRequest& b) { a.Swap(&b); }
   inline void Swap(CloseRequest* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -11580,7 +12030,7 @@ class CloseGraphPathQueryResponse final : public ::google::protobuf::internal::Z
     return *reinterpret_cast<const CloseGraphPathQueryResponse*>(
         &_CloseGraphPathQueryResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 80;
+  static constexpr int kIndexInFileMessages = 83;
   friend void swap(CloseGraphPathQueryResponse& a, CloseGraphPathQueryResponse& b) { a.Swap(&b); }
   inline void Swap(CloseGraphPathQueryResponse* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -11714,7 +12164,7 @@ class CloseGraphPathQueryRequest final : public ::google::protobuf::internal::Ze
     return *reinterpret_cast<const CloseGraphPathQueryRequest*>(
         &_CloseGraphPathQueryRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 79;
+  static constexpr int kIndexInFileMessages = 82;
   friend void swap(CloseGraphPathQueryRequest& a, CloseGraphPathQueryRequest& b) { a.Swap(&b); }
   inline void Swap(CloseGraphPathQueryRequest* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -12173,7 +12623,7 @@ class ApplyWorldOpResponse final : public ::google::protobuf::Message
     return *reinterpret_cast<const ApplyWorldOpResponse*>(
         &_ApplyWorldOpResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 60;
+  static constexpr int kIndexInFileMessages = 63;
   friend void swap(ApplyWorldOpResponse& a, ApplyWorldOpResponse& b) { a.Swap(&b); }
   inline void Swap(ApplyWorldOpResponse* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -12387,7 +12837,7 @@ class ApplyWorldOpRequest final : public ::google::protobuf::Message
     return *reinterpret_cast<const ApplyWorldOpRequest*>(
         &_ApplyWorldOpRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 59;
+  static constexpr int kIndexInFileMessages = 62;
   friend void swap(ApplyWorldOpRequest& a, ApplyWorldOpRequest& b) { a.Swap(&b); }
   inline void Swap(ApplyWorldOpRequest* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -12616,7 +13066,7 @@ class ApplyObjectOpResponse final : public ::google::protobuf::Message
     return *reinterpret_cast<const ApplyObjectOpResponse*>(
         &_ApplyObjectOpResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 88;
+  static constexpr int kIndexInFileMessages = 91;
   friend void swap(ApplyObjectOpResponse& a, ApplyObjectOpResponse& b) { a.Swap(&b); }
   inline void Swap(ApplyObjectOpResponse* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -12830,7 +13280,7 @@ class ApplyObjectOpRequest final : public ::google::protobuf::Message
     return *reinterpret_cast<const ApplyObjectOpRequest*>(
         &_ApplyObjectOpRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 87;
+  static constexpr int kIndexInFileMessages = 90;
   friend void swap(ApplyObjectOpRequest& a, ApplyObjectOpRequest& b) { a.Swap(&b); }
   inline void Swap(ApplyObjectOpRequest* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -13249,7 +13699,7 @@ class AccessTypedObjectResponse final : public ::google::protobuf::Message
     return *reinterpret_cast<const AccessTypedObjectResponse*>(
         &_AccessTypedObjectResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 94;
+  static constexpr int kIndexInFileMessages = 97;
   friend void swap(AccessTypedObjectResponse& a, AccessTypedObjectResponse& b) { a.Swap(&b); }
   inline void Swap(AccessTypedObjectResponse* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -13456,7 +13906,7 @@ class AccessTypedObjectRequest final : public ::google::protobuf::Message
     return *reinterpret_cast<const AccessTypedObjectRequest*>(
         &_AccessTypedObjectRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 93;
+  static constexpr int kIndexInFileMessages = 96;
   friend void swap(AccessTypedObjectRequest& a, AccessTypedObjectRequest& b) { a.Swap(&b); }
   inline void Swap(AccessTypedObjectRequest* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -13651,7 +14101,7 @@ class TrackedWorldStateSnapshot final : public ::google::protobuf::Message
     return *reinterpret_cast<const TrackedWorldStateSnapshot*>(
         &_TrackedWorldStateSnapshot_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 64;
+  static constexpr int kIndexInFileMessages = 67;
   friend void swap(TrackedWorldStateSnapshot& a, TrackedWorldStateSnapshot& b) { a.Swap(&b); }
   inline void Swap(TrackedWorldStateSnapshot* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -14068,7 +14518,7 @@ class QueryGraphPathRequest final : public ::google::protobuf::Message
     return *reinterpret_cast<const QueryGraphPathRequest*>(
         &_QueryGraphPathRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 55;
+  static constexpr int kIndexInFileMessages = 58;
   friend void swap(QueryGraphPathRequest& a, QueryGraphPathRequest& b) { a.Swap(&b); }
   inline void Swap(QueryGraphPathRequest* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -14325,7 +14775,7 @@ class NextGraphPathQueryResponse final : public ::google::protobuf::Message
     return *reinterpret_cast<const NextGraphPathQueryResponse*>(
         &_NextGraphPathQueryResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 78;
+  static constexpr int kIndexInFileMessages = 81;
   friend void swap(NextGraphPathQueryResponse& a, NextGraphPathQueryResponse& b) { a.Swap(&b); }
   inline void Swap(NextGraphPathQueryResponse* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -15767,6 +16217,227 @@ class GetObjectMetadataBatchResponse final : public ::google::protobuf::Message
 extern const ::google::protobuf::internal::ClassDataFull GetObjectMetadataBatchResponse_class_data_;
 // -------------------------------------------------------------------
 
+class GetObjectBodiesBatchResponse final : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:s4wave.world.GetObjectBodiesBatchResponse) */ {
+ public:
+  inline GetObjectBodiesBatchResponse() : GetObjectBodiesBatchResponse(nullptr) {}
+  ~GetObjectBodiesBatchResponse() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(GetObjectBodiesBatchResponse* PROTOBUF_NONNULL msg, ::std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(GetObjectBodiesBatchResponse));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR GetObjectBodiesBatchResponse(::google::protobuf::internal::ConstantInitialized);
+
+  inline GetObjectBodiesBatchResponse(const GetObjectBodiesBatchResponse& from) : GetObjectBodiesBatchResponse(nullptr, from) {}
+  inline GetObjectBodiesBatchResponse(GetObjectBodiesBatchResponse&& from) noexcept
+      : GetObjectBodiesBatchResponse(nullptr, ::std::move(from)) {}
+  inline GetObjectBodiesBatchResponse& operator=(const GetObjectBodiesBatchResponse& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline GetObjectBodiesBatchResponse& operator=(GetObjectBodiesBatchResponse&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* PROTOBUF_NONNULL mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* PROTOBUF_NONNULL descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* PROTOBUF_NONNULL GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* PROTOBUF_NONNULL GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const GetObjectBodiesBatchResponse& default_instance() {
+    return *reinterpret_cast<const GetObjectBodiesBatchResponse*>(
+        &_GetObjectBodiesBatchResponse_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 56;
+  friend void swap(GetObjectBodiesBatchResponse& a, GetObjectBodiesBatchResponse& b) { a.Swap(&b); }
+  inline void Swap(GetObjectBodiesBatchResponse* PROTOBUF_NONNULL other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(GetObjectBodiesBatchResponse* PROTOBUF_NONNULL other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  GetObjectBodiesBatchResponse* PROTOBUF_NONNULL New(::google::protobuf::Arena* PROTOBUF_NULLABLE arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<GetObjectBodiesBatchResponse>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const GetObjectBodiesBatchResponse& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const GetObjectBodiesBatchResponse& from) { GetObjectBodiesBatchResponse::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(::google::protobuf::MessageLite& to_msg,
+                        const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* PROTOBUF_NONNULL _InternalSerialize(
+      const ::google::protobuf::MessageLite& msg, ::uint8_t* PROTOBUF_NONNULL target,
+      ::google::protobuf::io::EpsCopyOutputStream* PROTOBUF_NONNULL stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* PROTOBUF_NONNULL _InternalSerialize(
+      ::uint8_t* PROTOBUF_NONNULL target,
+      ::google::protobuf::io::EpsCopyOutputStream* PROTOBUF_NONNULL stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* PROTOBUF_NONNULL _InternalSerialize(
+      ::uint8_t* PROTOBUF_NONNULL target,
+      ::google::protobuf::io::EpsCopyOutputStream* PROTOBUF_NONNULL stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* PROTOBUF_NULLABLE arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(GetObjectBodiesBatchResponse* PROTOBUF_NONNULL other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "s4wave.world.GetObjectBodiesBatchResponse"; }
+
+  explicit GetObjectBodiesBatchResponse(::google::protobuf::Arena* PROTOBUF_NULLABLE arena);
+  GetObjectBodiesBatchResponse(::google::protobuf::Arena* PROTOBUF_NULLABLE arena, const GetObjectBodiesBatchResponse& from);
+  GetObjectBodiesBatchResponse(
+      ::google::protobuf::Arena* PROTOBUF_NULLABLE arena, GetObjectBodiesBatchResponse&& from) noexcept
+      : GetObjectBodiesBatchResponse(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* PROTOBUF_NONNULL GetClassData() const PROTOBUF_FINAL;
+  static void* PROTOBUF_NONNULL PlacementNew_(
+      const void* PROTOBUF_NONNULL, void* PROTOBUF_NONNULL mem,
+      ::google::protobuf::Arena* PROTOBUF_NULLABLE arena);
+  static constexpr auto InternalNewImpl_();
+
+ public:
+  static constexpr auto InternalGenerateClassData_();
+
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kBodiesFieldNumber = 1,
+    kWorldSeqnoFieldNumber = 3,
+    kNextKeyIndexFieldNumber = 2,
+  };
+  // repeated .s4wave.world.ObjectBody bodies = 1;
+  int bodies_size() const;
+  private:
+  int _internal_bodies_size() const;
+
+  public:
+  void clear_bodies() ;
+  ::s4wave::world::ObjectBody* PROTOBUF_NONNULL mutable_bodies(int index);
+  ::google::protobuf::RepeatedPtrField<::s4wave::world::ObjectBody>* PROTOBUF_NONNULL mutable_bodies();
+
+  private:
+  const ::google::protobuf::RepeatedPtrField<::s4wave::world::ObjectBody>& _internal_bodies() const;
+  ::google::protobuf::RepeatedPtrField<::s4wave::world::ObjectBody>* PROTOBUF_NONNULL _internal_mutable_bodies();
+  public:
+  const ::s4wave::world::ObjectBody& bodies(int index) const;
+  ::s4wave::world::ObjectBody* PROTOBUF_NONNULL add_bodies();
+  const ::google::protobuf::RepeatedPtrField<::s4wave::world::ObjectBody>& bodies() const;
+  // uint64 world_seqno = 3;
+  void clear_world_seqno() ;
+  ::uint64_t world_seqno() const;
+  void set_world_seqno(::uint64_t value);
+
+  private:
+  ::uint64_t _internal_world_seqno() const;
+  void _internal_set_world_seqno(::uint64_t value);
+
+  public:
+  // uint32 next_key_index = 2;
+  void clear_next_key_index() ;
+  ::uint32_t next_key_index() const;
+  void set_next_key_index(::uint32_t value);
+
+  private:
+  ::uint32_t _internal_next_key_index() const;
+  void _internal_set_next_key_index(::uint32_t value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:s4wave.world.GetObjectBodiesBatchResponse)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<2, 3,
+                                   1, 0,
+                                   2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(
+        ::google::protobuf::internal::InternalVisibility visibility,
+        ::google::protobuf::Arena* PROTOBUF_NULLABLE arena);
+    inline explicit Impl_(
+        ::google::protobuf::internal::InternalVisibility visibility,
+        ::google::protobuf::Arena* PROTOBUF_NULLABLE arena, const Impl_& from,
+        const GetObjectBodiesBatchResponse& from_msg);
+    ::google::protobuf::internal::HasBits<1> _has_bits_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    ::google::protobuf::RepeatedPtrField< ::s4wave::world::ObjectBody > bodies_;
+    ::uint64_t world_seqno_;
+    ::uint32_t next_key_index_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_github_2ecom_2fs4wave_2fspacewave_2fsdk_2fworld_2fworld_2eproto;
+};
+
+extern const ::google::protobuf::internal::ClassDataFull GetObjectBodiesBatchResponse_class_data_;
+// -------------------------------------------------------------------
+
 class GetEngineInfoResponse final : public ::google::protobuf::Message
 /* @@protoc_insertion_point(class_definition:s4wave.world.GetEngineInfoResponse) */ {
  public:
@@ -16847,7 +17518,7 @@ class SetRootRefRequest final : public ::google::protobuf::Message
     return *reinterpret_cast<const SetRootRefRequest*>(
         &_SetRootRefRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 85;
+  static constexpr int kIndexInFileMessages = 88;
   friend void swap(SetRootRefRequest& a, SetRootRefRequest& b) { a.Swap(&b); }
   inline void Swap(SetRootRefRequest* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -17278,7 +17949,7 @@ class GetRootRefResponse final : public ::google::protobuf::Message
     return *reinterpret_cast<const GetRootRefResponse*>(
         &_GetRootRefResponse_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 84;
+  static constexpr int kIndexInFileMessages = 87;
   friend void swap(GetRootRefResponse& a, GetRootRefResponse& b) { a.Swap(&b); }
   inline void Swap(GetRootRefResponse* PROTOBUF_NONNULL other) {
     if (other == this) return;
@@ -21780,6 +22451,376 @@ inline ::google::protobuf::RepeatedPtrField<::s4wave::world::ObjectMetadata>* PR
 GetObjectMetadataBatchResponse::_internal_mutable_metadata() {
   ::google::protobuf::internal::TSanRead(&_impl_);
   return &_impl_.metadata_;
+}
+
+// -------------------------------------------------------------------
+
+// ObjectBody
+
+// string object_key = 1;
+inline void ObjectBody::clear_object_key() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.object_key_.ClearToEmpty();
+  ClearHasBit(_impl_._has_bits_[0],
+                  0x00000001U);
+}
+inline const ::std::string& ObjectBody::object_key() const
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:s4wave.world.ObjectBody.object_key)
+  return _internal_object_key();
+}
+template <typename Arg_, typename... Args_>
+PROTOBUF_ALWAYS_INLINE void ObjectBody::set_object_key(Arg_&& arg, Args_... args) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  SetHasBit(_impl_._has_bits_[0], 0x00000001U);
+  _impl_.object_key_.Set(static_cast<Arg_&&>(arg), args..., GetArena());
+  // @@protoc_insertion_point(field_set:s4wave.world.ObjectBody.object_key)
+}
+inline ::std::string* PROTOBUF_NONNULL ObjectBody::mutable_object_key()
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  SetHasBit(_impl_._has_bits_[0], 0x00000001U);
+  ::std::string* _s = _internal_mutable_object_key();
+  // @@protoc_insertion_point(field_mutable:s4wave.world.ObjectBody.object_key)
+  return _s;
+}
+inline const ::std::string& ObjectBody::_internal_object_key() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.object_key_.Get();
+}
+inline void ObjectBody::_internal_set_object_key(const ::std::string& value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.object_key_.Set(value, GetArena());
+}
+inline ::std::string* PROTOBUF_NONNULL ObjectBody::_internal_mutable_object_key() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  return _impl_.object_key_.Mutable( GetArena());
+}
+inline ::std::string* PROTOBUF_NULLABLE ObjectBody::release_object_key() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:s4wave.world.ObjectBody.object_key)
+  if (!CheckHasBit(_impl_._has_bits_[0], 0x00000001U)) {
+    return nullptr;
+  }
+  ClearHasBit(_impl_._has_bits_[0], 0x00000001U);
+  auto* released = _impl_.object_key_.Release();
+  if (::google::protobuf::internal::DebugHardenForceCopyDefaultString()) {
+    _impl_.object_key_.Set("", GetArena());
+  }
+  return released;
+}
+inline void ObjectBody::set_allocated_object_key(::std::string* PROTOBUF_NULLABLE value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (value != nullptr) {
+    SetHasBit(_impl_._has_bits_[0], 0x00000001U);
+  } else {
+    ClearHasBit(_impl_._has_bits_[0], 0x00000001U);
+  }
+  _impl_.object_key_.SetAllocated(value, GetArena());
+  if (::google::protobuf::internal::DebugHardenForceCopyDefaultString() && _impl_.object_key_.IsDefault()) {
+    _impl_.object_key_.Set("", GetArena());
+  }
+  // @@protoc_insertion_point(field_set_allocated:s4wave.world.ObjectBody.object_key)
+}
+
+// bytes body = 2;
+inline void ObjectBody::clear_body() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.body_.ClearToEmpty();
+  ClearHasBit(_impl_._has_bits_[0],
+                  0x00000002U);
+}
+inline const ::std::string& ObjectBody::body() const
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:s4wave.world.ObjectBody.body)
+  return _internal_body();
+}
+template <typename Arg_, typename... Args_>
+PROTOBUF_ALWAYS_INLINE void ObjectBody::set_body(Arg_&& arg, Args_... args) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  SetHasBit(_impl_._has_bits_[0], 0x00000002U);
+  _impl_.body_.SetBytes(static_cast<Arg_&&>(arg), args..., GetArena());
+  // @@protoc_insertion_point(field_set:s4wave.world.ObjectBody.body)
+}
+inline ::std::string* PROTOBUF_NONNULL ObjectBody::mutable_body()
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  SetHasBit(_impl_._has_bits_[0], 0x00000002U);
+  ::std::string* _s = _internal_mutable_body();
+  // @@protoc_insertion_point(field_mutable:s4wave.world.ObjectBody.body)
+  return _s;
+}
+inline const ::std::string& ObjectBody::_internal_body() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.body_.Get();
+}
+inline void ObjectBody::_internal_set_body(const ::std::string& value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.body_.Set(value, GetArena());
+}
+inline ::std::string* PROTOBUF_NONNULL ObjectBody::_internal_mutable_body() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  return _impl_.body_.Mutable( GetArena());
+}
+inline ::std::string* PROTOBUF_NULLABLE ObjectBody::release_body() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:s4wave.world.ObjectBody.body)
+  if (!CheckHasBit(_impl_._has_bits_[0], 0x00000002U)) {
+    return nullptr;
+  }
+  ClearHasBit(_impl_._has_bits_[0], 0x00000002U);
+  auto* released = _impl_.body_.Release();
+  if (::google::protobuf::internal::DebugHardenForceCopyDefaultString()) {
+    _impl_.body_.Set("", GetArena());
+  }
+  return released;
+}
+inline void ObjectBody::set_allocated_body(::std::string* PROTOBUF_NULLABLE value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (value != nullptr) {
+    SetHasBit(_impl_._has_bits_[0], 0x00000002U);
+  } else {
+    ClearHasBit(_impl_._has_bits_[0], 0x00000002U);
+  }
+  _impl_.body_.SetAllocated(value, GetArena());
+  if (::google::protobuf::internal::DebugHardenForceCopyDefaultString() && _impl_.body_.IsDefault()) {
+    _impl_.body_.Set("", GetArena());
+  }
+  // @@protoc_insertion_point(field_set_allocated:s4wave.world.ObjectBody.body)
+}
+
+// bool exists = 3;
+inline void ObjectBody::clear_exists() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.exists_ = false;
+  ClearHasBit(_impl_._has_bits_[0],
+                  0x00000004U);
+}
+inline bool ObjectBody::exists() const {
+  // @@protoc_insertion_point(field_get:s4wave.world.ObjectBody.exists)
+  return _internal_exists();
+}
+inline void ObjectBody::set_exists(bool value) {
+  _internal_set_exists(value);
+  SetHasBit(_impl_._has_bits_[0], 0x00000004U);
+  // @@protoc_insertion_point(field_set:s4wave.world.ObjectBody.exists)
+}
+inline bool ObjectBody::_internal_exists() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.exists_;
+}
+inline void ObjectBody::_internal_set_exists(bool value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.exists_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// GetObjectBodiesBatchRequest
+
+// repeated string object_keys = 1;
+inline int GetObjectBodiesBatchRequest::_internal_object_keys_size() const {
+  return _internal_object_keys().size();
+}
+inline int GetObjectBodiesBatchRequest::object_keys_size() const {
+  return _internal_object_keys_size();
+}
+inline void GetObjectBodiesBatchRequest::clear_object_keys() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.object_keys_.Clear();
+  ClearHasBitForRepeated(_impl_._has_bits_[0],
+                  0x00000001U);
+}
+inline ::std::string* PROTOBUF_NONNULL GetObjectBodiesBatchRequest::add_object_keys()
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::std::string* _s =
+      _internal_mutable_object_keys()->InternalAddWithArena(
+          ::google::protobuf::MessageLite::internal_visibility(), GetArena());
+  SetHasBitForRepeated(_impl_._has_bits_[0], 0x00000001U);
+  // @@protoc_insertion_point(field_add_mutable:s4wave.world.GetObjectBodiesBatchRequest.object_keys)
+  return _s;
+}
+inline const ::std::string& GetObjectBodiesBatchRequest::object_keys(int index) const
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:s4wave.world.GetObjectBodiesBatchRequest.object_keys)
+  return _internal_object_keys().Get(index);
+}
+inline ::std::string* PROTOBUF_NONNULL GetObjectBodiesBatchRequest::mutable_object_keys(int index)
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_mutable:s4wave.world.GetObjectBodiesBatchRequest.object_keys)
+  return _internal_mutable_object_keys()->Mutable(index);
+}
+template <typename Arg_, typename... Args_>
+inline void GetObjectBodiesBatchRequest::set_object_keys(int index, Arg_&& value, Args_... args) {
+  ::google::protobuf::internal::AssignToString(*_internal_mutable_object_keys()->Mutable(index), ::std::forward<Arg_>(value),
+                        args... );
+  // @@protoc_insertion_point(field_set:s4wave.world.GetObjectBodiesBatchRequest.object_keys)
+}
+template <typename Arg_, typename... Args_>
+inline void GetObjectBodiesBatchRequest::add_object_keys(Arg_&& value, Args_... args) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::google::protobuf::internal::AddToRepeatedPtrField(
+      ::google::protobuf::MessageLite::internal_visibility(), GetArena(),
+      *_internal_mutable_object_keys(), ::std::forward<Arg_>(value),
+      args... );
+  SetHasBitForRepeated(_impl_._has_bits_[0], 0x00000001U);
+  // @@protoc_insertion_point(field_add:s4wave.world.GetObjectBodiesBatchRequest.object_keys)
+}
+inline const ::google::protobuf::RepeatedPtrField<::std::string>& GetObjectBodiesBatchRequest::object_keys()
+    const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_list:s4wave.world.GetObjectBodiesBatchRequest.object_keys)
+  return _internal_object_keys();
+}
+inline ::google::protobuf::RepeatedPtrField<::std::string>* PROTOBUF_NONNULL
+GetObjectBodiesBatchRequest::mutable_object_keys() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  SetHasBitForRepeated(_impl_._has_bits_[0], 0x00000001U);
+  // @@protoc_insertion_point(field_mutable_list:s4wave.world.GetObjectBodiesBatchRequest.object_keys)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  return _internal_mutable_object_keys();
+}
+inline const ::google::protobuf::RepeatedPtrField<::std::string>&
+GetObjectBodiesBatchRequest::_internal_object_keys() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.object_keys_;
+}
+inline ::google::protobuf::RepeatedPtrField<::std::string>* PROTOBUF_NONNULL
+GetObjectBodiesBatchRequest::_internal_mutable_object_keys() {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return &_impl_.object_keys_;
+}
+
+// uint32 start_key_index = 2;
+inline void GetObjectBodiesBatchRequest::clear_start_key_index() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.start_key_index_ = 0u;
+  ClearHasBit(_impl_._has_bits_[0],
+                  0x00000002U);
+}
+inline ::uint32_t GetObjectBodiesBatchRequest::start_key_index() const {
+  // @@protoc_insertion_point(field_get:s4wave.world.GetObjectBodiesBatchRequest.start_key_index)
+  return _internal_start_key_index();
+}
+inline void GetObjectBodiesBatchRequest::set_start_key_index(::uint32_t value) {
+  _internal_set_start_key_index(value);
+  SetHasBit(_impl_._has_bits_[0], 0x00000002U);
+  // @@protoc_insertion_point(field_set:s4wave.world.GetObjectBodiesBatchRequest.start_key_index)
+}
+inline ::uint32_t GetObjectBodiesBatchRequest::_internal_start_key_index() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.start_key_index_;
+}
+inline void GetObjectBodiesBatchRequest::_internal_set_start_key_index(::uint32_t value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.start_key_index_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// GetObjectBodiesBatchResponse
+
+// repeated .s4wave.world.ObjectBody bodies = 1;
+inline int GetObjectBodiesBatchResponse::_internal_bodies_size() const {
+  return _internal_bodies().size();
+}
+inline int GetObjectBodiesBatchResponse::bodies_size() const {
+  return _internal_bodies_size();
+}
+inline void GetObjectBodiesBatchResponse::clear_bodies() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.bodies_.Clear();
+  ClearHasBitForRepeated(_impl_._has_bits_[0],
+                  0x00000001U);
+}
+inline ::s4wave::world::ObjectBody* PROTOBUF_NONNULL GetObjectBodiesBatchResponse::mutable_bodies(int index)
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_mutable:s4wave.world.GetObjectBodiesBatchResponse.bodies)
+  return _internal_mutable_bodies()->Mutable(index);
+}
+inline ::google::protobuf::RepeatedPtrField<::s4wave::world::ObjectBody>* PROTOBUF_NONNULL GetObjectBodiesBatchResponse::mutable_bodies()
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  SetHasBitForRepeated(_impl_._has_bits_[0], 0x00000001U);
+  // @@protoc_insertion_point(field_mutable_list:s4wave.world.GetObjectBodiesBatchResponse.bodies)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  return _internal_mutable_bodies();
+}
+inline const ::s4wave::world::ObjectBody& GetObjectBodiesBatchResponse::bodies(int index) const
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:s4wave.world.GetObjectBodiesBatchResponse.bodies)
+  return _internal_bodies().Get(index);
+}
+inline ::s4wave::world::ObjectBody* PROTOBUF_NONNULL GetObjectBodiesBatchResponse::add_bodies()
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::s4wave::world::ObjectBody* _add =
+      _internal_mutable_bodies()->InternalAddWithArena(
+          ::google::protobuf::MessageLite::internal_visibility(), GetArena());
+  SetHasBitForRepeated(_impl_._has_bits_[0], 0x00000001U);
+  // @@protoc_insertion_point(field_add:s4wave.world.GetObjectBodiesBatchResponse.bodies)
+  return _add;
+}
+inline const ::google::protobuf::RepeatedPtrField<::s4wave::world::ObjectBody>& GetObjectBodiesBatchResponse::bodies() const
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_list:s4wave.world.GetObjectBodiesBatchResponse.bodies)
+  return _internal_bodies();
+}
+inline const ::google::protobuf::RepeatedPtrField<::s4wave::world::ObjectBody>&
+GetObjectBodiesBatchResponse::_internal_bodies() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.bodies_;
+}
+inline ::google::protobuf::RepeatedPtrField<::s4wave::world::ObjectBody>* PROTOBUF_NONNULL
+GetObjectBodiesBatchResponse::_internal_mutable_bodies() {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return &_impl_.bodies_;
+}
+
+// uint32 next_key_index = 2;
+inline void GetObjectBodiesBatchResponse::clear_next_key_index() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.next_key_index_ = 0u;
+  ClearHasBit(_impl_._has_bits_[0],
+                  0x00000004U);
+}
+inline ::uint32_t GetObjectBodiesBatchResponse::next_key_index() const {
+  // @@protoc_insertion_point(field_get:s4wave.world.GetObjectBodiesBatchResponse.next_key_index)
+  return _internal_next_key_index();
+}
+inline void GetObjectBodiesBatchResponse::set_next_key_index(::uint32_t value) {
+  _internal_set_next_key_index(value);
+  SetHasBit(_impl_._has_bits_[0], 0x00000004U);
+  // @@protoc_insertion_point(field_set:s4wave.world.GetObjectBodiesBatchResponse.next_key_index)
+}
+inline ::uint32_t GetObjectBodiesBatchResponse::_internal_next_key_index() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.next_key_index_;
+}
+inline void GetObjectBodiesBatchResponse::_internal_set_next_key_index(::uint32_t value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.next_key_index_ = value;
+}
+
+// uint64 world_seqno = 3;
+inline void GetObjectBodiesBatchResponse::clear_world_seqno() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.world_seqno_ = ::uint64_t{0u};
+  ClearHasBit(_impl_._has_bits_[0],
+                  0x00000002U);
+}
+inline ::uint64_t GetObjectBodiesBatchResponse::world_seqno() const {
+  // @@protoc_insertion_point(field_get:s4wave.world.GetObjectBodiesBatchResponse.world_seqno)
+  return _internal_world_seqno();
+}
+inline void GetObjectBodiesBatchResponse::set_world_seqno(::uint64_t value) {
+  _internal_set_world_seqno(value);
+  SetHasBit(_impl_._has_bits_[0], 0x00000002U);
+  // @@protoc_insertion_point(field_set:s4wave.world.GetObjectBodiesBatchResponse.world_seqno)
+}
+inline ::uint64_t GetObjectBodiesBatchResponse::_internal_world_seqno() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.world_seqno_;
+}
+inline void GetObjectBodiesBatchResponse::_internal_set_world_seqno(::uint64_t value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.world_seqno_ = value;
 }
 
 // -------------------------------------------------------------------

--- a/sdk/world/world.pb.rs
+++ b/sdk/world/world.pb.rs
@@ -435,6 +435,44 @@ pub struct GetObjectMetadataBatchResponse {
     #[prost(message, repeated, tag="1")]
     pub metadata: ::prost::alloc::vec::Vec<ObjectMetadata>,
 }
+/// ObjectBody contains the serialized root body for one object key.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ObjectBody {
+    /// ObjectKey is the requested object key.
+    #[prost(string, tag="1")]
+    pub object_key: ::prost::alloc::string::String,
+    /// Body is the transformed root block data when the object exists.
+    #[prost(bytes="vec", tag="2")]
+    pub body: ::prost::alloc::vec::Vec<u8>,
+    /// Exists indicates whether the object key exists.
+    #[prost(bool, tag="3")]
+    pub exists: bool,
+}
+/// GetObjectBodiesBatchRequest is the request type for
+/// GetObjectBodiesBatch.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct GetObjectBodiesBatchRequest {
+    /// ObjectKeys is the list of object keys to inspect.
+    #[prost(string, repeated, tag="1")]
+    pub object_keys: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    /// StartKeyIndex is the first object key index to include in this page.
+    #[prost(uint32, tag="2")]
+    pub start_key_index: u32,
+}
+/// GetObjectBodiesBatchResponse is the response type for
+/// GetObjectBodiesBatch.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetObjectBodiesBatchResponse {
+    /// Bodies preserves the request object key order.
+    #[prost(message, repeated, tag="1")]
+    pub bodies: ::prost::alloc::vec::Vec<ObjectBody>,
+    /// NextKeyIndex is the next key index to request. Zero means complete.
+    #[prost(uint32, tag="2")]
+    pub next_key_index: u32,
+    /// WorldSeqno is the World sequence number observed for this page.
+    #[prost(uint64, tag="3")]
+    pub world_seqno: u64,
+}
 /// GraphPathStep is one bounded predicate traversal step.
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct GraphPathStep {

--- a/sdk/world/world.pb.ts
+++ b/sdk/world/world.pb.ts
@@ -1533,6 +1533,124 @@ export const GetObjectMetadataBatchResponse: MessageType<GetObjectMetadataBatchR
   })
 
 /**
+ * ObjectBody contains the serialized root body for one object key.
+ *
+ * @generated from message s4wave.world.ObjectBody
+ */
+export interface ObjectBody {
+  /**
+   * ObjectKey is the requested object key.
+   *
+   * @generated from field: string object_key = 1;
+   */
+  objectKey?: string
+  /**
+   * Body is the transformed root block data when the object exists.
+   *
+   * @generated from field: bytes body = 2;
+   */
+  body?: Uint8Array
+  /**
+   * Exists indicates whether the object key exists.
+   *
+   * @generated from field: bool exists = 3;
+   */
+  exists?: boolean
+}
+
+export const ObjectBody: MessageType<ObjectBody> =
+  /* @__PURE__ */ createMessageType({
+    typeName: 's4wave.world.ObjectBody',
+    fields: [
+      { no: 1, name: 'object_key', kind: 'scalar', T: ScalarType.STRING },
+      { no: 2, name: 'body', kind: 'scalar', T: ScalarType.BYTES },
+      { no: 3, name: 'exists', kind: 'scalar', T: ScalarType.BOOL },
+    ] satisfies readonly PartialFieldInfo[],
+    packedByDefault: true,
+  })
+
+/**
+ * GetObjectBodiesBatchRequest is the request type for
+ * GetObjectBodiesBatch.
+ *
+ * @generated from message s4wave.world.GetObjectBodiesBatchRequest
+ */
+export interface GetObjectBodiesBatchRequest {
+  /**
+   * ObjectKeys is the list of object keys to inspect.
+   *
+   * @generated from field: repeated string object_keys = 1;
+   */
+  objectKeys?: string[]
+  /**
+   * StartKeyIndex is the first object key index to include in this page.
+   *
+   * @generated from field: uint32 start_key_index = 2;
+   */
+  startKeyIndex?: number
+}
+
+export const GetObjectBodiesBatchRequest: MessageType<GetObjectBodiesBatchRequest> =
+  /* @__PURE__ */ createMessageType({
+    typeName: 's4wave.world.GetObjectBodiesBatchRequest',
+    fields: [
+      {
+        no: 1,
+        name: 'object_keys',
+        kind: 'scalar',
+        T: ScalarType.STRING,
+        repeated: true,
+      },
+      { no: 2, name: 'start_key_index', kind: 'scalar', T: ScalarType.UINT32 },
+    ] satisfies readonly PartialFieldInfo[],
+    packedByDefault: true,
+  })
+
+/**
+ * GetObjectBodiesBatchResponse is the response type for
+ * GetObjectBodiesBatch.
+ *
+ * @generated from message s4wave.world.GetObjectBodiesBatchResponse
+ */
+export interface GetObjectBodiesBatchResponse {
+  /**
+   * Bodies preserves the request object key order.
+   *
+   * @generated from field: repeated s4wave.world.ObjectBody bodies = 1;
+   */
+  bodies?: ObjectBody[]
+  /**
+   * NextKeyIndex is the next key index to request. Zero means complete.
+   *
+   * @generated from field: uint32 next_key_index = 2;
+   */
+  nextKeyIndex?: number
+  /**
+   * WorldSeqno is the World sequence number observed for this page.
+   *
+   * @generated from field: uint64 world_seqno = 3;
+   */
+  worldSeqno?: bigint
+}
+
+export const GetObjectBodiesBatchResponse: MessageType<GetObjectBodiesBatchResponse> =
+  /* @__PURE__ */ createMessageType({
+    typeName: 's4wave.world.GetObjectBodiesBatchResponse',
+    fields: [
+      {
+        no: 1,
+        name: 'bodies',
+        kind: 'message',
+        T: () => ObjectBody,
+        repeated: true,
+      },
+      { no: 2, name: 'next_key_index', kind: 'scalar', T: ScalarType.UINT32 },
+      { no: 3, name: 'world_seqno', kind: 'scalar', T: ScalarType.UINT64 },
+    ] satisfies readonly PartialFieldInfo[],
+    packedByDefault: true,
+  })
+
+/**
  * GraphPathStep is one bounded predicate traversal step.
  *
  * @generated from message s4wave.world.GraphPathStep

--- a/sdk/world/world.proto
+++ b/sdk/world/world.proto
@@ -154,6 +154,7 @@ service WorldStateResourceService {
   rpc GetObjectRootRefsBatch(GetObjectRootRefsBatchRequest) returns (GetObjectRootRefsBatchResponse);
 
   rpc GetObjectMetadataBatch(GetObjectMetadataBatchRequest) returns (GetObjectMetadataBatchResponse);
+  rpc GetObjectBodiesBatch(GetObjectBodiesBatchRequest) returns (GetObjectBodiesBatchResponse);
 
   rpc QueryGraphPath(QueryGraphPathRequest) returns (QueryGraphPathResponse);
 
@@ -446,6 +447,37 @@ message GetObjectMetadataBatchResponse {
   // Metadata preserves the request object key order.
   repeated ObjectMetadata metadata = 1;
 }
+
+// ObjectBody contains the serialized root body for one object key.
+message ObjectBody {
+  // ObjectKey is the requested object key.
+  string object_key = 1;
+  // Body is the transformed root block data when the object exists.
+  bytes body = 2;
+  // Exists indicates whether the object key exists.
+  bool exists = 3;
+}
+
+// GetObjectBodiesBatchRequest is the request type for
+// GetObjectBodiesBatch.
+message GetObjectBodiesBatchRequest {
+  // ObjectKeys is the list of object keys to inspect.
+  repeated string object_keys = 1;
+  // StartKeyIndex is the first object key index to include in this page.
+  uint32 start_key_index = 2;
+}
+
+// GetObjectBodiesBatchResponse is the response type for
+// GetObjectBodiesBatch.
+message GetObjectBodiesBatchResponse {
+  // Bodies preserves the request object key order.
+  repeated ObjectBody bodies = 1;
+  // NextKeyIndex is the next key index to request. Zero means complete.
+  uint32 next_key_index = 2;
+  // WorldSeqno is the World sequence number observed for this page.
+  uint64 world_seqno = 3;
+}
+
 
 // GraphPathDirection indicates which side of the current object key to follow.
 enum GraphPathDirection {

--- a/sdk/world/world_srpc.pb.go
+++ b/sdk/world/world_srpc.pb.go
@@ -481,6 +481,8 @@ type SRPCWorldStateResourceServiceClient interface {
 
 	GetObjectMetadataBatch(ctx context.Context, in *GetObjectMetadataBatchRequest) (*GetObjectMetadataBatchResponse, error)
 
+	GetObjectBodiesBatch(ctx context.Context, in *GetObjectBodiesBatchRequest) (*GetObjectBodiesBatchResponse, error)
+
 	QueryGraphPath(ctx context.Context, in *QueryGraphPathRequest) (*QueryGraphPathResponse, error)
 
 	DeleteGraphObject(ctx context.Context, in *DeleteGraphObjectRequest) (*DeleteGraphObjectResponse, error)
@@ -677,6 +679,15 @@ func (c *srpcWorldStateResourceServiceClient) GetObjectMetadataBatch(ctx context
 	return out, nil
 }
 
+func (c *srpcWorldStateResourceServiceClient) GetObjectBodiesBatch(ctx context.Context, in *GetObjectBodiesBatchRequest) (*GetObjectBodiesBatchResponse, error) {
+	out := new(GetObjectBodiesBatchResponse)
+	err := c.cc.ExecCall(ctx, c.serviceID, "GetObjectBodiesBatch", in, out)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *srpcWorldStateResourceServiceClient) QueryGraphPath(ctx context.Context, in *QueryGraphPathRequest) (*QueryGraphPathResponse, error) {
 	out := new(QueryGraphPathResponse)
 	err := c.cc.ExecCall(ctx, c.serviceID, "QueryGraphPath", in, out)
@@ -743,6 +754,8 @@ type SRPCWorldStateResourceServiceServer interface {
 
 	GetObjectMetadataBatch(context.Context, *GetObjectMetadataBatchRequest) (*GetObjectMetadataBatchResponse, error)
 
+	GetObjectBodiesBatch(context.Context, *GetObjectBodiesBatchRequest) (*GetObjectBodiesBatchResponse, error)
+
 	QueryGraphPath(context.Context, *QueryGraphPathRequest) (*QueryGraphPathResponse, error)
 
 	DeleteGraphObject(context.Context, *DeleteGraphObjectRequest) (*DeleteGraphObjectResponse, error)
@@ -795,6 +808,7 @@ func (SRPCWorldStateResourceServiceHandler) GetMethodIDs() []string {
 		"ListObjectsWithType",
 		"GetObjectRootRefsBatch",
 		"GetObjectMetadataBatch",
+		"GetObjectBodiesBatch",
 		"QueryGraphPath",
 		"DeleteGraphObject",
 		"ApplyWorldOp",
@@ -848,6 +862,8 @@ func (d *SRPCWorldStateResourceServiceHandler) InvokeMethod(
 		return true, d.InvokeMethod_GetObjectRootRefsBatch(d.impl, strm)
 	case "GetObjectMetadataBatch":
 		return true, d.InvokeMethod_GetObjectMetadataBatch(d.impl, strm)
+	case "GetObjectBodiesBatch":
+		return true, d.InvokeMethod_GetObjectBodiesBatch(d.impl, strm)
 	case "QueryGraphPath":
 		return true, d.InvokeMethod_QueryGraphPath(d.impl, strm)
 	case "DeleteGraphObject":
@@ -1087,6 +1103,18 @@ func (SRPCWorldStateResourceServiceHandler) InvokeMethod_GetObjectMetadataBatch(
 	return strm.MsgSend(out)
 }
 
+func (SRPCWorldStateResourceServiceHandler) InvokeMethod_GetObjectBodiesBatch(impl SRPCWorldStateResourceServiceServer, strm srpc.Stream) error {
+	req := new(GetObjectBodiesBatchRequest)
+	if err := strm.MsgRecv(req); err != nil {
+		return err
+	}
+	out, err := impl.GetObjectBodiesBatch(strm.Context(), req)
+	if err != nil {
+		return err
+	}
+	return strm.MsgSend(out)
+}
+
 func (SRPCWorldStateResourceServiceHandler) InvokeMethod_QueryGraphPath(impl SRPCWorldStateResourceServiceServer, strm srpc.Stream) error {
 	req := new(QueryGraphPathRequest)
 	if err := strm.MsgRecv(req); err != nil {
@@ -1272,6 +1300,14 @@ type SRPCWorldStateResourceService_GetObjectMetadataBatchStream interface {
 }
 
 type srpcWorldStateResourceService_GetObjectMetadataBatchStream struct {
+	srpc.Stream
+}
+
+type SRPCWorldStateResourceService_GetObjectBodiesBatchStream interface {
+	srpc.Stream
+}
+
+type srpcWorldStateResourceService_GetObjectBodiesBatchStream struct {
 	srpc.Stream
 }
 

--- a/sdk/world/world_srpc.pb.rs
+++ b/sdk/world/world_srpc.pb.rs
@@ -353,6 +353,8 @@ pub trait WorldStateResourceServiceClient: Send + Sync {
     async fn get_object_root_refs_batch(&self, request: &GetObjectRootRefsBatchRequest) -> starpc::Result<GetObjectRootRefsBatchResponse>;
     /// GetObjectMetadataBatch.
     async fn get_object_metadata_batch(&self, request: &GetObjectMetadataBatchRequest) -> starpc::Result<GetObjectMetadataBatchResponse>;
+    /// GetObjectBodiesBatch.
+    async fn get_object_bodies_batch(&self, request: &GetObjectBodiesBatchRequest) -> starpc::Result<GetObjectBodiesBatchResponse>;
     /// QueryGraphPath.
     async fn query_graph_path(&self, request: &QueryGraphPathRequest) -> starpc::Result<QueryGraphPathResponse>;
     /// DeleteGraphObject.
@@ -432,6 +434,9 @@ impl<C: starpc::Client + 'static> WorldStateResourceServiceClient for WorldState
     async fn get_object_metadata_batch(&self, request: &GetObjectMetadataBatchRequest) -> starpc::Result<GetObjectMetadataBatchResponse> {
         self.client.exec_call("s4wave.world.WorldStateResourceService", "GetObjectMetadataBatch", request).await
     }
+    async fn get_object_bodies_batch(&self, request: &GetObjectBodiesBatchRequest) -> starpc::Result<GetObjectBodiesBatchResponse> {
+        self.client.exec_call("s4wave.world.WorldStateResourceService", "GetObjectBodiesBatch", request).await
+    }
     async fn query_graph_path(&self, request: &QueryGraphPathRequest) -> starpc::Result<QueryGraphPathResponse> {
         self.client.exec_call("s4wave.world.WorldStateResourceService", "QueryGraphPath", request).await
     }
@@ -484,6 +489,8 @@ pub trait WorldStateResourceServiceServer: Send + Sync {
     async fn get_object_root_refs_batch(&self, request: GetObjectRootRefsBatchRequest) -> starpc::Result<GetObjectRootRefsBatchResponse>;
     /// GetObjectMetadataBatch.
     async fn get_object_metadata_batch(&self, request: GetObjectMetadataBatchRequest) -> starpc::Result<GetObjectMetadataBatchResponse>;
+    /// GetObjectBodiesBatch.
+    async fn get_object_bodies_batch(&self, request: GetObjectBodiesBatchRequest) -> starpc::Result<GetObjectBodiesBatchResponse>;
     /// QueryGraphPath.
     async fn query_graph_path(&self, request: QueryGraphPathRequest) -> starpc::Result<QueryGraphPathResponse>;
     /// DeleteGraphObject.
@@ -512,6 +519,7 @@ const WORLD_STATE_RESOURCE_SERVICE_METHOD_IDS: &[&str] = &[
     "ListObjectsWithType",
     "GetObjectRootRefsBatch",
     "GetObjectMetadataBatch",
+    "GetObjectBodiesBatch",
     "QueryGraphPath",
     "DeleteGraphObject",
     "ApplyWorldOp",
@@ -819,6 +827,21 @@ impl<S: WorldStateResourceServiceServer + 'static> starpc::Invoker for WorldStat
                     Err(e) => return (true, Err(e)),
                 };
                 match self.server.get_object_metadata_batch(request).await {
+                    Ok(response) => {
+                        if let Err(e) = stream.msg_send(&response).await {
+                            return (true, Err(e));
+                        }
+                        (true, Ok(()))
+                    }
+                    Err(e) => (true, Err(e)),
+                }
+            }
+            "GetObjectBodiesBatch" => {
+                let request: GetObjectBodiesBatchRequest = match stream.msg_recv().await {
+                    Ok(r) => r,
+                    Err(e) => return (true, Err(e)),
+                };
+                match self.server.get_object_bodies_batch(request).await {
                     Ok(response) => {
                         if let Err(e) = stream.msg_send(&response).await {
                             return (true, Err(e));

--- a/sdk/world/world_srpc.pb.ts
+++ b/sdk/world/world_srpc.pb.ts
@@ -35,6 +35,8 @@ import {
   GetEngineInfoResponse,
   GetKeyRequest,
   GetKeyResponse,
+  GetObjectBodiesBatchRequest,
+  GetObjectBodiesBatchResponse,
   GetObjectMetadataBatchRequest,
   GetObjectMetadataBatchResponse,
   GetObjectRequest,
@@ -91,7 +93,7 @@ import {
   WatchWorldStateResponse,
   WorldRootSnapshot,
 } from './world.pb.js'
-import { MethodKind } from '@aptre/protobuf-es-lite/service-type'
+import { MethodKind } from '@aptre/protobuf-es-lite'
 import { buildDecodeMessageTransform, MessageStream, ProtoRpc } from 'starpc'
 
 /**
@@ -608,6 +610,15 @@ export const WorldStateResourceServiceDefinition = {
       kind: MethodKind.Unary,
     },
     /**
+     * @generated from rpc s4wave.world.WorldStateResourceService.GetObjectBodiesBatch
+     */
+    GetObjectBodiesBatch: {
+      name: 'GetObjectBodiesBatch',
+      I: GetObjectBodiesBatchRequest,
+      O: GetObjectBodiesBatchResponse,
+      kind: MethodKind.Unary,
+    },
+    /**
      * @generated from rpc s4wave.world.WorldStateResourceService.QueryGraphPath
      */
     QueryGraphPath: {
@@ -791,6 +802,14 @@ export interface WorldStateResourceService {
   ): Promise<GetObjectMetadataBatchResponse>
 
   /**
+   * @generated from rpc s4wave.world.WorldStateResourceService.GetObjectBodiesBatch
+   */
+  GetObjectBodiesBatch(
+    request: GetObjectBodiesBatchRequest,
+    abortSignal?: AbortSignal,
+  ): Promise<GetObjectBodiesBatchResponse>
+
+  /**
    * @generated from rpc s4wave.world.WorldStateResourceService.QueryGraphPath
    */
   QueryGraphPath(
@@ -843,6 +862,7 @@ export class WorldStateResourceServiceClient implements WorldStateResourceServic
     this.ListObjectsWithType = this.ListObjectsWithType.bind(this)
     this.GetObjectRootRefsBatch = this.GetObjectRootRefsBatch.bind(this)
     this.GetObjectMetadataBatch = this.GetObjectMetadataBatch.bind(this)
+    this.GetObjectBodiesBatch = this.GetObjectBodiesBatch.bind(this)
     this.QueryGraphPath = this.QueryGraphPath.bind(this)
     this.DeleteGraphObject = this.DeleteGraphObject.bind(this)
     this.ApplyWorldOp = this.ApplyWorldOp.bind(this)
@@ -1168,6 +1188,23 @@ export class WorldStateResourceServiceClient implements WorldStateResourceServic
       abortSignal || undefined,
     )
     return GetObjectMetadataBatchResponse.fromBinary(result)
+  }
+
+  /**
+   * @generated from rpc s4wave.world.WorldStateResourceService.GetObjectBodiesBatch
+   */
+  async GetObjectBodiesBatch(
+    request: GetObjectBodiesBatchRequest,
+    abortSignal?: AbortSignal,
+  ): Promise<GetObjectBodiesBatchResponse> {
+    const requestMsg = GetObjectBodiesBatchRequest.create(request)
+    const result = await this.rpc.request(
+      this.service,
+      WorldStateResourceServiceDefinition.methods.GetObjectBodiesBatch.name,
+      GetObjectBodiesBatchRequest.toBinary(requestMsg),
+      abortSignal || undefined,
+    )
+    return GetObjectBodiesBatchResponse.fromBinary(result)
   }
 
   /**


### PR DESCRIPTION
Every caller that needs several object bodies inside one read transaction currently loops a per-key GetObject, so a remote WorldState pays one round trip per object and list surfaces stall as the object count grows. The existing batch RPCs only cover root references and metadata.

This adds GetObjectBodiesBatch beside those RPCs, copying their idiom: repeated keys in, one result per requested key in request order with duplicates preserved, and an explicit exists marker so a missing object does not fail the batch. The native engine answers from a single read transaction, the SDK wrappers send one RPC, and LookupObjectBodies decodes typed bodies through the same decoder the single-body helpers share. A WorldState without the batch interface falls back to the per-key loop, so callers adopt one uniform API. The proto change is additive only.

The capability test drives the real resource service and observes exactly one batch operation for four requested keys, asserting found bodies, the missing marker, request order, duplicates, and decoded contents. Focused suites for db/world, sdk/world, and core/sobject/world pass, along with js/wasm builds of the touched trees.

@codex review