### PR TITLE
fix(web): start the runtime when the service worker takes control

### DIFF
--- a/bldr/web/bldr/web-document.test.ts
+++ b/bldr/web/bldr/web-document.test.ts
@@ -64,7 +64,12 @@ type TestWebDocument = {
   webDocumentUuid: string
   onWebWorkerMessage(workerID: string, event: MessageEvent): void
   onWebDocumentClientMessage(event: MessageEvent): void
-  initServiceWorker(wb: TestWorkbox, swUrl: string): Promise<void>
+  initServiceWorker(
+    wb: TestWorkbox,
+    swUrl: string,
+    onControlReady?: () => void,
+  ): Promise<void>
+  startRuntimeOnce?: () => void
   onRuntimeOpfsBrokerMessage(brokerPort: MessagePort, event: MessageEvent): void
   refreshPluginSingletonLock(): void
   releasePluginSingletonLock(): void
@@ -513,6 +518,56 @@ describe('WebDocument service worker startup', () => {
 
     await doc.initServiceWorker(wb, '/sw.mjs')
     expect(storage.getItem('bldr-sw-controller-reload')).toBeNull()
+  })
+
+  it('starts the runtime from controllerchange when the awaited path returned early', async () => {
+    const controllerChangeListeners: Array<(ev: Event) => void> = []
+    installSessionStorage({ 'bldr-sw-controller-reload': '/sw.mjs' })
+    vi.stubGlobal('location', {
+      href: 'https://example.test/app',
+      reload: vi.fn(),
+    })
+    const sw = { postMessage: vi.fn() } as unknown as ServiceWorker
+    const serviceWorker = {
+      controller: null as ServiceWorker | null,
+      addEventListener: vi.fn((type: string, listener: EventListener) => {
+        if (type === 'controllerchange') {
+          controllerChangeListeners.push(listener as (ev: Event) => void)
+        }
+      }),
+      register: vi.fn(),
+    }
+    vi.stubGlobal('navigator', { serviceWorker })
+
+    const doc = buildTestWebDocument()
+    const startRuntimeOnce = vi.fn()
+    doc.startRuntimeOnce = startRuntimeOnce
+    vi.spyOn(
+      doc as unknown as { initServiceWorkerPort: (sw: ServiceWorker) => void },
+      'initServiceWorkerPort',
+    ).mockImplementation(() => {})
+    const onControlReady = vi.fn()
+    const wb: TestWorkbox = {
+      register: vi
+        .fn()
+        .mockResolvedValue({
+          scope: 'https://example.test/',
+        } as ServiceWorkerRegistration),
+      update: vi.fn().mockResolvedValue(undefined),
+      controlling: new Promise<ServiceWorker>(() => {}),
+    }
+
+    // The controller is already missing after a reload, so this returns before
+    // reaching onControlReady and nothing on the awaited path will ever start
+    // the runtime.
+    await doc.initServiceWorker(wb, '/sw.mjs', onControlReady)
+    expect(onControlReady).not.toHaveBeenCalled()
+    expect(startRuntimeOnce).not.toHaveBeenCalled()
+
+    serviceWorker.controller = sw
+    controllerChangeListeners[0](new Event('controllerchange'))
+
+    expect(startRuntimeOnce).toHaveBeenCalledOnce()
   })
 })
 

