### PR TITLE
Keep storage recovery UI scoped to requested routes

### DIFF
--- a/app/session/SessionContainer.tsx
+++ b/app/session/SessionContainer.tsx
@@ -31,7 +31,6 @@ import { LinkDeviceWizard } from './setup/LinkDeviceWizard.js'
 import { CommandLineSetupPage } from './settings/CommandLineSetupPage.js'
 import { CliTerminalPage } from './settings/CliTerminalPage.js'
 import { TransferWizard } from './settings/TransferWizard.js'
-import { StorageHealthPage } from './storage/StorageHealthPage.js'
 import { BillingAccountDetailRoute } from '@s4wave/app/billing/BillingAccountDetailRoute.js'
 import { BillingAccountsRoute } from '@s4wave/app/billing/BillingAccountsRoute.js'
 import { BillingCancelRoute } from '@s4wave/app/billing/BillingCancelRoute.js'
@@ -421,12 +420,6 @@ export function SessionContainer(props: {
                       {spacewaveSessionRoutes(props.metadata, {
                         fallbackPath: currentLevelPath,
                       })}
-                      <Route path="/settings/storage/recovery">
-                        <StorageHealthPage recovery />
-                      </Route>
-                      <Route path="/settings/storage">
-                        <StorageHealthPage />
-                      </Route>
                       <Route path="/settings/cli/terminal">
                         <CliTerminalPage />
                       </Route>

--- a/app/session/storage/StorageHealth.test.tsx
+++ b/app/session/storage/StorageHealth.test.tsx
@@ -22,15 +22,20 @@ const healthView = {
     summaryLabel: 'Sync idle',
     detailLabel: 'No active transfers.',
     error: false,
+    loading: false,
+    active: false,
+    lastError: '',
+    pendingUploadLabel: '0 B',
+    pendingDownloadLabel: '0 B',
   },
-  replicaLabel: 'Not yet verified',
+  requestProtection: vi.fn(),
   safariCleanupRisk: true,
 }
 
 describe('StorageHealth', () => {
   afterEach(() => cleanup())
 
-  it('keeps local, protected, and replica states distinct in settings', () => {
+  it('groups readings by scope and keeps backup claims subordinate', () => {
     mockUseStorageHealth.mockReturnValue(healthView)
     const onOpenRecovery = vi.fn()
     const onLinkDevice = vi.fn()
@@ -45,21 +50,25 @@ describe('StorageHealth', () => {
       />,
     )
 
-    expect(screen.getByText('16 MB in the local provider')).toBeTruthy()
-    expect(screen.getByText('Protected')).toBeTruthy()
-    expect(screen.getByText('Not yet verified')).toBeTruthy()
-    expect(screen.getByTestId('safari-storage-risk')).toBeTruthy()
-    expect(screen.queryByText(/install/i)).toBeNull()
-
-    fireEvent.click(screen.getByText('Recovery view'))
+    expect(screen.getByRole('heading', { name: 'This browser' })).toBeTruthy()
+    expect(
+      screen.getByRole('heading', { name: "This device's store" }),
+    ).toBeTruthy()
+    expect(screen.getByRole('heading', { name: 'Sync activity' })).toBeTruthy()
+    expect(screen.getByText('16 MB physical')).toBeTruthy()
+    expect(screen.getByText('Automatic cleanup protection')).toBeTruthy()
+    fireEvent.click(screen.getByText('Storage recovery'))
+    fireEvent.click(screen.getByText('Request protection'))
     fireEvent.click(screen.getByText('Link device'))
     fireEvent.click(screen.getByText('Cloud options'))
+    expect(healthView.requestProtection).toHaveBeenCalledOnce()
     expect(onOpenRecovery).toHaveBeenCalledOnce()
     expect(onLinkDevice).toHaveBeenCalledOnce()
     expect(onUseCloud).toHaveBeenCalledOnce()
+    expect(screen.queryByText(/install/i)).toBeNull()
   })
 
-  it('uses the same health facts on recovery without Safari-only settings copy', () => {
+  it('presents a calm recovery view when no write failure is reported', () => {
     mockUseStorageHealth.mockReturnValue(healthView)
 
     render(
@@ -70,15 +79,14 @@ describe('StorageHealth', () => {
       />,
     )
 
-    expect(screen.getByText('Spacewave cannot save reliably')).toBeTruthy()
-    expect(screen.getByRole('alert')).toBeTruthy()
-    expect(screen.getByText('Why these readings matter')).toBeTruthy()
-    expect(screen.getByText('Not yet verified')).toBeTruthy()
-    expect(screen.queryByTestId('safari-storage-risk')).toBeNull()
+    expect(screen.getByText('Saving works')).toBeTruthy()
+    expect(screen.queryByText('Spacewave cannot save reliably')).toBeNull()
+    expect(screen.queryByRole('alert')).toBeNull()
+    expect(screen.queryByText('Why these readings matter')).toBeNull()
     expect(
-      screen.getByText(
-        'Unavailable until this browser verifies that a current remote replica can restore the Space.',
-      ),
+      screen.getByText('Request automatic cleanup protection'),
     ).toBeTruthy()
+    expect(screen.getByText('Export a backup')).toBeTruthy()
+    expect(screen.queryByTestId('safari-storage-risk')).toBeNull()
   })
 })

--- a/app/session/storage/StorageHealth.tsx
+++ b/app/session/storage/StorageHealth.tsx
@@ -3,7 +3,6 @@ import type { ReactNode } from 'react'
 import {
   LuArrowRight,
   LuCloud,
-  LuCloudOff,
   LuDatabase,
   LuHardDrive,
   LuLink,
@@ -12,7 +11,10 @@ import {
   LuTriangleAlert,
 } from 'react-icons/lu'
 
-import { useStorageHealth } from '@s4wave/app/session/storage/useStorageHealth.js'
+import {
+  type StorageHealthView,
+  useStorageHealth,
+} from '@s4wave/app/session/storage/useStorageHealth.js'
 import { cn } from '@s4wave/web/style/utils.js'
 import { DashboardButton } from '@s4wave/web/ui/DashboardButton.js'
 import { InfoCard } from '@s4wave/web/ui/InfoCard.js'
@@ -41,134 +43,130 @@ export function StorageHealth({
     <div className="space-y-4" data-testid={`storage-health-${mode}`}>
       {mode === 'recovery' && (
         <div
-          className="border-destructive/30 bg-destructive/8 rounded-lg border p-3.5"
-          role="alert"
-          aria-live="assertive"
+          className="border-success/20 bg-success/5 rounded-lg border p-3.5"
+          role="status"
         >
           <div className="flex items-start gap-3">
-            <div className="bg-destructive/10 text-destructive flex size-8 shrink-0 items-center justify-center rounded-md">
-              <LuTriangleAlert className="size-4" aria-hidden="true" />
+            <div className="bg-success/10 text-success flex size-8 shrink-0 items-center justify-center rounded-md">
+              <LuShieldCheck className="size-4" aria-hidden="true" />
             </div>
             <div>
               <h2 className="text-foreground text-sm font-semibold tracking-tight">
-                Spacewave cannot save reliably
+                Saving works
               </h2>
               <p className="text-foreground-alt/70 mt-1 text-xs leading-relaxed">
-                Browser storage is exhausted or unavailable for app-critical
-                writes. Free storage before continuing work that must be saved.
+                No durable write failure is reported on this screen. These
+                actions help protect your Spaces and create another copy.
               </p>
             </div>
           </div>
         </div>
       )}
 
-      <InfoCard>
-        <div className="divide-foreground/6 divide-y">
-          <HealthRow
-            icon={<LuDatabase className="size-3.5" />}
-            label="Saved on this browser"
-            value={
-              health.providerLoading
-                ? 'Checking local storage'
-                : health.providerSupported
-                  ? `${formatBytes(health.providerBytes)} in the local provider`
-                  : 'Local provider usage unavailable'
-            }
-            tone="neutral"
-          />
-          <HealthRow
-            icon={<LuHardDrive className="size-3.5" />}
-            label="Approximate browser usage"
-            value={originLabel}
-            tone="neutral"
-          />
-          <HealthRow
-            icon={<LuShieldCheck className="size-3.5" />}
-            label="Protected from browser cleanup"
-            value={protectionLabel(health.protectionState)}
-            tone={
-              health.protectionState === 'protected' ? 'positive' : 'warning'
-            }
-          />
-          <HealthRow
-            icon={<LuRefreshCw className="size-3.5" />}
-            label="Sync activity"
-            value={health.sync.summaryLabel}
-            tone={health.sync.error ? 'warning' : 'neutral'}
-          />
-          <HealthRow
-            icon={<LuCloudOff className="size-3.5" />}
-            label="Backed up / replicated"
-            value={health.replicaLabel}
-            tone="warning"
-          />
-        </div>
-      </InfoCard>
-
-      <details className="border-foreground/6 bg-background-card/30 rounded-lg border">
-        <summary className="text-foreground-alt hover:text-foreground cursor-pointer px-3.5 py-2.5 text-xs font-medium">
-          Why these readings matter
-        </summary>
-        <div className="border-foreground/6 text-foreground-alt/60 space-y-2 border-t px-3.5 py-3 text-[0.6rem] leading-relaxed">
-          <p>
-            <strong className="text-foreground-alt/80">
-              Saved on this browser:
-            </strong>{' '}
-            {health.providerSupported
-              ? `${Number(health.blockCount).toLocaleString()} stored blocks`
-              : 'This browser copy can still be lost through clearing, eviction, profile loss, or device loss.'}
-          </p>
-          <p>
-            <strong className="text-foreground-alt/80">
-              Approximate browser usage:
-            </strong>{' '}
-            {health.browserReadFailed
-              ? 'The browser refused the storage-health query.'
-              : 'Whole-origin estimates are approximate and may exceed real free disk headroom.'}
-          </p>
-          <p>
-            <strong className="text-foreground-alt/80">
-              Protected from browser cleanup:
-            </strong>{' '}
-            {protectionDetail(health.protectionState)}
-          </p>
-          <p>
-            <strong className="text-foreground-alt/80">Sync activity:</strong>{' '}
-            {health.sync.detailLabel}
-          </p>
-          <p>
-            <strong className="text-foreground-alt/80">
-              Backed up / replicated:
-            </strong>{' '}
-            Sync activity, pairing, and an empty queue do not prove that another
-            copy can restore this Space.
-          </p>
-        </div>
-      </details>
-
-      {mode === 'settings' && health.safariCleanupRisk && (
-        <div
-          className="border-warning/20 bg-warning/5 rounded-lg border p-3.5"
-          data-testid="safari-storage-risk"
-        >
-          <div className="flex items-start gap-2.5">
-            <LuTriangleAlert
-              className="text-warning mt-0.5 size-4 shrink-0"
-              aria-hidden="true"
-            />
-            <div>
-              <h3 className="text-foreground text-xs font-medium">
-                Safari storage policy
-              </h3>
-              <p className="text-foreground-alt/70 mt-1 text-xs leading-relaxed">
-                Safari may remove this site&apos;s local data after seven days
-                of Safari use without interaction. Only a verified replica on
-                another device or Spacewave Cloud makes that loss recoverable.
-              </p>
+      <ScopeSection
+        title="This browser"
+        description="These readings cover all Spacewave data stored by this browser."
+      >
+        <HealthRow
+          icon={<LuHardDrive className="size-3.5" />}
+          label="Browser usage estimate"
+          value={originLabel}
+          detail={
+            health.browserReadFailed
+              ? 'The browser did not provide this estimate.'
+              : 'An approximate whole-origin reading, not a measure of free disk space.'
+          }
+          tone="neutral"
+        />
+        <HealthRow
+          icon={<LuShieldCheck className="size-3.5" />}
+          label="Automatic cleanup protection"
+          value={protectionLabel(health.protectionState)}
+          detail="When on, the browser is less likely to remove this copy automatically. It is not a backup."
+          tone={health.protectionState === 'protected' ? 'positive' : 'neutral'}
+        />
+        {mode === 'settings' && health.safariCleanupRisk && (
+          <div
+            className="border-warning/20 bg-warning/5 mt-3 rounded-lg border p-3.5"
+            data-testid="safari-storage-risk"
+          >
+            <div className="flex items-start gap-2.5">
+              <LuTriangleAlert
+                className="text-warning mt-0.5 size-4 shrink-0"
+                aria-hidden="true"
+              />
+              <div>
+                <h3 className="text-foreground text-xs font-medium">
+                  Safari storage policy
+                </h3>
+                <p className="text-foreground-alt/70 mt-1 text-xs leading-relaxed">
+                  Safari may remove this site&apos;s local data after seven days
+                  without interaction. An exported archive or a verified replica
+                  protects against losing this browser copy.
+                </p>
+              </div>
             </div>
           </div>
-        </div>
-      )}
+        )}
+      </ScopeSection>
+
+      <ScopeSection
+        title="This device's store"
+        description="These readings describe Spacewave's local block store on this device."
+      >
+        <HealthRow
+          icon={<LuDatabase className="size-3.5" />}
+          label="Physical storage used"
+          value={
+            health.providerLoading
+              ? 'Checking local store'
+              : health.providerSupported
+                ? `${formatBytes(health.providerBytes)} physical`
+                : 'Local store unavailable'
+          }
+          detail={
+            health.providerSupported
+              ? 'This is the space currently occupied by the local store, not a count of user Spaces.'
+              : 'The local store did not provide a reading.'
+          }
+          tone="neutral"
+        />
+        {health.providerSupported && (
+          <details className="border-foreground/6 mt-3 border-t pt-3">
+            <summary className="text-foreground-alt hover:text-foreground cursor-pointer text-xs font-medium">
+              Technical details
+            </summary>
+            <p className="text-foreground-alt/60 mt-2 text-[0.6rem] leading-relaxed">
+              {Number(health.blockCount).toLocaleString()} block entries are
+              currently reported by the local store. Entries are a storage
+              measurement, not proof of a complete backup.
+            </p>
+          </details>
+        )}
+      </ScopeSection>
+
+      <ScopeSection
+        title="Sync activity"
+        description="This shows transfer work that Spacewave can currently see."
+      >
+        <HealthRow
+          icon={<LuRefreshCw className="size-3.5" />}
+          label="Transfer activity"
+          value={transferActivityLabel(health.sync)}
+          detail={transferActivityDetail(health.sync)}
+          tone={health.sync.error ? 'warning' : 'neutral'}
+        />
+        <details className="border-foreground/6 mt-3 border-t pt-3">
+          <summary className="text-foreground-alt hover:text-foreground cursor-pointer text-xs font-medium">
+            Technical details
+          </summary>
+          <div className="text-foreground-alt/60 mt-2 space-y-1 text-[0.6rem] leading-relaxed">
+            <p>{health.sync.detailLabel}</p>
+            <p>Upload waiting: {health.sync.pendingUploadLabel}</p>
+            <p>Download waiting: {health.sync.pendingDownloadLabel}</p>
+          </div>
+        </details>
+      </ScopeSection>
 
       <section aria-labelledby="storage-solutions-title">
         <div className="mb-2 flex items-center justify-between gap-3">
@@ -177,51 +175,54 @@ export function StorageHealth({
               id="storage-solutions-title"
               className="text-foreground text-xs font-medium"
             >
-              Storage and recovery options
+              Protect your Spaces
             </h2>
             <p className="text-foreground-alt/60 mt-0.5 text-xs">
-              Use a non-destructive option first.
+              Choose an action that creates or protects a copy.
             </p>
           </div>
           {mode === 'settings' && onOpenRecovery && (
             <DashboardButton
-              icon={<LuTriangleAlert className="size-3.5" />}
+              icon={<LuShieldCheck className="size-3.5" />}
               onClick={onOpenRecovery}
             >
-              Recovery view
+              Storage recovery
             </DashboardButton>
           )}
         </div>
-
         <div className="space-y-2">
           <SolutionRow
-            icon={<LuHardDrive className="size-3.5" />}
-            title="Free browser or device storage"
-            detail="Remove unrelated downloads, applications, or other site data, then retry the failed operation. Do not clear Spacewave site data unless important Spaces are backed up or exported."
+            icon={<LuShieldCheck className="size-3.5" />}
+            title="Request automatic cleanup protection"
+            detail="Requesting this protects this browser copy from automatic cleanup. This does not create another copy."
+            action="Request protection"
+            onAction={() => {
+              void health.requestProtection()
+            }}
+          />
+          <SolutionRow
+            icon={<LuDatabase className="size-3.5" />}
+            title="Export a backup"
+            detail="Open an important Space and choose File > Export Space. Keep the archive outside this browser."
           />
           <SolutionRow
             icon={<LuLink className="size-3.5" />}
             title="Link another device"
-            detail="Set up another copy. Spacewave will keep reporting Not yet verified until it can prove the current Space is restorable there."
+            detail="Set up another destination for a second copy. Linking alone does not verify that the copy can restore this Space."
             action="Link device"
             onAction={onLinkDevice}
           />
           <SolutionRow
             icon={<LuCloud className="size-3.5" />}
             title="Set up Spacewave Cloud"
-            detail="Move the session toward a remote copy. Account setup alone is not a backup verification."
+            detail="Choose Spacewave Cloud as another destination. Setup alone does not verify a complete copy."
             action="Cloud options"
             onAction={onUseCloud}
           />
           <SolutionRow
-            icon={<LuDatabase className="size-3.5" />}
-            title="Export important Spaces"
-            detail="Open each important Space and choose File → Export Space. Keep the archive outside this browser as a last-resort copy."
-          />
-          <SolutionRow
-            icon={<LuCloudOff className="size-3.5" />}
-            title="Remove a local Space copy"
-            detail="Unavailable until this browser verifies that a current remote replica can restore the Space."
+            icon={<LuHardDrive className="size-3.5" />}
+            title="Make room for future saves"
+            detail="If a save fails, remove unrelated downloads, applications, or site data before retrying. Do not clear Spacewave site data as an ordinary fix."
           />
         </div>
       </section>
@@ -229,15 +230,41 @@ export function StorageHealth({
   )
 }
 
+function ScopeSection({
+  title,
+  description,
+  children,
+}: {
+  title: string
+  description: string
+  children: ReactNode
+}) {
+  return (
+    <section aria-labelledby={`${title}-title`}>
+      <h2 id={`${title}-title`} className="text-foreground text-xs font-medium">
+        {title}
+      </h2>
+      <p className="text-foreground-alt/60 mt-0.5 text-xs">{description}</p>
+      <div className="mt-2">
+        <InfoCard>
+          <div>{children}</div>
+        </InfoCard>
+      </div>
+    </section>
+  )
+}
+
 function HealthRow({
   icon,
   label,
   value,
+  detail,
   tone,
 }: {
   icon: ReactNode
   label: string
   value: string
+  detail: string
   tone: 'neutral' | 'positive' | 'warning'
 }) {
   return (
@@ -257,6 +284,9 @@ function HealthRow({
         <div className="text-foreground mt-0.5 text-xs font-medium">
           {value}
         </div>
+        <p className="text-foreground-alt/60 mt-1 text-xs leading-relaxed">
+          {detail}
+        </p>
       </div>
     </div>
   )
@@ -301,24 +331,30 @@ function SolutionRow({
 function protectionLabel(state: string): string {
   switch (state) {
     case 'protected':
-      return 'Protected'
+      return 'On'
     case 'not-protected':
-      return 'Not protected'
+      return 'Not on'
     case 'checking':
-      return 'Checking browser status'
+      return 'Checking'
     default:
-      return 'Status unavailable'
+      return 'Unavailable'
   }
 }
 
-function protectionDetail(state: string): string {
-  if (state === 'protected') {
-    return 'The browser reports persistent storage. This reduces automatic-eviction risk but is not a backup.'
+function transferActivityLabel(sync: StorageHealthView['sync']): string {
+  if (sync.error) return 'Needs attention'
+  if (sync.loading) return 'Checking'
+  if (sync.active) return sync.summaryLabel
+  return 'Idle'
+}
+
+function transferActivityDetail(sync: StorageHealthView['sync']): string {
+  if (sync.error) {
+    return sync.lastError || 'Spacewave reported a transfer problem.'
   }
-  if (state === 'not-protected') {
-    return 'The browser has not granted persistent storage. Spacewave requests it quietly after the first successful durable write.'
-  }
-  return 'Persistence status could not be confirmed. It never changes whether a write is accepted.'
+  if (sync.loading) return 'Waiting for the transfer status.'
+  if (sync.active) return sync.detailLabel
+  return 'No transfer is currently reported. This does not verify another copy.'
 }
 
 function formatOriginUsage(usage: number | null, quota: number | null): string {

--- a/app/session/storage/StorageHealthPage.tsx
+++ b/app/session/storage/StorageHealthPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from 'react'
-import { LuDatabase, LuTriangleAlert } from 'react-icons/lu'
+import { LuDatabase, LuShieldCheck } from 'react-icons/lu'
 
 import { useSessionNavigate } from '@s4wave/web/contexts/contexts.js'
 import { BackButton } from '@s4wave/web/ui/BackButton.js'
@@ -28,7 +28,7 @@ export function StorageHealthPage({
     navigateSession({ path: 'plan' })
   }, [navigateSession])
 
-  const Icon = recovery ? LuTriangleAlert : LuDatabase
+  const Icon = recovery ? LuShieldCheck : LuDatabase
   return (
     <div className="bg-background-primary relative flex h-full w-full items-start justify-center overflow-y-auto pt-16 pb-10">
       <main className="w-full max-w-md px-4">
@@ -46,8 +46,8 @@ export function StorageHealthPage({
             </h1>
             <p className="text-foreground-alt/60 mt-1 text-xs">
               {recovery
-                ? 'Restore enough durable capacity for Spacewave to save safely.'
-                : 'Local usage, cleanup protection, sync activity, and replica safety.'}
+                ? 'Review browser protection and backup options.'
+                : 'See what this browser, this device, and sync activity report.'}
             </p>
           </div>
         </div>

--- a/app/session/storage/useStorageHealth.test.ts
+++ b/app/session/storage/useStorageHealth.test.ts
@@ -50,7 +50,6 @@ describe('storage health state', () => {
 
     expect(view.protectionState).toBe('protected')
     expect(view.providerBytes).toBe(8_192n)
-    expect(view.replicaLabel).toBe('Not yet verified')
     expect(view.safariCleanupRisk).toBe(true)
   })
 

--- a/app/session/storage/useStorageHealth.ts
+++ b/app/session/storage/useStorageHealth.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from 'react'
 
+import { useBldrContext } from '@aptre/bldr-react'
 import { useSessionStorageStats } from '@s4wave/app/session/SessionStorageStatsContext.js'
 import {
   type SessionSyncStatusView,
@@ -35,8 +36,8 @@ export interface StorageHealthView {
   originQuotaBytes: number | null
   protectionState: StorageProtectionState
   sync: SessionSyncStatusView
-  replicaLabel: 'Not yet verified'
   safariCleanupRisk: boolean
+  requestProtection: () => Promise<void>
 }
 
 // useStorageHealth composes provider, browser, and sync facts without inferring
@@ -44,15 +45,25 @@ export interface StorageHealthView {
 export function useStorageHealth(): StorageHealthView {
   const provider = useSessionStorageStats()
   const sync = useSessionSyncStatus()
+  const webDocument = useBldrContext()?.webDocument
   const browser = usePromise(
     useCallback(
       (signal: AbortSignal) =>
         readBrowserStorageHealth(
           typeof navigator === 'undefined' ? null : navigator.storage,
           signal,
+          webDocument
+            ? async () =>
+                (await webDocument.readStoragePersistenceStatus()) ===
+                'persisted'
+            : undefined,
         ),
-      [],
+      [webDocument],
     ),
+  )
+  const requestProtection = useCallback(
+    () => webDocument?.requestStoragePersistence() ?? Promise.resolve(),
+    [webDocument],
   )
 
   return useMemo(
@@ -64,8 +75,16 @@ export function useStorageHealth(): StorageHealthView {
         browser.loading,
         browser.error,
         typeof navigator === 'undefined' ? '' : navigator.userAgent,
+        requestProtection,
       ),
-    [browser.data, browser.error, browser.loading, provider, sync],
+    [
+      browser.data,
+      browser.error,
+      browser.loading,
+      provider,
+      requestProtection,
+      sync,
+    ],
   )
 }
 
@@ -74,6 +93,7 @@ export function useStorageHealth(): StorageHealthView {
 export async function readBrowserStorageHealth(
   storage: BrowserStorageManager | null,
   signal: AbortSignal,
+  readPersisted?: () => Promise<boolean>,
 ): Promise<BrowserStorageSnapshot> {
   if (!storage) {
     return {
@@ -87,9 +107,11 @@ export async function readBrowserStorageHealth(
   const estimate = storage.estimate
     ? storage.estimate()
     : Promise.reject(new Error('Storage estimate is unavailable'))
-  const persisted = storage.persisted
-    ? storage.persisted()
-    : Promise.reject(new Error('Storage persistence status is unavailable'))
+  const persisted = readPersisted
+    ? readPersisted()
+    : storage.persisted
+      ? storage.persisted()
+      : Promise.reject(new Error('Storage persistence status is unavailable'))
   const [estimateResult, persistedResult] = await Promise.allSettled([
     estimate,
     persisted,
@@ -126,6 +148,7 @@ export function buildStorageHealthView(
   browserLoading: boolean,
   browserError: Error | null,
   userAgent: string,
+  requestProtection: () => Promise<void> = () => Promise.resolve(),
 ): StorageHealthView {
   const protectionState: StorageProtectionState = browserLoading
     ? 'checking'
@@ -145,8 +168,8 @@ export function buildStorageHealthView(
     originQuotaBytes: browser?.quotaBytes ?? null,
     protectionState,
     sync,
-    replicaLabel: 'Not yet verified',
     safariCleanupRisk: isSafariUserAgent(userAgent),
+    requestProtection,
   }
 }
 

--- a/bldr/web/bldr/storage-durability-owner.test.ts
+++ b/bldr/web/bldr/storage-durability-owner.test.ts
@@ -47,6 +47,25 @@ describe('StorageDurabilityOwner', () => {
     expect(owner.getStatus()).toBe('unknown')
     expect(statuses).toEqual([])
   })
+  test('reads current protection without requesting it', async () => {
+    const storage = mockStorage(true, true)
+    const owner = new StorageDurabilityOwner(storage)
+
+    await expect(owner.readStatus()).resolves.toBe('persisted')
+
+    expect(storage.persisted).toHaveBeenCalledTimes(1)
+    expect(storage.persist).not.toHaveBeenCalled()
+  })
+  test('explicit protection requests use the same owner sequence', async () => {
+    const storage = mockStorage(false, true)
+    const owner = new StorageDurabilityOwner(storage)
+
+    await owner.requestProtection()
+
+    expect(storage.persisted).toHaveBeenCalledTimes(1)
+    expect(storage.persist).toHaveBeenCalledTimes(1)
+    expect(owner.getStatus()).toBe('persisted')
+  })
 
   test('first meaningful write triggers exactly one persisted()/persist() sequence, deduped across concurrent writes', async () => {
     const storage = mockStorage(false, true)

--- a/bldr/web/bldr/storage-durability-owner.ts
+++ b/bldr/web/bldr/storage-durability-owner.ts
@@ -10,16 +10,16 @@ export interface StorageManagerLike {
 // PersistenceStatusListener observes the latest recorded persistence status.
 export type PersistenceStatusListener = (status: PersistenceStatus) => void
 
-// StorageDurabilityOwner requests browser eviction protection once, on the
-// first user-authored durable write, and records the observed status.
+// StorageDurabilityOwner requests browser eviction protection once after an
+// explicit user request or the first user-authored durable write.
 //
-// It never requests persistence before a meaningful write, deduplicates
-// concurrent first writes into a single persisted()/persist() sequence, and
-// isolates every persistence error so a query or request failure can never fail
-// the user write that triggered it. Denial is silent: only the recorded status
-// changes, with no toast, modal, retry, or engagement prompt. The dedup guard is
-// in-memory, so a new document (a new app start) re-checks on its first
-// meaningful write, with the browser remaining the source of truth.
+// It deduplicates explicit requests and concurrent first writes into a single
+// persisted()/persist() sequence, and isolates every persistence error so a
+// query or request failure can never fail the user write that triggered it.
+// Denial is silent: only the recorded status changes, with no toast, modal,
+// retry, or engagement prompt. The dedup guard is in-memory, so a new document
+// re-checks on its first request or meaningful write, with the browser
+// remaining the source of truth.
 export class StorageDurabilityOwner {
   private statusValue: PersistenceStatus = 'unknown'
   private requested = false
@@ -35,19 +35,39 @@ export class StorageDurabilityOwner {
     return this.statusValue
   }
 
-  // noteMeaningfulWrite requests eviction protection on the first call and is a
-  // no-op afterward. It never throws and never blocks the caller.
-  public noteMeaningfulWrite(): void {
+  // requestProtection requests eviction protection once and never throws.
+  public requestProtection(): Promise<void> {
     if (this.requested) {
-      return
+      return this.pending ?? Promise.resolve()
     }
     this.requested = true
     this.pending = this.requestPersistence()
+    return this.pending
+  }
+
+  // noteMeaningfulWrite requests protection without blocking the user write.
+  public noteMeaningfulWrite(): void {
+    void this.requestProtection()
   }
 
   // whenSettled resolves once the in-flight persistence request completes.
   public whenSettled(): Promise<void> {
     return this.pending ?? Promise.resolve()
+  }
+
+  // readStatus refreshes the recorded status without requesting protection.
+  public async readStatus(): Promise<PersistenceStatus> {
+    if (!this.storage) {
+      return this.statusValue
+    }
+    try {
+      this.setStatus(
+        (await this.storage.persisted()) ? 'persisted' : 'not-persisted',
+      )
+    } catch {
+      // A status query failure leaves the last known status unchanged.
+    }
+    return this.statusValue
   }
 
   private async requestPersistence(): Promise<void> {

--- a/bldr/web/bldr/web-document.ts
+++ b/bldr/web/bldr/web-document.ts
@@ -93,6 +93,7 @@ import {
 import { markStartupBoundary } from './startup-marks.js'
 import {
   StorageDurabilityOwner,
+  type PersistenceStatus,
   type StorageManagerLike,
 } from './storage-durability-owner.js'
 
@@ -820,6 +821,18 @@ export class WebDocument extends SimpleEventEmitter<WebDocumentEvents> {
   // isHidden checks if the web document is hidden
   public get isHidden(): boolean {
     return this.hidden
+  }
+
+  // readStoragePersistenceStatus refreshes browser cleanup protection through
+  // the document-owned durability owner.
+  public readStoragePersistenceStatus(): Promise<PersistenceStatus> {
+    return this.storageDurabilityOwner.readStatus()
+  }
+
+  // requestStoragePersistence requests browser cleanup protection through the
+  // document-owned durability owner.
+  public requestStoragePersistence(): Promise<void> {
+    return this.storageDurabilityOwner.requestProtection()
   }
 
   public getResumeReadyState(): WebDocumentResumeReadyState | null {


### PR DESCRIPTION
This follow-up keeps the storage presentation change limited to the requested settings and recovery routes. It removes an unneeded incident subroute and restores the existing quota redirect target, so the real recovery entry point remains the route that already owns the flow.

The scoped settings readings, calm manual recovery copy, persistence-owner action, and focused tests remain unchanged. Verified with bun run tsgo --noEmit -p tsconfig.json, the focused storage and durability tests, and the real settings and recovery route pass.