### PR TITLE
fix(db/coord): release a write lease even when the context is canceled

### DIFF
--- a/db/coord/conformance/conformance.go
+++ b/db/coord/conformance/conformance.go
@@ -23,6 +23,9 @@ func Check(t *testing.T, factory Factory) {
 	t.Run("lease wait and release", func(t *testing.T) {
 		checkLeaseWaitAndRelease(t, factory)
 	})
+	t.Run("release with canceled context", func(t *testing.T) {
+		checkReleaseWithCanceledContext(t, factory)
+	})
 	t.Run("unsupported fallback", func(t *testing.T) {
 		checkUnsupportedFallback(t)
 	})
@@ -163,6 +166,52 @@ func checkLeaseWaitAndRelease(t *testing.T, factory Factory) {
 	}
 	if _, err := leaseA.Refresh(ctx); !errors.Is(err, coord.ErrLeaseReleased) {
 		t.Fatalf("released lease Refresh() error = %v, want ErrLeaseReleased", err)
+	}
+}
+
+// checkReleaseWithCanceledContext proves a lease cannot be stranded by
+// cancellation. Cleanup paths release with the same context that was just
+// canceled, so a Release that returned early there would leave the scope locked
+// forever and hang every later writer.
+func checkReleaseWithCanceledContext(t *testing.T, factory Factory) {
+	t.Helper()
+
+	ctx := context.Background()
+	firstC, secondC := factory(t)
+	first := coord.Scope{
+		VolumeID:      "volume-a",
+		ObjectStoreID: "objects",
+		ParticipantID: "first",
+	}
+	second := coord.Scope{
+		VolumeID:      "volume-a",
+		ObjectStoreID: "objects",
+		ParticipantID: "second",
+	}
+
+	leaseA, ok, err := firstC.TryAcquireWriteLease(ctx, first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("first lease unexpectedly busy")
+	}
+
+	canceled, cancel := context.WithCancel(ctx)
+	cancel()
+	if err := leaseA.Release(canceled); err != nil {
+		t.Fatalf("Release() with canceled context error = %v", err)
+	}
+
+	leaseB, ok, err := secondC.TryAcquireWriteLease(ctx, second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("lease still held after release with a canceled context")
+	}
+	if err := leaseB.Release(ctx); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/db/coord/coordinator.go
+++ b/db/coord/coordinator.go
@@ -24,6 +24,11 @@ type WriteLease interface {
 	// Publish records an accepted generation/root/prefix change.
 	Publish(ctx context.Context, event Event) (*Snapshot, error)
 	// Release releases the logical write lease.
+	//
+	// Release must complete regardless of ctx cancellation. Callers release on
+	// cleanup paths that run precisely because their context ended, so a
+	// release that honored cancellation would strand the scope locked and
+	// every waiter blocked. ctx carries deadlines for backend I/O only.
 	Release(ctx context.Context) error
 }
 

--- a/db/coord/inmem/lease.go
+++ b/db/coord/inmem/lease.go
@@ -54,11 +54,10 @@ func (l *lease) Publish(ctx context.Context, event coord.Event) (*coord.Snapshot
 	return l.state.snapshot(l.scope), nil
 }
 
-func (l *lease) Release(ctx context.Context) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-
+// Release drops the lease and wakes waiters. It ignores its context: the
+// cleanup path that releases after a canceled write is the one that most needs
+// the scope unlocked.
+func (l *lease) Release(context.Context) error {
 	l.c.mu.Lock()
 	defer l.c.mu.Unlock()
 


### PR DESCRIPTION
A write lease could be stranded forever by cancellation. The in-memory coordinator's Release returned ctx.Err() before touching any state, so releasing with an already-canceled context left the scope locked and never broadcast on the wait condition. That is the worst possible moment for an early return: cleanup paths release precisely because the caller's context just ended. The world block engine commits through commitLease.Release(ctx) with the caller's context, so a single canceled commit locked the volume's write lease permanently. Later writers then blocked in WaitAcquireWriteLease with no timeout, and every reader waiting on the seqno that writer would have produced blocked behind them.

The bolt and opfs lease wrappers already passed context.Background() to the inner lease, which is the contract the implementations were meant to follow. This states that contract on coord.WriteLease rather than leaving each caller to work around it, and drops the early return from the in-memory lease. Releasing is not cancellable work: it hands a resource back, and skipping it can only lose the resource. Behavior change is confined to the canceled-context case, which previously leaked; an uncanceled release is unaffected.

The shared conformance suite gains a case that releases with a canceled context and then asserts the scope is acquirable again through TryAcquireWriteLease, a deterministic boolean rather than a timed acquire. It runs against the in-memory and kvtx volume coordinators and fails on both without the fix. db/coord, db/world/block, db/world/block/engine, db/world/block/tx, and db/volume/common/kvtx are green with it.