### PR TITLE
chore(ci): cancel superseded CI runs per branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ on:
       - 'CHANGELOG.org'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
CI is the only workflow in this repository without a concurrency group. CodeQL, DCO, dependency review, licenses update and the nightly E2E suite all group by workflow and pull request or ref and cancel the run in progress. CI does not, so every push adds another full thirty-job run to the queue and no earlier run for the same branch ever steps aside.

That matters more than the wasted minutes. The concurrent job pool is finite and CI is by far the widest workflow here, so a few superseded runs take the whole pool. This morning five master merges inside fifteen minutes plus a stale pull request head left thirteen runs queued behind one, and the head of an open pull request sat forty-eight minutes without a single job starting. A check that never starts reports nothing, so the merge gate goes quiet exactly when the branch is busiest.

This groups CI the same way its siblings are grouped, so a new push to a branch cancels that branch's earlier run. Results for superseded commits are lost, which is the trade the rest of the repository already makes: only the current head gates a merge, and the current head now starts right away. Verification is the run on this pull request itself, which exercises the new group.