### PR TITLE
Compose Session bucket reads without lookup directives

### DIFF
--- a/core/provider/local/bstore-cycle_test.go
+++ b/core/provider/local/bstore-cycle_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"testing/synctest"
 
-	"github.com/aperturerobotics/controllerbus/bus"
 	bus_bridge "github.com/aperturerobotics/controllerbus/bus/bridge"
 	bus_inmem "github.com/aperturerobotics/controllerbus/bus/inmem"
 	directive_controller "github.com/aperturerobotics/controllerbus/directive/controller"
@@ -45,14 +44,14 @@ func TestLocalBlockStoreNetworkLookupUsesLocalOwner(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		direct := &localDirectLookupStore{
-			busForSession: func() bus.Bus { return childBus },
-			bucketID:      storeID,
-			hashType:      ref.GetHash().GetHashType(),
-		}
+		readOps := block_store.NewStoreReadThrough(
+			func() block.StoreOps { return local },
+			nil,
+			true,
+		)
 		store := &BlockStore{
 			store:     local,
-			readStore: block_store.NewStore(storeID, &localReadStore{local: local, direct: direct}),
+			readStore: block_store.NewStore(storeID, readOps),
 		}
 
 		type lookupResult struct {

--- a/core/provider/local/bstore.go
+++ b/core/provider/local/bstore.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 
-	"github.com/aperturerobotics/controllerbus/bus"
 	"github.com/aperturerobotics/controllerbus/controller"
 	"github.com/aperturerobotics/controllerbus/controller/configset"
 	"github.com/aperturerobotics/util/ccontainer"
@@ -16,7 +15,6 @@ import (
 	block_store_controller "github.com/s4wave/spacewave/db/block/store/controller"
 	"github.com/s4wave/spacewave/db/bucket"
 	lookup_concurrent "github.com/s4wave/spacewave/db/bucket/lookup/concurrent"
-	"github.com/s4wave/spacewave/db/dex"
 	"github.com/s4wave/spacewave/net/hash"
 	"github.com/sirupsen/logrus"
 )
@@ -246,25 +244,20 @@ func (t *bstoreTracker) executeBlockStoreTracker(rctx context.Context) error {
 	}
 	defer decodedBlocks.Close()
 	localBucket := bucketHandle.GetBucket()
-	direct := &localDirectLookupStore{
-		busForSession: func() bus.Bus {
-			st := t.a.GetSessionTransport()
-			if st == nil {
-				return nil
-			}
-			return st.GetChildBus()
-		},
-		bucketID: BlockStoreBucketID(
-			t.a.t.p.info.GetProviderId(),
-			t.a.t.accountInfo.GetProviderAccountId(),
-			t.id,
-		),
-		hashType: localBucket.GetHashType(),
-	}
+	bucketID := BlockStoreBucketID(
+		t.a.t.p.info.GetProviderId(),
+		t.a.t.accountInfo.GetProviderAccountId(),
+		t.id,
+	)
 	localStore := block_store.NewStore(blockStoreLocalID, localBucket)
+	readOps := block_store.NewStoreReadThrough(
+		func() block.StoreOps { return localBucket },
+		func() block.StoreOps { return t.a.getP2PStore(bucketID) },
+		true,
+	)
 	bstoreHandle := &BlockStore{
 		store:         localStore,
-		readStore:     block_store.NewStore(blockStoreLocalID, &localReadStore{local: localBucket, direct: direct}),
+		readStore:     block_store.NewStore(blockStoreLocalID, readOps),
 		decodedBlocks: decodedBlocks,
 	}
 	bstoreCtrl := newLocalBlockStoreController(le, blockStoreLocalID, localStore)
@@ -317,177 +310,6 @@ func (t *bstoreTracker) buildBucketConf() (*bucket.Config, error) {
 	}
 	return bucket.NewConfig(bucketID, blockStoreBucketConfigRev, lookupConf)
 }
-
-// localReadStore keeps local writes on the bucket while routing uncached reads
-// to the active Session child DEX. There is intentionally no Cloud fallback.
-type localReadStore struct {
-	local  block.StoreOps
-	direct block.StoreOps
-}
-
-func (s *localReadStore) GetHashType() hash.HashType { return s.local.GetHashType() }
-func (s *localReadStore) GetSupportedFeatures() block.StoreFeature {
-	return s.local.GetSupportedFeatures()
-}
-
-func (s *localReadStore) BeginReadOperation(ctx context.Context) (block.StoreOps, func(), error) {
-	local, releaseLocal, err := s.local.BeginReadOperation(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	direct, releaseDirect, err := s.direct.BeginReadOperation(ctx)
-	if err != nil {
-		releaseLocal()
-		return nil, nil, err
-	}
-	return &localReadStore{local: local, direct: direct}, func() {
-		releaseDirect()
-		releaseLocal()
-	}, nil
-}
-
-func (s *localReadStore) PutBlock(context.Context, []byte, *block.PutOpts) (*block.BlockRef, bool, error) {
-	return nil, false, block_store.ErrReadOnly
-}
-
-func (s *localReadStore) PutBlockBatch(context.Context, []*block.PutBatchEntry) error {
-	return block_store.ErrReadOnly
-}
-
-func (s *localReadStore) RmBlock(context.Context, *block.BlockRef) error {
-	return block_store.ErrReadOnly
-}
-func (s *localReadStore) Sync(context.Context) (bool, error) { return true, nil }
-func (s *localReadStore) GetBlock(ctx context.Context, ref *block.BlockRef) ([]byte, bool, error) {
-	data, found, err := s.local.GetBlock(ctx, ref)
-	if err != nil || found {
-		return data, found, err
-	}
-	data, found, err = s.direct.GetBlock(ctx, ref)
-	if err != nil || !found {
-		return data, found, err
-	}
-	if _, _, cacheErr := s.local.PutBlock(ctx, data, &block.PutOpts{ForceBlockRef: ref.Clone()}); cacheErr != nil {
-		return nil, false, cacheErr
-	}
-	return data, true, nil
-}
-
-func (s *localReadStore) GetBlockExists(ctx context.Context, ref *block.BlockRef) (bool, error) {
-	_, found, err := s.GetBlock(ctx, ref)
-	return found, err
-}
-
-func (s *localReadStore) GetBlockExistsBatch(ctx context.Context, refs []*block.BlockRef) ([]bool, error) {
-	out := make([]bool, len(refs))
-	for i, ref := range refs {
-		found, err := s.GetBlockExists(ctx, ref)
-		if err != nil {
-			return nil, err
-		}
-		out[i] = found
-	}
-	return out, nil
-}
-
-func (s *localReadStore) StatBlock(ctx context.Context, ref *block.BlockRef) (*block.BlockStat, error) {
-	data, found, err := s.GetBlock(ctx, ref)
-	if err != nil || !found {
-		return nil, err
-	}
-	return &block.BlockStat{Ref: ref, Size: int64(len(data))}, nil
-}
-
-type localDirectLookupStore struct {
-	busForSession func() bus.Bus
-	bucketID      string
-	hashType      hash.HashType
-}
-
-func (s *localDirectLookupStore) GetHashType() hash.HashType { return s.hashType }
-func (s *localDirectLookupStore) GetSupportedFeatures() block.StoreFeature {
-	return 0
-}
-
-func (s *localDirectLookupStore) BeginReadOperation(context.Context) (block.StoreOps, func(), error) {
-	return s, func() {}, nil
-}
-
-func (s *localDirectLookupStore) PutBlock(context.Context, []byte, *block.PutOpts) (*block.BlockRef, bool, error) {
-	return nil, false, block_store.ErrReadOnly
-}
-
-func (s *localDirectLookupStore) PutBlockBatch(context.Context, []*block.PutBatchEntry) error {
-	return block_store.ErrReadOnly
-}
-
-func (s *localDirectLookupStore) RmBlock(context.Context, *block.BlockRef) error {
-	return block_store.ErrReadOnly
-}
-func (s *localDirectLookupStore) Sync(context.Context) (bool, error) { return true, nil }
-func (s *localDirectLookupStore) GetBlock(ctx context.Context, ref *block.BlockRef) ([]byte, bool, error) {
-	childBus := s.busForSession()
-	if childBus == nil {
-		return nil, false, nil
-	}
-	val, _, valRef, err := bus.ExecWaitValue[dex.LookupBlockFromNetworkValue](
-		ctx,
-		childBus,
-		dex.NewLookupBlockFromNetwork(s.bucketID, ref),
-		bus.ReturnWhenIdle(),
-		nil,
-		func(value dex.LookupBlockFromNetworkValue) (bool, error) {
-			if value.GetError() != nil && value.GetError() != block.ErrNotFound {
-				return true, value.GetError()
-			}
-			return true, nil
-		},
-	)
-	if valRef != nil {
-		valRef.Release()
-	}
-	if err != nil || val == nil {
-		return nil, false, err
-	}
-	if val.GetError() != nil {
-		if val.GetError() == block.ErrNotFound {
-			return nil, false, nil
-		}
-		return nil, false, val.GetError()
-	}
-	data := val.GetData()
-	return data, len(data) != 0, nil
-}
-
-func (s *localDirectLookupStore) GetBlockExists(ctx context.Context, ref *block.BlockRef) (bool, error) {
-	_, found, err := s.GetBlock(ctx, ref)
-	return found, err
-}
-
-func (s *localDirectLookupStore) GetBlockExistsBatch(ctx context.Context, refs []*block.BlockRef) ([]bool, error) {
-	out := make([]bool, len(refs))
-	for i, ref := range refs {
-		found, err := s.GetBlockExists(ctx, ref)
-		if err != nil {
-			return nil, err
-		}
-		out[i] = found
-	}
-	return out, nil
-}
-
-func (s *localDirectLookupStore) StatBlock(ctx context.Context, ref *block.BlockRef) (*block.BlockStat, error) {
-	data, found, err := s.GetBlock(ctx, ref)
-	if err != nil || !found {
-		return nil, err
-	}
-	return &block.BlockStat{Ref: ref, Size: int64(len(data))}, nil
-}
-
-var (
-	_ block.StoreOps = ((*localReadStore)(nil))
-	_ block.StoreOps = ((*localDirectLookupStore)(nil))
-)
 
 // createBlockStoreLocked creates a new bstore with the given details.
 // Assumes a.mtx is locked.

--- a/core/provider/local/bstore_test.go
+++ b/core/provider/local/bstore_test.go
@@ -6,21 +6,14 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/aperturerobotics/controllerbus/bus"
-	bus_inmem "github.com/aperturerobotics/controllerbus/bus/inmem"
-	bus_controller "github.com/aperturerobotics/controllerbus/controller"
-	"github.com/aperturerobotics/controllerbus/directive"
-	directive_controller "github.com/aperturerobotics/controllerbus/directive/controller"
 	"github.com/s4wave/spacewave/core/provider"
 	"github.com/s4wave/spacewave/db/block"
 	block_mock "github.com/s4wave/spacewave/db/block/mock"
 	block_store "github.com/s4wave/spacewave/db/block/store"
 	block_store_inmem "github.com/s4wave/spacewave/db/block/store/inmem"
 	lookup_concurrent "github.com/s4wave/spacewave/db/bucket/lookup/concurrent"
-	"github.com/s4wave/spacewave/db/dex"
 	store_kvkey "github.com/s4wave/spacewave/db/store/kvkey"
 	store_kvtx_inmem "github.com/s4wave/spacewave/db/store/kvtx/inmem"
-	"github.com/sirupsen/logrus"
 )
 
 type batchForwardTestStore struct {
@@ -62,101 +55,60 @@ var (
 	_ block.StoreOps    = ((*batchForwardTestStore)(nil))
 )
 
-type localDEXTestController struct {
-	value    []byte
+type localDEXTestStore struct {
+	block.StoreOps
 	requests atomic.Int32
 }
 
-func (c *localDEXTestController) GetControllerInfo() *bus_controller.Info {
-	return bus_controller.NewInfo(
-		"test/local-dex",
-		bus_controller.MustParseVersion("0.0.1"),
-		"local DEX test controller",
-	)
+func (s *localDEXTestStore) GetBlock(ctx context.Context, ref *block.BlockRef) ([]byte, bool, error) {
+	s.requests.Add(1)
+	return s.StoreOps.GetBlock(ctx, ref)
 }
 
-func (c *localDEXTestController) Execute(ctx context.Context) error {
-	<-ctx.Done()
-	return ctx.Err()
-}
-
-func (c *localDEXTestController) HandleDirective(
-	_ context.Context,
-	inst directive.Instance,
-) ([]directive.Resolver, error) {
-	dir, ok := inst.GetDirective().(dex.LookupBlockFromNetwork)
-	if !ok {
-		return nil, nil
-	}
-	return directive.R(directive.NewAccessResolver(func(
-		_ context.Context,
-		released func(),
-	) (dex.LookupBlockFromNetworkValue, func(), error) {
-		c.requests.Add(1)
-		_ = dir
-		return dex.NewLookupBlockFromNetworkValue(c.value, nil), func() {
-			if released != nil {
-				released()
-			}
-		}, nil
-	}), nil)
-}
-
-func (c *localDEXTestController) Close() error { return nil }
-
-var _ bus_controller.Controller = ((*localDEXTestController)(nil))
-
-func newLocalDEXTestBus(
-	ctx context.Context,
-	value []byte,
-) (bus.Bus, *localDEXTestController, func(), error) {
-	dc := directive_controller.NewController(ctx, logrus.NewEntry(logrus.New()))
-	b := bus_inmem.NewBus(dc)
-	ctrl := &localDEXTestController{value: value}
-	release, err := b.AddController(ctx, ctrl, nil)
-	return b, ctrl, release, err
-}
+var _ block.StoreOps = ((*localDEXTestStore)(nil))
 
 func TestLocalBlockStoreMissRoutesToSessionChildDEX(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
-	ref, err := block.BuildBlockRef([]byte("from-session-dex"), nil)
+	data := []byte("from-session-dex")
+	ref, err := block.BuildBlockRef(data, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	childBus, ctrl, release, err := newLocalDEXTestBus(ctx, []byte("from-session-dex"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer release()
 
-	local := newBatchForwardTestStore()
-	direct := &localDirectLookupStore{
-		busForSession: func() bus.Bus { return childBus },
-		bucketID:      "p/local/account/block-store",
-		hashType:      ref.GetHash().GetHashType(),
+	remote := newBatchForwardTestStore()
+	if _, _, err := remote.PutBlock(ctx, data, nil); err != nil {
+		t.Fatal(err)
 	}
+	dexStore := &localDEXTestStore{StoreOps: remote}
+	local := newBatchForwardTestStore()
+	readOps := block_store.NewStoreReadThrough(
+		func() block.StoreOps { return local },
+		func() block.StoreOps { return dexStore },
+		true,
+	)
 	store := &BlockStore{
 		store:     block_store.NewStore("local-store", local),
-		readStore: block_store.NewStore("local-store", &localReadStore{local: local, direct: direct}),
+		readStore: block_store.NewStore("local-store", readOps),
 	}
-	data, found, err := store.GetBlock(ctx, ref)
-	if err != nil || !found || string(data) != "from-session-dex" {
-		t.Fatalf("local DEX fallback = %q/%v/%v", data, found, err)
+
+	got, found, err := store.GetBlock(ctx, ref)
+	if err != nil || !found || string(got) != string(data) {
+		t.Fatalf("local DEX fallback = %q/%v/%v", got, found, err)
 	}
-	if ctrl.requests.Load() != 1 {
-		t.Fatalf("local DEX requests = %d, want 1", ctrl.requests.Load())
+	if dexStore.requests.Load() != 1 {
+		t.Fatalf("local DEX requests = %d, want 1", dexStore.requests.Load())
 	}
 	if local.putBlockHits != 1 {
 		t.Fatalf("local cache writes = %d, want 1", local.putBlockHits)
 	}
-	direct.busForSession = func() bus.Bus { return nil }
-	data, found, err = store.GetBlock(ctx, ref)
-	if err != nil || !found || string(data) != "from-session-dex" {
-		t.Fatalf("local cache hit after child disable = %q/%v/%v", data, found, err)
+
+	got, found, err = store.GetBlock(ctx, ref)
+	if err != nil || !found || string(got) != string(data) {
+		t.Fatalf("local cache hit = %q/%v/%v", got, found, err)
 	}
-	if ctrl.requests.Load() != 1 {
-		t.Fatalf("local DEX requests after cache hit = %d, want 1", ctrl.requests.Load())
+	if dexStore.requests.Load() != 1 {
+		t.Fatalf("local DEX requests after cache hit = %d, want 1", dexStore.requests.Load())
 	}
 }
 

--- a/core/provider/local/p2p-sync.go
+++ b/core/provider/local/p2p-sync.go
@@ -77,7 +77,6 @@ func (a *ProviderAccount) StartP2PSync(ctx context.Context, sessionTransport *tr
 				return ctx.Err()
 			}
 			a.le.WithError(err).WithField("bucket-id", bucketID).Warn("failed to start dex solicit")
-			continue
 		}
 
 		if err := a.startSOSync(syncCtx, childBus, ref, soID, state); err != nil {

--- a/core/provider/local/p2p-sync.go
+++ b/core/provider/local/p2p-sync.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/aperturerobotics/controllerbus/bus"
+	"github.com/aperturerobotics/controllerbus/controller/loader"
 	"github.com/aperturerobotics/controllerbus/controller/resolver"
 	"github.com/aperturerobotics/controllerbus/directive"
 	"github.com/pkg/errors"
@@ -13,17 +14,26 @@ import (
 	sobject_invite "github.com/s4wave/spacewave/core/sobject/invite"
 	sobject_sync "github.com/s4wave/spacewave/core/sobject/sync"
 	"github.com/s4wave/spacewave/core/transport"
+	"github.com/s4wave/spacewave/db/block"
 	dex_solicit "github.com/s4wave/spacewave/db/dex/solicit"
 	"github.com/s4wave/spacewave/net/crypto"
 	"github.com/s4wave/spacewave/net/peer"
 )
 
-// p2pSyncState holds running P2P sync state for a provider account.
+// p2pSyncState holds running P2P sync and DEX stores for a provider account.
 type p2pSyncState struct {
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
 	refs   []directive.Reference
 	relFns []func()
+	stores map[string]block.StoreOps
+}
+
+func (s *p2pSyncState) addStore(bucketID string, store block.StoreOps) {
+	if s.stores == nil {
+		s.stores = make(map[string]block.StoreOps)
+	}
+	s.stores[bucketID] = store
 }
 
 // StartP2PSync starts SO sync and DEX block exchange for all mounted
@@ -48,6 +58,7 @@ func (a *ProviderAccount) StartP2PSync(ctx context.Context, sessionTransport *tr
 
 	syncCtx, syncCancel := context.WithCancel(ctx)
 	state := &p2pSyncState{cancel: syncCancel}
+	a.p2pSync = state
 
 	soList := a.soListCtr.GetValue()
 	for _, entry := range soList.GetSharedObjects() {
@@ -56,25 +67,26 @@ func (a *ProviderAccount) StartP2PSync(ctx context.Context, sessionTransport *tr
 		soID := provRef.GetId()
 		blockStoreID := ref.GetBlockStoreId()
 
-		if err := a.startSOSync(syncCtx, childBus, ref, soID, state); err != nil {
-			if ctx.Err() != nil {
-				a.stopP2PSyncState(state)
-				return ctx.Err()
-			}
-			a.le.WithError(err).WithField("so-id", soID).Warn("failed to start so sync")
-			continue
-		}
-
 		providerID := provRef.GetProviderId()
 		providerAccountID := provRef.GetProviderAccountId()
 		bucketID := BlockStoreBucketID(providerID, providerAccountID, blockStoreID)
 		if err := a.startDEXSolicit(syncCtx, childBus, bucketID, state); err != nil {
 			if ctx.Err() != nil {
+				a.p2pSync = nil
 				a.stopP2PSyncState(state)
 				return ctx.Err()
 			}
 			a.le.WithError(err).WithField("bucket-id", bucketID).Warn("failed to start dex solicit")
 			continue
+		}
+
+		if err := a.startSOSync(syncCtx, childBus, ref, soID, state); err != nil {
+			if ctx.Err() != nil {
+				a.p2pSync = nil
+				a.stopP2PSyncState(state)
+				return ctx.Err()
+			}
+			a.le.WithError(err).WithField("so-id", soID).Warn("failed to start so sync")
 		}
 	}
 
@@ -82,8 +94,6 @@ func (a *ProviderAccount) StartP2PSync(ctx context.Context, sessionTransport *tr
 	if err := a.startInviteServer(syncCtx, childBus, sessionTransport, state); err != nil {
 		a.le.WithError(err).Warn("failed to start invite server")
 	}
-
-	a.p2pSync = state
 	return nil
 }
 
@@ -103,6 +113,17 @@ func (a *ProviderAccount) StopP2PSync() {
 	defer a.p2pSyncMtx.Unlock()
 
 	a.stopP2PSyncLocked()
+}
+
+func (a *ProviderAccount) getP2PStore(bucketID string) block.StoreOps {
+	a.p2pSyncMtx.Lock()
+	state := a.p2pSync
+	var store block.StoreOps
+	if state != nil {
+		store = state.stores[bucketID]
+	}
+	a.p2pSyncMtx.Unlock()
+	return store
 }
 
 func (a *ProviderAccount) stopP2PSyncLocked() {
@@ -248,7 +269,9 @@ func (a *ProviderAccount) startInviteServer(ctx context.Context, childBus bus.Bu
 // startDEXSolicit loads a DEX solicit controller on the child bus for
 // the given block store bucket.
 func (a *ProviderAccount) startDEXSolicit(ctx context.Context, childBus bus.Bus, bucketID string, state *p2pSyncState) error {
-	_, dexRef, err := childBus.AddDirective(
+	ctrl, _, dexRef, err := loader.WaitExecControllerRunningTyped[*dex_solicit.Controller](
+		ctx,
+		childBus,
 		resolver.NewLoadControllerWithConfig(&dex_solicit.Config{
 			BucketId: bucketID,
 		}),
@@ -258,5 +281,6 @@ func (a *ProviderAccount) startDEXSolicit(ctx context.Context, childBus bus.Bus,
 		return err
 	}
 	state.refs = append(state.refs, dexRef)
+	state.addStore(bucketID, dex_solicit.NewStore(ctrl))
 	return nil
 }

--- a/core/provider/spacewave/bstore.go
+++ b/core/provider/spacewave/bstore.go
@@ -505,10 +505,12 @@ func (t *bstoreTracker) buildBucketConf() (*bucket.Config, error) {
 // sourceTrackingStore records the source that satisfied completed block reads.
 type sourceTrackingStore struct {
 	block.StoreOps
-	account    *ProviderAccount
-	bstoreID   string
-	source     SyncTelemetryBlockSource
-	upperCache bool
+	account        *ProviderAccount
+	bstoreID       string
+	source         SyncTelemetryBlockSource
+	upperCache     bool
+	demandStarted  func()
+	demandFinished func()
 }
 
 // BeginReadOperation preserves source observation inside a scoped read.
@@ -518,11 +520,13 @@ func (s *sourceTrackingStore) BeginReadOperation(ctx context.Context) (block.Sto
 		return nil, nil, err
 	}
 	return &sourceTrackingStore{
-		StoreOps:   scoped,
-		account:    s.account,
-		bstoreID:   s.bstoreID,
-		source:     s.source,
-		upperCache: s.upperCache,
+		StoreOps:       scoped,
+		account:        s.account,
+		bstoreID:       s.bstoreID,
+		source:         s.source,
+		upperCache:     s.upperCache,
+		demandStarted:  s.demandStarted,
+		demandFinished: s.demandFinished,
 	}, release, nil
 }
 
@@ -535,6 +539,14 @@ func (s *sourceTrackingStore) GetBlock(ctx context.Context, ref *block.BlockRef)
 		if err != nil {
 			return nil, false, err
 		}
+	}
+	if s.demandStarted != nil {
+		s.demandStarted()
+		defer func() {
+			if s.demandFinished != nil {
+				s.demandFinished()
+			}
+		}()
 	}
 	data, found, err := s.StoreOps.GetBlock(ctx, ref)
 	if err != nil || !found {

--- a/core/provider/spacewave/p2p-sync.go
+++ b/core/provider/spacewave/p2p-sync.go
@@ -128,7 +128,6 @@ func (a *ProviderAccount) startP2PSyncForSession(
 			bucketID := BlockStoreBucketID(a.accountID, blockStoreID)
 			if err := a.startDEXSolicit(syncCtx, childBus, bucketID, state); err != nil {
 				a.le.WithError(err).WithField("bucket-id", bucketID).Warn("failed to start dex solicit")
-				continue
 			}
 
 			if err := a.startSOSync(syncCtx, childBus, ref, soID, state); err != nil {

--- a/core/provider/spacewave/p2p-sync.go
+++ b/core/provider/spacewave/p2p-sync.go
@@ -14,12 +14,14 @@ import (
 	sobject_invite "github.com/s4wave/spacewave/core/sobject/invite"
 	sobject_sync "github.com/s4wave/spacewave/core/sobject/sync"
 	"github.com/s4wave/spacewave/core/transport"
+	"github.com/s4wave/spacewave/db/block"
 	dex_solicit "github.com/s4wave/spacewave/db/dex/solicit"
 	"github.com/s4wave/spacewave/net/crypto"
 	"github.com/s4wave/spacewave/net/peer"
 )
 
-// p2pSyncState holds running P2P sync state for one mounted Session.
+// p2pSyncState holds running P2P sync and read stores for one mounted
+// Session.
 type p2pSyncState struct {
 	sessionID string
 	cancel    context.CancelFunc
@@ -27,6 +29,23 @@ type p2pSyncState struct {
 	mtx       sync.Mutex
 	refs      []directive.Reference
 	relFns    []func()
+	stores    map[string]block.StoreOps
+}
+
+func (s *p2pSyncState) addStore(bucketID string, store block.StoreOps) {
+	s.mtx.Lock()
+	if s.stores == nil {
+		s.stores = make(map[string]block.StoreOps)
+	}
+	s.stores[bucketID] = store
+	s.mtx.Unlock()
+}
+
+func (s *p2pSyncState) getStore(bucketID string) block.StoreOps {
+	s.mtx.Lock()
+	store := s.stores[bucketID]
+	s.mtx.Unlock()
+	return store
 }
 
 func (s *p2pSyncState) addRef(ref directive.Reference) {
@@ -77,10 +96,17 @@ func (a *ProviderAccount) startP2PSyncForSession(
 
 	syncCtx, syncCancel := context.WithCancel(ctx)
 	state := &p2pSyncState{sessionID: sessionID, cancel: syncCancel}
+	a.p2pSyncMtx.Lock()
+	if a.p2pSyncs == nil {
+		a.p2pSyncs = make(map[string]*p2pSyncState)
+	}
+	a.p2pSyncs[sessionID] = state
+	a.p2pSyncMtx.Unlock()
+
 	mountCtrl := &sessionSharedObjectMountController{account: a, sessionID: sessionID}
 	releaseMountCtrl, err := childBus.AddController(syncCtx, mountCtrl, nil)
 	if err != nil {
-		syncCancel()
+		a.stopP2PSyncForSession(sessionID)
 		return errors.Wrap(err, "register session shared object mount")
 	}
 	state.addRelease(releaseMountCtrl)
@@ -99,15 +125,14 @@ func (a *ProviderAccount) startP2PSyncForSession(
 			soID := provRef.GetId()
 			blockStoreID := ref.GetBlockStoreId()
 
-			if err := a.startSOSync(syncCtx, childBus, ref, soID, state); err != nil {
-				a.le.WithError(err).WithField("so-id", soID).Warn("failed to start so sync")
-				continue
-			}
-
 			bucketID := BlockStoreBucketID(a.accountID, blockStoreID)
 			if err := a.startDEXSolicit(syncCtx, childBus, bucketID, state); err != nil {
 				a.le.WithError(err).WithField("bucket-id", bucketID).Warn("failed to start dex solicit")
 				continue
+			}
+
+			if err := a.startSOSync(syncCtx, childBus, ref, soID, state); err != nil {
+				a.le.WithError(err).WithField("so-id", soID).Warn("failed to start so sync")
 			}
 		}
 	}
@@ -116,12 +141,6 @@ func (a *ProviderAccount) startP2PSyncForSession(
 		a.le.WithError(err).Warn("failed to start invite server")
 	}
 
-	a.p2pSyncMtx.Lock()
-	if a.p2pSyncs == nil {
-		a.p2pSyncs = make(map[string]*p2pSyncState)
-	}
-	a.p2pSyncs[sessionID] = state
-	a.p2pSyncMtx.Unlock()
 	return nil
 }
 
@@ -150,6 +169,7 @@ func (a *ProviderAccount) startSOSync(
 	ctx context.Context,
 	childBus bus.Bus,
 	ref *sobject.SharedObjectRef,
+
 	soID string,
 	state *p2pSyncState,
 ) error {
@@ -172,6 +192,16 @@ func (a *ProviderAccount) startSOSync(
 		}
 	})
 	return nil
+}
+
+func (a *ProviderAccount) getSessionDEXStore(sessionID, bucketID string) block.StoreOps {
+	a.p2pSyncMtx.Lock()
+	state := a.p2pSyncs[sessionID]
+	a.p2pSyncMtx.Unlock()
+	if state == nil {
+		return nil
+	}
+	return state.getStore(bucketID)
 }
 
 // startInviteServer registers the SO invite SRPC server on the child bus.
@@ -272,7 +302,7 @@ func (a *ProviderAccount) startDEXSolicit(
 	bucketID string,
 	state *p2pSyncState,
 ) error {
-	_, _, dexRef, err := loader.WaitExecControllerRunning(
+	ctrl, _, dexRef, err := loader.WaitExecControllerRunningTyped[*dex_solicit.Controller](
 		ctx,
 		childBus,
 		resolver.NewLoadControllerWithConfig(&dex_solicit.Config{
@@ -284,5 +314,6 @@ func (a *ProviderAccount) startDEXSolicit(
 		return err
 	}
 	state.addRef(dexRef)
+	state.addStore(bucketID, dex_solicit.NewStore(ctrl))
 	return nil
 }

--- a/core/provider/spacewave/session-shared-object.go
+++ b/core/provider/spacewave/session-shared-object.go
@@ -104,10 +104,12 @@ func (a *ProviderAccount) newSessionSharedObject(
 			return nil
 		}
 		return &sourceTrackingStore{
-			StoreOps: store,
-			account:  a,
-			bstoreID: ref.GetBlockStoreId(),
-			source:   SyncTelemetryBlockSourceDirect,
+			StoreOps:       store,
+			account:        a,
+			bstoreID:       ref.GetBlockStoreId(),
+			source:         SyncTelemetryBlockSourceDirect,
+			demandStarted:  func() { a.directDemandStarted(sessionID) },
+			demandFinished: func() { a.directDemandFinished(sessionID) },
 		}
 	}
 	facadeStore, err := base.newSessionBlockStore(direct)

--- a/core/provider/spacewave/session-shared-object.go
+++ b/core/provider/spacewave/session-shared-object.go
@@ -11,9 +11,6 @@ import (
 	"github.com/s4wave/spacewave/core/sobject"
 	"github.com/s4wave/spacewave/db/block"
 	block_store "github.com/s4wave/spacewave/db/block/store"
-	"github.com/s4wave/spacewave/db/dex"
-	"github.com/s4wave/spacewave/net/hash"
-	"github.com/sirupsen/logrus"
 )
 
 // sessionSharedObject is a shallow per-Session facade over one account-owned
@@ -78,7 +75,7 @@ func (c *sessionSharedObjectMountController) HandleDirective(
 		if err != nil {
 			return nil, nil, err
 		}
-		facade, err := c.account.newSessionSharedObject(ctx, c.sessionID, ref, baseValue)
+		facade, err := c.account.newSessionSharedObject(c.sessionID, ref, baseValue)
 		if err != nil {
 			baseRelease()
 			return nil, nil, err
@@ -92,7 +89,6 @@ func (c *sessionSharedObjectMountController) Close() error { return nil }
 var _ controller.Controller = ((*sessionSharedObjectMountController)(nil))
 
 func (a *ProviderAccount) newSessionSharedObject(
-	ctx context.Context,
 	sessionID string,
 	ref *sobject.SharedObjectRef,
 	baseValue sobject.MountSharedObjectValue,
@@ -101,16 +97,20 @@ func (a *ProviderAccount) newSessionSharedObject(
 	if !ok || base == nil {
 		return nil, errors.Errorf("unexpected account shared object type %T", baseValue)
 	}
-	direct := &sessionDirectLookupStore{
-		busForSession:  func() bus.Bus { return a.getSessionChildBusForSession(sessionID) },
-		bucketID:       BlockStoreBucketID(a.accountID, ref.GetBlockStoreId()),
-		hashType:       base.blkStore.GetHashType(),
-		account:        a,
-		bstoreID:       ref.GetBlockStoreId(),
-		demandStarted:  func() { a.directDemandStarted(sessionID) },
-		demandFinished: func() { a.directDemandFinished(sessionID) },
+	bucketID := BlockStoreBucketID(a.accountID, ref.GetBlockStoreId())
+	direct := func() block.StoreOps {
+		store := a.getSessionDEXStore(sessionID, bucketID)
+		if store == nil {
+			return nil
+		}
+		return &sourceTrackingStore{
+			StoreOps: store,
+			account:  a,
+			bstoreID: ref.GetBlockStoreId(),
+			source:   SyncTelemetryBlockSourceDirect,
+		}
 	}
-	facadeStore, err := base.newSessionBlockStore(ctx, a.le, direct)
+	facadeStore, err := base.newSessionBlockStore(direct)
 	if err != nil {
 		return nil, err
 	}
@@ -123,31 +123,29 @@ func (a *ProviderAccount) newSessionSharedObject(
 }
 
 func (s *SharedObject) newSessionBlockStore(
-	ctx context.Context,
-	le *logrus.Entry,
-	direct *sessionDirectLookupStore,
+	direct block_store.StoreSource,
 ) (bstore.BlockStore, error) {
 	baseStore, ok := s.blkStore.(*BlockStore)
 	if !ok || baseStore == nil {
 		return nil, errors.Errorf("unexpected shared object block store type %T", s.blkStore)
 	}
-	return baseStore.newSessionBlockStore(ctx, le, direct)
+	return baseStore.newSessionBlockStore(direct)
 }
 
 func (b *BlockStore) newSessionBlockStore(
-	ctx context.Context,
-	le *logrus.Entry,
-	direct *sessionDirectLookupStore,
+	direct block_store.StoreSource,
 ) (bstore.BlockStore, error) {
 	if b == nil || b.cacheStore == nil || b.cloudStore == nil {
 		return nil, errors.New("account block store read owners are unavailable")
 	}
-	readStore := &sessionReadStore{
-		cache:  b.cacheStore,
-		direct: direct,
-		cloud:  b.cloudStore,
-		le:     le,
-	}
+	remote := block_store.NewStoreReadThrough(direct, func() block.StoreOps {
+		return b.cloudStore
+	}, false)
+	readStore := block_store.NewStoreReadThrough(func() block.StoreOps {
+		return b.cacheStore
+	}, func() block.StoreOps {
+		return remote
+	}, true)
 	return &sessionBlockStore{
 		BlockStore: b,
 		readStore:  block_store.NewStore(b.GetID(), readStore),
@@ -188,210 +186,7 @@ func (s *sessionBlockStore) StatBlock(ctx context.Context, ref *block.BlockRef) 
 	return s.readStore.StatBlock(ctx, ref)
 }
 
-// sessionReadStore is the read-only Session pipeline. A direct hit is written
-// to the non-dirty account cache before returning to make the next read local.
-type sessionReadStore struct {
-	cache  block.StoreOps
-	direct block.StoreOps
-	cloud  block.StoreOps
-	le     *logrus.Entry
-}
-
-func (s *sessionReadStore) GetHashType() hash.HashType {
-	if hashType := s.cache.GetHashType(); hashType != 0 {
-		return hashType
-	}
-	if hashType := s.direct.GetHashType(); hashType != 0 {
-		return hashType
-	}
-	return s.cloud.GetHashType()
-}
-
-func (s *sessionReadStore) GetSupportedFeatures() block.StoreFeature {
-	return s.cache.GetSupportedFeatures() & s.cloud.GetSupportedFeatures()
-}
-
-func (s *sessionReadStore) BeginReadOperation(ctx context.Context) (block.StoreOps, func(), error) {
-	cache, releaseCache, err := s.cache.BeginReadOperation(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	direct, releaseDirect, err := s.direct.BeginReadOperation(ctx)
-	if err != nil {
-		releaseCache()
-		return nil, nil, err
-	}
-	cloud, releaseCloud, err := s.cloud.BeginReadOperation(ctx)
-	if err != nil {
-		releaseDirect()
-		releaseCache()
-		return nil, nil, err
-	}
-	return &sessionReadStore{
-			cache:  cache,
-			direct: direct,
-			cloud:  cloud,
-			le:     s.le,
-		}, func() {
-			releaseCloud()
-			releaseDirect()
-			releaseCache()
-		}, nil
-}
-
-func (s *sessionReadStore) PutBlock(context.Context, []byte, *block.PutOpts) (*block.BlockRef, bool, error) {
-	return nil, false, block_store.ErrReadOnly
-}
-
-func (s *sessionReadStore) PutBlockBatch(context.Context, []*block.PutBatchEntry) error {
-	return block_store.ErrReadOnly
-}
-
-func (s *sessionReadStore) RmBlock(context.Context, *block.BlockRef) error {
-	return block_store.ErrReadOnly
-}
-
-func (s *sessionReadStore) Sync(context.Context) (bool, error) { return true, nil }
-
-func (s *sessionReadStore) GetBlock(ctx context.Context, ref *block.BlockRef) ([]byte, bool, error) {
-	data, found, err := s.cache.GetBlock(ctx, ref)
-	if err != nil || found {
-		return data, found, err
-	}
-	data, found, err = s.direct.GetBlock(ctx, ref)
-	if err != nil || !found {
-		if err != nil {
-			return nil, false, err
-		}
-		return s.cloud.GetBlock(ctx, ref)
-	}
-	s.le.Debug("writing direct block through to session cache")
-	if _, _, cacheErr := s.cache.PutBlock(ctx, data, &block.PutOpts{ForceBlockRef: ref.Clone()}); cacheErr != nil {
-		return nil, false, cacheErr
-	}
-	return data, true, nil
-}
-
-func (s *sessionReadStore) GetBlockExists(ctx context.Context, ref *block.BlockRef) (bool, error) {
-	_, found, err := s.GetBlock(ctx, ref)
-	return found, err
-}
-
-func (s *sessionReadStore) GetBlockExistsBatch(ctx context.Context, refs []*block.BlockRef) ([]bool, error) {
-	out := make([]bool, len(refs))
-	for i, ref := range refs {
-		found, err := s.GetBlockExists(ctx, ref)
-		if err != nil {
-			return nil, err
-		}
-		out[i] = found
-	}
-	return out, nil
-}
-
-func (s *sessionReadStore) StatBlock(ctx context.Context, ref *block.BlockRef) (*block.BlockStat, error) {
-	data, found, err := s.GetBlock(ctx, ref)
-	if err != nil || !found {
-		return nil, err
-	}
-	return &block.BlockStat{Ref: ref, Size: int64(len(data))}, nil
-}
-
-var _ block.StoreOps = ((*sessionReadStore)(nil))
+var _ block.StoreOps = ((*block_store.StoreReadThrough)(nil))
 var _ block_store.Store = ((*sessionBlockStore)(nil))
 
-// sessionDirectLookupStore resolves only the direct DEX path. The account
-// BlockStore remains the overlay's lower Cloud/local fallback, so one miss
-// cannot re-enter the direct path or fan out to another Session.
-type sessionDirectLookupStore struct {
-	bus            bus.Bus
-	busForSession  func() bus.Bus
-	bucketID       string
-	hashType       hash.HashType
-	account        *ProviderAccount
-	bstoreID       string
-	demandStarted  func()
-	demandFinished func()
-}
-
-func (s *sessionDirectLookupStore) GetHashType() hash.HashType               { return s.hashType }
-func (s *sessionDirectLookupStore) GetSupportedFeatures() block.StoreFeature { return 0 }
-func (s *sessionDirectLookupStore) BeginReadOperation(context.Context) (block.StoreOps, func(), error) {
-	return s, func() {}, nil
-}
-func (s *sessionDirectLookupStore) PutBlock(context.Context, []byte, *block.PutOpts) (*block.BlockRef, bool, error) {
-	return nil, false, block_store.ErrReadOnly
-}
-func (s *sessionDirectLookupStore) PutBlockBatch(context.Context, []*block.PutBatchEntry) error {
-	return block_store.ErrReadOnly
-}
-func (s *sessionDirectLookupStore) RmBlock(context.Context, *block.BlockRef) error {
-	return block_store.ErrReadOnly
-}
-func (s *sessionDirectLookupStore) Sync(context.Context) (bool, error) { return true, nil }
-
-func (s *sessionDirectLookupStore) GetBlock(ctx context.Context, ref *block.BlockRef) ([]byte, bool, error) {
-	childBus := s.bus
-	if s.busForSession != nil {
-		childBus = s.busForSession()
-	}
-	if childBus == nil {
-		return nil, false, nil
-	}
-	if s.demandStarted != nil {
-		s.demandStarted()
-		defer s.demandFinished()
-	}
-	val, _, valRef, err := bus.ExecWaitValue[dex.LookupBlockFromNetworkValue](ctx, childBus, dex.NewLookupBlockFromNetwork(s.bucketID, ref), bus.ReturnWhenIdle(), nil,
-		func(value dex.LookupBlockFromNetworkValue) (bool, error) {
-			if value.GetError() != nil && value.GetError() != block.ErrNotFound {
-				return true, value.GetError()
-			}
-			return true, nil
-		})
-	if valRef != nil {
-		valRef.Release()
-	}
-	if err != nil || val == nil {
-		return nil, false, err
-	}
-	if val.GetError() != nil {
-		if val.GetError() == block.ErrNotFound {
-			return nil, false, nil
-		}
-		return nil, false, val.GetError()
-	}
-	data := val.GetData()
-	found := len(data) != 0
-	if found && s.account != nil {
-		s.account.recordSyncTelemetryBlockSource(s.bstoreID, SyncTelemetryBlockSourceDirect)
-	}
-	return data, found, nil
-}
-
-func (s *sessionDirectLookupStore) GetBlockExists(ctx context.Context, ref *block.BlockRef) (bool, error) {
-	_, found, err := s.GetBlock(ctx, ref)
-	return found, err
-}
-
-func (s *sessionDirectLookupStore) GetBlockExistsBatch(ctx context.Context, refs []*block.BlockRef) ([]bool, error) {
-	out := make([]bool, len(refs))
-	for i, ref := range refs {
-		found, err := s.GetBlockExists(ctx, ref)
-		if err != nil {
-			return nil, err
-		}
-		out[i] = found
-	}
-	return out, nil
-}
-
-func (s *sessionDirectLookupStore) StatBlock(ctx context.Context, ref *block.BlockRef) (*block.BlockStat, error) {
-	data, found, err := s.GetBlock(ctx, ref)
-	if err != nil || !found {
-		return nil, err
-	}
-	return &block.BlockStat{Ref: ref, Size: int64(len(data))}, nil
-}
-
-var _ block.StoreOps = ((*sessionDirectLookupStore)(nil))
+var _ block_store.Store = ((*sessionBlockStore)(nil))

--- a/core/provider/spacewave/session-shared-object_test.go
+++ b/core/provider/spacewave/session-shared-object_test.go
@@ -5,65 +5,15 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/aperturerobotics/controllerbus/bus"
 	bus_inmem "github.com/aperturerobotics/controllerbus/bus/inmem"
-	bus_controller "github.com/aperturerobotics/controllerbus/controller"
-	"github.com/aperturerobotics/controllerbus/directive"
 	directive_controller "github.com/aperturerobotics/controllerbus/directive/controller"
 	"github.com/s4wave/spacewave/core/provider"
 	"github.com/s4wave/spacewave/core/sobject"
-	"github.com/s4wave/spacewave/core/transport"
 	"github.com/s4wave/spacewave/db/block"
 	block_store "github.com/s4wave/spacewave/db/block/store"
-	"github.com/s4wave/spacewave/db/dex"
-	bifrost_crypto "github.com/s4wave/spacewave/net/crypto"
 	"github.com/s4wave/spacewave/net/hash"
 	"github.com/sirupsen/logrus"
 )
-
-type sessionLookupTestController struct {
-	values   map[string][]byte
-	requests atomic.Int32
-}
-
-func (c *sessionLookupTestController) GetControllerInfo() *bus_controller.Info {
-	return bus_controller.NewInfo(
-		"test/session-lookup",
-		bus_controller.MustParseVersion("0.0.1"),
-		"session lookup test controller",
-	)
-}
-
-func (c *sessionLookupTestController) Execute(ctx context.Context) error {
-	<-ctx.Done()
-	return ctx.Err()
-}
-
-func (c *sessionLookupTestController) HandleDirective(
-	_ context.Context,
-	inst directive.Instance,
-) ([]directive.Resolver, error) {
-	dir, ok := inst.GetDirective().(dex.LookupBlockFromNetwork)
-	if !ok {
-		return nil, nil
-	}
-	return directive.R(directive.NewAccessResolver(func(
-		_ context.Context,
-		released func(),
-	) (dex.LookupBlockFromNetworkValue, func(), error) {
-		c.requests.Add(1)
-		data := c.values[dir.LookupBlockFromNetworkRef().MarshalString()]
-		return dex.NewLookupBlockFromNetworkValue(data, nil), func() {
-			if released != nil {
-				released()
-			}
-		}, nil
-	}), nil)
-}
-
-func (c *sessionLookupTestController) Close() error { return nil }
-
-var _ bus_controller.Controller = ((*sessionLookupTestController)(nil))
 
 type sessionLookupTestLower struct {
 	data     []byte
@@ -140,23 +90,10 @@ func (s *sessionLookupTestLower) StatBlock(ctx context.Context, ref *block.Block
 
 var _ block.StoreOps = ((*sessionLookupTestLower)(nil))
 
-func newSessionLookupTestBus(
-	ctx context.Context,
-	values map[string][]byte,
-) (bus.Bus, *sessionLookupTestController, func(), error) {
-	dc := directive_controller.NewController(ctx, logrus.NewEntry(logrus.New()))
-	b := bus_inmem.NewBus(dc)
-	ctrl := &sessionLookupTestController{values: values}
-	release, err := b.AddController(ctx, ctrl, nil)
-	return b, ctrl, release, err
-}
-
 func newProductionSessionStore(
-	ctx context.Context,
 	account *ProviderAccount,
 	id string,
-	childBus bus.Bus,
-	cache, cloud *sessionLookupTestLower,
+	direct, cache, cloud *sessionLookupTestLower,
 ) (*sessionBlockStore, error) {
 	cacheOwner := &sourceTrackingStore{
 		StoreOps:   cache,
@@ -164,6 +101,12 @@ func newProductionSessionStore(
 		bstoreID:   id,
 		source:     SyncTelemetryBlockSourceDirect,
 		upperCache: true,
+	}
+	directOwner := &sourceTrackingStore{
+		StoreOps: direct,
+		account:  account,
+		bstoreID: id,
+		source:   SyncTelemetryBlockSourceDirect,
 	}
 	cloudOwner := &sourceTrackingStore{
 		StoreOps: cloud,
@@ -176,14 +119,9 @@ func newProductionSessionStore(
 		cacheStore: cacheOwner,
 		cloudStore: cloudOwner,
 	}
-	direct := &sessionDirectLookupStore{
-		bus:      childBus,
-		bucketID: id,
-		hashType: cache.GetHashType(),
-		account:  account,
-		bstoreID: id,
-	}
-	store, err := accountStore.newSessionBlockStore(ctx, logrus.NewEntry(logrus.New()), direct)
+	store, err := accountStore.newSessionBlockStore(func() block.StoreOps {
+		return directOwner
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -219,20 +157,12 @@ func TestSessionDirectLookupRoutesPerChildAndFallsBackOnce(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	child1, ctrl1, release1, err := newSessionLookupTestBus(ctx, map[string][]byte{
-		refDirect.MarshalString(): []byte("session-one"),
-	})
-	if err != nil {
-		t.Fatal(err)
+	direct1 := &sessionLookupTestLower{
+		blocks: map[string][]byte{refDirect.MarshalString(): []byte("session-one")},
 	}
-	defer release1()
-	child2, ctrl2, release2, err := newSessionLookupTestBus(ctx, map[string][]byte{
-		refDirect.MarshalString(): []byte("session-two"),
-	})
-	if err != nil {
-		t.Fatal(err)
+	direct2 := &sessionLookupTestLower{
+		blocks: map[string][]byte{refDirect.MarshalString(): []byte("session-two")},
 	}
-	defer release2()
 
 	cache1 := &sessionLookupTestLower{
 		blocks:   map[string][]byte{refCache.MarshalString(): []byte("cached-one")},
@@ -244,11 +174,11 @@ func TestSessionDirectLookupRoutesPerChildAndFallsBackOnce(t *testing.T) {
 	cache2 := &sessionLookupTestLower{blocks: map[string][]byte{}, writable: true}
 	cloud2 := &sessionLookupTestLower{blocks: map[string][]byte{}}
 	account := &ProviderAccount{}
-	store1, err := newProductionSessionStore(ctx, account, "session-one", child1, cache1, cloud1)
+	store1, err := newProductionSessionStore(account, "session-one", direct1, cache1, cloud1)
 	if err != nil {
 		t.Fatal(err)
 	}
-	store2, err := newProductionSessionStore(ctx, account, "session-two", child2, cache2, cloud2)
+	store2, err := newProductionSessionStore(account, "session-two", direct2, cache2, cloud2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -257,31 +187,31 @@ func TestSessionDirectLookupRoutesPerChildAndFallsBackOnce(t *testing.T) {
 	if err != nil || !found || string(data) != "cached-one" {
 		t.Fatalf("local cache read = %q/%v/%v", data, found, err)
 	}
-	if ctrl1.requests.Load() != 0 || cloud1.getCalls.Load() != 0 {
-		t.Fatalf("local cache hit touched DEX/Cloud: %d/%d", ctrl1.requests.Load(), cloud1.getCalls.Load())
+	if direct1.getCalls.Load() != 0 || cloud1.getCalls.Load() != 0 {
+		t.Fatalf("local cache hit touched DEX/Cloud: %d/%d", direct1.getCalls.Load(), cloud1.getCalls.Load())
 	}
 
 	data, found, err = store1.GetBlock(ctx, refDirect)
 	if err != nil || !found || string(data) != "session-one" {
 		t.Fatalf("session one direct read = %q/%v/%v", data, found, err)
 	}
-	if ctrl1.requests.Load() != 1 || cloud1.getCalls.Load() != 0 || cache1.putCalls.Load() != 1 {
-		t.Fatalf("direct hit calls = dex %d/cloud %d/cache puts %d, want 1/0/1", ctrl1.requests.Load(), cloud1.getCalls.Load(), cache1.putCalls.Load())
+	if direct1.getCalls.Load() != 1 || cloud1.getCalls.Load() != 0 || cache1.putCalls.Load() != 1 {
+		t.Fatalf("direct hit calls = dex %d/cloud %d/cache puts %d, want 1/0/1", direct1.getCalls.Load(), cloud1.getCalls.Load(), cache1.putCalls.Load())
 	}
 	data, found, err = store1.GetBlock(ctx, refDirect)
 	if err != nil || !found || string(data) != "session-one" {
 		t.Fatalf("session one cached direct read = %q/%v/%v", data, found, err)
 	}
-	if ctrl1.requests.Load() != 1 || cloud1.getCalls.Load() != 0 {
-		t.Fatalf("cached direct read touched DEX/Cloud: %d/%d", ctrl1.requests.Load(), cloud1.getCalls.Load())
+	if direct1.getCalls.Load() != 1 || cloud1.getCalls.Load() != 0 {
+		t.Fatalf("cached direct read touched DEX/Cloud: %d/%d", direct1.getCalls.Load(), cloud1.getCalls.Load())
 	}
 
 	data, found, err = store1.GetBlock(ctx, refFallback)
 	if err != nil || !found || string(data) != "cloud-one" {
 		t.Fatalf("Cloud fallback read = %q/%v/%v", data, found, err)
 	}
-	if ctrl1.requests.Load() != 2 || cloud1.getCalls.Load() != 1 {
-		t.Fatalf("fallback calls = dex %d/cloud %d, want 2/1", ctrl1.requests.Load(), cloud1.getCalls.Load())
+	if direct1.getCalls.Load() != 2 || cloud1.getCalls.Load() != 1 {
+		t.Fatalf("fallback calls = dex %d/cloud %d, want 2/1", direct1.getCalls.Load(), cloud1.getCalls.Load())
 	}
 
 	data, found, err = store2.GetBlock(ctx, refDirect)
@@ -292,17 +222,8 @@ func TestSessionDirectLookupRoutesPerChildAndFallsBackOnce(t *testing.T) {
 	if err != nil || !found || string(data) != "session-two" {
 		t.Fatalf("session two cached direct read = %q/%v/%v", data, found, err)
 	}
-	if ctrl2.requests.Load() != 1 || cloud2.getCalls.Load() != 0 {
-		t.Fatalf("session two cache routing = dex %d/cloud %d, want 1/0", ctrl2.requests.Load(), cloud2.getCalls.Load())
-	}
-
-	release1()
-	data, found, err = store2.GetBlock(ctx, refDirect)
-	if err != nil || !found || string(data) != "session-two" {
-		t.Fatalf("session two survived session one teardown = %q/%v/%v", data, found, err)
-	}
-	if ctrl2.requests.Load() != 1 {
-		t.Fatalf("session two request count after session one teardown = %d, want 1", ctrl2.requests.Load())
+	if direct2.getCalls.Load() != 1 || cloud2.getCalls.Load() != 0 {
+		t.Fatalf("session two cache routing = dex %d/cloud %d, want 1/0", direct2.getCalls.Load(), cloud2.getCalls.Load())
 	}
 
 	one := telemetryStore(t, account, "session-one")
@@ -311,8 +232,8 @@ func TestSessionDirectLookupRoutesPerChildAndFallsBackOnce(t *testing.T) {
 	}
 
 	two := telemetryStore(t, account, "session-two")
-	if two.DirectHitCount != 1 || two.CloudHitCount != 0 || two.CacheHitCount != 2 {
-		t.Fatalf("session two telemetry = %+v, want direct=1 cloud=0 cache=2", two)
+	if two.DirectHitCount != 1 || two.CloudHitCount != 0 || two.CacheHitCount != 1 {
+		t.Fatalf("session two telemetry = %+v, want direct=1 cloud=0 cache=1", two)
 	}
 }
 func TestSessionFacadeMountDisabledThenEnablesDirectRoute(t *testing.T) {
@@ -332,10 +253,13 @@ func TestSessionFacadeMountDisabledThenEnablesDirectRoute(t *testing.T) {
 	}
 	cache := &sessionLookupTestLower{blocks: map[string][]byte{}, writable: true}
 	cloud := &sessionLookupTestLower{blocks: map[string][]byte{}}
+	direct := &sessionLookupTestLower{
+		blocks: map[string][]byte{refDirect.MarshalString(): []byte("enabled-direct")},
+	}
 	account := &ProviderAccount{
-		accountID:         "account",
-		le:                logrus.NewEntry(logrus.New()),
-		sessionTransports: make(map[string]*sessionTransportState),
+		accountID: "account",
+		le:        logrus.NewEntry(logrus.New()),
+		p2pSyncs:  make(map[string]*p2pSyncState),
 	}
 	cacheOwner := &sourceTrackingStore{
 		StoreOps:   cache,
@@ -356,52 +280,25 @@ func TestSessionFacadeMountDisabledThenEnablesDirectRoute(t *testing.T) {
 		cloudStore: cloudOwner,
 	}
 	base := &SharedObject{blkStore: baseStore}
-	facade, err := account.newSessionSharedObject(ctx, "A", ref, base)
+	facade, err := account.newSessionSharedObject("A", ref, base)
 	if err != nil {
 		t.Fatalf("mount while direct disabled: %v", err)
 	}
 
-	parentBus, _, releaseParent, err := newSessionLookupTestBus(ctx, nil)
-	if err != nil {
-		t.Fatal(err)
+	account.p2pSyncMtx.Lock()
+	account.p2pSyncs["A"] = &p2pSyncState{
+		stores: map[string]block.StoreOps{
+			BlockStoreBucketID("account", "store"): direct,
+		},
 	}
-	defer releaseParent()
-	priv, _, err := bifrost_crypto.GenerateKeyPair(bifrost_crypto.KeyType_Ed25519, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
-	st, err := transport.NewSessionTransport(logrus.NewEntry(logrus.New()), parentBus, priv, "", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	transportCtx, cancelTransport := context.WithCancel(ctx)
-	defer cancelTransport()
-	go func() { _ = st.Execute(transportCtx) }()
-	if err := st.AwaitReady(ctx); err != nil {
-		t.Fatal(err)
-	}
-	ctrl := &sessionLookupTestController{values: map[string][]byte{
-		refDirect.MarshalString(): []byte("enabled-direct"),
-	}}
-	releaseCtrl, err := st.GetChildBus().AddController(ctx, ctrl, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer releaseCtrl()
-	account.transportBcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
-		account.sessionTransports["A"] = &sessionTransportState{
-			sessionID: "A",
-			transport: st,
-		}
-		broadcast()
-	})
+	account.p2pSyncMtx.Unlock()
 
 	data, found, err := facade.GetBlockStore().GetBlock(ctx, refDirect)
 	if err != nil || !found || string(data) != "enabled-direct" {
 		t.Fatalf("enabled direct read on stable facade = %q/%v/%v", data, found, err)
 	}
-	if ctrl.requests.Load() != 1 {
-		t.Fatalf("enabled direct requests = %d, want 1", ctrl.requests.Load())
+	if direct.getCalls.Load() != 1 {
+		t.Fatalf("enabled direct requests = %d, want 1", direct.getCalls.Load())
 	}
 }
 

--- a/core/provider/spacewave/session-shared-object_test.go
+++ b/core/provider/spacewave/session-shared-object_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	bus_inmem "github.com/aperturerobotics/controllerbus/bus/inmem"
 	directive_controller "github.com/aperturerobotics/controllerbus/directive/controller"
@@ -16,11 +17,12 @@ import (
 )
 
 type sessionLookupTestLower struct {
-	data     []byte
-	blocks   map[string][]byte
-	getCalls atomic.Int32
-	putCalls atomic.Int32
-	writable bool
+	data      []byte
+	blocks    map[string][]byte
+	getCalls  atomic.Int32
+	putCalls  atomic.Int32
+	writable  bool
+	beforeGet func()
 }
 
 func (s *sessionLookupTestLower) GetHashType() hash.HashType {
@@ -53,6 +55,9 @@ func (s *sessionLookupTestLower) RmBlock(context.Context, *block.BlockRef) error
 }
 func (s *sessionLookupTestLower) Sync(context.Context) (bool, error) { return true, nil }
 func (s *sessionLookupTestLower) GetBlock(_ context.Context, ref *block.BlockRef) ([]byte, bool, error) {
+	if s.beforeGet != nil {
+		s.beforeGet()
+	}
 	s.getCalls.Add(1)
 	var data []byte
 	if s.blocks != nil {
@@ -103,10 +108,12 @@ func newProductionSessionStore(
 		upperCache: true,
 	}
 	directOwner := &sourceTrackingStore{
-		StoreOps: direct,
-		account:  account,
-		bstoreID: id,
-		source:   SyncTelemetryBlockSourceDirect,
+		StoreOps:       direct,
+		account:        account,
+		bstoreID:       id,
+		source:         SyncTelemetryBlockSourceDirect,
+		demandStarted:  func() { account.directDemandStarted(id) },
+		demandFinished: func() { account.directDemandFinished(id) },
 	}
 	cloudOwner := &sourceTrackingStore{
 		StoreOps: cloud,
@@ -236,6 +243,84 @@ func TestSessionDirectLookupRoutesPerChildAndFallsBackOnce(t *testing.T) {
 		t.Fatalf("session two telemetry = %+v, want direct=1 cloud=0 cache=1", two)
 	}
 }
+
+func TestSessionDirectLookupTracksActiveDemand(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	account := &ProviderAccount{}
+	owner := &account.transportComposition
+	owner.init(account)
+	state := newTransportCompositionSession()
+	state.snapshot = TransportCompositionSnapshot{
+		DirectP2PEnabled: true,
+		P2PState:         TransportCompositionP2PStateIdle,
+		ActivePeerCount:  1,
+	}
+	owner.mtx.Lock()
+	owner.sessions["session"] = state
+	owner.mtx.Unlock()
+
+	data := []byte("active direct")
+	ref, err := block.BuildBlockRef(data, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	started := make(chan struct{})
+	release := make(chan struct{})
+	direct := &sessionLookupTestLower{
+		blocks: map[string][]byte{ref.MarshalString(): data},
+		beforeGet: func() {
+			close(started)
+			<-release
+		},
+	}
+	cache := &sessionLookupTestLower{writable: true}
+	cloud := &sessionLookupTestLower{}
+	store, err := newProductionSessionStore(account, "session", direct, cache, cloud)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resultCh := make(chan struct {
+		data  []byte
+		found bool
+		err   error
+	}, 1)
+	go func() {
+		got, found, getErr := store.GetBlock(ctx, ref)
+		resultCh <- struct {
+			data  []byte
+			found bool
+			err   error
+		}{data: got, found: found, err: getErr}
+	}()
+
+	select {
+	case <-started:
+	case <-ctx.Done():
+		t.Fatal("direct lookup did not start")
+	}
+	snapshot, _ := account.GetTransportCompositionSnapshotWithWait("session")
+	if snapshot.P2PState != TransportCompositionP2PStateActive {
+		t.Fatalf("demand state while reading = %v, want active", snapshot.P2PState)
+	}
+	close(release)
+
+	select {
+	case result := <-resultCh:
+		if result.err != nil || !result.found || string(result.data) != string(data) {
+			t.Fatalf("direct lookup = %q/%v/%v", result.data, result.found, result.err)
+		}
+	case <-ctx.Done():
+		t.Fatal("direct lookup did not finish")
+	}
+	snapshot, _ = account.GetTransportCompositionSnapshotWithWait("session")
+	if snapshot.P2PState != TransportCompositionP2PStateIdle {
+		t.Fatalf("demand state after reading = %v, want idle", snapshot.P2PState)
+	}
+}
+
 func TestSessionFacadeMountDisabledThenEnablesDirectRoute(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()

--- a/core/provider/spacewave/transport-composition.go
+++ b/core/provider/spacewave/transport-composition.go
@@ -158,18 +158,6 @@ func (a *ProviderAccount) GetTransportCompositionSnapshotWithWait(sessionID stri
 	return o.snapshotWithWait(sessionID)
 }
 
-func (a *ProviderAccount) directDemandStarted(sessionID string) {
-	o := &a.transportComposition
-	o.init(a)
-	o.demandStarted(sessionID)
-}
-
-func (a *ProviderAccount) directDemandFinished(sessionID string) {
-	o := &a.transportComposition
-	o.init(a)
-	o.demandFinished(sessionID)
-}
-
 func (o *transportCompositionOwner) configure(config *transportCompositionConfig) error {
 	state := o.sessionForConfigure(config.sessionID)
 	state.mtx.Lock()

--- a/core/provider/spacewave/transport-composition.go
+++ b/core/provider/spacewave/transport-composition.go
@@ -158,6 +158,18 @@ func (a *ProviderAccount) GetTransportCompositionSnapshotWithWait(sessionID stri
 	return o.snapshotWithWait(sessionID)
 }
 
+func (a *ProviderAccount) directDemandStarted(sessionID string) {
+	o := &a.transportComposition
+	o.init(a)
+	o.demandStarted(sessionID)
+}
+
+func (a *ProviderAccount) directDemandFinished(sessionID string) {
+	o := &a.transportComposition
+	o.init(a)
+	o.demandFinished(sessionID)
+}
+
 func (o *transportCompositionOwner) configure(config *transportCompositionConfig) error {
 	state := o.sessionForConfigure(config.sessionID)
 	state.mtx.Lock()

--- a/db/block/store/store-read-through.go
+++ b/db/block/store/store-read-through.go
@@ -1,0 +1,177 @@
+package block_store
+
+import (
+	"context"
+
+	"github.com/s4wave/spacewave/db/block"
+	"github.com/s4wave/spacewave/net/hash"
+)
+
+// StoreSource resolves the current store for a read pipeline.
+//
+// A nil result means that the source is unavailable and the pipeline moves to
+// its next source.
+type StoreSource func() block.StoreOps
+
+// StoreReadThrough reads from a primary source, then an optional lower source.
+// When writeback is enabled, lower hits are synchronously written to primary.
+//
+// This owner is separate from block.StoreOverlay because StoreOverlay readback
+// is intentionally asynchronous.
+type StoreReadThrough struct {
+	primary   StoreSource
+	lower     StoreSource
+	writeback bool
+}
+
+// NewStoreReadThrough constructs a synchronous read-through store.
+func NewStoreReadThrough(primary, lower StoreSource, writeback bool) *StoreReadThrough {
+	return &StoreReadThrough{primary: primary, lower: lower, writeback: writeback}
+}
+
+// GetHashType returns the first available source hash type.
+func (s *StoreReadThrough) GetHashType() hash.HashType {
+	for _, source := range []StoreSource{s.primary, s.lower} {
+		if source == nil {
+			continue
+		}
+		if store := source(); store != nil {
+			if hashType := store.GetHashType(); hashType != 0 {
+				return hashType
+			}
+		}
+	}
+	return 0
+}
+
+// GetSupportedFeatures returns the primary source's feature set.
+func (s *StoreReadThrough) GetSupportedFeatures() block.StoreFeature {
+	if s.primary == nil {
+		return 0
+	}
+	if primary := s.primary(); primary != nil {
+		return primary.GetSupportedFeatures()
+	}
+	return 0
+}
+
+// BeginReadOperation opens read scopes on the currently available sources.
+func (s *StoreReadThrough) BeginReadOperation(ctx context.Context) (block.StoreOps, func(), error) {
+	primary := block.StoreOps(nil)
+	if s.primary != nil {
+		primary = s.primary()
+	}
+	if primary == nil {
+		return &StoreReadThrough{primary: s.primary, lower: s.lower, writeback: s.writeback}, func() {}, nil
+	}
+	primary, releasePrimary, err := primary.BeginReadOperation(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	lower := block.StoreOps(nil)
+	if s.lower != nil {
+		lower = s.lower()
+	}
+	if lower == nil {
+		return &StoreReadThrough{
+			primary:   func() block.StoreOps { return primary },
+			lower:     s.lower,
+			writeback: s.writeback,
+		}, releasePrimary, nil
+	}
+	lower, releaseLower, err := lower.BeginReadOperation(ctx)
+	if err != nil {
+		releasePrimary()
+		return nil, nil, err
+	}
+	return &StoreReadThrough{
+			primary:   func() block.StoreOps { return primary },
+			lower:     func() block.StoreOps { return lower },
+			writeback: s.writeback,
+		}, func() {
+			releaseLower()
+			releasePrimary()
+		}, nil
+}
+
+// PutBlock is unsupported because this store is read-only.
+func (*StoreReadThrough) PutBlock(context.Context, []byte, *block.PutOpts) (*block.BlockRef, bool, error) {
+	return nil, false, ErrReadOnly
+}
+
+// PutBlockBatch is unsupported because this store is read-only.
+func (*StoreReadThrough) PutBlockBatch(context.Context, []*block.PutBatchEntry) error {
+	return ErrReadOnly
+}
+
+// RmBlock is unsupported because this store is read-only.
+func (*StoreReadThrough) RmBlock(context.Context, *block.BlockRef) error {
+	return ErrReadOnly
+}
+
+// Sync reports that no durability barrier is needed for this read-only view.
+func (*StoreReadThrough) Sync(context.Context) (bool, error) { return true, nil }
+
+// GetBlock reads the primary source, then the current lower source. When
+// writeback is enabled, a lower hit is synchronously inserted into primary.
+func (s *StoreReadThrough) GetBlock(ctx context.Context, ref *block.BlockRef) ([]byte, bool, error) {
+	primary := block.StoreOps(nil)
+	if s.primary != nil {
+		primary = s.primary()
+	}
+	if primary != nil {
+		data, found, err := primary.GetBlock(ctx, ref)
+		if err != nil || found {
+			return data, found, err
+		}
+	}
+	if s.lower == nil {
+		return nil, false, nil
+	}
+	lower := s.lower()
+	if lower == nil {
+		return nil, false, nil
+	}
+	data, found, err := lower.GetBlock(ctx, ref)
+	if err != nil || !found {
+		return data, found, err
+	}
+	if !s.writeback || primary == nil {
+		return data, true, nil
+	}
+	if _, _, err := primary.PutBlock(ctx, data, &block.PutOpts{ForceBlockRef: ref.Clone()}); err != nil {
+		return nil, false, err
+	}
+	return data, true, nil
+}
+
+// GetBlockExists follows the same source order as GetBlock.
+func (s *StoreReadThrough) GetBlockExists(ctx context.Context, ref *block.BlockRef) (bool, error) {
+	_, found, err := s.GetBlock(ctx, ref)
+	return found, err
+}
+
+// GetBlockExistsBatch follows the same source order as GetBlock.
+func (s *StoreReadThrough) GetBlockExistsBatch(ctx context.Context, refs []*block.BlockRef) ([]bool, error) {
+	out := make([]bool, len(refs))
+	for i, ref := range refs {
+		found, err := s.GetBlockExists(ctx, ref)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = found
+	}
+	return out, nil
+}
+
+// StatBlock follows the same source order as GetBlock.
+func (s *StoreReadThrough) StatBlock(ctx context.Context, ref *block.BlockRef) (*block.BlockStat, error) {
+	data, found, err := s.GetBlock(ctx, ref)
+	if err != nil || !found {
+		return nil, err
+	}
+	return &block.BlockStat{Ref: ref, Size: int64(len(data))}, nil
+}
+
+var _ block.StoreOps = ((*StoreReadThrough)(nil))

--- a/db/block/store/store-read-through.go
+++ b/db/block/store/store-read-through.go
@@ -61,38 +61,51 @@ func (s *StoreReadThrough) BeginReadOperation(ctx context.Context) (block.StoreO
 	if s.primary != nil {
 		primary = s.primary()
 	}
-	if primary == nil {
-		return &StoreReadThrough{primary: s.primary, lower: s.lower, writeback: s.writeback}, func() {}, nil
-	}
-	primary, releasePrimary, err := primary.BeginReadOperation(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-
 	lower := block.StoreOps(nil)
 	if s.lower != nil {
 		lower = s.lower()
 	}
-	if lower == nil {
-		return &StoreReadThrough{
-			primary:   func() block.StoreOps { return primary },
-			lower:     s.lower,
-			writeback: s.writeback,
-		}, releasePrimary, nil
+
+	var releasePrimary, releaseLower func()
+	if primary != nil {
+		scoped, release, err := primary.BeginReadOperation(ctx)
+		if err != nil {
+			return nil, nil, err
+		}
+		primary = scoped
+		releasePrimary = release
 	}
-	lower, releaseLower, err := lower.BeginReadOperation(ctx)
-	if err != nil {
-		releasePrimary()
-		return nil, nil, err
+	if lower != nil {
+		scoped, release, err := lower.BeginReadOperation(ctx)
+		if err != nil {
+			if releasePrimary != nil {
+				releasePrimary()
+			}
+			return nil, nil, err
+		}
+		lower = scoped
+		releaseLower = release
 	}
-	return &StoreReadThrough{
-			primary:   func() block.StoreOps { return primary },
-			lower:     func() block.StoreOps { return lower },
-			writeback: s.writeback,
-		}, func() {
+
+	scoped := &StoreReadThrough{
+		primary:   s.primary,
+		lower:     s.lower,
+		writeback: s.writeback,
+	}
+	if primary != nil {
+		scoped.primary = func() block.StoreOps { return primary }
+	}
+	if lower != nil {
+		scoped.lower = func() block.StoreOps { return lower }
+	}
+	return scoped, func() {
+		if releaseLower != nil {
 			releaseLower()
+		}
+		if releasePrimary != nil {
 			releasePrimary()
-		}, nil
+		}
+	}, nil
 }
 
 // PutBlock is unsupported because this store is read-only.

--- a/db/block/store/store_test.go
+++ b/db/block/store/store_test.go
@@ -2,6 +2,7 @@ package block_store_test
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 
 	"github.com/s4wave/spacewave/db/block"
@@ -11,6 +12,73 @@ import (
 	store_kvtx_inmem "github.com/s4wave/spacewave/db/store/kvtx/inmem"
 	hash "github.com/s4wave/spacewave/net/hash"
 )
+
+type readScopeTestStore struct {
+	block.StoreOps
+	beginCalls  *atomic.Int32
+	scopedCalls *atomic.Int32
+	scoped      bool
+}
+
+func (s *readScopeTestStore) BeginReadOperation(context.Context) (block.StoreOps, func(), error) {
+	s.beginCalls.Add(1)
+	return &readScopeTestStore{
+		StoreOps:    s.StoreOps,
+		beginCalls:  s.beginCalls,
+		scopedCalls: s.scopedCalls,
+		scoped:      true,
+	}, func() {}, nil
+}
+
+func (s *readScopeTestStore) GetBlock(ctx context.Context, ref *block.BlockRef) ([]byte, bool, error) {
+	if s.scoped {
+		s.scopedCalls.Add(1)
+	}
+	return s.StoreOps.GetBlock(ctx, ref)
+}
+
+func TestStoreReadThroughScopesLowerWhenPrimaryUnavailable(t *testing.T) {
+	ctx := context.Background()
+	inner := block_store_inmem.NewInmemBlock(
+		store_kvkey.NewDefaultKVKey(),
+		store_kvtx_inmem.NewStore(),
+		hash.HashType_HashType_BLAKE3,
+		false,
+	)
+	beginCalls := &atomic.Int32{}
+	scopedCalls := &atomic.Int32{}
+	lower := &readScopeTestStore{
+		StoreOps:    inner,
+		beginCalls:  beginCalls,
+		scopedCalls: scopedCalls,
+	}
+	data := []byte("scoped lower")
+	ref, _, err := lower.PutBlock(ctx, data, &block.PutOpts{HashType: hash.HashType_HashType_BLAKE3})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store := block_store.NewStoreReadThrough(
+		func() block.StoreOps { return nil },
+		func() block.StoreOps { return lower },
+		false,
+	)
+	scoped, release, err := store.BeginReadOperation(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer release()
+	if beginCalls.Load() != 1 {
+		t.Fatalf("lower BeginReadOperation calls = %d, want 1", beginCalls.Load())
+	}
+	got, found, err := scoped.GetBlock(ctx, ref)
+	if err != nil || !found || string(got) != string(data) {
+		t.Fatalf("scoped lower read = %q/%v/%v", got, found, err)
+	}
+	if scopedCalls.Load() != 1 {
+		t.Fatalf("scoped lower GetBlock calls = %d, want 1", scopedCalls.Load())
+	}
+}
 
 type wrapperBatchTestStore struct {
 	block.StoreOps

--- a/db/dex/solicit/controller.go
+++ b/db/dex/solicit/controller.go
@@ -152,6 +152,16 @@ func (c *Controller) forwardToPeers(ctx context.Context, ref *block.BlockRef, ho
 	return peerBlockFanout{sessions: sessions, ref: ref, hops: hops}.run(ctx)
 }
 
+func (c *Controller) snapshotSessions() []*peerSession {
+	var sessions []*peerSession
+	c.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		for _, s := range c.sessions {
+			sessions = append(sessions, s)
+		}
+	})
+	return sessions
+}
+
 // HandleDirective asks if the handler can resolve the directive.
 func (c *Controller) HandleDirective(
 	ctx context.Context,

--- a/db/dex/solicit/store.go
+++ b/db/dex/solicit/store.go
@@ -1,0 +1,90 @@
+package dex_solicit
+
+import (
+	"context"
+
+	"github.com/s4wave/spacewave/db/block"
+	block_store "github.com/s4wave/spacewave/db/block/store"
+	"github.com/s4wave/spacewave/net/hash"
+)
+
+// Store is a read-only block store view owned by a solicitation Controller.
+// Reads snapshot the controller's current peer sessions and fan out directly.
+type Store struct {
+	controller *Controller
+}
+
+// NewStore constructs a read-only block store view for a controller.
+func NewStore(controller *Controller) *Store {
+	return &Store{controller: controller}
+}
+
+// GetHashType returns the unset preferred hash type because the peer set may
+// serve references using more than one hash type.
+func (*Store) GetHashType() hash.HashType { return 0 }
+
+// GetSupportedFeatures returns no writable or native batch features.
+func (*Store) GetSupportedFeatures() block.StoreFeature { return 0 }
+
+// BeginReadOperation opens a no-op read scope for the controller view.
+func (s *Store) BeginReadOperation(context.Context) (block.StoreOps, func(), error) {
+	return s, func() {}, nil
+}
+
+// PutBlock is unsupported because the DEX view is read-only.
+func (*Store) PutBlock(context.Context, []byte, *block.PutOpts) (*block.BlockRef, bool, error) {
+	return nil, false, block_store.ErrReadOnly
+}
+
+// PutBlockBatch is unsupported because the DEX view is read-only.
+func (*Store) PutBlockBatch(context.Context, []*block.PutBatchEntry) error {
+	return block_store.ErrReadOnly
+}
+
+// RmBlock is unsupported because the DEX view is read-only.
+func (*Store) RmBlock(context.Context, *block.BlockRef) error {
+	return block_store.ErrReadOnly
+}
+
+// Sync reports that the read-only view has no durability barrier.
+func (*Store) Sync(context.Context) (bool, error) { return true, nil }
+
+// GetBlock fans the request out to the controller's current peer sessions.
+func (s *Store) GetBlock(ctx context.Context, ref *block.BlockRef) ([]byte, bool, error) {
+	data, found := peerBlockFanout{
+		sessions: s.controller.snapshotSessions(),
+		ref:      ref,
+		hops:     s.controller.cc.GetMaxForwardHops(),
+	}.run(ctx)
+	return data, found, nil
+}
+
+// GetBlockExists checks whether any connected peer has the block.
+func (s *Store) GetBlockExists(ctx context.Context, ref *block.BlockRef) (bool, error) {
+	_, found, err := s.GetBlock(ctx, ref)
+	return found, err
+}
+
+// GetBlockExistsBatch checks whether any connected peer has each block.
+func (s *Store) GetBlockExistsBatch(ctx context.Context, refs []*block.BlockRef) ([]bool, error) {
+	out := make([]bool, len(refs))
+	for i, ref := range refs {
+		found, err := s.GetBlockExists(ctx, ref)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = found
+	}
+	return out, nil
+}
+
+// StatBlock returns metadata for a block found on a connected peer.
+func (s *Store) StatBlock(ctx context.Context, ref *block.BlockRef) (*block.BlockStat, error) {
+	data, found, err := s.GetBlock(ctx, ref)
+	if err != nil || !found {
+		return nil, err
+	}
+	return &block.BlockStat{Ref: ref, Size: int64(len(data))}, nil
+}
+
+var _ block.StoreOps = ((*Store)(nil))


### PR DESCRIPTION
Local and Cloud block misses previously published one LookupBlockFromNetwork directive for each uncached block. The directive lifecycle added debug-log volume and kept Session peer selection in caller-owned read wrappers.

The Session bucket now retains a read-only DEX StoreOps view and composes local cache, Session DEX, and optional Cloud Packfile reads through a synchronous read-through owner. Writes and durability remain on local and account owners, existing StoreOverlay timing is unchanged, and peer sets remain isolated by Session ID.

Focused local and Cloud composition checks, the overlay matrix, the DEX package checks, and the P2P startup checks passed with GOWORK=off GOFLAGS=-mod=vendor.