--- a/bldr/web/bldr/web-document.ts
+++ b/bldr/web/bldr/web-document.ts
@@ -735,6 +735,11 @@ export class WebDocument extends SimpleEventEmitter<WebDocumentEvents> {
   private forceDedicatedWorkers?: boolean
   // dedicatedRuntimeHost owns the temporary DedicatedWorker host election.
   private dedicatedRuntimeHost?: DedicatedWorkerHostOwner
+  // startRuntimeOnce starts the runtime worker and its connection the first
+  // time it is called. The runtime start waits for ServiceWorker control, and
+  // control arrives by several routes, so every route that observes control
+  // calls this rather than starting the runtime itself.
+  private startRuntimeOnce?: () => void
   // forceMessagePortWorkerComms forces MessagePort-only worker communication.
   private forceMessagePortWorkerComms?: boolean
   // webRuntimePort is the Port connected to the WebRuntime (Shared Worker or Electron Main).
@@ -1252,37 +1257,39 @@ export class WebDocument extends SimpleEventEmitter<WebDocumentEvents> {
     const wb = new Workbox(swUrl) // Not supported in Firefox: {type: 'module'}
     this.serviceWorker = wb
 
-    if (useDedicatedRuntime) {
-      void this.initServiceWorker(wb, swUrl, () => {
-        queueMicrotask(startDedicatedRuntime)
-      })
-    } else {
-      // Shared-worker mode: the shared worker imports /b/* runtime and plugin
-      // bundle paths, which only resolve once the ServiceWorker is controlling
-      // this page. Starting the worker before control means those imports hit the
-      // origin, which serves the SPA index.html for unmatched paths, so the
-      // module loads fail and the runtime never comes up. Gate
-      // the start on SW control like the dedicated branch, with a bounded fallback
-      // so a browser whose SW never reaches controlling state still loads
-      // (degraded) instead of hanging forever.
-      let runtimeStarted = false
-      const startRuntimeOnce = () => {
-        if (runtimeStarted || this.closed) {
-          return
-        }
-        runtimeStarted = true
-        startWebRuntimeWorker()
-        this.startWebRuntimeConnection()
+    // Both runtime modes import /b/* runtime and plugin bundle paths, which
+    // only resolve once the ServiceWorker is controlling this page. Starting a
+    // worker before control means those imports hit the origin, which serves
+    // the SPA index.html for unmatched paths, so the module loads fail and the
+    // runtime never comes up. So both modes gate the start on SW control, and
+    // neither may gate on it forever: a document that never starts a runtime
+    // has nothing left scheduled to start one, and the boot parks silently for
+    // as long as the tab stays open. The bounded fallback starts the runtime
+    // anyway, degraded, rather than hanging.
+    let runtimeStarted = false
+    const startRuntimeOnce = () => {
+      if (runtimeStarted || this.closed) {
+        return
       }
-      const controlFallback = globalThis.setTimeout(
-        startRuntimeOnce,
-        sharedWorkerControlFallbackMs,
-      )
-      void this.initServiceWorker(wb, swUrl, () => {
-        globalThis.clearTimeout(controlFallback)
-        startRuntimeOnce()
-      })
+      runtimeStarted = true
+      if (useDedicatedRuntime) {
+        // The dedicated host election reads the ServiceWorker tracker, so let
+        // the caller finish binding its port before the election starts.
+        queueMicrotask(startDedicatedRuntime)
+        return
+      }
+      startWebRuntimeWorker()
+      this.startWebRuntimeConnection()
     }
+    this.startRuntimeOnce = startRuntimeOnce
+    const controlFallback = globalThis.setTimeout(
+      startRuntimeOnce,
+      sharedWorkerControlFallbackMs,
+    )
+    void this.initServiceWorker(wb, swUrl, () => {
+      globalThis.clearTimeout(controlFallback)
+      startRuntimeOnce()
+    })
   }
 
   // openWebDocumentHostStream opens an RPC stream with the WebDocumentHost.
@@ -1762,6 +1769,9 @@ export class WebDocument extends SimpleEventEmitter<WebDocumentEvents> {
       const currSw = navigator.serviceWorker.controller || sw
       // the service worker wants a new message port for requests
       this.initServiceWorkerPort(currSw)
+      // A service worker talking to this document is proof that one controls
+      // it, which is the condition the runtime start is waiting for.
+      this.startRuntimeOnce?.()
       if (!this.runtimeConnected) {
         this.taskEnsureWebRuntimeConn()
       }
@@ -1786,6 +1796,11 @@ export class WebDocument extends SimpleEventEmitter<WebDocumentEvents> {
       // the still-live host without waiting for a failed connection to solicit
       // another registration.
       this.initServiceWorkerPort(controller)
+      // controllerchange is the event form of the condition the runtime start
+      // gate waits for. The awaited path below can return early or never
+      // settle, so this route must start the runtime rather than only rebind
+      // the port to it.
+      this.startRuntimeOnce?.()
       if (!this.runtimeConnected) {
         this.taskEnsureWebRuntimeConn()
       }


### PR DESCRIPTION
Opening a second tab of the app in Chrome could park forever on "Connecting the service worker bridge". The tab never started its runtime, and only a manual reload rescued it.

The browser runtime cannot start before a service worker controls the page, because the runtime worker imports /b/* bundle paths that only the service worker serves. Both runtime modes gate the runtime start on control for that reason, but only shared worker mode bounded the wait. Dedicated worker mode, which every Chromium document uses today, waited on the awaited registration path alone. That path has two early returns and four awaits that can fail to settle, and a document that leaves it without starting a runtime has nothing left scheduled to start one. A second tab arriving while a service worker generation is being replaced lands in exactly that window: its controllerchange listener still fires and binds the service worker port, which is why the boot bar reaches the bridge stage and stops there rather than reporting an error.

Both modes now share one start closure behind a single guard, both keep the bounded fallback, and the controllerchange listener starts the runtime as well as rebinding the port. controllerchange is the event form of the condition the gate is waiting for, and that listener was already bound, so it is the route that still observes control after the awaited path has returned. A document that never reaches control starts degraded at the end of the existing fallback window instead of parking silently.

Verified with a regression case that drives the early return and then fires controllerchange; it fails without the listener change and passes with it.
