### PR TITLE
test(web): follow the quota incident route rename

### DIFF
--- a/app/session/SessionSharedObjectContainer.test.tsx
+++ b/app/session/SessionSharedObjectContainer.test.tsx
@@ -540,7 +540,7 @@ describe('SessionSharedObjectContainer', () => {
 
     await waitFor(() => {
       expect(mockNavigateSession).toHaveBeenCalledWith({
-        path: 'settings/storage/recovery',
+        path: 'settings/storage/recovery/incident',
         replace: true,
       })
     })


### PR DESCRIPTION
Routing an app-critical storage quota failure to the incident page instead of the recovery index changed where the session container navigates, but this expectation still named the old path. The alpha test job has failed on every master commit since, so a red check on a pull request stopped telling you anything: it looked the same whether the branch was broken or not.

The expectation now names the route the container actually navigates to. The contract under test does not change, and a quota error still has to send the session to storage recovery rather than render a broken object.

Verified by running the file: twenty of twenty pass here, and the same case fails at master's head.