### PR TITLE
fix(webrtc): centralize signal ingress lease ownership

### DIFF
--- a/net/transport/webrtc/handler.go
+++ b/net/transport/webrtc/handler.go
@@ -64,6 +64,9 @@ func (c *WebRTCSignalHandler) Close() error {
 type handleSignalPeerResolver struct {
 	t    *WebRTC
 	sess signaling.SignalPeerSession
+	// held indicates this resolver has held the peer's ingress lease.
+	// guarded by t.bcast.
+	held bool
 }
 
 // Resolve resolves the directive.

--- a/net/transport/webrtc/handler.go
+++ b/net/transport/webrtc/handler.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/aperturerobotics/controllerbus/controller"
 	"github.com/aperturerobotics/controllerbus/directive"
-	"github.com/aperturerobotics/util/keyed"
 	"github.com/aperturerobotics/util/scrub"
 	"github.com/s4wave/spacewave/net/signaling"
 )
@@ -63,33 +62,8 @@ func (c *WebRTCSignalHandler) Close() error {
 
 // handleSignalPeerResolver resolves HandleSignalPeer.
 type handleSignalPeerResolver struct {
-	t          *WebRTC
-	sess       signaling.SignalPeerSession
-	releaseRef func(*keyed.KeyedRef[string, *sessionTracker])
-	refStored  func(*keyed.KeyedRef[string, *sessionTracker], *keyed.KeyedRef[string, *sessionTracker])
-}
-
-func (r *handleSignalPeerResolver) releaseIncomingRef(ref *keyed.KeyedRef[string, *sessionTracker]) {
-	if r.releaseRef != nil {
-		r.releaseRef(ref)
-		return
-	}
-	ref.Release()
-}
-
-// storeIncomingRef replaces the map-held reference while r.t.bcast is locked.
-func (r *handleSignalPeerResolver) storeIncomingRef(
-	remotePeerIDStr string,
-	ref *keyed.KeyedRef[string, *sessionTracker],
-) {
-	prev := r.t.incomingSessions[remotePeerIDStr]
-	if prev != nil {
-		r.releaseIncomingRef(prev)
-	}
-	r.t.incomingSessions[remotePeerIDStr] = ref
-	if r.refStored != nil {
-		r.refStored(prev, ref)
-	}
+	t    *WebRTC
+	sess signaling.SignalPeerSession
 }
 
 // Resolve resolves the directive.
@@ -97,29 +71,7 @@ func (r *handleSignalPeerResolver) Resolve(ctx context.Context, handler directiv
 	remotePeerID := r.sess.GetRemotePeerID()
 	remotePeerIDStr := remotePeerID.String()
 	r.t.le.Debugf("started signaling session with %v", remotePeerIDStr)
-
-	// Wait for the remote peer to indicate they want a session before starting one.
-	// If the link is lost with this nonce, the ref will also be released.
-	// The ref is then added back if the remote peer sends a request to start the session again.
-	var tkr *sessionTracker
-	var ref *keyed.KeyedRef[string, *sessionTracker]
-	defer func() {
-		if ref == nil {
-			return
-		}
-
-		var release bool
-		r.t.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
-			if r.t.incomingSessions[remotePeerIDStr] == ref {
-				delete(r.t.incomingSessions, remotePeerIDStr)
-				release = true
-				broadcast()
-			}
-		})
-		if release {
-			r.releaseIncomingRef(ref)
-		}
-	}()
+	defer r.t.closeSignalIngress(remotePeerIDStr, r)
 
 	for {
 		// Wait for an incoming message.
@@ -148,85 +100,8 @@ func (r *handleSignalPeerResolver) Resolve(ctx context.Context, handler directiv
 			sig:      sig,
 			accepted: make(chan struct{}),
 		}
-
-		// Loop until the current tracker accepts this message.
-		var deliveredTracker *sessionTracker
-		var deliveredGeneration uint64
-	ProcessLoop:
-		for {
-			// Acceptance wins over an unrelated transport broadcast. Once accepted,
-			// this signal must never be delivered to another tracker generation.
-			select {
-			case <-incoming.accepted:
-				break ProcessLoop
-			default:
-			}
-
-			// Read the tracker execution and its transition wait channel together.
-			var execution *sessionTrackerExecution
-			var waitCh <-chan struct{}
-			r.t.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
-				if ref != nil {
-					// The registry transition that replaced or removed this
-					// reference already released it.
-					if currRef := r.t.incomingSessions[remotePeerIDStr]; currRef != ref {
-						ref = nil
-						tkr = nil
-					}
-				}
-
-				// Add the reference if it doesn't exist anymore.
-				if ref == nil {
-					ref, tkr, _, err = r.t.addSessionTrackerRef(remotePeerIDStr)
-					if err == nil && ref != nil {
-						r.storeIncomingRef(remotePeerIDStr, ref)
-						broadcast()
-					}
-				}
-
-				if tkr != nil {
-					execution = tkr.execution
-				}
-				waitCh = getWaitCh()
-			})
-			if err != nil {
-				return err
-			}
-
-			if execution == nil {
-				select {
-				case <-ctx.Done():
-					return context.Canceled
-				case <-incoming.accepted:
-					break ProcessLoop
-				case <-waitCh:
-					continue ProcessLoop
-				}
-			}
-
-			if deliveredTracker != tkr || deliveredGeneration != execution.generation {
-				select {
-				case <-ctx.Done():
-					return context.Canceled
-				case <-incoming.accepted:
-					break ProcessLoop
-				case <-waitCh:
-					continue ProcessLoop
-				case execution.rxSignal <- incoming:
-					deliveredTracker = tkr
-					deliveredGeneration = execution.generation
-				}
-				continue ProcessLoop
-			}
-
-			select {
-			case <-ctx.Done():
-				return context.Canceled
-			case <-incoming.accepted:
-				break ProcessLoop
-			case <-waitCh:
-				continue ProcessLoop
-			}
+		if err := r.t.deliverSignal(ctx, remotePeerIDStr, r, incoming); err != nil {
+			return err
 		}
 	}
 }

