### PR TITLE
fix(db/world/control): release the watched object handle each iteration

### DIFF
--- a/core/provider/spacewave/friend-dm-owner.go
+++ b/core/provider/spacewave/friend-dm-owner.go
@@ -467,17 +467,19 @@ func ensureFriendDmChannel(
 		return errors.Wrap(waitErr, "create friend dm channel")
 	}
 
-	if _, err := world_control.WaitForObjectRev(
+	projected, err := world_control.WaitForObjectRev(
 		ctx,
 		le,
 		ws,
 		FriendDmChannelObjectKey,
 		0,
-	); err != nil {
+	)
+	if err != nil {
 		if waitErr != nil {
 			return errors.Wrap(waitErr, "wait for friend dm channel projection")
 		}
 		return errors.Wrap(err, "wait for friend dm channel projection")
 	}
+	world.ReleaseObjectState(projected)
 	return nil
 }

--- a/db/world/control/handler.go
+++ b/db/world/control/handler.go
@@ -43,6 +43,11 @@ func NewWaitForStateHandler(
 
 // WaitForObjectRev waits for the object to exist equal at or greater than the given rev.
 // If rev=0, waits for the object to exist at any rev.
+//
+// The returned object state is the caller's to own: release it with
+// world.ReleaseObjectState. The handle the watch loop hands its handler lives
+// for one iteration only, so this acquires a fresh one after the loop ends
+// rather than keeping the handler's.
 func WaitForObjectRev(
 	ctx context.Context,
 	le *logrus.Entry,
@@ -50,7 +55,7 @@ func WaitForObjectRev(
 	objKey string,
 	rev uint64,
 ) (world.ObjectState, error) {
-	var out world.ObjectState
+	var reached bool
 	lp := NewWatchLoop(
 		le,
 		objKey,
@@ -58,13 +63,22 @@ func WaitForObjectRev(
 			if obj == nil || crev < rev {
 				return true, nil
 			}
-			out = obj
+			reached = true
 			return false, nil
 		}),
 	)
-	err := lp.Execute(ctx, ws)
+	if err := lp.Execute(ctx, ws); err != nil {
+		return nil, err
+	}
+	if !reached {
+		return nil, nil
+	}
+	out, found, err := ws.GetObject(ctx, objKey)
 	if err != nil {
 		return nil, err
+	}
+	if !found {
+		return nil, nil
 	}
 	return out, nil
 }

--- a/db/world/control/watch-loop.go
+++ b/db/world/control/watch-loop.go
@@ -39,6 +39,11 @@ type watchLoopWaiter struct {
 }
 
 // WatchLoopHandler is the callback function for the WatchLoop.
+//
+// obj is borrowed for the duration of the call: the loop releases it before the
+// next iteration. A handler that needs the object state afterwards acquires its
+// own handle with world.WorldState.GetObject.
+//
 // le may be nil
 type WatchLoopHandler = func(
 	ctx context.Context,

--- a/db/world/control/watch-loop.go
+++ b/db/world/control/watch-loop.go
@@ -142,85 +142,101 @@ func (c *WatchLoop) Execute(ctx context.Context, ws world.WorldState) error {
 	}
 
 	for {
-		var rootRef *bucket.ObjectRef
-		var rev uint64
-
-		if ctx.Err() != nil {
-			return context.Canceled
-		}
-
-		seqno, err := ws.GetSeqno(ctx)
-		if err != nil {
-			return err
-		}
-
-		var objState world.ObjectState
-		var objFound bool
-		if c.objectKey != "" {
-			var err error
-			objState, objFound, err = ws.GetObject(ctx, c.objectKey)
-			if err != nil {
-				return err
-			}
-		}
-		if objFound {
-			rootRef, rev, err = objState.GetRootRef(ctx)
-			if err != nil {
-				return err
-			}
-			if c.le != nil {
-				c.le.
-					WithField("object-key", c.objectKey).
-					Debugf("object found at rev %d", rev)
-			}
-		} else {
-			objState = nil
-		}
-
-		waitForChanges, err := c.handler(
-			ctx, c.le,
-			ws, objState,
-			rootRef, rev,
-		)
-		if errors.Is(err, world.ErrUnhandledOp) {
-			if c.le != nil {
-				c.le.Debug("handler skipped unhandled operation")
-			}
-			waitForChanges = true
-			err = nil
-		} else if err != nil && c.le != nil &&
-			(ctx.Err() == nil || !errors.Is(err, context.Canceled)) {
-			le := c.le.WithError(err)
-			if c.objectKey != "" {
-				le = le.WithField("object-key", c.objectKey)
-			}
-			le.
-				WithField("world-seqno", seqno).
-				WithField("wait-for-changes", waitForChanges).
-				Warn("handler returned error")
-		}
-		if !waitForChanges {
-			return err
-		}
-
-		wakeCtx, finishWake, skipWait := c.wake.beginWait(ctx)
-		if skipWait {
-			continue
-		}
-
-		if objState != nil {
-			_, err = objState.WaitRev(wakeCtx, rev+1, !objFound)
-			if err == world.ErrObjectNotFound && objFound {
-				// ignore ErrObjectNotFound if we previously found the object
-				// allow the handler to be notified of the deletion
-				err = nil
-			}
-		} else {
-			_, err = ws.WaitSeqno(wakeCtx, seqno+1)
-		}
-		finishWake()
-		if err != nil && err != context.Canceled {
+		done, err := c.executeOnce(ctx, ws)
+		if done {
 			return err
 		}
 	}
+}
+
+// executeOnce runs one iteration: it reads the watched object, calls the
+// handler, then waits for the next revision. done reports that the loop is
+// finished and Execute should return err.
+//
+// The object-state handle lives for exactly one iteration. A remote world state
+// allocates a server-side resource per GetObject, so a loop that watches a
+// long-running object would otherwise accumulate one handle per revision for as
+// long as it runs.
+func (c *WatchLoop) executeOnce(ctx context.Context, ws world.WorldState) (bool, error) {
+	var rootRef *bucket.ObjectRef
+	var rev uint64
+
+	if ctx.Err() != nil {
+		return true, context.Canceled
+	}
+
+	seqno, err := ws.GetSeqno(ctx)
+	if err != nil {
+		return true, err
+	}
+
+	var objState world.ObjectState
+	var objFound bool
+	if c.objectKey != "" {
+		objState, objFound, err = ws.GetObject(ctx, c.objectKey)
+		if err != nil {
+			return true, err
+		}
+		defer world.ReleaseObjectState(objState)
+	}
+	if objFound {
+		rootRef, rev, err = objState.GetRootRef(ctx)
+		if err != nil {
+			return true, err
+		}
+		if c.le != nil {
+			c.le.
+				WithField("object-key", c.objectKey).
+				Debugf("object found at rev %d", rev)
+		}
+	} else {
+		objState = nil
+	}
+
+	waitForChanges, err := c.handler(
+		ctx, c.le,
+		ws, objState,
+		rootRef, rev,
+	)
+	if errors.Is(err, world.ErrUnhandledOp) {
+		if c.le != nil {
+			c.le.Debug("handler skipped unhandled operation")
+		}
+		waitForChanges = true
+		err = nil
+	} else if err != nil && c.le != nil &&
+		(ctx.Err() == nil || !errors.Is(err, context.Canceled)) {
+		le := c.le.WithError(err)
+		if c.objectKey != "" {
+			le = le.WithField("object-key", c.objectKey)
+		}
+		le.
+			WithField("world-seqno", seqno).
+			WithField("wait-for-changes", waitForChanges).
+			Warn("handler returned error")
+	}
+	if !waitForChanges {
+		return true, err
+	}
+
+	wakeCtx, finishWake, skipWait := c.wake.beginWait(ctx)
+	if skipWait {
+		return false, nil
+	}
+
+	if objState != nil {
+		_, err = objState.WaitRev(wakeCtx, rev+1, !objFound)
+		if err == world.ErrObjectNotFound && objFound {
+			// ignore ErrObjectNotFound if we previously found the object
+			// allow the handler to be notified of the deletion
+			err = nil
+		}
+	} else {
+		_, err = ws.WaitSeqno(wakeCtx, seqno+1)
+	}
+	finishWake()
+	if err != nil && err != context.Canceled {
+		return true, err
+	}
+	return false, nil
 }

--- a/db/world/control/watch-loop_test.go
+++ b/db/world/control/watch-loop_test.go
@@ -65,6 +65,7 @@ func TestWatchLoop(t *testing.T) {
 		if outRev != 2 {
 			t.Fatalf("expected rev: %v but got %v", 2, outRev)
 		}
+		world.ReleaseObjectState(res)
 	}
 
 	revCh := make(chan uint64, 10)
@@ -475,6 +476,7 @@ func TestWatchLoopReleasesObjectStatePerIteration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err.Error())
 	}
