### PR TITLE
revert(bldr/goscript): drop the emitted chunk size cap

### DIFF
--- a/bldr/web/runtime/goscript/build/build.go
+++ b/bldr/web/runtime/goscript/build/build.go
@@ -29,19 +29,6 @@ const (
 	GoScriptSharedWebPkgID       = "@s4wave/goscript-shared"
 	goScriptBundleReportFilename = "plugin-goscript-bundle-report.json"
 	rolldownCLIRelPath           = "node_modules/rolldown/dist/cli.mjs"
-
-	// goScriptChunkMaxSizeBytes caps the size of a single emitted chunk. Oxc
-	// minifies chunks in parallel, so bundle wall time tracks the largest chunk
-	// rather than the total: an uncapped spacewave-core build emitted one 31MB
-	// chunk and minified it on a single core. Splitting also costs gzip ratio,
-	// because each chunk compresses against its own window.
-	//
-	// Measured on spacewave-core (5231 modules, 45MB minified output), the cap
-	// stops paying below 4MB: 1MB, 2MB, and 4MB all bottom out at a 2.5MB
-	// largest chunk and ~2.0s, while gzip overhead climbs from 2.3% to 7.0% as
-	// chunk count grows from 67 to 245. Above 4MB the largest chunk grows again
-	// and wall time follows it.
-	goScriptChunkMaxSizeBytes = 4_000_000
 )
 
 // GoScriptSharedImportMap maps a local @goscript import to the provider URL
@@ -889,12 +876,10 @@ func renderRolldownGoScriptOutputConfig(codeSplitting bool) string {
           name: "shared",
           test: (id) => isGoScriptModule(id, "") && !isGoScriptModule(id, "github.com/s4wave/"),
           priority: 1,
-          maxSize: ` + strconv.Itoa(goScriptChunkMaxSizeBytes) + `,
         },
         {
           name: "app",
           test: (id) => isGoScriptModule(id, "github.com/s4wave/"),
-          maxSize: ` + strconv.Itoa(goScriptChunkMaxSizeBytes) + `,
         },
       ],
     },

--- a/bldr/web/runtime/goscript/build/build_test.go
+++ b/bldr/web/runtime/goscript/build/build_test.go
@@ -857,12 +857,6 @@ func TestRenderRolldownGoScriptConfigCodeSplittingWritesManualGroups(t *testing.
 	if !strings.Contains(config, `name:"app",test:(id)=>isGoScriptModule(id,"github.com/s4wave/")`) {
 		t.Fatalf("rendered config missing app GoScript group:\n%s", config)
 	}
-	// Both groups must carry the chunk cap. Without it Oxc minifies one
-	// oversized chunk on a single core and the bundle step serializes.
-	maxSizeClause := "maxSize:" + strconv.Itoa(goScriptChunkMaxSizeBytes)
-	if got := strings.Count(config, maxSizeClause); got != 2 {
-		t.Fatalf("rendered config must cap both GoScript groups with %s, found %d:\n%s", maxSizeClause, got, config)
-	}
 }
 
 func TestRenderRolldownGoScriptConfigCodeSplittingFalseKeepsSingleFileOutput(t *testing.T) {


### PR DESCRIPTION
Master cannot start a GoScript browser plugin. Capping both rolldown groups at 4MB in d2deba295 split the shared runtime group across several chunks, and every plugin now dies at load with "ReferenceError: Cannot access 'w' before initialization" thrown from a static initializer inside a shared-*.mjs chunk. The launcher and core plugins exit before startup completes. All ten E2E (wasm) jobs pass on the parent commit a03227373 and fail on d2deba295, so the attribution is not in doubt.

The reverted change assumed chunk boundaries cannot affect load order. They can. GoScript emits package-level static initializers, those packages reference each other cyclically, and a cycle that resolves fine inside one chunk becomes a temporal dead zone read once its two halves land in separate chunks and the bundler has to choose an evaluation order between them.

This restores the single-chunk grouping so the runtime starts again, at the cost of returning the spacewave-core bundle step to roughly 22 seconds. The perf work is worth relanding, but only with a split that respects initialization order: the cap can apply to a group whose modules have no cross-module initializer cycle, and the reland needs a wasm e2e run as its proof rather than a bundle-time measurement.