--- a/net/transport/webrtc/handler_test.go
+++ b/net/transport/webrtc/handler_test.go
@@ -866,3 +866,135 @@ func testHandleSignalPeerRetriesRetiredTrackerSignal(t *testing.T, routineFailur
 }
 
 var _ signaling.SignalPeerSession = ((*testSignalPeerSession)(nil))
+
+// TestHandleSignalPeerReacquiresAfterSupersedingIngressRetires pins the
+// reacquisition contract: a resolver whose ingress lease was replaced by a
+// newer resolver must reacquire a lease and redeliver its unaccepted signal
+// after the superseding ingress retires, instead of parking forever with no
+// tracker live.
+func TestHandleSignalPeerReacquiresAfterSupersedingIngressRetires(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	localPriv, _, err := crypto.GenerateEd25519Key(rand.Reader)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	localPeerID, err := peer.IDFromPrivateKey(localPriv)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	remotePriv, _, err := crypto.GenerateEd25519Key(rand.Reader)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	remotePeerID, err := peer.IDFromPrivateKey(remotePriv)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	peerKey := remotePeerID.String()
+
+	tpt := &WebRTC{
+		le:               logrus.NewEntry(logrus.New()),
+		conf:             &Config{},
+		peerID:           localPeerID,
+		privKey:          localPriv,
+		incomingSessions: make(map[string]*signalIngress),
+	}
+
+	firstDelivered := make(chan *incomingSignal, 1)
+	var constructions atomic.Int32
+	var firstTracker *sessionTracker
+	tpt.sessionTrackers = keyed.NewKeyedRefCount(
+		func(key string) (keyed.Routine, *sessionTracker) {
+			construction := constructions.Add(1)
+			tkr := &sessionTracker{w: tpt, le: tpt.le, key: key}
+			if construction == 1 {
+				firstTracker = tkr
+			}
+			return func(ctx context.Context) error {
+				execution := tkr.beginExecution()
+				defer tkr.retireExecution(execution)
+				select {
+				case <-ctx.Done():
+					return context.Canceled
+				case incoming := <-execution.rxSignal:
+					if construction == 1 {
+						// Receive without accepting; the test retires this
+						// ingress while the signal is still pending.
+						firstDelivered <- incoming
+						<-ctx.Done()
+						return context.Canceled
+					}
+					sess := &session{t: tkr}
+					sess.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+						sess.acceptIncomingSignalLocked(incoming)
+					})
+					<-ctx.Done()
+					return context.Canceled
+				}
+			}, tkr
+		},
+		keyed.WithBackoff[string, *sessionTracker](func(string) cbackoff.BackOff {
+			return new(cbackoff.ZeroBackOff)
+		}),
+	)
+	tpt.sessionTrackers.SetContext(ctx, true)
+	t.Cleanup(tpt.sessionTrackers.ClearContext)
+
+	resolverA := &handleSignalPeerResolver{t: tpt}
+	resolverB := &handleSignalPeerResolver{t: tpt}
+	incoming := &incomingSignal{accepted: make(chan struct{})}
+
+	deliverErr := make(chan error, 1)
+	go func() {
+		deliverErr <- tpt.deliverSignal(ctx, peerKey, resolverA, incoming)
+	}()
+
+	// Resolver A acquires the first ingress and delivers without acceptance.
+	<-firstDelivered
+
+	// Resolver B supersedes A's lease on the same live tracker.
+	var supersedingTracker *sessionTracker
+	tpt.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+		ingress, err := tpt.acquireSignalIngressLocked(peerKey, resolverB, broadcast)
+		if err != nil {
+			t.Errorf("acquire superseding ingress: %v", err)
+			return
+		}
+		supersedingTracker = ingress.tracker
+	})
+	if t.Failed() {
+		return
+	}
+
+	// Force resolver A to observe the superseding ingress before it retires:
+	// publish a fresh execution generation on the shared tracker, then receive
+	// A's redelivery on it. The same locked loop iteration that redelivers
+	// also sees resolver B owning the lease.
+	replacementExecution := firstTracker.beginExecution()
+	redelivered := <-replacementExecution.rxSignal
+	if redelivered != incoming {
+		t.Fatal("redelivery carried a different signal")
+	}
+
+	// The superseding ingress retires before A's signal is accepted, leaving
+	// the peer with no ingress lease at all.
+	tpt.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+		tpt.retireSignalIngressLocked(peerKey, supersedingTracker)
+		broadcast()
+	})
+
+	// A must reacquire a fresh tracker and redeliver until acceptance.
+	if err := <-deliverErr; err != nil {
+		t.Fatalf("deliverSignal returned %v, want nil after reacquisition", err)
+	}
+	select {
+	case <-incoming.accepted:
+	default:
+		t.Fatal("signal was not accepted after reacquisition")
+	}
+	if got := constructions.Load(); got != 2 {
+		t.Fatalf("tracker constructions %d, want 2 (original plus reacquired)", got)
+	}
+}

