### PR TITLE
Refresh storage protection state after a request

### DIFF
--- a/app/session/storage/useStorageHealth.test.ts
+++ b/app/session/storage/useStorageHealth.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, vi } from 'vitest'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { buildSessionSyncStatusView } from '@s4wave/app/session/SessionSyncStatusContext.js'
 
@@ -6,7 +7,73 @@ import {
   buildStorageHealthView,
   isSafariUserAgent,
   readBrowserStorageHealth,
+  useStorageHealth,
 } from './useStorageHealth.js'
+
+const mockWebDocument = vi.hoisted(() => ({
+  readStoragePersistenceStatus: vi.fn(),
+  requestStoragePersistence: vi.fn(),
+}))
+
+vi.mock('@aptre/bldr-react', () => ({
+  useBldrContext: () => ({ webDocument: mockWebDocument }),
+}))
+
+vi.mock('@s4wave/app/session/SessionStorageStatsContext.js', () => ({
+  useSessionStorageStats: () => ({
+    loading: false,
+    supported: true,
+    totalBytes: 0n,
+    blockCount: 0n,
+  }),
+}))
+
+vi.mock('@s4wave/app/session/SessionSyncStatusContext.js', async (orig) => {
+  const mod =
+    await orig<
+      typeof import('@s4wave/app/session/SessionSyncStatusContext.js')
+    >()
+  return {
+    ...mod,
+    useSessionSyncStatus: () =>
+      mod.buildSessionSyncStatusView(null, false, null),
+  }
+})
+
+describe('useStorageHealth', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    mockWebDocument.readStoragePersistenceStatus.mockReset()
+    mockWebDocument.requestStoragePersistence.mockReset()
+  })
+
+  it('re-reads protection state after an explicit request', async () => {
+    vi.stubGlobal('navigator', {
+      storage: { estimate: async () => ({ usage: 1_024, quota: 4_096 }) },
+      userAgent: 'Mozilla/5.0 Chrome/136.0.0.0 Safari/537.36',
+    })
+    mockWebDocument.readStoragePersistenceStatus.mockResolvedValue(
+      'not-persisted',
+    )
+    mockWebDocument.requestStoragePersistence.mockImplementation(async () => {
+      mockWebDocument.readStoragePersistenceStatus.mockResolvedValue(
+        'persisted',
+      )
+    })
+
+    const { result } = renderHook(() => useStorageHealth())
+    await waitFor(() =>
+      expect(result.current.protectionState).toBe('not-protected'),
+    )
+
+    await act(() => result.current.requestProtection())
+
+    await waitFor(() =>
+      expect(result.current.protectionState).toBe('protected'),
+    )
+    expect(mockWebDocument.requestStoragePersistence).toHaveBeenCalledTimes(1)
+  })
+})
 
 describe('storage health state', () => {
   it('keeps an available estimate when the persistence query fails', async () => {

--- a/app/session/storage/useStorageHealth.ts
+++ b/app/session/storage/useStorageHealth.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 
 import { useBldrContext } from '@aptre/bldr-react'
 import { useSessionStorageStats } from '@s4wave/app/session/SessionStorageStatsContext.js'
@@ -46,10 +46,14 @@ export function useStorageHealth(): StorageHealthView {
   const provider = useSessionStorageStats()
   const sync = useSessionSyncStatus()
   const webDocument = useBldrContext()?.webDocument
+  // browserReadCount re-arms the snapshot read after an explicit protection
+  // request so the displayed state reflects the browser's answer.
+  const [browserReadCount, setBrowserReadCount] = useState(0)
   const browser = usePromise(
     useCallback(
-      (signal: AbortSignal) =>
-        readBrowserStorageHealth(
+      (signal: AbortSignal) => {
+        void browserReadCount
+        return readBrowserStorageHealth(
           typeof navigator === 'undefined' ? null : navigator.storage,
           signal,
           webDocument
@@ -57,14 +61,18 @@ export function useStorageHealth(): StorageHealthView {
                 (await webDocument.readStoragePersistenceStatus()) ===
                 'persisted'
             : undefined,
-        ),
-      [webDocument],
+        )
+      },
+      [webDocument, browserReadCount],
     ),
   )
-  const requestProtection = useCallback(
-    () => webDocument?.requestStoragePersistence() ?? Promise.resolve(),
-    [webDocument],
-  )
+  const requestProtection = useCallback(async () => {
+    if (!webDocument) {
+      return
+    }
+    await webDocument.requestStoragePersistence()
+    setBrowserReadCount((count) => count + 1)
+  }, [webDocument])
 
   return useMemo(
     () =>


### PR DESCRIPTION
Pressing Request protection on the storage settings and recovery screens sent the persistence request but never re-read the browser's answer, so the displayed protection state stayed at its initial value (typically Not on) until the page was remounted.

The useStorageHealth hook now awaits the request through the document-owned durability path and then re-arms the browser snapshot read, so the screen reflects the browser's actual persisted answer immediately after the user acts. The refresh is driven by the explicit action, not a timer.

Verified by a hook-level test that fails without the fix (protection state stays not-protected after the request) and passes with it, plus the existing storage health tests and a clean typecheck.