### PR TITLE
test(sharingstate): assert coalescing state provenance

### DIFF
--- a/core/resource/space/sharingstate/state_test.go
+++ b/core/resource/space/sharingstate/state_test.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"slices"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/aperturerobotics/util/ccontainer"
 	"github.com/s4wave/spacewave/core/sobject"
@@ -247,6 +247,34 @@ func TestBuildParticipantInfoFallsBackToAccountAndPeer(t *testing.T) {
 	}
 }
 
+type gatedWatchable struct {
+	ccontainer.Watchable[*sobject.SOState]
+	observed chan<- struct{}
+	release  <-chan struct{}
+}
+
+func (w *gatedWatchable) WaitValueChange(
+	ctx context.Context,
+	old *sobject.SOState,
+	errCh <-chan error,
+) (*sobject.SOState, error) {
+	next, err := w.Watchable.WaitValueChange(ctx, old, errCh)
+	if err != nil {
+		return next, err
+	}
+	select {
+	case w.observed <- struct{}{}:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	select {
+	case <-w.release:
+		return next, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
 func TestCoalescingEndToEnd(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
@@ -260,8 +288,21 @@ func TestCoalescingEndToEnd(t *testing.T) {
 		},
 	}
 
+	participantKey := func(participants []*sobject.SOParticipantConfig) string {
+		keys := make([]string, 0, len(participants))
+		for _, participant := range participants {
+			keys = append(keys,
+				participant.GetPeerId()+":"+strconv.Itoa(int(participant.GetRole()))+
+					":"+participant.GetEntityId(),
+			)
+		}
+		return strings.Join(keys, ",")
+	}
+
 	state := NewState(initialSO, nil, nil)
 	ctr := ccontainer.NewCContainer[*sobject.SOState](initialSO)
+	bridgeObserved := make(chan struct{}, 1)
+	bridgeRelease := make(chan struct{})
 
 	var (
 		emissionsMu sync.Mutex
@@ -269,39 +310,44 @@ func TestCoalescingEndToEnd(t *testing.T) {
 	)
 	released := make(chan struct{})
 	emitted := make(chan struct{}, 1)
+	finalPeer := "peer-4"
+	finalEmitted := make(chan struct{})
 
 	send := func(s *SharingState) error {
 		emissionsMu.Lock()
 		idx := len(emissions)
 		emissions = append(emissions, s)
 		emissionsMu.Unlock()
-		select {
-		case emitted <- struct{}{}:
-		default:
-		}
 		if idx == 0 {
+			emitted <- struct{}{}
 			<-released
+		}
+		if len(s.Participants) == 2 &&
+			s.Participants[1].GetPeerId() == finalPeer {
+			finalEmitted <- struct{}{}
 		}
 		return nil
 	}
 
 	bridgeCtx, cancelBridge := context.WithCancel(ctx)
 	defer cancelBridge()
-	go state.BridgeSOState(bridgeCtx, ctr)
+	go state.BridgeSOState(bridgeCtx, &gatedWatchable{
+		Watchable: ctr,
+		observed:  bridgeObserved,
+		release:   bridgeRelease,
+	})
 
 	loopErr := make(chan error, 1)
 	go func() {
 		loopErr <- state.RunWatchLoop(ctx, "peer-1", send)
 	}()
-
 	<-emitted
 
-	// Write many revisions while the first send is still blocked. Coalescing
-	// promises the loop skips intermediate values, so emissions stay far below
-	// the write count however the writer, the bridge, and the loop interleave.
-	const writes = 200
-	for i := 2; i <= writes+1; i++ {
-		ctr.SetValue(&sobject.SOState{
+	written := map[string]struct{}{
+		participantKey(initialParticipants): {},
+	}
+	for i := 2; i <= 4; i++ {
+		next := &sobject.SOState{
 			Config: &sobject.SharedObjectConfig{
 				Participants: append(slices.Clone(initialParticipants),
 					&sobject.SOParticipantConfig{
@@ -310,43 +356,40 @@ func TestCoalescingEndToEnd(t *testing.T) {
 					},
 				),
 			},
-		})
+		}
+		ctr.SetValue(next)
+		written[participantKey(next.GetConfig().GetParticipants())] = struct{}{}
+		if i == 2 {
+			<-bridgeObserved
+		}
 	}
-	finalPeer := "peer-" + strconv.Itoa(writes+1)
 
+	close(bridgeRelease)
 	close(released)
-
-	converged := time.NewTimer(5 * time.Second)
-	defer converged.Stop()
-	var last *SharingState
-	for {
-		emissionsMu.Lock()
-		if n := len(emissions); n != 0 {
-			last = emissions[n-1]
-		}
-		emissionsMu.Unlock()
-		if last != nil && len(last.Participants) == 2 &&
-			last.Participants[1].GetPeerId() == finalPeer {
-			break
-		}
-		select {
-		case <-emitted:
-		case <-converged.C:
-			t.Fatalf("watch loop never converged on %s, last emission was %+v", finalPeer, last)
-		}
-	}
+	<-finalEmitted
 
 	cancel()
-	<-loopErr
-
-	if !last.CanManage {
-		t.Fatal("converged emission lost owner role classification")
+	cancelBridge()
+	if err := <-loopErr; err != context.Canceled {
+		t.Fatalf("watch loop returned %v, want context canceled", err)
 	}
 
 	emissionsMu.Lock()
-	total := len(emissions)
-	emissionsMu.Unlock()
-	if total > writes/4 {
-		t.Fatalf("watch loop did not coalesce: %d emissions for %d writes during one blocked send", total, writes)
+	defer emissionsMu.Unlock()
+	last := emissions[len(emissions)-1]
+	finalParticipants := []*sobject.SOParticipantConfig{
+		initialParticipants[0],
+		{PeerId: finalPeer, Role: sobject.SOParticipantRole_SOParticipantRole_WRITER},
+	}
+	if got, want := participantKey(last.Participants), participantKey(finalParticipants); got != want {
+		t.Fatalf("last emission has participant set %q, want %q", got, want)
+	}
+	if !last.CanManage {
+		t.Fatal("final emission lost owner role classification")
+	}
+	for _, emission := range emissions {
+		if _, ok := written[participantKey(emission.Participants)]; !ok {
+			t.Fatalf("emission carried unwritten participant set %q", participantKey(emission.Participants))
+		}
 	}
 }

--- a/core/resource/space/sharingstate/state_test.go
+++ b/core/resource/space/sharingstate/state_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/aperturerobotics/util/ccontainer"
 	"github.com/s4wave/spacewave/core/sobject"
@@ -275,6 +276,23 @@ func (w *gatedWatchable) WaitValueChange(
 	}
 }
 
+// awaitSignal receives from ch, failing the test by name if it never arrives.
+//
+// Each caller's signal is produced by this test's own causation and lands in
+// microseconds, so the deadline is not a schedule assertion: it exists so an
+// owner that stops converging reports which signal was missed instead of
+// hanging until the package timeout dumps every goroutine.
+func awaitSignal(t *testing.T, ch <-chan struct{}, what string) {
+	t.Helper()
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
+	select {
+	case <-ch:
+	case <-timer.C:
+		t.Fatalf("timed out waiting for %s", what)
+	}
+}
+
 func TestCoalescingEndToEnd(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
@@ -341,7 +359,7 @@ func TestCoalescingEndToEnd(t *testing.T) {
 	go func() {
 		loopErr <- state.RunWatchLoop(ctx, "peer-1", send)
 	}()
-	<-emitted
+	awaitSignal(t, emitted, "the first emission to block the send")
 
 	written := map[string]struct{}{
 		participantKey(initialParticipants): {},
@@ -360,13 +378,13 @@ func TestCoalescingEndToEnd(t *testing.T) {
 		ctr.SetValue(next)
 		written[participantKey(next.GetConfig().GetParticipants())] = struct{}{}
 		if i == 2 {
-			<-bridgeObserved
+			awaitSignal(t, bridgeObserved, "the bridge to observe the first write")
 		}
 	}
 
 	close(bridgeRelease)
 	close(released)
-	<-finalEmitted
+	awaitSignal(t, finalEmitted, "the loop to converge on the final participant set")
 
 	cancel()
 	cancelBridge()


### PR DESCRIPTION
TestCoalescingEndToEnd previously bounded emission count while the first send was blocked. The bridge and writer goroutines were unsynchronized, so a loaded runner could observe an intermediate revision and emit it separately. That scheduling outcome is valid coalescer behavior and made the test fail on master.

The test now gates the bridge after it observes the first write, then releases three written revisions while the initial send remains blocked. It requires the last emission to carry peer-4 and checks every emission against the initial or written participant sets. It does not assert an emission count or use a settle window.

Verified with `go test ./core/resource/space/sharingstate -run TestCoalescingEndToEnd -count=50`. The owner was temporarily changed to discard bridged updates; the test then failed with `panic: test timed out after 2s` while waiting for the final emission. The owner was restored before commit.