--- a/net/transport/webrtc/handler_test.go
+++ b/net/transport/webrtc/handler_test.go
@@ -48,6 +48,27 @@ func (s *testSignalPeerSession) Recv(ctx context.Context) ([]byte, error) {
 	}
 }
 
+func waitForSignalIngress(
+	t *testing.T,
+	tpt *WebRTC,
+	peerID string,
+	resolver *handleSignalPeerResolver,
+) *signalIngress {
+	t.Helper()
+	for {
+		var ingress *signalIngress
+		var waitCh <-chan struct{}
+		tpt.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+			ingress = tpt.incomingSessions[peerID]
+			waitCh = getWaitCh()
+		})
+		if ingress != nil && ingress.resolver == resolver {
+			return ingress
+		}
+		<-waitCh
+	}
+}
+
 func TestHandleSignalPeerRetriesRetiredTrackerSignal(t *testing.T) {
 	testHandleSignalPeerRetriesRetiredTrackerSignal(t, false)
 }
@@ -97,7 +118,7 @@ func TestHandleSignalPeerRetriesSameTrackerExecutionGeneration(t *testing.T) {
 		conf:             &Config{},
 		peerID:           localPeerID,
 		privKey:          localPriv,
-		incomingSessions: make(map[string]*keyed.KeyedRef[string, *sessionTracker]),
+		incomingSessions: make(map[string]*signalIngress),
 	}
 
 	type executionDelivery struct {
@@ -272,7 +293,7 @@ func TestHandleSignalPeerRetriesSameTrackerExecutionGeneration(t *testing.T) {
 		if dialTracker.execution != nil {
 			t.Error("tracker execution remained published after cancellation")
 		}
-		if ref := tpt.incomingSessions[remotePeerIDStr]; ref != nil {
+		if ingress := tpt.incomingSessions[remotePeerIDStr]; ingress != nil {
 			t.Error("incoming session reference remained after cancellation")
 		}
 	})
@@ -298,7 +319,6 @@ func TestHandleSignalPeerDeliversOncePerTrackerGeneration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	remotePeerIDStr := remotePeerID.String()
 
 	sig := &WebRtcSignal{Body: &WebRtcSignal_RequestOffer{RequestOffer: 1}}
 	msg, err := EncodeWebRtcSignal(sig, localPub)
@@ -306,6 +326,7 @@ func TestHandleSignalPeerDeliversOncePerTrackerGeneration(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 	firstRecvStarted := make(chan struct{}, 2)
+	secondRecvStarted := make(chan struct{}, 1)
 	firstSession := &testSignalPeerSession{
 		localPeerID:  localPeerID,
 		remotePeerID: remotePeerID,
@@ -317,6 +338,7 @@ func TestHandleSignalPeerDeliversOncePerTrackerGeneration(t *testing.T) {
 		localPeerID:  localPeerID,
 		remotePeerID: remotePeerID,
 		recvCh:       make(chan []byte, 1),
+		recvStarted:  secondRecvStarted,
 	}
 	secondSession.recvCh <- msg
 
@@ -325,7 +347,7 @@ func TestHandleSignalPeerDeliversOncePerTrackerGeneration(t *testing.T) {
 		conf:             &Config{},
 		peerID:           localPeerID,
 		privKey:          localPriv,
-		incomingSessions: make(map[string]*keyed.KeyedRef[string, *sessionTracker]),
+		incomingSessions: make(map[string]*signalIngress),
 	}
 
 	firstReceived := make(chan *incomingSignal, 1)
@@ -408,38 +430,21 @@ func TestHandleSignalPeerDeliversOncePerTrackerGeneration(t *testing.T) {
 
 	<-firstRecvStarted
 	firstIncoming := <-firstReceived
-	var firstRef *keyed.KeyedRef[string, *sessionTracker]
-	tpt.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
-		firstRef = tpt.incomingSessions[remotePeerIDStr]
-	})
-	if firstRef == nil {
-		t.Fatal("first resolver did not install its incoming session reference")
-	}
+	firstRef := waitForSignalIngress(t, tpt, remotePeerID.String(), firstResolver).ref
 
-	replacementReady := make(chan struct{})
-	continueReplacement := make(chan struct{})
 	secondCtx, cancelSecond := context.WithCancel(ctx)
 	secondResolverErr := make(chan error, 1)
-	secondResolver := &handleSignalPeerResolver{
-		t:    tpt,
-		sess: secondSession,
-		refStored: func(
-			prev *keyed.KeyedRef[string, *sessionTracker],
-			next *keyed.KeyedRef[string, *sessionTracker],
-		) {
-			if prev == firstRef {
-				close(replacementReady)
-				<-continueReplacement
-			}
-		},
-	}
+	secondResolver := &handleSignalPeerResolver{t: tpt, sess: secondSession}
 	go func() {
 		secondResolverErr <- secondResolver.Resolve(secondCtx, nil)
 	}()
 
-	<-replacementReady
+	<-secondRecvStarted
+	secondRef := waitForSignalIngress(t, tpt, remotePeerID.String(), secondResolver).ref
+	if secondRef == firstRef {
+		t.Fatal("second resolver retained the first ingress reference")
+	}
 	close(acceptFirst)
-	close(continueReplacement)
 	select {
 	case <-trackerStable:
 	case err := <-trackerDone:
@@ -524,14 +529,13 @@ func TestHandleSignalPeerReleasesOverlappingResolverReferences(t *testing.T) {
 		conf:             &Config{},
 		peerID:           localPeerID,
 		privKey:          localPriv,
-		incomingSessions: make(map[string]*keyed.KeyedRef[string, *sessionTracker]),
+		incomingSessions: make(map[string]*signalIngress),
 	}
 
 	firstReceived := make(chan *incomingSignal, 1)
 	secondReceived := make(chan *incomingSignal, 1)
-	retireTracker := make(chan struct{})
-	trackerRetired := make(chan struct{})
 	trackerDone := make(chan error, 1)
+	trackerContextDone := make(chan struct{})
 	var tracker *sessionTracker
 	tpt.sessionTrackers = keyed.NewKeyedRefCount(
 		func(key string) (keyed.Routine, *sessionTracker) {
@@ -545,10 +549,10 @@ func TestHandleSignalPeerReleasesOverlappingResolverReferences(t *testing.T) {
 			tracker = tkr
 			return func(ctx context.Context) (err error) {
 				execution := tkr.beginExecution()
-				defer tkr.retireExecution(execution)
 				defer func() {
 					trackerDone <- err
 				}()
+				defer tkr.retireExecution(execution)
 
 				var incoming *incomingSignal
 				select {
@@ -565,96 +569,41 @@ func TestHandleSignalPeerReleasesOverlappingResolverReferences(t *testing.T) {
 				}
 				secondReceived <- incoming
 
-				select {
-				case <-ctx.Done():
-					return context.Canceled
-				case <-retireTracker:
-				}
-				tkr.retireExecution(execution)
-				close(trackerRetired)
-				return nil
+				<-ctx.Done()
+				close(trackerContextDone)
+				return context.Canceled
 			}, tkr
 		},
 	)
 	tpt.sessionTrackers.SetContext(ctx, true)
 	t.Cleanup(tpt.sessionTrackers.ClearContext)
 
-	releaseCalls := make(chan *keyed.KeyedRef[string, *sessionTracker], 4)
-	refReplaced := make(chan [2]*keyed.KeyedRef[string, *sessionTracker], 1)
-	continueReplacement := make(chan struct{})
-	releaseRef := func(ref *keyed.KeyedRef[string, *sessionTracker]) {
-		releaseCalls <- ref
-		ref.Release()
-	}
-	refStored := func(
-		prev *keyed.KeyedRef[string, *sessionTracker],
-		next *keyed.KeyedRef[string, *sessionTracker],
-	) {
-		if prev != nil {
-			refReplaced <- [2]*keyed.KeyedRef[string, *sessionTracker]{prev, next}
-			<-continueReplacement
-		}
-	}
-
 	firstCtx, cancelFirst := context.WithCancel(ctx)
 	firstResolverErr := make(chan error, 1)
-	firstResolver := &handleSignalPeerResolver{
-		t:          tpt,
-		sess:       firstSession,
-		releaseRef: releaseRef,
-		refStored:  refStored,
-	}
+	firstResolver := &handleSignalPeerResolver{t: tpt, sess: firstSession}
 	go func() {
 		firstResolverErr <- firstResolver.Resolve(firstCtx, nil)
 	}()
 
 	<-firstRecvStarted
 	firstIncoming := <-firstReceived
-	var firstRef *keyed.KeyedRef[string, *sessionTracker]
-	tpt.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
-		firstRef = tpt.incomingSessions[remotePeerIDStr]
-	})
-	if firstRef == nil {
-		t.Fatal("first resolver did not install its incoming session reference")
-	}
+	firstRef := waitForSignalIngress(t, tpt, remotePeerIDStr, firstResolver).ref
 
 	secondCtx, cancelSecond := context.WithCancel(ctx)
 	secondResolverErr := make(chan error, 1)
-	secondResolver := &handleSignalPeerResolver{
-		t:          tpt,
-		sess:       secondSession,
-		releaseRef: releaseRef,
-		refStored:  refStored,
-	}
+	secondResolver := &handleSignalPeerResolver{t: tpt, sess: secondSession}
 	go func() {
 		secondResolverErr <- secondResolver.Resolve(secondCtx, nil)
 	}()
 
 	<-secondRecvStarted
-	replaced := <-refReplaced
-	if replaced[0] != firstRef {
-		close(continueReplacement)
-		t.Fatal("overlapping resolver replaced an unexpected reference")
-	}
-	select {
-	case released := <-releaseCalls:
-		if released != firstRef {
-			close(continueReplacement)
-			t.Fatal("overlapping resolver released an unexpected reference")
-		}
-	default:
-		close(continueReplacement)
-		t.Fatal("overlapping resolver did not release the superseded reference")
-	}
-
+	secondRef := waitForSignalIngress(t, tpt, remotePeerIDStr, secondResolver).ref
 	firstLiveSession := &session{t: tracker}
 	firstLiveSession.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
 		firstLiveSession.acceptIncomingSignalLocked(firstIncoming)
 	})
-	close(continueReplacement)
 
 	secondIncoming := <-secondReceived
-	secondRef := replaced[1]
 	if secondRef == nil || secondRef == firstRef {
 		t.Fatal("second resolver did not install a distinct incoming session reference")
 	}
@@ -663,39 +612,33 @@ func TestHandleSignalPeerReleasesOverlappingResolverReferences(t *testing.T) {
 		secondLiveSession.acceptIncomingSignalLocked(secondIncoming)
 	})
 
