### PR TITLE
test(sharingstate): assert coalescing convergence instead of an emission count

### DIFF
--- a/core/resource/space/sharingstate/state_test.go
+++ b/core/resource/space/sharingstate/state_test.go
@@ -3,6 +3,7 @@ package sharingstate
 import (
 	"context"
 	"slices"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -267,14 +268,17 @@ func TestCoalescingEndToEnd(t *testing.T) {
 		emissions   []*SharingState
 	)
 	released := make(chan struct{})
-	emitted := make(chan struct{}, 16)
+	emitted := make(chan struct{}, 1)
 
 	send := func(s *SharingState) error {
 		emissionsMu.Lock()
 		idx := len(emissions)
 		emissions = append(emissions, s)
 		emissionsMu.Unlock()
-		emitted <- struct{}{}
+		select {
+		case emitted <- struct{}{}:
+		default:
+		}
 		if idx == 0 {
 			<-released
 		}
@@ -292,64 +296,57 @@ func TestCoalescingEndToEnd(t *testing.T) {
 
 	<-emitted
 
-	for i := 2; i <= 4; i++ {
-		next := &sobject.SOState{
+	// Write many revisions while the first send is still blocked. Coalescing
+	// promises the loop skips intermediate values, so emissions stay far below
+	// the write count however the writer, the bridge, and the loop interleave.
+	const writes = 200
+	for i := 2; i <= writes+1; i++ {
+		ctr.SetValue(&sobject.SOState{
 			Config: &sobject.SharedObjectConfig{
 				Participants: append(slices.Clone(initialParticipants),
 					&sobject.SOParticipantConfig{
-						PeerId: "peer-" + string(rune('0'+i)),
+						PeerId: "peer-" + strconv.Itoa(i),
 						Role:   sobject.SOParticipantRole_SOParticipantRole_WRITER,
 					},
 				),
 			},
-		}
-		ctr.SetValue(next)
+		})
 	}
+	finalPeer := "peer-" + strconv.Itoa(writes+1)
 
 	close(released)
-	<-emitted
 
-	drainTimer := time.NewTimer(50 * time.Millisecond)
-	defer drainTimer.Stop()
-	var extras int
-drain:
+	converged := time.NewTimer(5 * time.Second)
+	defer converged.Stop()
+	var last *SharingState
 	for {
+		emissionsMu.Lock()
+		if n := len(emissions); n != 0 {
+			last = emissions[n-1]
+		}
+		emissionsMu.Unlock()
+		if last != nil && len(last.Participants) == 2 &&
+			last.Participants[1].GetPeerId() == finalPeer {
+			break
+		}
 		select {
 		case <-emitted:
-			extras++
-			if !drainTimer.Stop() {
-				select {
-				case <-drainTimer.C:
-				default:
-				}
-			}
-			drainTimer.Reset(50 * time.Millisecond)
-		case <-drainTimer.C:
-			break drain
+		case <-converged.C:
+			t.Fatalf("watch loop never converged on %s, last emission was %+v", finalPeer, last)
 		}
 	}
 
 	cancel()
 	<-loopErr
 
-	if extras != 0 {
-		t.Fatalf("expected 0 extra emissions after the coalesced follow-on, got %d", extras)
+	if !last.CanManage {
+		t.Fatal("converged emission lost owner role classification")
 	}
 
 	emissionsMu.Lock()
-	defer emissionsMu.Unlock()
-
-	if got := len(emissions); got != 2 {
-		t.Fatalf("expected 2 emissions (initial + coalesced follow-on), got %d", got)
-	}
-	last := emissions[1]
-	if got := len(last.Participants); got != 2 {
-		t.Fatalf("coalesced follow-on missing latest mutation: got %d participants, want 2", got)
-	}
-	if got := last.Participants[1].GetPeerId(); got != "peer-4" {
-		t.Fatalf("coalesced follow-on did not reflect latest mutation: got %s, want peer-4", got)
-	}
-	if !last.CanManage {
-		t.Fatal("coalesced follow-on lost owner role classification")
+	total := len(emissions)
+	emissionsMu.Unlock()
+	if total > writes/4 {
+		t.Fatalf("watch loop did not coalesce: %d emissions for %d writes during one blocked send", total, writes)
 	}
 }


### PR DESCRIPTION
TestCoalescingEndToEnd has been failing intermittently on CI (alpha). It writes three revisions into the shared object container while the first send is blocked, then asserts that exactly one follow-on emission arrives and that nothing else shows up within a fifty millisecond drain window. Both halves are bets on goroutine wake order: the container writes reach the watch loop through the bridge goroutine, so the loop can observe an intermediate revision, emit it, and emit again once the bridge catches up. On master the test passes five of five at -count=1 and fails at -count=10.

Coalescing promises that intermediate values may be dropped and that the consumer converges on the latest one. It promises nothing about how many emissions a particular interleaving produces, which is exactly what the old assertion measured. This rewrites the test against the promise: two hundred revisions during the blocked send, wait until an emission carries the final revision, then assert that emission's contents and that the total emission count stayed far below the write count. Convergence is now established by causation rather than by a drain window, and the count bound is wide enough that scheduling cannot move it while still failing loudly if a blocked consumer starts accumulating a per-write backlog.

The two sibling tests in the file keep their exact counts, since they drive writes through State.SetSOState, which is synchronous with the broadcast, so their interleaving is determined rather than raced.

Verified with 30 consecutive runs of the package and 5 more under the race detector, all green.
