### PR TITLE
fix(scheduler): copy startup manifests outside world access and make retries complete

### DIFF
--- a/bldr/plugin/host/scheduler/config.go
+++ b/bldr/plugin/host/scheduler/config.go
@@ -1,7 +1,6 @@
 package plugin_host_scheduler
 
 import (
-	"runtime"
 	"slices"
 
 	"github.com/aperturerobotics/controllerbus/config"
@@ -150,10 +149,7 @@ func (c *Config) BuildFetchBackoff() *backoff.Backoff {
 }
 
 func (c *Config) manifestCopyConcurrency() int {
-	if concurrency := c.GetFetchConcurrency(); concurrency > 0 {
-		return int(concurrency)
-	}
-	return runtime.GOMAXPROCS(0)
+	return int(c.GetFetchConcurrency())
 }
 
 // _ is a type assertion

--- a/bldr/plugin/host/scheduler/config.go
+++ b/bldr/plugin/host/scheduler/config.go
@@ -1,6 +1,7 @@
 package plugin_host_scheduler
 
 import (
+	"runtime"
 	"slices"
 
 	"github.com/aperturerobotics/controllerbus/config"
@@ -146,6 +147,13 @@ func (c *Config) BuildFetchBackoff() *backoff.Backoff {
 		backoffConf.Exponential.MaxInterval = 1200
 	}
 	return backoffConf
+}
+
+func (c *Config) manifestCopyConcurrency() int {
+	if concurrency := c.GetFetchConcurrency(); concurrency > 0 {
+		return int(concurrency)
+	}
+	return runtime.GOMAXPROCS(0)
 }
 
 // _ is a type assertion

--- a/bldr/plugin/host/scheduler/controller.go
+++ b/bldr/plugin/host/scheduler/controller.go
@@ -70,6 +70,10 @@ type Controller struct {
 	pluginHostsCtr *ccontainer.CContainer[*pluginHostSet]
 	// manifestCopyGate delays startup copies until runtime readiness.
 	manifestCopyGateCtr *ccontainer.CContainer[ManifestCopyGate]
+	// manifestCommitOnce initializes manifestCommitSlots.
+	manifestCommitOnce sync.Once
+	// manifestCommitSlots serializes world manifest publication and sync.
+	manifestCommitSlots chan struct{}
 
 	// pluginInstances manages the list of running plugins by plugin ID.
 	// key: plugin ID
@@ -185,6 +189,23 @@ func (c *Controller) getManifestCopyGate() ManifestCopyGate {
 		return nil
 	}
 	return c.manifestCopyGateCtr.GetValue()
+}
+
+func (c *Controller) acquireManifestCommit(ctx context.Context) (func(), error) {
+	if c == nil {
+		return func() {}, nil
+	}
+	c.manifestCommitOnce.Do(func() {
+		c.manifestCommitSlots = make(chan struct{}, 1)
+	})
+	select {
+	case c.manifestCommitSlots <- struct{}{}:
+		return func() {
+			<-c.manifestCommitSlots
+		}, nil
+	case <-ctx.Done():
+		return nil, context.Canceled
+	}
 }
 
 // GetControllerInfo returns information about the controller.

--- a/bldr/plugin/host/scheduler/download-manifest.go
+++ b/bldr/plugin/host/scheduler/download-manifest.go
@@ -241,40 +241,51 @@ func (t *pluginInstance) execDownloadManifest(
 		return err
 	}
 
-	// Access the world root bucket (dest) then the manifest source bucket (src).
-	accessCtx, accessTask := trace.NewTask(ctx, "bldr/plugin-host-scheduler/download-manifest/access-world-state")
-	err = ws.AccessWorldState(accessCtx, nil, func(dest *bucket_lookup.Cursor) error {
-		src, err := bldr_manifest_world.FollowObjectRefReadOnly(accessCtx, dest, ref)
-		if err != nil {
-			return err
-		}
-		defer src.Release()
-		destBucketID := dest.GetOpArgs().GetBucketId()
-		accounting = t.updateManifestCopyBuckets(accessCtx, accounting, src.GetOpArgs().GetBucketId(), destBucketID)
-		trace.Log(accessCtx, "world-bucket-id", destBucketID)
-		trace.Log(accessCtx, "source-bucket-id", src.GetOpArgs().GetBucketId())
-		le.Infof("copying manifest DAG from bucket %s to %s", src.GetOpArgs().GetBucketId(), destBucketID)
+	// Build cursors outside AccessWorldState so source reads and destination
+	// block writes cannot wait while holding a world-state access.
+	dest, err := ws.BuildStorageCursor(ctx)
+	if err != nil {
+		return err
+	}
+	defer dest.Release()
+	src, err := bldr_manifest_world.FollowObjectRefReadOnly(ctx, dest, ref)
+	if err != nil {
+		return err
+	}
+	defer src.Release()
+	destBucketID := dest.GetOpArgs().GetBucketId()
+	accounting = t.updateManifestCopyBuckets(ctx, accounting, src.GetOpArgs().GetBucketId(), destBucketID)
+	trace.Log(ctx, "world-bucket-id", destBucketID)
+	trace.Log(ctx, "source-bucket-id", src.GetOpArgs().GetBucketId())
+	le.Infof("copying manifest DAG from bucket %s to %s", src.GetOpArgs().GetBucketId(), destBucketID)
 
-		copyCtx, copyTask := trace.NewTask(accessCtx, "bldr/plugin-host-scheduler/download-manifest/copy-dag")
-		trace.Log(copyCtx, "accounting-phase", "decode-verify-deserialize-block-publish")
-		localRef, stats, err := bucket_lookup.CopyObjectToBucketWithStats(
-			copyCtx,
-			dest,
-			src,
-			bldr_manifest.NewManifestBlock,
-			1,
-			false,
-			nil,
-		)
-		copyStats = accounting.apply(stats)
-		copyTask.End()
-		if err != nil {
-			return errors.Wrap(err, "copy manifest block DAG")
-		}
-		logObjectRefAccountingFields(accessCtx, "local-manifest", localRef)
+	copyCtx, copyTask := trace.NewTask(ctx, "bldr/plugin-host-scheduler/download-manifest/copy-dag")
+	trace.Log(copyCtx, "accounting-phase", "decode-verify-deserialize-block-publish")
+	localRef, stats, err := bucket_lookup.CopyObjectToBucketWithStats(
+		copyCtx,
+		dest,
+		src,
+		bldr_manifest.NewManifestBlock,
+		t.c.conf.manifestCopyConcurrency(),
+		true,
+		nil,
+	)
+	copyStats = accounting.apply(stats)
+	copyTask.End()
+	if err != nil {
+		return errors.Wrap(err, "copy manifest block DAG")
+	}
+	logObjectRefAccountingFields(ctx, "local-manifest", localRef)
 
+	var synced bool
+	releaseCommit, err := t.c.acquireManifestCommit(ctx)
+	if err != nil {
+		return err
+	}
+	if err := func() error {
+		defer releaseCommit()
 		if !t.c.conf.GetDisableStoreManifest() {
-			storeCtx, storeTask := trace.NewTask(accessCtx, "bldr/plugin-host-scheduler/download-manifest/store-local-ref")
+			storeCtx, storeTask := trace.NewTask(ctx, "bldr/plugin-host-scheduler/download-manifest/store-local-ref")
 			trace.Log(storeCtx, "accounting-phase", "world-op-store-local-manifest-ref")
 			trace.Log(storeCtx, "manifest-copy-phase", "local-ref-publication")
 			manifestKey := bldr_manifest.NewManifestKey(t.c.objKey, manifestMeta)
@@ -292,9 +303,10 @@ func (t *pluginInstance) execDownloadManifest(
 			storeTask.End()
 		}
 
-		syncCtx, syncTask := trace.NewTask(accessCtx, "bldr/plugin-host-scheduler/download-manifest/sync")
+		syncCtx, syncTask := trace.NewTask(ctx, "bldr/plugin-host-scheduler/download-manifest/sync")
 		trace.Log(syncCtx, "accounting-phase", "world-sync-block-barrier-and-head-commit")
-		synced, syncErr := ws.Sync(syncCtx)
+		var syncErr error
+		synced, syncErr = ws.Sync(syncCtx)
 		if syncErr != nil {
 			syncTask.End()
 			return errors.Wrap(syncErr, "sync local manifest blocks")
@@ -307,12 +319,13 @@ func (t *pluginInstance) execDownloadManifest(
 		trace.Logf(syncCtx, "destination-durable-bytes-known", "%t", copyStats.DestinationDurableBytesKnown)
 		trace.Log(syncCtx, "manifest-copy-phase", "sync-complete")
 		syncTask.End()
-		copyStats = accounting.apply(copyStats)
-		t.setManifestCopyStatus(manifestCopyPhaseDone, class, manifestSnapshot, accounting, copyStats)
-		t.emitManifestCopyStartupMark(manifestCopyPhaseDone, copyStats, accounting)
-		le.Info("manifest download complete")
 		return nil
-	})
-	accessTask.End()
-	return err
+	}(); err != nil {
+		return err
+	}
+	copyStats = accounting.apply(copyStats)
+	t.setManifestCopyStatus(manifestCopyPhaseDone, class, manifestSnapshot, accounting, copyStats)
+	t.emitManifestCopyStartupMark(manifestCopyPhaseDone, copyStats, accounting)
+	le.Info("manifest download complete")
+	return nil
 }

--- a/bldr/plugin/host/scheduler/download-manifest.go
+++ b/bldr/plugin/host/scheduler/download-manifest.go
@@ -267,7 +267,7 @@ func (t *pluginInstance) execDownloadManifest(
 		src,
 		bldr_manifest.NewManifestBlock,
 		t.c.conf.manifestCopyConcurrency(),
-		true,
+		false,
 		nil,
 	)
 	copyStats = accounting.apply(stats)
@@ -278,12 +278,12 @@ func (t *pluginInstance) execDownloadManifest(
 	logObjectRefAccountingFields(ctx, "local-manifest", localRef)
 
 	var synced bool
-	releaseCommit, err := t.c.acquireManifestCommit(ctx)
+	releaseManifestCommit, err := t.c.acquireManifestCommit(ctx)
 	if err != nil {
 		return err
 	}
 	if err := func() error {
-		defer releaseCommit()
+		defer releaseManifestCommit()
 		if !t.c.conf.GetDisableStoreManifest() {
 			storeCtx, storeTask := trace.NewTask(ctx, "bldr/plugin-host-scheduler/download-manifest/store-local-ref")
 			trace.Log(storeCtx, "accounting-phase", "world-op-store-local-manifest-ref")

--- a/bldr/plugin/host/scheduler/fetch-world-manifest_test.go
+++ b/bldr/plugin/host/scheduler/fetch-world-manifest_test.go
@@ -2,6 +2,7 @@ package plugin_host_scheduler
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -2748,6 +2749,139 @@ func TestDownloadManifestCopiesRemoteDAGAndStoresLocalWorldRef(t *testing.T) {
 	}
 }
 
+func TestDownloadManifestRetriesIncompleteCopyBeforePublication(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	le := logrus.NewEntry(logrus.New())
+
+	tb, err := testbed.NewTestbed(ctx, le)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer tb.Release()
+
+	ocs, err := tb.BuildEmptyCursor(ctx)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer ocs.Release()
+
+	ws, err := world_block.BuildMockWorldState(ctx, le, true, ocs, false)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	const objKey = "plugin-host"
+	if _, err := bldr_manifest_world.CreateManifestStore(ctx, ws, objKey); err != nil {
+		t.Fatal(err.Error())
+	}
+
+	const remoteBucketID = "spacewave-release"
+	remote := newTestExternalManifestRefWithDistAssets(t, ctx, remoteBucketID, "spacewave-core", "desktop/darwin/arm64", 14)
+	sourceStore := &failAfterRootBlockStore{
+		StoreOps: remote.store,
+		getCalls: &atomic.Int32{},
+		failed:   &atomic.Bool{},
+	}
+	sourceConf, err := bucket.NewConfig(remoteBucketID, 1, nil)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	lookupRel, err := tb.Bus.AddController(ctx, &testSchedulerStaticLookupController{
+		bucketID: remoteBucketID,
+		handle: &testSchedulerStaticLookupHandle{
+			conf:   sourceConf,
+			lookup: &testSchedulerStaticLookup{store: sourceStore},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer lookupRel()
+
+	var wsv world.WorldState = ws
+	pi := &pluginInstance{
+		c: &Controller{
+			conf:            &Config{},
+			objKey:          objKey,
+			peerID:          peer.ID("test"),
+			worldStateCtr:   ccontainer.NewCContainer(wsv),
+			pluginStatus:    make(map[string]*bldr_plugin.PluginStatus),
+			pluginStatusCtr: ccontainer.NewCContainer(&PluginStatusSnapshot{}),
+		},
+		le:       le,
+		pluginID: "spacewave-core",
+	}
+	snapshot := &bldr_manifest.ManifestSnapshot{
+		ManifestRef: remote.ref.GetManifestRef(),
+		Manifest:    remote.manifest,
+	}
+
+	if err := pi.execDownloadManifest(ctx, snapshot); err == nil {
+		t.Fatal("first copy attempt succeeded despite injected descendant failure")
+	}
+	got, errs, err := bldr_manifest_world.CollectManifestsForManifestID(
+		ctx,
+		ws,
+		"spacewave-core",
+		[]string{"desktop/darwin/arm64"},
+		objKey,
+	)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if len(errs) != 0 {
+		t.Fatalf("manifest errors after failed copy = %v", errs)
+	}
+	if len(got) != 0 {
+		t.Fatalf("manifest was published after failed copy: %d", len(got))
+	}
+
+	if err := pi.execDownloadManifest(ctx, snapshot); err != nil {
+		t.Fatalf("retry copy failed: %v", err)
+	}
+	got, errs, err = bldr_manifest_world.CollectManifestsForManifestID(
+		ctx,
+		ws,
+		"spacewave-core",
+		[]string{"desktop/darwin/arm64"},
+		objKey,
+	)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if len(errs) != 0 {
+		t.Fatalf("manifest errors after retry = %v", errs)
+	}
+	if len(got) != 1 {
+		t.Fatalf("manifest count after retry = %d, want 1", len(got))
+	}
+	localRef := got[0].ManifestRef
+	if err := bldr_manifest_world.AccessManifest(
+		ctx,
+		le,
+		ws.AccessWorldState,
+		localRef,
+		func(
+			ctx context.Context,
+			_ *bucket_lookup.Cursor,
+			_ *block.Cursor,
+			manifest *bldr_manifest.Manifest,
+			distFS *unixfs.FSHandle,
+			assetsFS *unixfs.FSHandle,
+		) error {
+			if _, _, err := distFS.LookupPath(ctx, manifest.GetEntrypoint()); err != nil {
+				return err
+			}
+			if _, _, err := assetsFS.LookupPath(ctx, "asset.txt"); err != nil {
+				return err
+			}
+			return nil
+		},
+	); err != nil {
+		t.Fatalf("incomplete local manifest DAG after retry: %v", err)
+	}
+}
+
 func TestDownloadManifestCopiesExternalVolumeDAGAndCachesSourceReads(t *testing.T) {
 	ctx := context.Background()
 	le := logrus.NewEntry(logrus.New())
@@ -2878,7 +3012,8 @@ func TestDownloadManifestCopiesExternalVolumeDAGAndCachesSourceReads(t *testing.
 }
 
 func TestDownloadManifestCopiesSeveralRemoteDAGsOutsideWorldAccess(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 	le := logrus.NewEntry(logrus.New())
 
 	tb, err := testbed.NewTestbed(ctx, le)
@@ -2970,17 +3105,26 @@ func TestDownloadManifestCopiesSeveralRemoteDAGsOutsideWorldAccess(t *testing.T)
 
 	seen := make(map[string]bool, 3)
 	for len(seen) < 3 {
-		next := <-observed
-		seen[next.manifestID] = true
-		if next.active != 0 {
-			close(releaseCopy)
-			t.Fatalf("source block read for %s ran with %d active world access(es)", next.manifestID, next.active)
+		select {
+		case next := <-observed:
+			seen[next.manifestID] = true
+			if next.active != 0 {
+				close(releaseCopy)
+				t.Fatalf("source block read for %s ran with %d active world access(es)", next.manifestID, next.active)
+			}
+		case <-ctx.Done():
+			t.Fatalf("timed out waiting for source observations: %v", ctx.Err())
 		}
 	}
 	close(releaseCopy)
 	for range 3 {
-		if err := <-errCh; err != nil {
-			t.Fatal(err.Error())
+		select {
+		case err := <-errCh:
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+		case <-ctx.Done():
+			t.Fatalf("timed out waiting for manifest copies: %v", ctx.Err())
 		}
 	}
 
@@ -3059,6 +3203,7 @@ func TestWatchWorldManifestSkipsUnchangedSelectionInputs(t *testing.T) {
 		t.Fatal("expected plugin host object")
 	}
 	host := &testPluginHost{id: "desktop/darwin/arm64"}
+	hostSet := &pluginHostSet{pluginHosts: []bldr_plugin_host.PluginHost{host}}
 	pi := &pluginInstance{
 		c: &Controller{
 			conf:   &Config{},
@@ -3069,9 +3214,7 @@ func TestWatchWorldManifestSkipsUnchangedSelectionInputs(t *testing.T) {
 		downloadManifestRoutine: routine.NewStateRoutineContainerWithLoggerVT[*bldr_manifest.ManifestSnapshot](le),
 		executePluginRoutine:    routine.NewStateRoutineContainerWithLogger(executePluginArgsEqual, le),
 	}
-	if _, err := pi.processManifestWorldState(ctx, le, &pluginHostSet{
-		pluginHosts: []bldr_plugin_host.PluginHost{host},
-	}, ws, obj); err != nil {
+	if _, err := pi.processManifestWorldState(ctx, le, hostSet, ws, obj); err != nil {
 		t.Fatal(err.Error())
 	}
 	if got := ws.total.Load(); got != 1 {
@@ -3098,13 +3241,160 @@ func TestWatchWorldManifestSkipsUnchangedSelectionInputs(t *testing.T) {
 	if !ok {
 		t.Fatal("expected plugin host object after unrelated manifest store")
 	}
-	if _, err := pi.processManifestWorldState(ctx, le, &pluginHostSet{
-		pluginHosts: []bldr_plugin_host.PluginHost{host},
-	}, ws, obj); err != nil {
+	if _, err := pi.processManifestWorldState(ctx, le, hostSet, ws, obj); err != nil {
 		t.Fatal(err.Error())
 	}
 	if got := ws.total.Load(); got != 1 {
 		t.Fatalf("unchanged selection world accesses = %d, want 1", got)
+	}
+}
+
+func TestWatchWorldManifestReprocessesReplacementHostWithSamePlatform(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	le := logrus.NewEntry(logrus.New())
+
+	tb, err := testbed.NewTestbed(ctx, le)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer tb.Release()
+
+	ocs, err := tb.BuildEmptyCursor(ctx)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer ocs.Release()
+
+	ws, err := world_block.BuildMockWorldState(ctx, le, true, ocs, false)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	const objKey = "plugin-host"
+	if _, err := bldr_manifest_world.CreateManifestStore(ctx, ws, objKey); err != nil {
+		t.Fatal(err.Error())
+	}
+	manifest, key := storeTestWorldManifest(t, ctx, ws, "spacewave-core", "desktop/darwin/arm64", 1)
+	if err := ws.SetGraphQuad(ctx, bldr_manifest_world.NewManifestQuad(objKey, key, "spacewave-core")); err != nil {
+		t.Fatal(err.Error())
+	}
+	obj, ok, err := ws.GetObject(ctx, objKey)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if !ok {
+		t.Fatal("expected plugin host object")
+	}
+
+	host1 := &testPluginHost{id: "desktop/darwin/arm64"}
+	hostSet1 := &pluginHostSet{pluginHosts: []bldr_plugin_host.PluginHost{host1}}
+	pi := &pluginInstance{
+		c: &Controller{
+			conf:   &Config{},
+			objKey: objKey,
+		},
+		le:                      le,
+		pluginID:                "spacewave-core",
+		downloadManifestRoutine: routine.NewStateRoutineContainerWithLoggerVT[*bldr_manifest.ManifestSnapshot](le),
+		executePluginRoutine:    routine.NewStateRoutineContainerWithLogger(executePluginArgsEqual, le),
+	}
+	if _, err := pi.processManifestWorldState(ctx, le, hostSet1, ws, obj); err != nil {
+		t.Fatal(err.Error())
+	}
+	initial := pi.executePluginRoutine.GetState()
+	if initial == nil || initial.pluginHost != host1 {
+		t.Fatal("expected first host to be selected")
+	}
+	if !initial.manifestSnapshot.GetManifestRef().EqualVT(manifest.GetManifestRef()) {
+		t.Fatal("expected first manifest to be selected")
+	}
+
+	host2 := &testPluginHost{id: "desktop/darwin/arm64"}
+	if _, err := pi.processManifestWorldState(ctx, le, &pluginHostSet{
+		pluginHosts: []bldr_plugin_host.PluginHost{host2},
+	}, ws, obj); err != nil {
+		t.Fatal(err.Error())
+	}
+	replaced := pi.executePluginRoutine.GetState()
+	if replaced == nil || replaced.pluginHost != host2 {
+		t.Fatal("replacement host with the same platform was not selected")
+	}
+}
+
+func TestWatchWorldManifestReprocessesNestedSelectionGraphChange(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	le := logrus.NewEntry(logrus.New())
+
+	tb, err := testbed.NewTestbed(ctx, le)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer tb.Release()
+
+	ocs, err := tb.BuildEmptyCursor(ctx)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer ocs.Release()
+
+	ws, err := world_block.BuildMockWorldState(ctx, le, true, ocs, false)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	const objKey = "plugin-host"
+	const nestedKey = "plugin-host/retained"
+	if _, err := bldr_manifest_world.CreateManifestStore(ctx, ws, objKey); err != nil {
+		t.Fatal(err.Error())
+	}
+	if _, err := bldr_manifest_world.CreateManifestStore(ctx, ws, nestedKey); err != nil {
+		t.Fatal(err.Error())
+	}
+	if err := ws.SetGraphQuad(ctx, bldr_manifest_world.NewManifestQuad(objKey, nestedKey, "")); err != nil {
+		t.Fatal(err.Error())
+	}
+	first, firstKey := storeTestWorldManifest(t, ctx, ws, "spacewave-core", "desktop/darwin/arm64", 1)
+	if err := ws.SetGraphQuad(ctx, bldr_manifest_world.NewManifestQuad(nestedKey, firstKey, "spacewave-core")); err != nil {
+		t.Fatal(err.Error())
+	}
+	obj, ok, err := ws.GetObject(ctx, objKey)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if !ok {
+		t.Fatal("expected plugin host object")
+	}
+
+	host := &testPluginHost{id: "desktop/darwin/arm64"}
+	hostSet := &pluginHostSet{pluginHosts: []bldr_plugin_host.PluginHost{host}}
+	pi := &pluginInstance{
+		c: &Controller{
+			conf:   &Config{},
+			objKey: objKey,
+		},
+		le:                      le,
+		pluginID:                "spacewave-core",
+		downloadManifestRoutine: routine.NewStateRoutineContainerWithLoggerVT[*bldr_manifest.ManifestSnapshot](le),
+		executePluginRoutine:    routine.NewStateRoutineContainerWithLogger(executePluginArgsEqual, le),
+	}
+	if _, err := pi.processManifestWorldState(ctx, le, hostSet, ws, obj); err != nil {
+		t.Fatal(err.Error())
+	}
+	initial := pi.executePluginRoutine.GetState()
+	if initial == nil || !initial.manifestSnapshot.GetManifestRef().EqualVT(first.GetManifestRef()) {
+		t.Fatal("expected first nested manifest to be selected")
+	}
+
+	second, secondKey := storeTestWorldManifest(t, ctx, ws, "spacewave-core", "desktop/darwin/arm64", 2)
+	if err := ws.SetGraphQuad(ctx, bldr_manifest_world.NewManifestQuad(nestedKey, secondKey, "spacewave-core")); err != nil {
+		t.Fatal(err.Error())
+	}
+	if _, err := pi.processManifestWorldState(ctx, le, hostSet, ws, obj); err != nil {
+		t.Fatal(err.Error())
+	}
+	updated := pi.executePluginRoutine.GetState()
+	if updated == nil || !updated.manifestSnapshot.GetManifestRef().EqualVT(second.GetManifestRef()) {
+		t.Fatal("nested manifest graph change did not update selection")
 	}
 }
 
@@ -3648,6 +3938,31 @@ func newTestStoredManifestRefWithDistInBucketAndTransform(
 	ref := oc.GetRef()
 	ref.RootRef = rootRef
 	return bldr_manifest.NewManifestRef(meta, ref)
+}
+
+type failAfterRootBlockStore struct {
+	block.StoreOps
+	getCalls *atomic.Int32
+	failed   *atomic.Bool
+}
+
+func (s *failAfterRootBlockStore) BeginReadOperation(ctx context.Context) (block.StoreOps, func(), error) {
+	store, release, err := s.StoreOps.BeginReadOperation(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &failAfterRootBlockStore{
+		StoreOps: store,
+		getCalls: s.getCalls,
+		failed:   s.failed,
+	}, release, nil
+}
+
+func (s *failAfterRootBlockStore) GetBlock(ctx context.Context, ref *block.BlockRef) ([]byte, bool, error) {
+	if s.getCalls.Add(1) == 2 && s.failed.CompareAndSwap(false, true) {
+		return nil, false, errors.New("injected descendant failure")
+	}
+	return s.StoreOps.GetBlock(ctx, ref)
 }
 
 type testExternalManifestRef struct {

--- a/bldr/plugin/host/scheduler/fetch-world-manifest_test.go
+++ b/bldr/plugin/host/scheduler/fetch-world-manifest_test.go
@@ -3,6 +3,7 @@ package plugin_host_scheduler
 import (
 	"context"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -2876,6 +2877,133 @@ func TestDownloadManifestCopiesExternalVolumeDAGAndCachesSourceReads(t *testing.
 	}
 }
 
+func TestDownloadManifestCopiesSeveralRemoteDAGsOutsideWorldAccess(t *testing.T) {
+	ctx := context.Background()
+	le := logrus.NewEntry(logrus.New())
+
+	tb, err := testbed.NewTestbed(ctx, le)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer tb.Release()
+
+	ocs, err := tb.BuildEmptyCursor(ctx)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer ocs.Release()
+
+	baseWS, err := world_block.BuildMockWorldState(ctx, le, true, ocs, false)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	const objKey = "plugin-host"
+	if _, err := bldr_manifest_world.CreateManifestStore(ctx, baseWS, objKey); err != nil {
+		t.Fatal(err.Error())
+	}
+
+	ws := &accessCountingWorldState{WorldState: baseWS}
+	var wsv world.WorldState = ws
+	pi := &pluginInstance{
+		c: &Controller{
+			conf: &Config{
+				FetchConcurrency: 4,
+			},
+			objKey:          objKey,
+			peerID:          peer.ID("test"),
+			worldStateCtr:   ccontainer.NewCContainer(wsv),
+			pluginStatus:    make(map[string]*bldr_plugin.PluginStatus),
+			pluginStatusCtr: ccontainer.NewCContainer(&PluginStatusSnapshot{}),
+		},
+		le:       le,
+		pluginID: "spacewave-core",
+	}
+
+	observed := make(chan manifestCopyObservation, 3)
+	errCh := make(chan error, 3)
+	releaseCopy := make(chan struct{})
+	for i := range 3 {
+		suffix := string(rune('a' + i))
+		remoteBucketID := "remote-manifest-bucket-" + suffix
+		remote := newTestExternalManifestRefWithDistAssets(
+			t,
+			ctx,
+			remoteBucketID,
+			"spacewave-core-"+suffix,
+			"desktop/darwin/arm64",
+			uint64(20+i),
+		)
+		sourceStore := &blockingLookupBlockStore{
+			StoreOps:     remote.store,
+			activeAccess: &ws.active,
+			observed:     observed,
+			release:      releaseCopy,
+			once:         &sync.Once{},
+			manifestID:   remote.ref.GetMeta().GetManifestId(),
+		}
+		sourceConf, err := bucket.NewConfig(remoteBucketID, 1, nil)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		lookupRel, err := tb.Bus.AddController(ctx, &testSchedulerStaticLookupController{
+			bucketID: remoteBucketID,
+			handle: &testSchedulerStaticLookupHandle{
+				conf: sourceConf,
+				lookup: &testSchedulerStaticLookup{
+					store: sourceStore,
+				},
+			},
+		}, nil)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		defer lookupRel()
+
+		snapshot := &bldr_manifest.ManifestSnapshot{
+			ManifestRef: remote.ref.GetManifestRef(),
+			Manifest:    remote.manifest,
+		}
+		go func() {
+			errCh <- pi.execDownloadManifest(ctx, snapshot)
+		}()
+	}
+
+	seen := make(map[string]bool, 3)
+	for len(seen) < 3 {
+		next := <-observed
+		seen[next.manifestID] = true
+		if next.active != 0 {
+			close(releaseCopy)
+			t.Fatalf("source block read for %s ran with %d active world access(es)", next.manifestID, next.active)
+		}
+	}
+	close(releaseCopy)
+	for range 3 {
+		if err := <-errCh; err != nil {
+			t.Fatal(err.Error())
+		}
+	}
+
+	for manifestID := range seen {
+		got, errs, err := bldr_manifest_world.CollectManifestsForManifestID(
+			ctx,
+			baseWS,
+			manifestID,
+			[]string{"desktop/darwin/arm64"},
+			objKey,
+		)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+		if len(errs) != 0 {
+			t.Fatalf("manifest errors for %s = %v", manifestID, errs)
+		}
+		if len(got) != 1 {
+			t.Fatalf("manifest count for %s = %d, want 1", manifestID, len(got))
+		}
+	}
+}
+
 func TestDownloadManifestYieldsColdStartCopyUntilStartupGroupReady(t *testing.T) {
 	ctx := context.Background()
 	le := logrus.NewEntry(logrus.New())
@@ -3484,6 +3612,69 @@ func newTestExternalManifestRefWithDistAssets(
 		manifest: manifest.CloneVT(),
 		store:    store,
 	}
+}
+
+type accessCountingWorldState struct {
+	world.WorldState
+	active atomic.Int32
+}
+
+func (s *accessCountingWorldState) AccessWorldState(
+	ctx context.Context,
+	ref *bucket.ObjectRef,
+	cb func(*bucket_lookup.Cursor) error,
+) error {
+	s.active.Add(1)
+	defer s.active.Add(-1)
+	return s.WorldState.AccessWorldState(ctx, ref, cb)
+}
+
+type manifestCopyObservation struct {
+	manifestID string
+	active     int32
+}
+
+type blockingLookupBlockStore struct {
+	block.StoreOps
+	activeAccess *atomic.Int32
+	observed     chan<- manifestCopyObservation
+	release      <-chan struct{}
+	once         *sync.Once
+	manifestID   string
+}
+
+func (s *blockingLookupBlockStore) BeginReadOperation(ctx context.Context) (block.StoreOps, func(), error) {
+	store, release, err := s.StoreOps.BeginReadOperation(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	once := s.once
+	if once == nil {
+		once = &sync.Once{}
+	}
+	return &blockingLookupBlockStore{
+		StoreOps:     store,
+		activeAccess: s.activeAccess,
+		observed:     s.observed,
+		release:      s.release,
+		once:         once,
+		manifestID:   s.manifestID,
+	}, release, nil
+}
+
+func (s *blockingLookupBlockStore) GetBlock(ctx context.Context, ref *block.BlockRef) ([]byte, bool, error) {
+	s.once.Do(func() {
+		s.observed <- manifestCopyObservation{
+			manifestID: s.manifestID,
+			active:     s.activeAccess.Load(),
+		}
+	})
+	select {
+	case <-ctx.Done():
+		return nil, false, context.Canceled
+	case <-s.release:
+	}
+	return s.StoreOps.GetBlock(ctx, ref)
 }
 
 type startupDemandLookupObserver struct {

--- a/bldr/plugin/host/scheduler/fetch-world-manifest_test.go
+++ b/bldr/plugin/host/scheduler/fetch-world-manifest_test.go
@@ -3004,6 +3004,110 @@ func TestDownloadManifestCopiesSeveralRemoteDAGsOutsideWorldAccess(t *testing.T)
 	}
 }
 
+func TestWatchWorldManifestSkipsUnchangedSelectionInputs(t *testing.T) {
+	ctx := context.Background()
+	le := logrus.NewEntry(logrus.New())
+
+	tb, err := testbed.NewTestbed(ctx, le)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer tb.Release()
+
+	ocs, err := tb.BuildEmptyCursor(ctx)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer ocs.Release()
+
+	baseWS, err := world_block.BuildMockWorldState(ctx, le, true, ocs, false)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	const objKey = "plugin-host"
+	if _, err := bldr_manifest_world.CreateManifestStore(ctx, baseWS, objKey); err != nil {
+		t.Fatal(err.Error())
+	}
+	var worldBucketID string
+	if err := baseWS.AccessWorldState(ctx, nil, func(cursor *bucket_lookup.Cursor) error {
+		worldBucketID = cursor.GetOpArgs().GetBucketId()
+		return nil
+	}); err != nil {
+		t.Fatal(err.Error())
+	}
+
+	coreRef := newTestStoredManifestRefWithDistInBucket(
+		t,
+		ctx,
+		tb,
+		worldBucketID,
+		"spacewave-core",
+		"desktop/darwin/arm64",
+		1,
+	)
+	coreKey := bldr_manifest.NewManifestKey(objKey, coreRef.GetMeta())
+	if err := bldr_manifest_world.ExStoreManifestOp(ctx, baseWS, peer.ID("test"), coreKey, []string{objKey}, coreRef); err != nil {
+		t.Fatal(err.Error())
+	}
+
+	ws := &accessCountingWorldState{WorldState: baseWS}
+	obj, ok, err := baseWS.GetObject(ctx, objKey)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if !ok {
+		t.Fatal("expected plugin host object")
+	}
+	host := &testPluginHost{id: "desktop/darwin/arm64"}
+	pi := &pluginInstance{
+		c: &Controller{
+			conf:   &Config{},
+			objKey: objKey,
+		},
+		le:                      le,
+		pluginID:                "spacewave-core",
+		downloadManifestRoutine: routine.NewStateRoutineContainerWithLoggerVT[*bldr_manifest.ManifestSnapshot](le),
+		executePluginRoutine:    routine.NewStateRoutineContainerWithLogger(executePluginArgsEqual, le),
+	}
+	if _, err := pi.processManifestWorldState(ctx, le, &pluginHostSet{
+		pluginHosts: []bldr_plugin_host.PluginHost{host},
+	}, ws, obj); err != nil {
+		t.Fatal(err.Error())
+	}
+	if got := ws.total.Load(); got != 1 {
+		t.Fatalf("initial selection world accesses = %d, want 1", got)
+	}
+
+	webRef := newTestStoredManifestRefWithDistInBucket(
+		t,
+		ctx,
+		tb,
+		worldBucketID,
+		"spacewave-web",
+		"desktop/darwin/arm64",
+		1,
+	)
+	webKey := bldr_manifest.NewManifestKey(objKey, webRef.GetMeta())
+	if err := bldr_manifest_world.ExStoreManifestOp(ctx, baseWS, peer.ID("test"), webKey, []string{objKey}, webRef); err != nil {
+		t.Fatal(err.Error())
+	}
+	obj, ok, err = baseWS.GetObject(ctx, objKey)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if !ok {
+		t.Fatal("expected plugin host object after unrelated manifest store")
+	}
+	if _, err := pi.processManifestWorldState(ctx, le, &pluginHostSet{
+		pluginHosts: []bldr_plugin_host.PluginHost{host},
+	}, ws, obj); err != nil {
+		t.Fatal(err.Error())
+	}
+	if got := ws.total.Load(); got != 1 {
+		t.Fatalf("unchanged selection world accesses = %d, want 1", got)
+	}
+}
+
 func TestDownloadManifestYieldsColdStartCopyUntilStartupGroupReady(t *testing.T) {
 	ctx := context.Background()
 	le := logrus.NewEntry(logrus.New())
@@ -3617,6 +3721,7 @@ func newTestExternalManifestRefWithDistAssets(
 type accessCountingWorldState struct {
 	world.WorldState
 	active atomic.Int32
+	total  atomic.Int32
 }
 
 func (s *accessCountingWorldState) AccessWorldState(
@@ -3624,6 +3729,7 @@ func (s *accessCountingWorldState) AccessWorldState(
 	ref *bucket.ObjectRef,
 	cb func(*bucket_lookup.Cursor) error,
 ) error {
+	s.total.Add(1)
 	s.active.Add(1)
 	defer s.active.Add(-1)
 	return s.WorldState.AccessWorldState(ctx, ref, cb)

--- a/bldr/plugin/host/scheduler/plugin-instance.go
+++ b/bldr/plugin/host/scheduler/plugin-instance.go
@@ -33,6 +33,9 @@ type pluginInstance struct {
 	loggedNotFound atomic.Bool
 	// manifestCopyAccounting owns demand and copy counters for the selected candidate.
 	manifestCopyAccounting atomic.Pointer[manifestCopyAccounting]
+	// manifestSelectionFingerprint is the last input set fully processed by
+	// watchWorldManifestRoutine.
+	manifestSelectionFingerprint atomic.Pointer[string]
 
 	// runningPluginCtr contains the running plugin ref
 	runningPluginCtr *ccontainer.CContainer[bldr_plugin.RunningPlugin]

--- a/bldr/plugin/host/scheduler/plugin-instance.go
+++ b/bldr/plugin/host/scheduler/plugin-instance.go
@@ -35,7 +35,7 @@ type pluginInstance struct {
 	manifestCopyAccounting atomic.Pointer[manifestCopyAccounting]
 	// manifestSelectionFingerprint is the last input set fully processed by
 	// watchWorldManifestRoutine.
-	manifestSelectionFingerprint atomic.Pointer[string]
+	manifestSelectionFingerprint atomic.Pointer[manifestSelectionInput]
 
 	// runningPluginCtr contains the running plugin ref
 	runningPluginCtr *ccontainer.CContainer[bldr_plugin.RunningPlugin]

--- a/bldr/plugin/host/scheduler/watch-world-manifest.go
+++ b/bldr/plugin/host/scheduler/watch-world-manifest.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/aperturerobotics/cayley/quad"
 	"github.com/pkg/errors"
 	bldr_manifest "github.com/s4wave/spacewave/bldr/manifest"
 	bldr_manifest_world "github.com/s4wave/spacewave/bldr/manifest/world"
@@ -72,6 +73,14 @@ func (t *pluginInstance) processManifestWorldState(
 	platformIDs := slices.Collect(maps.Keys(platformIDsMap))
 	slices.Sort(platformIDs)
 	trace.Log(ctx, "platform-ids", strings.Join(platformIDs, ","))
+	selectionFingerprint, err := t.manifestSelectionInputFingerprint(ctx, ws, platformIDs)
+	if err != nil {
+		return true, err
+	}
+	if t.manifestSelectionInputUnchanged(selectionFingerprint) {
+		trace.Log(ctx, "manifest-selection-phase", "skipped-unchanged-inputs")
+		return true, nil
+	}
 
 	// configure logger
 	le = le.WithFields(logrus.Fields{
@@ -124,6 +133,7 @@ func (t *pluginInstance) processManifestWorldState(
 		t.c.clearPluginStatusErrorStage(t.pluginID, t.instanceKey, "startup manifest refs")
 	}
 	if len(manifests) == 0 {
+		t.storeManifestSelectionInputFingerprint(selectionFingerprint)
 		t.c.recordPluginManifestRecoveryStatus(t.pluginID, t.instanceKey, nil, nil, candidateEligibility)
 		// When store is disabled, the fetch handler may drive
 		// execute/download directly from fetched ManifestRefs.
@@ -285,10 +295,79 @@ func (t *pluginInstance) processManifestWorldState(
 				le.WithFields(fields).Debug("selected download and execute manifests for plugin")
 			}
 
-			// done
+			t.storeManifestSelectionInputFingerprint(selectionFingerprint)
 			return nil
 		},
 	)
+}
+
+func (t *pluginInstance) manifestSelectionInputUnchanged(fingerprint string) bool {
+	current := t.manifestSelectionFingerprint.Load()
+	return current != nil && *current == fingerprint
+}
+
+func (t *pluginInstance) storeManifestSelectionInputFingerprint(fingerprint string) {
+	t.manifestSelectionFingerprint.Store(&fingerprint)
+}
+
+func (t *pluginInstance) manifestSelectionInputFingerprint(
+	ctx context.Context,
+	ws world.WorldState,
+	platformIDs []string,
+) (string, error) {
+	var fingerprint strings.Builder
+	fingerprint.WriteString(t.pluginID)
+	for _, platformID := range platformIDs {
+		fingerprint.WriteByte(0)
+		fingerprint.WriteString(platformID)
+	}
+	exactLabel := quad.IRI(t.pluginID).String()
+	quads, err := ws.LookupGraphQuads(
+		ctx,
+		world.NewGraphQuadWithKeys(t.c.objKey, bldr_manifest_world.PredManifest.String(), "", ""),
+		0,
+	)
+	if err != nil {
+		return "", err
+	}
+	slices.SortFunc(quads, func(a, b world.GraphQuad) int {
+		if cmp := strings.Compare(a.GetLabel(), b.GetLabel()); cmp != 0 {
+			return cmp
+		}
+		return strings.Compare(a.GetObj(), b.GetObj())
+	})
+	for _, graphQuad := range quads {
+		if label := graphQuad.GetLabel(); label != exactLabel && label != "" {
+			continue
+		}
+		objKey, err := world.GraphValueToKey(graphQuad.GetObj())
+		if err != nil {
+			return "", err
+		}
+		fingerprint.WriteByte(0)
+		fingerprint.WriteString(graphQuad.GetLabel())
+		fingerprint.WriteByte(0)
+		fingerprint.WriteString(objKey)
+		obj, ok, err := ws.GetObject(ctx, objKey)
+		if err != nil {
+			return "", err
+		}
+		if !ok {
+			fingerprint.WriteString("\x00missing")
+			continue
+		}
+		ref, rev, err := obj.GetRootRef(ctx)
+		if err != nil {
+			return "", err
+		}
+		fingerprint.WriteByte(0)
+		fingerprint.WriteString(strconv.FormatUint(rev, 10))
+		if ref != nil && !ref.GetEmpty() {
+			fingerprint.WriteByte(0)
+			fingerprint.WriteString(ref.MarshalString())
+		}
+	}
+	return fingerprint.String(), nil
 }
 
 const maxStartupManifestSkipSummaryItems = 3

--- a/bldr/plugin/host/scheduler/watch-world-manifest.go
+++ b/bldr/plugin/host/scheduler/watch-world-manifest.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/aperturerobotics/cayley/quad"
 	"github.com/pkg/errors"
 	bldr_manifest "github.com/s4wave/spacewave/bldr/manifest"
 	bldr_manifest_world "github.com/s4wave/spacewave/bldr/manifest/world"
@@ -73,21 +72,6 @@ func (t *pluginInstance) processManifestWorldState(
 	platformIDs := slices.Collect(maps.Keys(platformIDsMap))
 	slices.Sort(platformIDs)
 	trace.Log(ctx, "platform-ids", strings.Join(platformIDs, ","))
-	selectionFingerprint, err := t.manifestSelectionInputFingerprint(ctx, ws, platformIDs)
-	if err != nil {
-		return true, err
-	}
-	if t.manifestSelectionInputUnchanged(selectionFingerprint) {
-		trace.Log(ctx, "manifest-selection-phase", "skipped-unchanged-inputs")
-		return true, nil
-	}
-
-	// configure logger
-	le = le.WithFields(logrus.Fields{
-		"platform-ids":    platformIDs,
-		"host-object-key": t.c.objKey,
-	})
-
 	// collect and classify retained startup manifest candidates
 	candidateEligibility, err := bldr_manifest_world.CollectStartupManifestEligibilityForManifestID(
 		ctx,
@@ -98,6 +82,11 @@ func (t *pluginInstance) processManifestWorldState(
 	)
 	if err != nil {
 		return true, err
+	}
+	selectionFingerprint := manifestSelectionInputFingerprint(platformIDs, candidateEligibility)
+	if t.manifestSelectionInputUnchanged(hosts, selectionFingerprint) {
+		trace.Log(ctx, "manifest-selection-phase", "skipped-unchanged-inputs")
+		return true, nil
 	}
 	if ctx.Err() != nil {
 		return true, context.Canceled
@@ -133,7 +122,7 @@ func (t *pluginInstance) processManifestWorldState(
 		t.c.clearPluginStatusErrorStage(t.pluginID, t.instanceKey, "startup manifest refs")
 	}
 	if len(manifests) == 0 {
-		t.storeManifestSelectionInputFingerprint(selectionFingerprint)
+		t.storeManifestSelectionInputFingerprint(hosts, selectionFingerprint)
 		t.c.recordPluginManifestRecoveryStatus(t.pluginID, t.instanceKey, nil, nil, candidateEligibility)
 		// When store is disabled, the fetch handler may drive
 		// execute/download directly from fetched ManifestRefs.
@@ -295,79 +284,87 @@ func (t *pluginInstance) processManifestWorldState(
 				le.WithFields(fields).Debug("selected download and execute manifests for plugin")
 			}
 
-			t.storeManifestSelectionInputFingerprint(selectionFingerprint)
+			t.storeManifestSelectionInputFingerprint(hosts, selectionFingerprint)
 			return nil
 		},
 	)
 }
 
-func (t *pluginInstance) manifestSelectionInputUnchanged(fingerprint string) bool {
+type manifestSelectionInput struct {
+	hostSet     *pluginHostSet
+	fingerprint string
+}
+
+func (t *pluginInstance) manifestSelectionInputUnchanged(hosts *pluginHostSet, fingerprint string) bool {
 	current := t.manifestSelectionFingerprint.Load()
-	return current != nil && *current == fingerprint
+	return current != nil &&
+		current.hostSet == hosts &&
+		current.fingerprint == fingerprint
 }
 
-func (t *pluginInstance) storeManifestSelectionInputFingerprint(fingerprint string) {
-	t.manifestSelectionFingerprint.Store(&fingerprint)
-}
-
-func (t *pluginInstance) manifestSelectionInputFingerprint(
-	ctx context.Context,
-	ws world.WorldState,
-	platformIDs []string,
-) (string, error) {
-	var fingerprint strings.Builder
-	fingerprint.WriteString(t.pluginID)
-	for _, platformID := range platformIDs {
-		fingerprint.WriteByte(0)
-		fingerprint.WriteString(platformID)
-	}
-	exactLabel := quad.IRI(t.pluginID).String()
-	quads, err := ws.LookupGraphQuads(
-		ctx,
-		world.NewGraphQuadWithKeys(t.c.objKey, bldr_manifest_world.PredManifest.String(), "", ""),
-		0,
-	)
-	if err != nil {
-		return "", err
-	}
-	slices.SortFunc(quads, func(a, b world.GraphQuad) int {
-		if cmp := strings.Compare(a.GetLabel(), b.GetLabel()); cmp != 0 {
-			return cmp
-		}
-		return strings.Compare(a.GetObj(), b.GetObj())
+func (t *pluginInstance) storeManifestSelectionInputFingerprint(hosts *pluginHostSet, fingerprint string) {
+	t.manifestSelectionFingerprint.Store(&manifestSelectionInput{
+		hostSet:     hosts,
+		fingerprint: fingerprint,
 	})
-	for _, graphQuad := range quads {
-		if label := graphQuad.GetLabel(); label != exactLabel && label != "" {
+}
+
+func manifestSelectionInputFingerprint(
+	platformIDs []string,
+	candidates []*bldr_manifest_world.StartupManifestCandidateEligibility,
+) string {
+	var fingerprint strings.Builder
+	writeField := func(value string) {
+		fingerprint.WriteByte(0)
+		fingerprint.WriteString(strconv.Itoa(len(value)))
+		fingerprint.WriteByte(':')
+		fingerprint.WriteString(value)
+	}
+	for _, platformID := range platformIDs {
+		writeField(platformID)
+	}
+	candidates = slices.Clone(candidates)
+	slices.SortStableFunc(candidates, func(a, b *bldr_manifest_world.StartupManifestCandidateEligibility) int {
+		if a == nil || b == nil {
+			if a == nil && b == nil {
+				return 0
+			}
+			if a == nil {
+				return -1
+			}
+			return 1
+		}
+		return strings.Compare(a.ObjectKey, b.ObjectKey)
+	})
+	for _, candidate := range candidates {
+		if candidate == nil {
+			writeField("<nil>")
 			continue
 		}
-		objKey, err := world.GraphValueToKey(graphQuad.GetObj())
-		if err != nil {
-			return "", err
+		writeField(candidate.ObjectKey)
+		writeField(candidate.EdgeLabel)
+		writeField(string(candidate.Eligibility))
+		writeField(candidate.Reason)
+		writeField(candidate.ManifestID)
+		writeField(candidate.PlatformID)
+		writeField(strconv.FormatUint(candidate.Rev, 10))
+		if candidate.ObjectRef != nil {
+			writeField(candidate.ObjectRef.MarshalString())
+		} else {
+			writeField("<nil>")
 		}
-		fingerprint.WriteByte(0)
-		fingerprint.WriteString(graphQuad.GetLabel())
-		fingerprint.WriteByte(0)
-		fingerprint.WriteString(objKey)
-		obj, ok, err := ws.GetObject(ctx, objKey)
-		if err != nil {
-			return "", err
+		if candidate.ManifestRef != nil {
+			writeField(candidate.ManifestRef.String())
+		} else {
+			writeField("<nil>")
 		}
-		if !ok {
-			fingerprint.WriteString("\x00missing")
-			continue
-		}
-		ref, rev, err := obj.GetRootRef(ctx)
-		if err != nil {
-			return "", err
-		}
-		fingerprint.WriteByte(0)
-		fingerprint.WriteString(strconv.FormatUint(rev, 10))
-		if ref != nil && !ref.GetEmpty() {
-			fingerprint.WriteByte(0)
-			fingerprint.WriteString(ref.MarshalString())
+		if candidate.Manifest != nil && candidate.Manifest.GetMeta() != nil {
+			writeField(candidate.Manifest.GetMeta().MarshalB58())
+		} else {
+			writeField("<nil>")
 		}
 	}
-	return fingerprint.String(), nil
+	return fingerprint.String()
 }
 
 const maxStartupManifestSkipSummaryItems = 3


### PR DESCRIPTION
Startup manifest processing previously copied plugin manifests while holding world access, retried failed copies from scratch, and could publish an incomplete DAG after a partial failure: a previously written root was treated as proof that every descendant existed, so a retry skipped the incomplete subtree entirely. Selection change detection also fingerprinted only the top-level manifest list, so nested graph changes and replacement hosts with identical IDs were not reprocessed.

Copies now run outside world access with publication serialized until the full copy succeeds, existing subtrees are traversed on every copy so missing descendants are filled in, and the selection fingerprint covers the complete eligibility traversal plus the immutable host-set snapshot. A zero fetch concurrency value passes through to the copy owner, which defines it as unlimited.

Verified with the scheduler package tests including the race detector; the new tests cover incomplete-subtree retry, nested selection changes, and host replacement.