-	<-firstRecvStarted
-	<-secondRecvStarted
-	close(retireTracker)
-	<-trackerRetired
-	if err := <-trackerDone; err != nil {
-		t.Fatalf("tracker returned %v, want nil", err)
+	cancelSecond()
+	if err := <-secondResolverErr; err != context.Canceled {
+		t.Fatalf("second resolver returned %v, want context canceled", err)
 	}
-
+	var currentIngress *signalIngress
 	tpt.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
-		if ref := tpt.incomingSessions[remotePeerIDStr]; ref != nil {
-			t.Errorf("incoming session reference remained after retirement: %p", ref)
-		}
+		currentIngress = tpt.incomingSessions[remotePeerIDStr]
 	})
+	if currentIngress != nil {
+		t.Fatalf(
+			"final resolver release retained ingress owned by %p (first=%t second=%t), want nil",
+			currentIngress.resolver,
+			currentIngress.resolver == firstResolver,
+			currentIngress.resolver == secondResolver,
+		)
+	}
 	if keys := tpt.sessionTrackers.GetKeys(); len(keys) != 0 {
-		t.Fatalf("session trackers still registered after both references released: %v", keys)
+		t.Fatalf("session tracker remained after final resolver release: %v", keys)
+	}
+	<-trackerContextDone
+	if err := <-trackerDone; err != context.Canceled {
+		t.Fatalf("tracker returned %v, want context canceled", err)
 	}
 
 	cancelFirst()
 	if err := <-firstResolverErr; err != context.Canceled {
 		t.Fatalf("first resolver returned %v, want context canceled", err)
-	}
-	cancelSecond()
-	if err := <-secondResolverErr; err != context.Canceled {
-		t.Fatalf("second resolver returned %v, want context canceled", err)
-	}
-
-	select {
-	case released := <-releaseCalls:
-		if released == secondRef {
-			t.Fatal("resolver released the reference already released by tracker retirement")
-		}
-		t.Fatalf("resolver released superseded reference %p more than once", released)
-	default:
 	}
 }
 
