### PR TITLE
test: match the strings and controls the app actually renders

### DIFF
--- a/app/billing/BillingPage.test.tsx
+++ b/app/billing/BillingPage.test.tsx
@@ -144,9 +144,10 @@ describe('BillingPage', () => {
     await waitFor(() =>
       expect(mockRefreshBillingState).toHaveBeenCalledWith('ba_test'),
     )
-    expect(
-      screen.getByRole('button', { name: 'Refreshing...' }),
-    ).toHaveProperty('disabled', true)
+    expect(screen.getByRole('button', { name: 'Refreshing…' })).toHaveProperty(
+      'disabled',
+      true,
+    )
 
     resolveRefresh?.()
 

--- a/app/docs/DocsRoutes.e2e.test.tsx
+++ b/app/docs/DocsRoutes.e2e.test.tsx
@@ -61,8 +61,12 @@ describe('DocsRoutes browser smoke', () => {
     await expect
       .element(page.getByRole('heading', { name: 'Create Your First Space' }))
       .toBeInTheDocument()
-    await expect.element(page.getByText('Previous')).toBeInTheDocument()
-    await expect.element(page.getByText('Next')).toBeInTheDocument()
+    await expect
+      .element(page.getByRole('button', { name: /^Previous/ }))
+      .toBeInTheDocument()
+    await expect
+      .element(page.getByRole('button', { name: /^Next/ }))
+      .toBeInTheDocument()
 
     await expect
       .poll(() =>

--- a/app/docs/DocsRoutes.e2e.test.tsx
+++ b/app/docs/DocsRoutes.e2e.test.tsx
@@ -76,7 +76,7 @@ describe('DocsRoutes browser smoke', () => {
         'https://raw.githubusercontent.com/s4wave/spacewave/master/app/docs/content/users/start/02-create-your-first-space.md',
       )
 
-    await page.getByPlaceholder('Search docs...').fill('backup')
+    await page.getByPlaceholder('Search docs…').fill('backup')
     await expect
       .element(
         page.getByRole('button', {

--- a/app/landing/LandingDemos.test.tsx
+++ b/app/landing/LandingDemos.test.tsx
@@ -40,7 +40,7 @@ describe('landing demos', () => {
   it('lets the chat demo send a local message through the shared chat widgets', async () => {
     render(<ChatLandingDemo />)
 
-    const input = screen.getByPlaceholderText('Type a message...')
+    const input = screen.getByPlaceholderText('Type a message…')
     fireEvent.change(input, { target: { value: 'Ship the docs update next.' } })
     fireEvent.keyDown(input, { key: 'Enter' })
 

--- a/app/pair/PairCodePage.test.tsx
+++ b/app/pair/PairCodePage.test.tsx
@@ -55,12 +55,9 @@ describe('PairCodePage', () => {
     }
 
     render(<PairCodePage session={session as never} />)
-    fireEvent.change(
-      screen.getByPlaceholderText('Paste offer payload here...'),
-      {
-        target: { value: 'offer-payload' },
-      },
-    )
+    fireEvent.change(screen.getByPlaceholderText('Paste offer payload here…'), {
+      target: { value: 'offer-payload' },
+    })
     fireEvent.click(screen.getByRole('button', { name: 'Accept offer' }))
 
     expect(await screen.findByText('Verification failed')).toBeDefined()

--- a/app/provider/spacewave/DeleteCloudAccountPage.test.tsx
+++ b/app/provider/spacewave/DeleteCloudAccountPage.test.tsx
@@ -185,9 +185,7 @@ describe('DeleteCloudAccountPage', () => {
 
     expect(mockRequestDeleteNowEmail).toHaveBeenCalledTimes(1)
     expect(
-      screen.getByRole('button', { name: 'Sending...' }).hasAttribute(
-        'disabled',
-      ),
+      screen.getByRole('button', { name: 'Sending…' }).hasAttribute('disabled'),
     ).toBe(true)
 
     await act(async () => {
@@ -219,9 +217,9 @@ describe('DeleteCloudAccountPage', () => {
     expect(mockConfirmDeleteNowCode).toHaveBeenCalledWith('123456')
     expect(mockNavigate).not.toHaveBeenCalled()
     expect(
-      screen.getByRole('button', { name: 'Confirming...' }).hasAttribute(
-        'disabled',
-      ),
+      screen
+        .getByRole('button', { name: 'Confirming…' })
+        .hasAttribute('disabled'),
     ).toBe(true)
 
     await act(async () => {
@@ -240,7 +238,7 @@ describe('DeleteCloudAccountPage', () => {
       'Deletion confirmed. The account is now read-only.',
     )
     expect(mockNavigate).toHaveBeenCalledWith({ path: '../', replace: true })
-    expect(screen.queryByText('Confirming...')).toBeNull()
+    expect(screen.queryByText('Confirming…')).toBeNull()
     expect(screen.queryByText(/Deleting/i)).toBeNull()
     expect(
       screen.getByRole('button', { name: 'Confirm delete account' }),

--- a/app/provider/spacewave/PlanSelectionPage.test.tsx
+++ b/app/provider/spacewave/PlanSelectionPage.test.tsx
@@ -337,7 +337,7 @@ describe('PlanSelectionPage', () => {
     it('renders activating subscription view when checkoutResult is success', () => {
       render(<PlanSelectionPage checkoutResult="success" />)
 
-      expect(screen.getByText('Activating subscription...')).toBeDefined()
+      expect(screen.getByText('Activating subscription…')).toBeDefined()
     })
   })
 

--- a/app/session/PinUnlockOverlay.test.tsx
+++ b/app/session/PinUnlockOverlay.test.tsx
@@ -182,7 +182,7 @@ describe('PinUnlockOverlay', () => {
     act(() => {
       fireEvent.click(unlockButton!)
     })
-    expect(screen.getByText('Unlocking...')).toBeDefined()
+    expect(screen.getByText('Unlocking…')).toBeDefined()
   })
 
   it('renders "Forgot PIN?" button', () => {

--- a/app/session/dashboard/DeleteSpaceEscapeHatchDialog.test.tsx
+++ b/app/session/dashboard/DeleteSpaceEscapeHatchDialog.test.tsx
@@ -216,7 +216,7 @@ describe('DeleteSpaceEscapeHatchDialog', () => {
     )
 
     expect(screen.getAllByText('Broken Space').length).toBeGreaterThan(0)
-    expect(screen.getByRole('button', { name: 'Deleting...' })).toBeDefined()
+    expect(screen.getByRole('button', { name: 'Deleting…' })).toBeDefined()
 
     deleteControl.resolve?.()
   })

--- a/app/session/dashboard/OrganizationsSection.test.tsx
+++ b/app/session/dashboard/OrganizationsSection.test.tsx
@@ -97,7 +97,7 @@ describe('OrganizationsSection', () => {
     fireEvent.click(screen.getByText('Create'))
 
     const input = screen.getByPlaceholderText('Organization name')
-    const createButton = screen.getByText('Creating...')
+    const createButton = screen.getByText('Creating…')
     const cancelButton = screen.getByText('Cancel')
 
     expect(mockCreateOrganization).toHaveBeenCalledWith('New Org')

--- a/app/session/setup/LinkDeviceDoneStep.test.tsx
+++ b/app/session/setup/LinkDeviceDoneStep.test.tsx
@@ -74,7 +74,7 @@ describe('LinkDeviceDoneStep', () => {
     })
 
     await waitFor(() => {
-      expect(screen.getByText('Finishing device sync...')).toBeDefined()
+      expect(screen.getByText('Finishing device sync…')).toBeDefined()
     })
     expect(screen.queryByText('All set!')).toBeNull()
     expect(screen.getByText('Skip and continue to dashboard')).toBeDefined()
@@ -139,7 +139,7 @@ describe('LinkDeviceDoneStep', () => {
         expect.any(AbortSignal),
       )
     })
-    expect(screen.getByText('Finishing device sync...')).toBeDefined()
+    expect(screen.getByText('Finishing device sync…')).toBeDefined()
     expect(screen.queryByText('All set!')).toBeNull()
   })
 })

--- a/app/session/setup/LinkDeviceWizard.test.tsx
+++ b/app/session/setup/LinkDeviceWizard.test.tsx
@@ -238,7 +238,7 @@ describe('LinkDeviceWizard', () => {
     render(<LinkDeviceWizard />)
     fireEvent.click(screen.getByText('Show QR code'))
     const answerInput = await screen.findByPlaceholderText(
-      'Paste answer payload here...',
+      'Paste answer payload here…',
     )
     fireEvent.change(answerInput, { target: { value: 'answer-payload' } })
     fireEvent.click(screen.getByRole('button', { name: 'Connect' }))

--- a/app/sobject/AddUserDialog.test.tsx
+++ b/app/sobject/AddUserDialog.test.tsx
@@ -124,13 +124,13 @@ describe('AddUserDialog', () => {
     ).toBeDefined()
     expect(screen.getByText('alice')).toBeDefined()
     expect(screen.getByText('acct-alice')).toBeDefined()
-    expect(screen.getByPlaceholderText('Search org members...')).toBeDefined()
+    expect(screen.getByPlaceholderText('Search org members…')).toBeDefined()
   })
 
   it('filters org members by attested label', () => {
     renderDialog()
 
-    fireEvent.change(screen.getByPlaceholderText('Search org members...'), {
+    fireEvent.change(screen.getByPlaceholderText('Search org members…'), {
       target: { value: 'casey' },
     })
 

--- a/app/wizard/IntroWizardOverlay.test.tsx
+++ b/app/wizard/IntroWizardOverlay.test.tsx
@@ -128,7 +128,7 @@ describe('IntroWizardOverlay', () => {
       />,
     )
 
-    const finish = screen.getByRole('button', { name: 'Opening...' })
+    const finish = screen.getByRole('button', { name: 'Opening…' })
     const skip = screen.getByRole('button', { name: 'Skip' })
     expect((finish as HTMLButtonElement).disabled).toBe(true)
     expect((skip as HTMLButtonElement).disabled).toBe(true)

--- a/app/wizard/intro-wizard.e2e.test.tsx
+++ b/app/wizard/intro-wizard.e2e.test.tsx
@@ -100,7 +100,7 @@ describe('intro wizard overlay', () => {
     await page.getByRole('button', { name: 'Got it, start exploring' }).click()
 
     await expect
-      .element(page.getByRole('button', { name: 'Opening...' }))
+      .element(page.getByRole('button', { name: 'Opening…' }))
       .toBeInTheDocument()
 
     await capture('finishing')

--- a/plugin/notes/NoteList.test.tsx
+++ b/plugin/notes/NoteList.test.tsx
@@ -283,7 +283,7 @@ describe('NoteList', () => {
 
     renderList()
 
-    const input = await screen.findByPlaceholderText('Search notes...')
+    const input = await screen.findByPlaceholderText('Search notes…')
     fireEvent.change(input, { target: { value: 'proj' } })
     expect(screen.getByText('projects')).toBeDefined()
     expect(screen.queryByText('alpha')).toBeNull()

--- a/web/command/KeybindingEditor.test.tsx
+++ b/web/command/KeybindingEditor.test.tsx
@@ -254,7 +254,7 @@ describe('KeybindingEditor', () => {
     expect(view.getAllByText('Open Terminal').length).toBeGreaterThan(0)
     expect(view.getAllByText('Special Command').length).toBeGreaterThan(0)
 
-    const search = view.getByPlaceholderText('Search commands...')
+    const search = view.getByPlaceholderText('Search commands…')
 
     await act(async () =>
       fireEvent.input(search, { target: { value: 'brush' } }),


### PR DESCRIPTION
The lint fix in b9e1a1fdc changed about a hundred product strings from three periods to the single ellipsis character, which is what this repository's own rule requires, and left the tests that match those strings behind. Sixteen cases across fourteen files looked for text nothing renders, so master went red and every open pull request inherited it. This updates the assertions and leaves every product source untouched. The change is confined to string literals inside matchers, checked one at a time against what the component now renders, because three periods are also spread and rest syntax and a blanket replacement would rewrite live code.

The second commit fixes a different defect in the docs browser test, which failed for its own reason. It proved the article pager rendered by asking for the text "Next", and that matcher is substring based and case insensitive, so it claimed any element on the page containing the word. The docs rewrite ended a bullet with "ready for whatever you add next", which gave it a second match and a strict mode violation. Both pager assertions now target the button by role with the name anchored at the start, so article prose cannot collide with them again.

The alpha script goes from sixteen failures to none of this class: 2560 tests pass across 400 files. One unrelated failure remains locally in app/routes/AppRoutes.test.tsx, where the /debug route renders an empty body. It passes on its own and it passed in CI on the current master, so it looks like local worker sharding rather than anything here; CI on this branch is the check that settles it.