+	defer world.ReleaseObjectState(obj)
 
 	ws := &countingWorldState{WorldState: remote}
 	revs := make(chan uint64, 8)

--- a/db/world/control/watch-loop_test.go
+++ b/db/world/control/watch-loop_test.go
@@ -3,6 +3,7 @@ package world_control_test
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -458,4 +459,103 @@ func recvWatchLoopValue[T any](t *testing.T, ch <-chan T, name string) T {
 	}
 	var zero T
 	return zero
+}
+
+// TestWatchLoopReleasesObjectStatePerIteration proves the loop hands back every
+// object handle it takes. A remote world state allocates a server-side resource
+// per GetObject, so a loop that watched a busy object for minutes used to leave
+// one tracked handle behind per revision.
+func TestWatchLoopReleasesObjectStatePerIteration(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	remote := setupRemoteWorldState(ctx, t)
+	objKey := "release-object"
+	obj, err := remote.CreateObject(ctx, objKey, nil)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	ws := &countingWorldState{WorldState: remote}
+	revs := make(chan uint64, 8)
+	loop := world_control.NewWatchLoop(
+		logrus.NewEntry(logrus.New()),
+		objKey,
+		world_control.NewWaitForStateHandler(func(
+			_ context.Context,
+			_ world.WorldState,
+			_ world.ObjectState,
+			_ *block.Cursor,
+			rev uint64,
+		) (bool, error) {
+			revs <- rev
+			return true, nil
+		}),
+	)
+	done := make(chan error, 1)
+	go func() {
+		done <- loop.Execute(ctx, ws)
+	}()
+
+	const revisions = 3
+	for i := 0; i <= revisions; i++ {
+		recvWatchLoopValue(t, revs, "handler call")
+		if outstanding := ws.outstanding.Load(); outstanding > 1 {
+			t.Fatalf("outstanding object handles = %d, want at most 1", outstanding)
+		}
+		if i == revisions {
+			break
+		}
+		if _, err := obj.IncrementRev(ctx); err != nil {
+			t.Fatal(err.Error())
+		}
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("watch loop did not exit")
+	}
+
+	if acquired := ws.acquired.Load(); acquired < revisions {
+		t.Fatalf("acquired object handles = %d, want at least %d", acquired, revisions)
+	}
+	if outstanding := ws.outstanding.Load(); outstanding != 0 {
+		t.Fatalf("outstanding object handles after exit = %d, want 0", outstanding)
+	}
+}
+
+// countingWorldState counts the object handles taken from a real world state
+// and the ones handed back.
+type countingWorldState struct {
+	world.WorldState
+
+	acquired    atomic.Int64
+	outstanding atomic.Int64
+}
+
+func (c *countingWorldState) GetObject(ctx context.Context, objKey string) (world.ObjectState, bool, error) {
+	obj, found, err := c.WorldState.GetObject(ctx, objKey)
+	if obj == nil {
+		return obj, found, err
+	}
+	c.acquired.Add(1)
+	c.outstanding.Add(1)
+	return &countingObjectState{ObjectState: obj, ws: c}, found, err
+}
+
+// countingObjectState reports its release to the owning countingWorldState.
+type countingObjectState struct {
+	world.ObjectState
+
+	ws       *countingWorldState
+	released atomic.Bool
+}
+
+func (c *countingObjectState) Release() {
+	if !c.released.Swap(true) {
+		c.ws.outstanding.Add(-1)
+	}
+	world.ReleaseObjectState(c.ObjectState)
 }


### PR DESCRIPTION
WatchLoop.Execute took an object handle from the world state on every iteration and never gave it back. Over an in-process world state that is free, but over an SDK-backed one each GetObject allocates a server-side resource that stays tracked until it is released, so a loop watching a single object through a long operation left one live handle behind per revision. The loops that watch the busiest objects are the ones that run longest, so the accumulation is worst exactly where it matters.

The iteration body moves into executeOnce, which gives the handle a scope and releases it there. The wait for the next revision still needs the handle, so the release lands after that wait rather than after the handler, and every exit path from an iteration now runs the same defer. Nothing changes for in-process callers: ReleaseObjectState is a no-op for a state that does not implement the release seam.

The regression test drives a real SDK-backed world state through several revisions and counts handles taken against handles returned. Without the fix it reports two outstanding handles at the second revision. db/world/... and core/resource/... are otherwise green; the one failure in core/resource/listener/control is a unix socket path length limit in the worktree directory, not related to this change.

This is the owner-level fix for the P2 raised on #350, which observed the leak from a Forge e2e observer that starts one watch loop per linked object.