@@ -737,7 +680,7 @@ func testHandleSignalPeerRetriesRetiredTrackerSignal(t *testing.T, routineFailur
 		conf:             &Config{},
 		peerID:           localPeerID,
 		privKey:          localPriv,
-		incomingSessions: make(map[string]*keyed.KeyedRef[string, *sessionTracker]),
+		incomingSessions: make(map[string]*signalIngress),
 	}
 
 	type replacementResult struct {

--- a/net/transport/webrtc/handler_test.go
+++ b/net/transport/webrtc/handler_test.go
@@ -621,11 +621,18 @@ func TestHandleSignalPeerReleasesOverlappingResolverReferences(t *testing.T) {
 		currentIngress = tpt.incomingSessions[remotePeerIDStr]
 	})
 	if currentIngress != nil {
+		firstAccepted := false
+		select {
+		case <-firstIncoming.accepted:
+			firstAccepted = true
+		default:
+		}
 		t.Fatalf(
-			"final resolver release retained ingress owned by %p (first=%t second=%t), want nil",
+			"final resolver release retained ingress owned by %p (first=%t second=%t firstAccepted=%t), want nil",
 			currentIngress.resolver,
 			currentIngress.resolver == firstResolver,
 			currentIngress.resolver == secondResolver,
+			firstAccepted,
 		)
 	}
 	if keys := tpt.sessionTrackers.GetKeys(); len(keys) != 0 {
@@ -996,5 +1003,103 @@ func TestHandleSignalPeerReacquiresAfterSupersedingIngressRetires(t *testing.T) 
 	}
 	if got := constructions.Load(); got != 2 {
 		t.Fatalf("tracker constructions %d, want 2 (original plus reacquired)", got)
+	}
+}
+
+func TestHandleSignalPeerSupersededResolverKeepsSuccessorLease(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	localPriv, _, err := crypto.GenerateEd25519Key(rand.Reader)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	localPeerID, err := peer.IDFromPrivateKey(localPriv)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	remotePriv, _, err := crypto.GenerateEd25519Key(rand.Reader)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	remotePeerID, err := peer.IDFromPrivateKey(remotePriv)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	peerKey := remotePeerID.String()
+
+	tpt := &WebRTC{
+		le:               logrus.NewEntry(logrus.New()),
+		conf:             &Config{},
+		peerID:           localPeerID,
+		privKey:          localPriv,
+		incomingSessions: make(map[string]*signalIngress),
+	}
+
+	tpt.sessionTrackers = keyed.NewKeyedRefCount(
+		func(key string) (keyed.Routine, *sessionTracker) {
+			tkr := &sessionTracker{w: tpt, le: tpt.le, key: key}
+			return func(ctx context.Context) error {
+				execution := tkr.beginExecution()
+				defer tkr.retireExecution(execution)
+				sess := &session{t: tkr}
+				for {
+					select {
+					case <-ctx.Done():
+						return context.Canceled
+					case incoming := <-execution.rxSignal:
+						sess.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+							sess.acceptIncomingSignalLocked(incoming)
+						})
+					}
+				}
+			}, tkr
+		},
+		keyed.WithBackoff[string, *sessionTracker](func(string) cbackoff.BackOff {
+			return new(cbackoff.ZeroBackOff)
+		}),
+	)
+	tpt.sessionTrackers.SetContext(ctx, true)
+	t.Cleanup(tpt.sessionTrackers.ClearContext)
+
+	resolverA := &handleSignalPeerResolver{t: tpt}
+	resolverB := &handleSignalPeerResolver{t: tpt}
+
+	// Resolver A delivers its first signal and holds the lease.
+	first := &incomingSignal{accepted: make(chan struct{})}
+	if err := tpt.deliverSignal(ctx, peerKey, resolverA, first); err != nil {
+		t.Fatalf("first delivery returned %v", err)
+	}
+
+	// Resolver B supersedes A's lease.
+	tpt.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+		if _, err := tpt.acquireSignalIngressLocked(peerKey, resolverB, broadcast); err != nil {
+			t.Errorf("acquire superseding ingress: %v", err)
+		}
+	})
+	if t.Failed() {
+		return
+	}
+
+	// A later signal on the superseded session must deliver to the live
+	// successor's execution without retaking its lease.
+	second := &incomingSignal{accepted: make(chan struct{})}
+	if err := tpt.deliverSignal(ctx, peerKey, resolverA, second); err != nil {
+		t.Fatalf("second delivery returned %v", err)
+	}
+	select {
+	case <-second.accepted:
+	default:
+		t.Fatal("second signal was not accepted")
+	}
+
+	var owner *handleSignalPeerResolver
+	tpt.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+		if ingress := tpt.incomingSessions[peerKey]; ingress != nil {
+			owner = ingress.resolver
+		}
+	})
+	if owner != resolverB {
+		t.Fatal("superseded resolver retook the live successor's lease")
 	}
 }

