### PR TITLE
fix(forge): advance tasks from checking

### DIFF
--- a/forge/task/controller/process-state.go
+++ b/forge/task/controller/process-state.go
@@ -9,7 +9,6 @@ import (
 	"github.com/s4wave/spacewave/db/bucket"
 	"github.com/s4wave/spacewave/db/world"
 	world_control "github.com/s4wave/spacewave/db/world/control"
-	forge_pass "github.com/s4wave/spacewave/forge/pass"
 	forge_target "github.com/s4wave/spacewave/forge/target"
 	forge_task "github.com/s4wave/spacewave/forge/task"
 	task_tx "github.com/s4wave/spacewave/forge/task/tx"
@@ -233,53 +232,9 @@ func buildUpdateInputValueSet(
 // processCheckTaskResult processes the task in the CHECKING state.
 // in the future, additional checks may be added here.
 func (c *Controller) processCheckTaskResult(ctx context.Context, ws world.WorldState, taskState *forge_task.Task) error {
-	passNonce := taskState.GetPassNonce()
-
-	// look up the completed pass
-	taskPass, taskPassTgt, _, err := forge_task.LookupTaskPass(ctx, ws, c.objKey, passNonce)
-	if err == nil {
-
-		if taskPass == nil {
-			err = errors.Wrap(world.ErrObjectNotFound, "task pass")
-		} else {
-			err = taskPass.Validate(false)
-		}
-	}
-
-	// check that the pass completed successfully
-	passResult := taskPass.GetResult()
-	if err == nil && !passResult.GetSuccess() {
-		passResult.FillFailError()
-		err = errors.New(passResult.GetFailError())
-		err = errors.Wrap(err, "pass failed")
-	}
-
-	// look up the outputs
-	outputs := taskPassTgt.GetOutputs()
-	if err == nil && len(outputs) != 0 {
-		// compute the outputs from the exec states
-		var passOutputs forge_value.ValueSlice
-		passOutputs, err = forge_pass.ComputeOutputsWithStates(outputs, taskPass.GetExecStates(), int(taskState.GetReplicas()))
-		if err != nil {
-			err = errors.Wrapf(err, "pass[%d]: compute outputs", passNonce)
-		}
-		// verify the outputs match what the pass has
-		if err == nil && !passOutputs.Equals(taskState.GetValueSet().GetOutputs()) {
-			err = errors.Wrapf(err, "pass[%d]: outputs mismatch re-computed values", passNonce)
-		}
-	}
-	if err != nil {
-		if ctx.Err() == nil || !errors.Is(err, context.Canceled) {
-			c.le.WithError(err).Warn("marking task as failed w/ error")
-		}
-		tx := task_tx.NewTxComplete(c.objKey, forge_value.NewResultWithError(err))
-		_, _, err = ws.ApplyWorldOp(ctx, tx, c.peerID)
-		return err
-	}
-
-	c.le.Info("marking task as complete")
+	c.le.Debug("submitting CHECKING completion")
 	tx := task_tx.NewTxComplete(c.objKey, forge_value.NewResultWithSuccess())
-	_, _, err = ws.ApplyWorldOp(ctx, tx, c.peerID)
+	_, _, err := ws.ApplyWorldOp(ctx, tx, c.peerID)
 	return err
 }
 

--- a/forge/task/controller/process-state_test.go
+++ b/forge/task/controller/process-state_test.go
@@ -1,10 +1,16 @@
 package task_controller
 
 import (
+	"context"
 	"testing"
+	"time"
 
+	"github.com/s4wave/spacewave/db/world"
+	forge_task "github.com/s4wave/spacewave/forge/task"
 	task_tx "github.com/s4wave/spacewave/forge/task/tx"
 	forge_value "github.com/s4wave/spacewave/forge/value"
+	"github.com/s4wave/spacewave/net/peer"
+	"github.com/sirupsen/logrus"
 )
 
 func TestBuildUpdateInputValueSetForTargetOnlyUpdate(t *testing.T) {
@@ -20,4 +26,73 @@ func TestBuildUpdateInputValueSetForTargetOnlyUpdate(t *testing.T) {
 	if len(valueSet.GetInputs()) != 1 || valueSet.GetInputs()[0].GetName() != "scheduler-input" {
 		t.Fatalf("value set inputs = %v, want stored input", valueSet.GetInputs())
 	}
+}
+
+func TestProcessCheckTaskResultAppliesCompletionWithoutLinkedPassRead(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	ws := &checkTaskWorldState{
+		lookupStarted: make(chan struct{}),
+		applyCalled:   make(chan world.Operation, 1),
+	}
+	controller := &Controller{
+		le:     logrus.NewEntry(logrus.New()),
+		objKey: "task",
+		peerID: peer.ID("12D3KooWGVhTGboSk5zPHWcnuw66ysJ29F8r9RYu75qUTxZ83JL8"),
+	}
+	taskState := &forge_task.Task{PassNonce: 1}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- controller.processCheckTaskResult(ctx, ws, taskState)
+	}()
+
+	select {
+	case op := <-ws.applyCalled:
+		tx, ok := op.(*task_tx.Tx)
+		if !ok {
+			t.Fatalf("completion operation type = %T, want *task_tx.Tx", op)
+		}
+		if tx.GetTxType() != task_tx.TxType_TxType_COMPLETE {
+			t.Fatalf("completion operation type = %s, want COMPLETE", tx.GetTxType())
+		}
+	case <-time.After(time.Second):
+		cancel()
+		<-errCh
+		t.Fatal("CHECKING processing blocked before ApplyWorldOp")
+	}
+
+	if err := <-errCh; err != nil {
+		t.Fatalf("processCheckTaskResult: %v", err)
+	}
+	select {
+	case <-ws.lookupStarted:
+		t.Fatal("CHECKING processing performed a linked Pass lookup")
+	default:
+	}
+}
+
+type checkTaskWorldState struct {
+	world.WorldState
+	lookupStarted chan struct{}
+	applyCalled   chan world.Operation
+}
+
+func (w *checkTaskWorldState) LookupGraphQuads(
+	ctx context.Context,
+	_ world.GraphQuad,
+	_ uint32,
+) ([]world.GraphQuad, error) {
+	close(w.lookupStarted)
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (w *checkTaskWorldState) ApplyWorldOp(
+	_ context.Context,
+	op world.Operation,
+	_ peer.ID,
+) (uint64, bool, error) {
+	w.applyCalled <- op
+	return 0, false, nil
 }

--- a/forge/task/tx/tx-complete.go
+++ b/forge/task/tx/tx-complete.go
@@ -79,6 +79,15 @@ func (t *TxComplete) ExecuteTx(
 
 	var passOutputs forge_value.ValueSlice
 	if result.IsSuccessful() {
+		// an illegal source state is a precondition violation, not an outcome:
+		// reject the operation rather than terminally failing a Task that is
+		// still running or that already recorded a successful completion.
+		if root.GetTaskState() != forge_task.State_TaskState_CHECKING {
+			return errors.Errorf(
+				"%s: must be in CHECKING state if completing successfully",
+				root.GetTaskState().String(),
+			)
+		}
 		passOutputs, err = validateTaskCompletion(
 			ctx,
 			worldState,
@@ -117,13 +126,6 @@ func validateTaskCompletion(
 	root *forge_task.Task,
 	tgt *forge_target.Target,
 ) (forge_value.ValueSlice, error) {
-	if root.GetTaskState() != forge_task.State_TaskState_CHECKING {
-		return nil, errors.Errorf(
-			"%s: must be in CHECKING state if completing successfully",
-			root.GetTaskState().String(),
-		)
-	}
-
 	tpass, _, _, err := forge_task.LookupTaskPass(
 		ctx,
 		worldState,

--- a/forge/task/tx/tx-complete.go
+++ b/forge/task/tx/tx-complete.go
@@ -72,65 +72,112 @@ func (t *TxComplete) ExecuteTx(
 		return err
 	}
 
-	// ensure CHECKING state if the result is not failed
-	taskState := root.GetTaskState()
-	isSuccess := t.GetResult().IsSuccessful()
-	if isSuccess {
-		if taskState != forge_task.State_TaskState_CHECKING {
-			return errors.Errorf(
-				"%s: must be in CHECKING state if completing successfully",
-				taskState.String(),
-			)
-		}
-
-		// lookup the successful pass
-		tpass, _, _, err := forge_task.LookupTaskPass(ctx, worldState, objKey, root.GetPassNonce())
-		if err != nil {
-			return errors.Wrapf(err, "lookup pass[%d]", root.GetPassNonce())
-		}
-		if tpass.GetPassState() != forge_pass.State_PassState_COMPLETE {
-			return errors.Errorf(
-				"expected pass[%d] to be complete: %s",
-				root.GetPassNonce(),
-				tpass.GetPassState().String(),
-			)
-		}
-
-		// compute the outputs from the exec states
-		outputs := tgt.GetOutputs()
-		passOutputs, err := forge_pass.ComputeOutputsWithStates(outputs, tpass.GetExecStates(), int(root.GetReplicas()))
-		if err != nil {
-			return errors.Wrapf(err, "pass[%d]: compute outputs", root.GetPassNonce())
-		}
-
-		// verify the outputs match what the pass has
-		if !passOutputs.Equals(tpass.GetValueSet().GetOutputs()) {
-			return errors.Wrapf(err, "pass[%d]: outputs mismatch re-computed values", root.GetPassNonce())
-		}
-		if root.ValueSet == nil {
-			root.ValueSet = &forge_target.ValueSet{}
-		}
-		root.ValueSet.Outputs = passOutputs
-	} else {
-		if taskState == forge_task.State_TaskState_COMPLETE {
-			return errors.Wrapf(
-				forge_value.ErrUnknownState,
-				"%s", taskState.String(),
-			)
-		}
-	}
-
 	result := t.GetResult()
 	if result == nil {
 		result = &forge_value.Result{}
 	}
-	result.FillFailError()
 
-	// promote to COMPLETE
+	var passOutputs forge_value.ValueSlice
+	if result.IsSuccessful() {
+		passOutputs, err = validateTaskCompletion(
+			ctx,
+			worldState,
+			objKey,
+			root,
+			tgt,
+		)
+		if err != nil {
+			result = forge_value.NewResultWithError(err)
+		}
+	} else if root.GetTaskState() == forge_task.State_TaskState_COMPLETE {
+		return errors.Wrapf(
+			forge_value.ErrUnknownState,
+			"%s", root.GetTaskState().String(),
+		)
+	}
+
+	result.FillFailError()
+	if result.GetSuccess() && len(tgt.GetOutputs()) != 0 {
+		if root.ValueSet == nil {
+			root.ValueSet = &forge_target.ValueSet{}
+		}
+		root.ValueSet.Outputs = passOutputs
+	}
+
 	root.TaskState = forge_task.State_TaskState_COMPLETE
 	root.Result = result
 	bcs.SetBlock(root, true)
 	return nil
+}
+
+func validateTaskCompletion(
+	ctx context.Context,
+	worldState world.WorldState,
+	objKey string,
+	root *forge_task.Task,
+	tgt *forge_target.Target,
+) (forge_value.ValueSlice, error) {
+	if root.GetTaskState() != forge_task.State_TaskState_CHECKING {
+		return nil, errors.Errorf(
+			"%s: must be in CHECKING state if completing successfully",
+			root.GetTaskState().String(),
+		)
+	}
+
+	tpass, _, _, err := forge_task.LookupTaskPass(
+		ctx,
+		worldState,
+		objKey,
+		root.GetPassNonce(),
+	)
+	if err != nil {
+		return nil, errors.Wrapf(err, "lookup pass[%d]", root.GetPassNonce())
+	}
+	if tpass == nil {
+		return nil, errors.Wrap(world.ErrObjectNotFound, "task pass")
+	}
+	if err := tpass.Validate(false); err != nil {
+		return nil, errors.Wrap(err, "pass")
+	}
+
+	passResult := tpass.GetResult()
+	if !passResult.GetSuccess() {
+		passResult.FillFailError()
+		return nil, errors.Wrap(errors.New(passResult.GetFailError()), "pass failed")
+	}
+	if tpass.GetPassState() != forge_pass.State_PassState_COMPLETE {
+		return nil, errors.Errorf(
+			"expected pass[%d] to be complete: %s",
+			root.GetPassNonce(),
+			tpass.GetPassState().String(),
+		)
+	}
+
+	outputs := tgt.GetOutputs()
+	if len(outputs) == 0 {
+		return nil, nil
+	}
+	passOutputs, err := forge_pass.ComputeOutputsWithStates(
+		outputs,
+		tpass.GetExecStates(),
+		int(root.GetReplicas()),
+	)
+	if err != nil {
+		return nil, errors.Wrapf(err, "pass[%d]: compute outputs", root.GetPassNonce())
+	}
+	if !passOutputs.Equals(tpass.GetValueSet().GetOutputs()) {
+		return nil, errors.Errorf(
+			"pass[%d]: outputs mismatch re-computed pass values",
+			root.GetPassNonce(),
+		)
+	}
+	if !passOutputs.Equals(root.GetValueSet().GetOutputs()) {
+		return nil, errors.Errorf(
+			"pass[%d]: outputs mismatch re-computed task values",
+			root.GetPassNonce(),
+		)
+	}
+	return passOutputs, nil
 }
 
 // _ is a type assertion

--- a/forge/task/tx/tx-complete.go
+++ b/forge/task/tx/tx-complete.go
@@ -173,12 +173,6 @@ func validateTaskCompletion(
 			root.GetPassNonce(),
 		)
 	}
-	if !passOutputs.Equals(root.GetValueSet().GetOutputs()) {
-		return nil, errors.Errorf(
-			"pass[%d]: outputs mismatch re-computed task values",
-			root.GetPassNonce(),
-		)
-	}
 	return passOutputs, nil
 }
 

--- a/forge/task/tx/tx-complete_test.go
+++ b/forge/task/tx/tx-complete_test.go
@@ -13,19 +13,23 @@ import (
 	forge_task "github.com/s4wave/spacewave/forge/task"
 	task_tx "github.com/s4wave/spacewave/forge/task/tx"
 	forge_value "github.com/s4wave/spacewave/forge/value"
+	"github.com/s4wave/spacewave/net/peer"
 )
 
-func TestTxCompleteConvertsFailedPassToFailedTask(t *testing.T) {
+// buildTaskWithPass stands up a Task linked to a single Pass, forcing both into
+// the given states so a completion transaction can be applied against them.
+func buildTaskWithPass(
+	t *testing.T,
+	tb *world_testbed.Testbed,
+	taskKey string,
+	taskState forge_task.State,
+	taskResult *forge_value.Result,
+	passResult *forge_value.Result,
+) peer.ID {
+	t.Helper()
 	ctx := t.Context()
-	tb, err := world_testbed.Default(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(tb.Release)
-
 	sender := tb.Volume.GetPeerID()
 	target := &forge_target.Target{Exec: &forge_target.Exec{Disable: true}}
-	taskKey := "test/task/complete-failed-pass"
 	passKey := forge_task.NewPassKey(taskKey, 1)
 	ts := timestamp.Now()
 	if _, _, err := forge_task.CreateTaskWithTarget(
@@ -33,7 +37,7 @@ func TestTxCompleteConvertsFailedPassToFailedTask(t *testing.T) {
 		tb.WorldState,
 		sender,
 		taskKey,
-		"complete-failed-pass",
+		"tx-complete",
 		target,
 		"",
 		1,
@@ -72,7 +76,8 @@ func TestTxCompleteConvertsFailedPassToFailedTask(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		task.TaskState = forge_task.State_TaskState_CHECKING
+		task.TaskState = taskState
+		task.Result = taskResult
 		task.PassNonce = 1
 		bcs.SetBlock(task, true)
 		return nil
@@ -85,12 +90,30 @@ func TestTxCompleteConvertsFailedPassToFailedTask(t *testing.T) {
 			return err
 		}
 		pass.PassState = forge_pass.State_PassState_COMPLETE
-		pass.Result = forge_value.NewResultWithError(errors.New("pass failed"))
+		pass.Result = passResult
 		bcs.SetBlock(pass, true)
 		return nil
 	}); err != nil {
 		t.Fatal(err)
 	}
+	return sender
+}
+
+func TestTxCompleteConvertsFailedPassToFailedTask(t *testing.T) {
+	ctx := t.Context()
+	tb, err := world_testbed.Default(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(tb.Release)
+
+	taskKey := "test/task/complete-failed-pass"
+	sender := buildTaskWithPass(
+		t, tb, taskKey,
+		forge_task.State_TaskState_CHECKING,
+		nil,
+		forge_value.NewResultWithError(errors.New("pass failed")),
+	)
 
 	if _, _, err := tb.WorldState.ApplyWorldOp(
 		ctx,
@@ -112,5 +135,38 @@ func TestTxCompleteConvertsFailedPassToFailedTask(t *testing.T) {
 	}
 	if task.GetResult().GetFailError() == "" {
 		t.Fatal("failed pass completion did not preserve a failure error")
+	}
+}
+
+func TestTxCompleteRejectsSuccessOutsideChecking(t *testing.T) {
+	ctx := t.Context()
+	tb, err := world_testbed.Default(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(tb.Release)
+
+	taskKey := "test/task/complete-twice"
+	sender := buildTaskWithPass(
+		t, tb, taskKey,
+		forge_task.State_TaskState_COMPLETE,
+		forge_value.NewResultWithSuccess(),
+		forge_value.NewResultWithSuccess(),
+	)
+
+	if _, _, err := tb.WorldState.ApplyWorldOp(
+		ctx,
+		task_tx.NewTxComplete(taskKey, forge_value.NewResultWithSuccess()),
+		sender,
+	); err == nil {
+		t.Fatal("completing an already complete task was accepted")
+	}
+
+	task, _, err := forge_task.LookupTask(ctx, tb.WorldState, taskKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !task.GetResult().GetSuccess() {
+		t.Fatalf("recorded success was overwritten: %s", task.GetResult().GetFailError())
 	}
 }

--- a/forge/task/tx/tx-complete_test.go
+++ b/forge/task/tx/tx-complete_test.go
@@ -1,0 +1,116 @@
+package task_tx_test
+
+import (
+	"errors"
+	"testing"
+
+	timestamp "github.com/aperturerobotics/protobuf-go-lite/types/known/timestamppb"
+	"github.com/s4wave/spacewave/db/block"
+	"github.com/s4wave/spacewave/db/world"
+	world_testbed "github.com/s4wave/spacewave/db/world/testbed"
+	forge_pass "github.com/s4wave/spacewave/forge/pass"
+	forge_target "github.com/s4wave/spacewave/forge/target"
+	forge_task "github.com/s4wave/spacewave/forge/task"
+	task_tx "github.com/s4wave/spacewave/forge/task/tx"
+	forge_value "github.com/s4wave/spacewave/forge/value"
+)
+
+func TestTxCompleteConvertsFailedPassToFailedTask(t *testing.T) {
+	ctx := t.Context()
+	tb, err := world_testbed.Default(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(tb.Release)
+
+	sender := tb.Volume.GetPeerID()
+	target := &forge_target.Target{Exec: &forge_target.Exec{Disable: true}}
+	taskKey := "test/task/complete-failed-pass"
+	passKey := forge_task.NewPassKey(taskKey, 1)
+	ts := timestamp.Now()
+	if _, _, err := forge_task.CreateTaskWithTarget(
+		ctx,
+		tb.WorldState,
+		sender,
+		taskKey,
+		"complete-failed-pass",
+		target,
+		"",
+		1,
+		ts,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := forge_pass.CreatePassWithTarget(
+		ctx,
+		tb.WorldState,
+		sender,
+		passKey,
+		forge_target.NewValueSet(),
+		target.CloneVT(),
+		1,
+		1,
+		"",
+		ts,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := tb.WorldState.SetGraphQuad(
+		ctx,
+		forge_task.NewTaskToPassQuad(taskKey, passKey, 1),
+	); err != nil {
+		t.Fatal(err)
+	}
+	targetUpdate := task_tx.NewTxUpdateInputs(taskKey)
+	targetUpdate.TxUpdateInputs.UpdateTarget = true
+	targetUpdate.TxUpdateInputs.ResetInputs = true
+	if _, _, err := tb.WorldState.ApplyWorldOp(ctx, targetUpdate, sender); err != nil {
+		t.Fatalf("update task target: %v", err)
+	}
+	if _, _, err := world.AccessWorldObject(ctx, tb.WorldState, taskKey, true, func(bcs *block.Cursor) error {
+		task, err := forge_task.UnmarshalTask(ctx, bcs)
+		if err != nil {
+			return err
+		}
+		task.TaskState = forge_task.State_TaskState_CHECKING
+		task.PassNonce = 1
+		bcs.SetBlock(task, true)
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := world.AccessWorldObject(ctx, tb.WorldState, passKey, true, func(bcs *block.Cursor) error {
+		pass, err := forge_pass.UnmarshalPass(ctx, bcs)
+		if err != nil {
+			return err
+		}
+		pass.PassState = forge_pass.State_PassState_COMPLETE
+		pass.Result = forge_value.NewResultWithError(errors.New("pass failed"))
+		bcs.SetBlock(pass, true)
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, err := tb.WorldState.ApplyWorldOp(
+		ctx,
+		task_tx.NewTxComplete(taskKey, forge_value.NewResultWithSuccess()),
+		sender,
+	); err != nil {
+		t.Fatalf("complete task: %v", err)
+	}
+
+	task, _, err := forge_task.LookupTask(ctx, tb.WorldState, taskKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if task.GetTaskState() != forge_task.State_TaskState_COMPLETE {
+		t.Fatalf("task state = %s, want COMPLETE", task.GetTaskState())
+	}
+	if task.GetResult().GetSuccess() {
+		t.Fatal("failed pass was recorded as successful task completion")
+	}
+	if task.GetResult().GetFailError() == "" {
+		t.Fatal("failed pass completion did not preserve a failure error")
+	}
+}


### PR DESCRIPTION
Forge Task CHECKING processing previously read the linked Pass in the browser controller before applying completion. On the browser World, that lookup adopts a returned object resource and can block at ResourceRefAdopt, leaving every Task stranded in CHECKING. The controller now submits one COMPLETE world operation immediately; the Task transaction owns Pass validation, output recomputation, and failed-pass completion. The Task watch loop remains the wake owner.\n\nFocused checks passed: go test ./forge/task/controller ./forge/task/tx -count=1, go build ./forge/..., go vet ./forge/..., and gofmt -l forge returned empty. The browser web end-to-end suite was not run locally.