### PR TITLE
fix(web): keep tab contents mounted across the grid transition

### DIFF
--- a/app/EditorShell.tsx
+++ b/app/EditorShell.tsx
@@ -5,9 +5,6 @@ import { useResource } from '@aptre/bldr-sdk/hooks/useResource.js'
 import { getAppPath } from '@s4wave/web/router/app-path.js'
 import { BottomBarRoot } from '@s4wave/web/frame/bottom-bar-root.js'
 import { useStateAtom, useStateNamespace } from '@s4wave/web/state/index.js'
-import { HashRouter } from '@s4wave/web/router/HashRouter.js'
-import { Routes, Route } from '@s4wave/web/router/router.js'
-import { NavigatePath } from '@s4wave/web/router/NavigatePath.js'
 import { KeyDispatcher } from '@s4wave/web/command/KeyDispatcher.js'
 import { CommandPalette } from '@s4wave/web/command/CommandPalette.js'
 import { WhichKeyPanel } from '@s4wave/web/command/WhichKeyPanel.js'
@@ -22,19 +19,10 @@ import {
 import { BuiltinCommands } from '@s4wave/app/BuiltinCommands.js'
 import { CliTerminalSessionProvider } from '@s4wave/app/terminal/CliTerminalSessionProvider.js'
 import { DebugCommands } from '@s4wave/app/DebugCommands.js'
-import {
-  TabContextProvider,
-  type TabContextValue,
-} from '@s4wave/web/object/TabContext.js'
 import { getTabDisplayName } from './shell-tab.js'
 import { ShellTabStrip } from './ShellFlexLayout.js'
-import { ShellGridLayout } from './ShellGridLayout.js'
 import { ShellMenuBar } from './ShellMenuBar.js'
-import {
-  ShellTabsProvider,
-  useShellTabs,
-  ShellTabStateProvider,
-} from './ShellTabContext.js'
+import { useShellTabs } from './ShellTabContext.js'
 import {
   classifyShellDocumentEntry,
   type ShellDocumentEntry,
@@ -43,10 +31,6 @@ import { ShellProvider } from './ShellContext.js'
 
 // isDebug is true in debug builds (BLDR_DEBUG injected by esbuild).
 const isDebug = typeof BLDR_DEBUG === 'boolean' && BLDR_DEBUG
-
-// noop stubs for TabContextValue in the command scope.
-const noopAddTab = () => Promise.resolve({ tabId: '' })
-const noopNavigateTab = () => Promise.resolve({})
 
 function CommandSessionScope({ children }: { children: ReactNode }) {
   const rootResource = useRootResource()
@@ -92,28 +76,6 @@ function CommandRuntime({ children }: { children?: ReactNode }) {
         </KeyDispatcher>
       </CommandSessionScope>
     </ShellTabFocusContextProvider>
-  )
-}
-
-// ActiveTabCommandScope provides command system components scoped to
-// the currently active tab. Wraps children in ShellTabStateProvider
-// and TabContextProvider so useTabId() works from either context.
-function ActiveTabCommandScope({ children }: { children: ReactNode }) {
-  const { activeTabId } = useShellTabs()
-  const tabContext = useMemo<TabContextValue>(
-    () => ({
-      tabId: activeTabId,
-      addTab: noopAddTab,
-      navigateTab: noopNavigateTab,
-    }),
-    [activeTabId],
-  )
-  return (
-    <ShellTabStateProvider tabId={activeTabId}>
-      <TabContextProvider value={tabContext}>
-        <CommandRuntime>{children}</CommandRuntime>
-      </TabContextProvider>
-    </ShellTabStateProvider>
   )
 }
 
@@ -170,45 +132,11 @@ function EditorShellContent() {
     return () => window.removeEventListener('hashchange', handleHashChange)
   }, [])
 
-  // In grid mode, render ShellGridLayout directly without ShellTabStrip's Layout.
-  // ShellTabStateProvider scopes command components to the active tab so
-  // useTabId() works for the command runtime.
-  if (isGridMode) {
-    return (
-      <ShellProvider isGridMode={true}>
-        <ShellTabsProvider entry={documentEntry}>
-          <ShellDocumentTitle />
-          <ActiveTabCommandScope>
-            <BottomBarRoot openMenu={openMenu} setOpenMenu={setOpenMenu}>
-              <div className="flex h-full flex-1 flex-col overflow-hidden">
-                {/* Header: menu bar */}
-                <div className="bg-topbar-back h-shell-header relative flex shrink-0 items-center">
-                  <ShellMenuBar />
-                </div>
-                {/* Grid layout */}
-                <HashRouter>
-                  <Routes>
-                    <Route path="/g/:layoutData">
-                      <ShellGridLayout />
-                    </Route>
-                    <Route path="*">
-                      <NavigatePath to="/" replace />
-                    </Route>
-                  </Routes>
-                </HashRouter>
-              </div>
-            </BottomBarRoot>
-          </ActiveTabCommandScope>
-        </ShellTabsProvider>
-      </ShellProvider>
-    )
-  }
-
-  // Normal mode: ShellTabStrip handles routing via FlexLayout.
-  // ShellTabStrip provides ShellTabsProvider and ShellTabStateProvider internally,
-  // so command components placed as children have access to useTabId().
+  // Keep ShellTabStrip (and its single OptimizedLayout owner) mounted for
+  // both URL modes. Its model handoff preserves FlexLayout's tab nodes and
+  // therefore the mounted per-tab application trees.
   return (
-    <ShellProvider isGridMode={false}>
+    <ShellProvider isGridMode={isGridMode}>
       <BottomBarRoot openMenu={openMenu} setOpenMenu={setOpenMenu}>
         <ShellTabStrip entry={documentEntry}>
           <ShellDocumentTitle />

--- a/app/ShellFlexLayout.tsx
+++ b/app/ShellFlexLayout.tsx
@@ -7,6 +7,7 @@ import {
   useMemo,
   useRef,
   useState,
+  useSyncExternalStore,
 } from 'react'
 import {
   OptimizedLayout,
@@ -55,11 +56,15 @@ import {
   type ShellTabContextMenuState,
 } from './ShellTabContextMenu.js'
 import { ShellTabContent } from './ShellTabContent.js'
+import { reconcileModelWithTabs } from './ShellGridLayout.js'
 import { ShellTabLabel } from './ShellTabLabel.js'
 import {
   encodeGridLayout,
   getTabIdsFromModel,
   hasGridLayout,
+  decodeGridLayout,
+  applyLocalStateToModel,
+  SHELL_GRID_BASE_MODEL,
 } from './shell-grid-utils.js'
 import { buildShellExternalDrag } from './shell-app-drag.js'
 import { openShellTabInNewTab } from './shell-popout.js'
@@ -298,12 +303,28 @@ function ShellTabStripInner({
   const isGridMode = useCallback(() => {
     return getAppPath().startsWith('/g/')
   }, [])
+  const routePath = useSyncExternalStore(
+    (onChange) => {
+      window.addEventListener('hashchange', onChange)
+      return () => window.removeEventListener('hashchange', onChange)
+    },
+    getAppPath,
+    getAppPath,
+  )
 
   // Initialize model from storage or default, and perform URL sync during initialization
   // This avoids calling setState in the sync effect
   const [model, setModel] = useState<Model>(() => {
-    const jsonModel = loadModelFromStorage(tabs, activeTabId)
+    const path = getAppPath()
+    const gridData = path.startsWith('/g/') ? path.slice(3) : ''
+    const decoded = gridData
+      ? decodeGridLayout(gridData, SHELL_GRID_BASE_MODEL)
+      : null
+    const jsonModel = decoded
+      ? reconcileModelWithTabs(decoded.model, tabs)
+      : loadModelFromStorage(tabs, activeTabId)
     const m = Model.fromJson(jsonModel)
+    if (decoded) applyLocalStateToModel(m, decoded.localState)
     // Disable tabset dragging in non-grid mode, and tab dragging initially
     m.doAction(
       Actions.updateModelAttributes({
@@ -315,7 +336,34 @@ function ShellTabStripInner({
     return m
   })
 
+  const gridPathRef = useRef<string | null>(null)
   const initializedRef = useRef(false)
+
+  // A deep link or back/forward navigation can supply a new grid structure
+  // without remounting this owner. Replace only the model; tab nodes retain
+  // their stable IDs and OptimizedLayout remains mounted.
+  useEffect(() => {
+    const path = getAppPath()
+    if (!path.startsWith('/g/')) {
+      if (gridPathRef.current !== null) {
+        const next = Model.fromJson(
+          buildDefaultModel(tabsRef.current, activeTabId),
+        )
+        gridPathRef.current = null
+        setModel(next)
+      }
+      return
+    }
+    if (gridPathRef.current === path) return
+    const decoded = decodeGridLayout(path.slice(3), SHELL_GRID_BASE_MODEL)
+    if (!decoded) return
+    const next = Model.fromJson(
+      reconcileModelWithTabs(decoded.model, tabsRef.current),
+    )
+    applyLocalStateToModel(next, decoded.localState)
+    gridPathRef.current = path
+    setModel(next)
+  }, [activeTabId, routePath, tabs])
   const didSyncEntryRef = useRef(false)
   const lastSyncedActiveTabIdRef = useRef(activeTabId)
   const suppressedHashPathRef = useRef<string | null>(null)
@@ -526,12 +574,21 @@ function ShellTabStripInner({
   // renderTab function - renders content for each tab
   // Path comes from tabs state via ref (single source of truth)
   // Using ref ensures stable callback identity to prevent FlexLayout re-renders
-  const renderTab = useCallback((node: TabNode) => {
-    const tabId = node.getId()
-    const tab = findShellTab(tabsRef.current, tabId)
-    const path = tab?.path ?? '/'
-    return <ShellTabContent tabId={tabId} path={path} />
-  }, [])
+  const renderTab = useCallback(
+    (node: TabNode) => {
+      const tabId = node.getId()
+      const tab = findShellTab(tabsRef.current, tabId)
+      const path = tab?.path ?? '/'
+      return (
+        <ShellTabContent
+          tabId={tabId}
+          path={path}
+          syncAppPath={!isGridMode()}
+        />
+      )
+    },
+    [isGridMode],
+  )
 
   // Handle model changes - sync tabs state, check for grid mode transition
   const handleModelChange = useCallback(

--- a/app/ShellFlexLayout.tsx
+++ b/app/ShellFlexLayout.tsx
@@ -24,6 +24,7 @@ import { LuExternalLink, LuPlus, LuX } from 'react-icons/lu'
 
 import { BASE_MODEL } from '@s4wave/web/layout/layout.js'
 import { getAppPath, setAppPath } from '@s4wave/web/router/app-path.js'
+import { useNavigate } from '@s4wave/web/router/router.js'
 import {
   ShellTab,
   getTabDisplayName,
@@ -284,6 +285,7 @@ function ShellTabStripInner({
     startRenaming,
     registerActiveTabsetPathOpener,
   } = useShellTabs()
+  const navigate = useNavigate()
 
   const [, setHasEngaged] = useStateAtom<boolean>(null, 'hasEngaged', false)
   const hasMarkedEngagedRef = useRef(false)
@@ -356,14 +358,20 @@ function ShellTabStripInner({
     }
     if (gridPathRef.current === path) return
     const decoded = decodeGridLayout(path.slice(3), SHELL_GRID_BASE_MODEL)
-    if (!decoded) return
+    if (!decoded) {
+      // A grid deep link that does not decode has no layout to show. Return
+      // home rather than leaving the shell on a URL it cannot render, and
+      // replace the entry so Back does not land on it again.
+      queueMicrotask(() => navigate({ path: '/', replace: true }))
+      return
+    }
     const next = Model.fromJson(
       reconcileModelWithTabs(decoded.model, tabsRef.current),
     )
     applyLocalStateToModel(next, decoded.localState)
     gridPathRef.current = path
     setModel(next)
-  }, [activeTabId, routePath, tabs])
+  }, [activeTabId, navigate, routePath, tabs])
   const didSyncEntryRef = useRef(false)
   const lastSyncedActiveTabIdRef = useRef(activeTabId)
   const suppressedHashPathRef = useRef<string | null>(null)

--- a/app/ShellFlexLayout.tsx
+++ b/app/ShellFlexLayout.tsx
@@ -60,6 +60,9 @@ import { reconcileModelWithTabs } from './ShellGridLayout.js'
 import { ShellTabLabel } from './ShellTabLabel.js'
 import {
   encodeGridLayout,
+  encodeGridLayoutStructure,
+  getActiveTabsetId,
+  getSelectedTabId,
   getTabIdsFromModel,
   hasGridLayout,
   decodeGridLayout,
@@ -312,9 +315,12 @@ function ShellTabStripInner({
     getAppPath,
   )
 
-  // Initialize model from storage or default, and perform URL sync during initialization
-  // This avoids calling setState in the sync effect
-  const [model, setModel] = useState<Model>(() => {
+  // Initialize model from storage or default, and perform URL sync during
+  // initialization. This avoids calling setState in the sync effect. A grid
+  // deep link is decoded here so the first paint already shows the split, and
+  // the decoded path travels with it: the hash effect must not decode the same
+  // URL a second time and throw this model away.
+  const [initial] = useState(() => {
     const path = getAppPath()
     const gridData = path.startsWith('/g/') ? path.slice(3) : ''
     const decoded = gridData
@@ -324,8 +330,17 @@ function ShellTabStripInner({
       ? reconcileModelWithTabs(decoded.model, tabs)
       : loadModelFromStorage(tabs, activeTabId)
     const m = Model.fromJson(jsonModel)
-    if (decoded) applyLocalStateToModel(m, decoded.localState)
-    // Disable tabset dragging in non-grid mode, and tab dragging initially
+    if (decoded) {
+      applyLocalStateToModel(m, decoded.localState)
+      // Grid mode keeps FlexLayout's own tabset behavior: panes are draggable
+      // and an emptied one disappears. Only normal mode pins the layout to a
+      // single fixed tabset.
+      return {
+        model: m,
+        gridPath: path,
+        structure: encodeGridLayoutStructure(m),
+      }
+    }
     m.doAction(
       Actions.updateModelAttributes({
         tabSetEnableDeleteWhenEmpty: false,
@@ -333,10 +348,12 @@ function ShellTabStripInner({
         tabEnableDrag: false,
       }),
     )
-    return m
+    return { model: m, gridPath: null, structure: null }
   })
+  const [model, setModel] = useState<Model>(initial.model)
 
-  const gridPathRef = useRef<string | null>(null)
+  const gridPathRef = useRef<string | null>(initial.gridPath)
+  const gridStructureRef = useRef<string | null>(initial.structure)
   const initializedRef = useRef(false)
 
   // A deep link or back/forward navigation can supply a new grid structure
@@ -349,7 +366,19 @@ function ShellTabStripInner({
         const next = Model.fromJson(
           buildDefaultModel(tabsRef.current, activeTabId),
         )
+        // Normal mode configures the layout as one fixed tabset. The default
+        // model does not carry those attributes, so a rebuild that skipped
+        // them would leave FlexLayout's draggable tabsets on in a mode that
+        // has nowhere to drag them to.
+        next.doAction(
+          Actions.updateModelAttributes({
+            tabSetEnableDeleteWhenEmpty: false,
+            tabSetEnableDrag: false,
+            tabEnableDrag: tabsRef.current.length >= 2,
+          }),
+        )
         gridPathRef.current = null
+        gridStructureRef.current = null
         setModel(next)
       }
       return
@@ -367,6 +396,7 @@ function ShellTabStripInner({
     )
     applyLocalStateToModel(next, decoded.localState)
     gridPathRef.current = path
+    gridStructureRef.current = encodeGridLayoutStructure(next)
     setModel(next)
   }, [activeTabId, routePath, tabs])
   const didSyncEntryRef = useRef(false)
@@ -378,9 +408,17 @@ function ShellTabStripInner({
   } | null>(null)
   const projectingTabsToModelRef = useRef(false)
 
+  // openPathInFlexTabset opens a path as a shell tab for command handlers such
+  // as the terminal opener. In a split the tab belongs to whichever tabset the
+  // user is working in, and the route stays on the grid URL: writing the tab's
+  // own path there would collapse the split the command was invoked from.
   const openPathInFlexTabset = useCallback(
     (path: string, options: OpenShellTabOptions = {}) => {
       const select = options.select ?? true
+      const gridMode = isGridMode()
+      const tabsetId = gridMode
+        ? (getActiveTabsetId(model) ?? 'shell-tabset')
+        : 'shell-tabset'
       const existingTab = options.focusExisting
         ? tabsRef.current.find(
             (tab) => tab.path === path && model.getNodeById(tab.id),
@@ -391,7 +429,7 @@ function ShellTabStripInner({
         if (select) {
           selectShellTab(existingTab.id)
           model.doAction(Actions.selectTab(existingTab.id))
-          if (existingTab.path !== getAppPath()) {
+          if (!gridMode && existingTab.path !== getAppPath()) {
             setAppPath(existingTab.path)
           }
         }
@@ -404,21 +442,16 @@ function ShellTabStripInner({
         select,
         onCommitted: () => {
           if (select) {
-            addAndSelectShellModelTab(
-              model,
-              'shell-tabset',
-              newTab,
-              'shell-content',
-            )
-            setAppPath(path)
+            addAndSelectShellModelTab(model, tabsetId, newTab, 'shell-content')
+            if (!gridMode) setAppPath(path)
           } else {
-            addShellModelTab(model, 'shell-tabset', newTab, 'shell-content')
+            addShellModelTab(model, tabsetId, newTab, 'shell-content')
           }
         },
       })
       return newTab.id
     },
-    [addShellTab, model, selectShellTab],
+    [addShellTab, isGridMode, model, selectShellTab],
   )
 
   useEffect(
@@ -579,21 +612,14 @@ function ShellTabStripInner({
   // renderTab function - renders content for each tab
   // Path comes from tabs state via ref (single source of truth)
   // Using ref ensures stable callback identity to prevent FlexLayout re-renders
-  const renderTab = useCallback(
-    (node: TabNode) => {
-      const tabId = node.getId()
-      const tab = findShellTab(tabsRef.current, tabId)
-      const path = tab?.path ?? '/'
-      return (
-        <ShellTabContent
-          tabId={tabId}
-          path={path}
-          syncAppPath={!isGridMode()}
-        />
-      )
-    },
-    [isGridMode],
-  )
+  // Grid mode is not passed down: the content survives the mode transition, so
+  // it reads the live mode from the shell context itself.
+  const renderTab = useCallback((node: TabNode) => {
+    const tabId = node.getId()
+    const tab = findShellTab(tabsRef.current, tabId)
+    const path = tab?.path ?? '/'
+    return <ShellTabContent tabId={tabId} path={path} />
+  }, [])
 
   // Handle model changes - sync tabs state, check for grid mode transition
   const handleModelChange = useCallback(
@@ -618,9 +644,39 @@ function ShellTabStripInner({
       if (hasGridLayout(newModel)) {
         const committedTabIds = new Set(tabsRef.current.map((tab) => tab.id))
         if (
-          getTabIdsFromModel(newModel).every((id) => committedTabIds.has(id))
+          !getTabIdsFromModel(newModel).every((id) => committedTabIds.has(id))
         ) {
-          setAppPath(`/g/${encodeGridLayout(newModel)}`)
+          return
+        }
+        // Selection follows the user across panes. The tab owner drives the
+        // document title, the command session, and the toolbar actions, so a
+        // selection left behind here points all three at the wrong pane.
+        const selectedId = getSelectedTabId(newModel)
+        retainShellTabs(
+          new Set(getTabIdsFromModel(newModel)),
+          selectedId ?? undefined,
+        )
+        if (
+          selectedId &&
+          selectedId !== activeTabId &&
+          tabsRef.current.some((tab) => tab.id === selectedId)
+        ) {
+          selectShellTab(selectedId)
+          markShellEngaged()
+        }
+        // Only a structural change earns a URL write. Selecting a tab or
+        // dragging a splitter also changes the encoded model, and publishing
+        // those would make Back walk through every layout interaction before
+        // it reaches the route the user came from.
+        const structure = encodeGridLayoutStructure(newModel)
+        if (structure !== gridStructureRef.current) {
+          gridStructureRef.current = structure
+          const gridPath = `/g/${encodeGridLayout(newModel)}`
+          // The model already holds this structure, so record the path as the
+          // one in effect: the hash listener would otherwise decode our own
+          // write back into a replacement model.
+          gridPathRef.current = gridPath
+          setAppPath(gridPath)
         }
         return
       }
@@ -796,7 +852,10 @@ function ShellTabStripInner({
               'shell-content',
             )
           }
-          setAppPath(activeTab.path)
+          // A drop that created a split leaves the route on the grid URL.
+          // Writing the dropped tab's own path there would collapse the split
+          // the drop just made.
+          if (!isGridMode()) setAppPath(activeTab.path)
           model.doAction(Actions.selectTab(activeTab.id))
           markShellEngaged()
         }
@@ -809,7 +868,7 @@ function ShellTabStripInner({
           })
         }
       }),
-    [addShellTab, markShellEngaged, model],
+    [addShellTab, isGridMode, markShellEngaged, model],
   )
 
   const [contextMenu, setContextMenu] =

--- a/app/ShellFlexLayout.tsx
+++ b/app/ShellFlexLayout.tsx
@@ -24,7 +24,6 @@ import { LuExternalLink, LuPlus, LuX } from 'react-icons/lu'
 
 import { BASE_MODEL } from '@s4wave/web/layout/layout.js'
 import { getAppPath, setAppPath } from '@s4wave/web/router/app-path.js'
-import { useNavigate } from '@s4wave/web/router/router.js'
 import {
   ShellTab,
   getTabDisplayName,
@@ -285,7 +284,6 @@ function ShellTabStripInner({
     startRenaming,
     registerActiveTabsetPathOpener,
   } = useShellTabs()
-  const navigate = useNavigate()
 
   const [, setHasEngaged] = useStateAtom<boolean>(null, 'hasEngaged', false)
   const hasMarkedEngagedRef = useRef(false)
@@ -360,9 +358,8 @@ function ShellTabStripInner({
     const decoded = decodeGridLayout(path.slice(3), SHELL_GRID_BASE_MODEL)
     if (!decoded) {
       // A grid deep link that does not decode has no layout to show. Return
-      // home rather than leaving the shell on a URL it cannot render, and
-      // replace the entry so Back does not land on it again.
-      queueMicrotask(() => navigate({ path: '/', replace: true }))
+      // home rather than leaving the shell on a URL it cannot render.
+      queueMicrotask(() => setAppPath('/'))
       return
     }
     const next = Model.fromJson(
@@ -371,7 +368,7 @@ function ShellTabStripInner({
     applyLocalStateToModel(next, decoded.localState)
     gridPathRef.current = path
     setModel(next)
-  }, [activeTabId, navigate, routePath, tabs])
+  }, [activeTabId, routePath, tabs])
   const didSyncEntryRef = useRef(false)
   const lastSyncedActiveTabIdRef = useRef(activeTabId)
   const suppressedHashPathRef = useRef<string | null>(null)

--- a/app/ShellGridLayout.tsx
+++ b/app/ShellGridLayout.tsx
@@ -490,7 +490,7 @@ function normalizeSelectedIndex(
 // reconcileModelWithTabs ensures all tabs in the model exist in global state.
 // Shell tab paths and display names are owned by ShellTabsContext, so decoded
 // grid URL tabs with no global state entry cannot be rendered correctly.
-function reconcileModelWithTabs(
+export function reconcileModelWithTabs(
   model: IJsonModel,
   tabs: ShellTab[],
 ): IJsonModel {

--- a/app/ShellTabContent.tsx
+++ b/app/ShellTabContent.tsx
@@ -4,17 +4,22 @@ import { ShellAppPanel } from './ShellAppPanel.js'
 export interface ShellTabContentProps {
   tabId: string
   path: string
+  syncAppPath?: boolean
 }
 
 // ShellTabContent renders the content for a single tab panel in the FlexLayout.
-// Each tab reuses the shared shell app panel with URL syncing enabled.
-export function ShellTabContent({ tabId, path }: ShellTabContentProps) {
+// Each tab reuses the shared shell app panel; grid mode disables only URL syncing.
+export function ShellTabContent({
+  tabId,
+  path,
+  syncAppPath = true,
+}: ShellTabContentProps) {
   return (
     <ShellAppPanel
       tabId={tabId}
       initialPath={path}
       namespace={['shell-tab', tabId]}
-      syncAppPath
+      syncAppPath={syncAppPath}
     />
   )
 }

--- a/app/ShellTabContent.tsx
+++ b/app/ShellTabContent.tsx
@@ -1,25 +1,29 @@
 import { ShellAppPanel } from './ShellAppPanel.js'
+import { useIsGridMode } from './ShellContext.js'
 
 // ShellTabContentProps are the props for ShellTabContent.
 export interface ShellTabContentProps {
   tabId: string
   path: string
-  syncAppPath?: boolean
 }
 
 // ShellTabContent renders the content for a single tab panel in the FlexLayout.
 // Each tab reuses the shared shell app panel; grid mode disables only URL syncing.
-export function ShellTabContent({
-  tabId,
-  path,
-  syncAppPath = true,
-}: ShellTabContentProps) {
+//
+// Grid mode comes from the shell context, not from a prop. The layout keeps this
+// element mounted across the mode transition, so a value sampled when the
+// content was first created would describe the mode the tab was born in: a tab
+// created in normal mode would keep writing its own path over the grid URL, and
+// a tab opened from a grid deep link would stop synchronizing once the split
+// collapsed.
+export function ShellTabContent({ tabId, path }: ShellTabContentProps) {
+  const isGridMode = useIsGridMode()
   return (
     <ShellAppPanel
       tabId={tabId}
       initialPath={path}
       namespace={['shell-tab', tabId]}
-      syncAppPath={syncAppPath}
+      syncAppPath={!isGridMode}
     />
   )
 }

--- a/app/ShellTabStrip.test.tsx
+++ b/app/ShellTabStrip.test.tsx
@@ -28,6 +28,7 @@ import type { ShellDocumentEntry } from './ShellDocumentEntry.js'
 import { buildUnixFSEntryAppDragEnvelope } from './unixfs/unixfs-app-drag.js'
 
 const mockOptimizedLayoutProps = vi.hoisted(() => vi.fn())
+const navigateMock = vi.hoisted(() => vi.fn())
 const mockCreateSpace = vi.hoisted(() => vi.fn())
 const continuationEntry: ShellDocumentEntry = {
   kind: 'continuation',
@@ -92,7 +93,13 @@ vi.mock('./ShellTabContextMenu.js', () => ({
   ShellTabContextMenu: () => null,
 }))
 
-vi.mock('./shell-grid-utils.js', () => ({
+vi.mock('@s4wave/web/router/router.js', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useNavigate: () => navigateMock,
+}))
+
+vi.mock('./shell-grid-utils.js', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
   encodeGridLayout: () => 'grid-layout',
   getTabIdsFromModel: (model: { tabs: Array<{ id: string }> }) =>
     model.tabs.map((tab) => tab.id),

--- a/app/ShellTabStrip.test.tsx
+++ b/app/ShellTabStrip.test.tsx
@@ -28,7 +28,6 @@ import type { ShellDocumentEntry } from './ShellDocumentEntry.js'
 import { buildUnixFSEntryAppDragEnvelope } from './unixfs/unixfs-app-drag.js'
 
 const mockOptimizedLayoutProps = vi.hoisted(() => vi.fn())
-const navigateMock = vi.hoisted(() => vi.fn())
 const mockCreateSpace = vi.hoisted(() => vi.fn())
 const continuationEntry: ShellDocumentEntry = {
   kind: 'continuation',
@@ -91,11 +90,6 @@ vi.mock('./ShellTabLabel.js', () => ({
 
 vi.mock('./ShellTabContextMenu.js', () => ({
   ShellTabContextMenu: () => null,
-}))
-
-vi.mock('@s4wave/web/router/router.js', async (importOriginal) => ({
-  ...(await importOriginal<Record<string, unknown>>()),
-  useNavigate: () => navigateMock,
 }))
 
 vi.mock('./shell-grid-utils.js', async (importOriginal) => ({

--- a/app/ShellTabStrip.test.tsx
+++ b/app/ShellTabStrip.test.tsx
@@ -124,6 +124,11 @@ vi.mock('@aptre/flex-layout', () => {
       const tabId = this.selectedTabId ?? this.children[0]?.id ?? null
       return this.children.find((child) => child.id === tabId) ?? null
     }
+
+    // The model only ever visits this tabset, so it is the active one.
+    isActive() {
+      return true
+    }
   }
 
   class MockTabNode {


### PR DESCRIPTION
Splitting a shell tab into grid mode used to return a wholly separate tree from EditorShell, with its own parents and its own router. React unmounted the old tree, so every component holding a session resource handle was destroyed and each replacement re-acquired from scratch. What the user saw was several seconds of "Loading session" and a full space reload for what is only a layout change. The same unmount ran the upload manager's cleanup, so any transfer in flight was cancelled silently.

OptimizedLayout already solves this. It renders tab content in a sibling container outside the layout's own DOM precisely so tab components survive layout mutations. The catch is that the guarantee is scoped to a single instance, and the mode switch was mounting a second one and throwing the first away, so it never applied across the transition.

EditorShell now keeps one tab strip mounted and passes grid-mode state through the shell provider. The single OptimizedLayout owner decodes a grid URL into its existing model, and a later hash change replaces only the model instance. Stable tab ids let it reuse its TabInfo entries and their container children, and tab content always uses one namespace now, with path synchronization selected by the live mode rather than by which tree happened to render it. Resource ownership stays with the components that hold the handles.

Verified by driving the real app: two tabs open, split through the live layout model action, and the two content elements compare identical by node identity before and after, with no loading state and the expected two-tabset grid URL. Upload survival follows from the same surviving tree and the cleanup's unmount contract, but no transfer was actually in flight during that run, so it is source-backed rather than observed.