--- a/net/transport/webrtc/ingress.go
+++ b/net/transport/webrtc/ingress.go
@@ -83,10 +83,9 @@ func (w *WebRTC) deliverSignal(
 	resolver *handleSignalPeerResolver,
 	incoming *incomingSignal,
 ) error {
-	var lease *signalIngress
-	var superseded bool
 	var deliveredTracker *sessionTracker
 	var deliveredGeneration uint64
+	var held bool
 
 	for {
 		select {
@@ -100,24 +99,22 @@ func (w *WebRTC) deliverSignal(
 		var waitCh <-chan struct{}
 		var err error
 		w.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+			// A resolver that has never held the lease supersedes the
+			// current holder: a fresh inbound signal session replaces the
+			// previous one. A resolver that held the lease and was
+			// superseded reacquires only when the peer has no lease at
+			// all, including after the superseding ingress retires, so it
+			// never steals the lease from a live successor; otherwise
+			// delivery targets the successor's live execution.
 			current := w.incomingSessions[peerID]
-			if lease == nil {
-				lease, err = w.acquireSignalIngressLocked(peerID, resolver, broadcast)
-				if err != nil {
+			if current == nil || (current.resolver != resolver && !held) {
+				if _, err = w.acquireSignalIngressLocked(peerID, resolver, broadcast); err != nil {
 					return
 				}
 				current = w.incomingSessions[peerID]
-			} else {
-				if current != nil && current.resolver != resolver {
-					superseded = true
-				}
-				if current == nil && !superseded {
-					lease, err = w.acquireSignalIngressLocked(peerID, resolver, broadcast)
-					if err != nil {
-						return
-					}
-					current = w.incomingSessions[peerID]
-				}
+			}
+			if current.resolver == resolver {
+				held = true
 			}
 			ingress = current
 			execution = w.snapshotSignalExecutionLocked(ingress)

--- a/net/transport/webrtc/ingress.go
+++ b/net/transport/webrtc/ingress.go
@@ -85,7 +85,6 @@ func (w *WebRTC) deliverSignal(
 ) error {
 	var deliveredTracker *sessionTracker
 	var deliveredGeneration uint64
-	var held bool
 
 	for {
 		select {
@@ -97,29 +96,44 @@ func (w *WebRTC) deliverSignal(
 		var ingress *signalIngress
 		var execution *sessionTrackerExecution
 		var waitCh <-chan struct{}
+		var accepted bool
 		var err error
 		w.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+			// Recheck acceptance under the lock: a signal accepted between
+			// the unlocked check above and lock entry must not acquire a
+			// lease it will never use.
+			select {
+			case <-incoming.accepted:
+				accepted = true
+				return
+			default:
+			}
 			// A resolver that has never held the lease supersedes the
 			// current holder: a fresh inbound signal session replaces the
 			// previous one. A resolver that held the lease and was
 			// superseded reacquires only when the peer has no lease at
 			// all, including after the superseding ingress retires, so it
 			// never steals the lease from a live successor; otherwise
-			// delivery targets the successor's live execution.
+			// delivery targets the successor's live execution. The held
+			// history lives on the resolver so every later signal from a
+			// superseded session observes it.
 			current := w.incomingSessions[peerID]
-			if current == nil || (current.resolver != resolver && !held) {
+			if current == nil || (current.resolver != resolver && !resolver.held) {
 				if _, err = w.acquireSignalIngressLocked(peerID, resolver, broadcast); err != nil {
 					return
 				}
 				current = w.incomingSessions[peerID]
 			}
 			if current.resolver == resolver {
-				held = true
+				resolver.held = true
 			}
 			ingress = current
 			execution = w.snapshotSignalExecutionLocked(ingress)
 			waitCh = getWaitCh()
 		})
+		if accepted {
+			return nil
+		}
 		if err != nil {
 			return err
 		}

--- a/net/transport/webrtc/ingress.go
+++ b/net/transport/webrtc/ingress.go
@@ -1,0 +1,165 @@
+package webrtc
+
+import (
+	"context"
+
+	"github.com/aperturerobotics/util/keyed"
+)
+
+// signalIngress owns the one keyed lease that keeps a peer's signal tracker live.
+type signalIngress struct {
+	resolver *handleSignalPeerResolver
+	ref      *keyed.KeyedRef[string, *sessionTracker]
+	tracker  *sessionTracker
+}
+
+// acquireSignalIngressLocked acquires or replaces the peer's ingress lease.
+// The caller must hold w.bcast.
+func (w *WebRTC) acquireSignalIngressLocked(
+	peerID string,
+	resolver *handleSignalPeerResolver,
+	broadcast func(),
+) (*signalIngress, error) {
+	current := w.incomingSessions[peerID]
+	if current != nil && current.resolver == resolver {
+		return current, nil
+	}
+
+	ref, tracker, _, err := w.addSessionTrackerRef(peerID)
+	if err != nil {
+		return nil, err
+	}
+
+	next := &signalIngress{
+		resolver: resolver,
+		ref:      ref,
+		tracker:  tracker,
+	}
+	w.incomingSessions[peerID] = next
+	if current != nil {
+		current.ref.Release()
+	}
+	broadcast()
+	return next, nil
+}
+
+// snapshotSignalExecutionLocked returns the current live execution.
+// The caller must hold w.bcast.
+func (w *WebRTC) snapshotSignalExecutionLocked(ingress *signalIngress) *sessionTrackerExecution {
+	if ingress == nil || ingress.tracker == nil {
+		return nil
+	}
+	return ingress.tracker.execution
+}
+
+// retireSignalIngressLocked retires the lease for a completed execution.
+// The caller must hold w.bcast.
+func (w *WebRTC) retireSignalIngressLocked(peerID string, tracker *sessionTracker) {
+	ingress := w.incomingSessions[peerID]
+	if ingress == nil || ingress.tracker != tracker {
+		return
+	}
+	delete(w.incomingSessions, peerID)
+	ingress.ref.Release()
+}
+
+// closeSignalIngress closes the current lease for a resolver.
+func (w *WebRTC) closeSignalIngress(peerID string, resolver *handleSignalPeerResolver) {
+	w.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+		ingress := w.incomingSessions[peerID]
+		if ingress == nil || ingress.resolver != resolver {
+			return
+		}
+		delete(w.incomingSessions, peerID)
+		ingress.ref.Release()
+		broadcast()
+	})
+}
+
+// deliverSignal submits a decoded signal to the live execution at most once.
+func (w *WebRTC) deliverSignal(
+	ctx context.Context,
+	peerID string,
+	resolver *handleSignalPeerResolver,
+	incoming *incomingSignal,
+) error {
+	var lease *signalIngress
+	var superseded bool
+	var deliveredTracker *sessionTracker
+	var deliveredGeneration uint64
+
+	for {
+		select {
+		case <-incoming.accepted:
+			return nil
+		default:
+		}
+
+		var ingress *signalIngress
+		var execution *sessionTrackerExecution
+		var waitCh <-chan struct{}
+		var err error
+		w.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+			current := w.incomingSessions[peerID]
+			if lease == nil {
+				lease, err = w.acquireSignalIngressLocked(peerID, resolver, broadcast)
+				if err != nil {
+					return
+				}
+				current = w.incomingSessions[peerID]
+			} else {
+				if current != nil && current.resolver != resolver {
+					superseded = true
+				}
+				if current == nil && !superseded {
+					lease, err = w.acquireSignalIngressLocked(peerID, resolver, broadcast)
+					if err != nil {
+						return
+					}
+					current = w.incomingSessions[peerID]
+				}
+			}
+			ingress = current
+			execution = w.snapshotSignalExecutionLocked(ingress)
+			waitCh = getWaitCh()
+		})
+		if err != nil {
+			return err
+		}
+
+		if execution == nil {
+			select {
+			case <-ctx.Done():
+				return context.Canceled
+			case <-incoming.accepted:
+				return nil
+			case <-waitCh:
+				continue
+			}
+		}
+
+		if deliveredTracker != ingress.tracker || deliveredGeneration != execution.generation {
+			select {
+			case <-ctx.Done():
+				return context.Canceled
+			case <-incoming.accepted:
+				return nil
+			case <-waitCh:
+				continue
+			case execution.rxSignal <- incoming:
+				deliveredTracker = ingress.tracker
+				deliveredGeneration = execution.generation
+			}
+			continue
+		}
+
+		select {
+		case <-ctx.Done():
+			return context.Canceled
+		case <-incoming.accepted:
+			return nil
+		case <-waitCh:
+			continue
+		}
+	}
+}

--- a/net/transport/webrtc/session.go
+++ b/net/transport/webrtc/session.go
@@ -72,17 +72,14 @@ func (s *sessionTracker) beginExecution() *sessionTrackerExecution {
 	return execution
 }
 
-// retireExecution clears a generation and its incoming-session reference.
+// retireExecution clears a generation and reports its lease retirement.
 func (s *sessionTracker) retireExecution(execution *sessionTrackerExecution) {
 	s.w.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
 		if s.execution != execution {
 			return
 		}
 		s.execution = nil
-		if ref := s.w.incomingSessions[s.key]; ref != nil {
-			ref.Release()
-			delete(s.w.incomingSessions, s.key)
-		}
+		s.w.retireSignalIngressLocked(s.key, s)
 		broadcast()
 	})
 }

--- a/net/transport/webrtc/webrtc.go
+++ b/net/transport/webrtc/webrtc.go
@@ -110,10 +110,8 @@ type WebRTC struct {
 	bcast broadcast.Broadcast
 	// relSignalHandler releases the signal handler controller
 	relSignalHandler func()
-	// incomingSessions contains the set of sessions that were started due to
-	// HandleSignalPeer directives. These references are dropped when a link
-	// closes in order to prevent "bouncing" (repeatedly re-connecting).
-	incomingSessions map[string]*keyed.KeyedRef[string, *sessionTracker]
+	// incomingSessions contains the per-peer signal-ingress leases.
+	incomingSessions map[string]*signalIngress
 }
 
 // NewWebRTC builds a new WebRTC transport.
@@ -188,7 +186,7 @@ func NewWebRTC(
 	}
 
 	// The session tracker starts when we want a session with a remote peer.
-	tpt.incomingSessions = make(map[string]*keyed.KeyedRef[string, *sessionTracker])
+	tpt.incomingSessions = make(map[string]*signalIngress)
 	tpt.sessionTrackers = keyed.NewKeyedRefCount[string, *sessionTracker](
 		tpt.newSessionTracker,
 		keyed.WithExitLogger[string, *sessionTracker](le),


### PR DESCRIPTION
The webrtc signal tests could hang for the full 10 minute CI timeout, and the hang reproduces locally under a race stress loop at any GOMAXPROCS above 1. After one signal resolver superseded another, the peer's session tracker could wait on its keyed context forever: resolver cleanup and tracker retirement each released incoming keyed references independently, so during overlapping replacement either path could remove the current lease after ownership had already moved.

Per-peer signal ingress leases now live behind WebRTC-owned methods that alone acquire, replace, retire, and close them. Replacement publishes the new lease before releasing the old one, retirement releases only the matching tracker's lease, and resolver close releases only the lease that resolver still owns, all idempotent. The resolver keeps only its receive and decode loop, and the signal wire format and protocol behavior are unchanged.

The previously hanging test now passes -race -count=100 at GOMAXPROCS 1, 2, and 16, and the overlap test additionally asserts that the final lease release closes the keyed tracker context. Whole-package stress runs reach only the separately tracked TestTransportReconnect timeout.
