### PR TITLE
feat(bldr): add opt-in browser startup trace attribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
             test_js_script: ''
           - name: db
             build_script: ''
-            check_script: ''
+            check_script: check:go:startup-trace
             lint_go_script: lint:go:db
             lint_js_script: lint:js:db
             test_go_script: test:go:db

--- a/bldr/devtool/start-web-wasm.go
+++ b/bldr/devtool/start-web-wasm.go
@@ -320,7 +320,7 @@ func (d *DevtoolBus) ExecuteWebWasm(
 		runtimeOut,
 		false, // disable cgo
 		useTinygo,
-		nil,
+		gocompiler.RuntimeStartupTraceBuildTagsForWebWasm(true, useTinygo),
 		nil,
 	); err != nil {
 		return err

--- a/bldr/devtool/web/entrypoint/startup-trace_js.go
+++ b/bldr/devtool/web/entrypoint/startup-trace_js.go
@@ -1,0 +1,9 @@
+//go:build js && bldr_startup_trace
+
+package main
+
+import startuptrace "github.com/s4wave/spacewave/bldr/web/entrypoint/startuptrace"
+
+func init() {
+	startuptrace.Install()
+}

--- a/bldr/dist.go
+++ b/bldr/dist.go
@@ -37,7 +37,7 @@ import (
 //go:embed plugin/plugin.pb.ts plugin/plugin_srpc.pb.ts
 //go:embed manifest/manifest.pb.ts manifest/manifest_srpc.pb.ts
 //go:embed devtool/status/status.pb.ts devtool/status/status_srpc.pb.ts
-//go:embed devtool/deps.go devtool/web/entrypoint/web.go
+//go:embed devtool/deps.go devtool/web/entrypoint/web.go devtool/web/entrypoint/startup-trace_js.go
 //go:embed dist/deps/deps.go dist/deps/package.json dist/deps/bun.lock
 //go:embed web/bundler/bundler.pb.ts
 //go:embed web/bundler/vite/build.ts web/bundler/vite/run-build.ts

--- a/bldr/dist/compiler/bundle.go
+++ b/bldr/dist/compiler/bundle.go
@@ -527,7 +527,7 @@ func BuildDistBundle(
 		outBinPath,
 		enableCgo,
 		enableTinygo,
-		nil,
+		gocompiler.RuntimeStartupTraceBuildTagsForWebWasm(isWebPlatform, enableTinygo),
 		distEntrypointLDFlags(buildPlatform, meta.GetEntrypointRole()),
 	)
 	if err != nil {
@@ -579,6 +579,7 @@ func resolveDistGoCompiler(
 func newDistGoScriptBuildFlags(buildType bldr_manifest.BuildType, enableCgo bool) []string {
 	buildTags := gocompiler.NewBuildTags(buildType, enableCgo)
 	buildTags = append(buildTags, gocompiler.GoScriptBuildTag, gocompiler.SQLLiteBuildTag)
+	buildTags = append(buildTags, gocompiler.RuntimeStartupTraceBuildTags()...)
 	return []string{"-tags=" + strings.Join(buildTags, ",")}
 }
 

--- a/bldr/dist/compiler/entrypoint_test.go
+++ b/bldr/dist/compiler/entrypoint_test.go
@@ -95,10 +95,21 @@ func TestResolveDistGoCompiler(t *testing.T) {
 	}
 }
 
-func TestNewDistGoScriptBuildFlagsAddsGoScriptTag(t *testing.T) {
+// TestNewDistGoScriptBuildFlags verifies opt-in startup trace propagation for GoScript.
+func TestNewDistGoScriptBuildFlags(t *testing.T) {
+	t.Setenv(gocompiler.RuntimeStartupTraceEnv, "")
 	flags := strings.Join(newDistGoScriptBuildFlags(bldr_manifest.BuildType_RELEASE, false), " ")
-	if !strings.Contains(flags, "goscript") {
-		t.Fatalf("flags = %q, want goscript tag", flags)
+	if !strings.Contains(flags, gocompiler.GoScriptBuildTag) {
+		t.Fatalf("flags = %q, want %s tag", flags, gocompiler.GoScriptBuildTag)
+	}
+	if strings.Contains(flags, gocompiler.RuntimeStartupTraceBuildTag) {
+		t.Fatalf("flags = %q, unexpected %s tag", flags, gocompiler.RuntimeStartupTraceBuildTag)
+	}
+
+	t.Setenv(gocompiler.RuntimeStartupTraceEnv, "1")
+	flags = strings.Join(newDistGoScriptBuildFlags(bldr_manifest.BuildType_RELEASE, false), " ")
+	if !strings.Contains(flags, gocompiler.RuntimeStartupTraceBuildTag) {
+		t.Fatalf("flags = %q, want %s tag", flags, gocompiler.RuntimeStartupTraceBuildTag)
 	}
 }
 

--- a/bldr/dist/entrypoint/startup-trace_js.go
+++ b/bldr/dist/entrypoint/startup-trace_js.go
@@ -1,0 +1,9 @@
+//go:build js && bldr_startup_trace
+
+package dist_entrypoint
+
+import startuptrace "github.com/s4wave/spacewave/bldr/web/entrypoint/startuptrace"
+
+func init() {
+	startuptrace.Install()
+}

--- a/bldr/dist_test.go
+++ b/bldr/dist_test.go
@@ -45,6 +45,7 @@ func TestDistSourcesFSCursor(t *testing.T) {
 		"web/bldr/web-runtime.ts",
 		"web/electron/main/index.ts",
 		"web/bldr-react/WebView.tsx",
+		"devtool/web/entrypoint/startup-trace_js.go",
 	)
 	if err != nil {
 		t.Fatal(err.Error())

--- a/bldr/manifest/fetch/world/res-fetch-manifest.go
+++ b/bldr/manifest/fetch/world/res-fetch-manifest.go
@@ -9,6 +9,7 @@ import (
 	"github.com/s4wave/spacewave/db/block"
 	"github.com/s4wave/spacewave/db/world"
 	world_control "github.com/s4wave/spacewave/db/world/control"
+	"github.com/sirupsen/logrus"
 )
 
 // fetchManifestResolver resolves FetchManifest with the controller optionally watching for changes.
@@ -17,19 +18,18 @@ type fetchManifestResolver struct {
 	c *Controller
 	// dir is the FetchManifest directive
 	dir manifest.FetchManifest
+	// emittedValue is the previously emitted value, if any.
+	emittedValue *manifest.FetchManifestValue
 }
 
-// resolve runs the FetchManifest watch loop.
-func (r *fetchManifestResolver) resolve(ctx context.Context, handler directive.ResolverHandler) error {
+// Resolve resolves the values, emitting them to the handler.
+func (r *fetchManifestResolver) Resolve(ctx context.Context, handler directive.ResolverHandler) error {
 	_ = handler.ClearValues()
 
 	// Watch the world state and re-check the manifests list when it changes.
 	le := r.c.le.WithField("engine-id", r.c.conf.GetEngineId()).WithField("manifest-id", r.dir.GetManifestId())
 	le.Debug("starting watch world for manifest details")
 	defer le.Debug("exiting watch world for manifest details")
-
-	// previous emitted value, if any
-	var emittedValue *manifest.FetchManifestValue
 
 	watchLoop := world_control.NewWatchLoop(r.c.le, "", world_control.NewWaitForStateHandler(func(
 		ctx context.Context,
@@ -38,79 +38,7 @@ func (r *fetchManifestResolver) resolve(ctx context.Context, handler directive.R
 		rootCs *block.Cursor,
 		rev uint64,
 	) (bool, error) {
-		// Skip marking as not-idle as it doesn't help and causes unnecessary churn.
-		// handler.MarkIdle(false)
-
-		// collect manifests for the manifest ID and the desired platform IDs.
-		// note that GetPlatformIds may be empty which is OK (collects for all platforms).
-		var manifests []*bldr_manifest_world.CollectedManifest
-		var manifestErrs []error
-		var err error
-		// empty means match any platform
-		manifests, manifestErrs, err = bldr_manifest_world.CollectManifestsForManifestIDResettingUnsupportedHash(
-			ctx,
-			r.c.le,
-			ws,
-			r.dir.GetManifestId(),
-			r.dir.GetPlatformIds(),
-			r.c.conf.GetObjectKeys()...,
-		)
-		if err != nil {
-			return true, err
-		}
-		for _, err := range manifestErrs {
-			r.c.le.WithError(err).Warn("ignoring invalid manifest")
-		}
-
-		// filter by build types if specified
-		manifests = bldr_manifest_world.FilterCollectedManifestsByBuildTypes(manifests, r.dir.GetBuildTypes())
-
-		// filter by minimum revision if specified
-		manifests = bldr_manifest_world.FilterCollectedManifestsByMinRev(manifests, r.dir.GetRev())
-
-		// filter to latest revision for each ManifestID+PlatformID combination.
-		// this sorts the slice as well.
-		manifests = bldr_manifest_world.FilterCollectedManifestsByLatestRev(manifests)
-
-		// transform to a list of ManifestRef
-		manifestRefs := make([]*manifest.ManifestRef, len(manifests))
-		for i, m := range manifests {
-			manifestRefs[i] = &manifest.ManifestRef{
-				Meta:        m.Manifest.Meta,
-				ManifestRef: m.ManifestRef,
-			}
-		}
-
-		// A cache miss is absence of a value, not a successful zero-ref
-		// FetchManifestValue. Devtool builder resolvers can share the same
-		// directive, and early empty cache values can otherwise win startup
-		// races before builders publish their manifest refs.
-		if len(manifestRefs) == 0 {
-			if emittedValue != nil {
-				emittedValue = nil
-				_ = handler.ClearValues()
-			}
-			le.Debugf("fetched %v manifest(s) from world", len(manifests))
-		} else {
-			nextValue := &manifest.FetchManifestValue{ManifestRefs: manifestRefs}
-			if emittedValue == nil || !nextValue.EqualVT(emittedValue) {
-				emittedValue = nextValue
-				_ = handler.ClearValues()
-				_, _ = handler.AddValue(nextValue)
-				le.Debugf("fetched %v manifest(s) from world", len(manifests))
-			}
-		}
-
-		// we are done
-		handler.MarkIdle(true)
-
-		// if DisableWatch is true exit the resolver.
-		if r.c.conf.GetDisableWatch() {
-			return false, nil
-		}
-
-		// otherwise wait for changes.
-		return true, nil
+		return r.reconcileManifests(ctx, le, handler, ws)
 	}))
 
 	// execute the watch loop
@@ -121,6 +49,90 @@ func (r *fetchManifestResolver) resolve(ctx context.Context, handler directive.R
 		false,
 		watchLoop,
 	)
+}
+
+// reconcileManifestsCore re-collects the manifests for this directive from the
+// given world state and emits them when they differ from the last emission. It
+// returns whether the watch loop should wait for further changes.
+func (r *fetchManifestResolver) reconcileManifestsCore(
+	ctx context.Context,
+	le *logrus.Entry,
+	handler directive.ResolverHandler,
+	ws world.WorldState,
+) (bool, error) {
+	// Skip marking as not-idle as it doesn't help and causes unnecessary churn.
+	// handler.MarkIdle(false)
+
+	// collect manifests for the manifest ID and the desired platform IDs.
+	// note that GetPlatformIds may be empty which is OK (collects for all platforms).
+	var manifests []*bldr_manifest_world.CollectedManifest
+	var manifestErrs []error
+	var err error
+	// empty means match any platform
+	manifests, manifestErrs, err = bldr_manifest_world.CollectManifestsForManifestIDResettingUnsupportedHash(
+		ctx,
+		r.c.le,
+		ws,
+		r.dir.GetManifestId(),
+		r.dir.GetPlatformIds(),
+		r.c.conf.GetObjectKeys()...,
+	)
+	if err != nil {
+		return true, err
+	}
+	for _, err := range manifestErrs {
+		r.c.le.WithError(err).Warn("ignoring invalid manifest")
+	}
+
+	// filter by build types if specified
+	manifests = bldr_manifest_world.FilterCollectedManifestsByBuildTypes(manifests, r.dir.GetBuildTypes())
+
+	// filter by minimum revision if specified
+	manifests = bldr_manifest_world.FilterCollectedManifestsByMinRev(manifests, r.dir.GetRev())
+
+	// filter to latest revision for each ManifestID+PlatformID combination.
+	// this sorts the slice as well.
+	manifests = bldr_manifest_world.FilterCollectedManifestsByLatestRev(manifests)
+
+	// transform to a list of ManifestRef
+	manifestRefs := make([]*manifest.ManifestRef, len(manifests))
+	for i, m := range manifests {
+		manifestRefs[i] = &manifest.ManifestRef{
+			Meta:        m.Manifest.Meta,
+			ManifestRef: m.ManifestRef,
+		}
+	}
+
+	// A cache miss is absence of a value, not a successful zero-ref
+	// FetchManifestValue. Devtool builder resolvers can share the same
+	// directive, and early empty cache values can otherwise win startup
+	// races before builders publish their manifest refs.
+	if len(manifestRefs) == 0 {
+		if r.emittedValue != nil {
+			r.emittedValue = nil
+			_ = handler.ClearValues()
+		}
+		le.Debugf("fetched %v manifest(s) from world", len(manifests))
+	} else {
+		nextValue := &manifest.FetchManifestValue{ManifestRefs: manifestRefs}
+		if r.emittedValue == nil || !nextValue.EqualVT(r.emittedValue) {
+			r.emittedValue = nextValue
+			_ = handler.ClearValues()
+			_, _ = handler.AddValue(nextValue)
+			le.Debugf("fetched %v manifest(s) from world", len(manifests))
+		}
+	}
+
+	// we are done
+	handler.MarkIdle(true)
+
+	// if DisableWatch is true exit the resolver.
+	if r.c.conf.GetDisableWatch() {
+		return false, nil
+	}
+
+	// otherwise wait for changes.
+	return true, nil
 }
 
 // _ is a type assertion

--- a/bldr/manifest/fetch/world/res-fetch-manifest.go
+++ b/bldr/manifest/fetch/world/res-fetch-manifest.go
@@ -19,8 +19,8 @@ type fetchManifestResolver struct {
 	dir manifest.FetchManifest
 }
 
-// Resolve resolves the values, emitting them to the handler.
-func (r *fetchManifestResolver) Resolve(ctx context.Context, handler directive.ResolverHandler) error {
+// resolve runs the FetchManifest watch loop.
+func (r *fetchManifestResolver) resolve(ctx context.Context, handler directive.ResolverHandler) error {
 	_ = handler.ClearValues()
 
 	// Watch the world state and re-check the manifests list when it changes.

--- a/bldr/manifest/fetch/world/res-fetch-manifest_disabled.go
+++ b/bldr/manifest/fetch/world/res-fetch-manifest_disabled.go
@@ -1,0 +1,14 @@
+//go:build !bldr_startup_trace || tinygo
+
+package manifest_fetch_world
+
+import (
+	"context"
+
+	"github.com/aperturerobotics/controllerbus/directive"
+)
+
+// Resolve resolves the values, emitting them to the handler.
+func (r *fetchManifestResolver) Resolve(ctx context.Context, handler directive.ResolverHandler) error {
+	return r.resolve(ctx, handler)
+}

--- a/bldr/manifest/fetch/world/res-fetch-manifest_disabled.go
+++ b/bldr/manifest/fetch/world/res-fetch-manifest_disabled.go
@@ -6,9 +6,16 @@ import (
 	"context"
 
 	"github.com/aperturerobotics/controllerbus/directive"
+	"github.com/s4wave/spacewave/db/world"
+	"github.com/sirupsen/logrus"
 )
 
-// Resolve resolves the values, emitting them to the handler.
-func (r *fetchManifestResolver) Resolve(ctx context.Context, handler directive.ResolverHandler) error {
-	return r.resolve(ctx, handler)
+// reconcileManifests re-collects and emits the manifests for this directive.
+func (r *fetchManifestResolver) reconcileManifests(
+	ctx context.Context,
+	le *logrus.Entry,
+	handler directive.ResolverHandler,
+	ws world.WorldState,
+) (bool, error) {
+	return r.reconcileManifestsCore(ctx, le, handler, ws)
 }

--- a/bldr/manifest/fetch/world/res-fetch-manifest_startup_trace.go
+++ b/bldr/manifest/fetch/world/res-fetch-manifest_startup_trace.go
@@ -1,0 +1,17 @@
+//go:build bldr_startup_trace && !tinygo
+
+package manifest_fetch_world
+
+import (
+	"context"
+
+	"github.com/aperturerobotics/controllerbus/directive"
+	startuptrace "github.com/s4wave/spacewave/db/traceutil/startup"
+)
+
+// Resolve resolves the values, emitting them to the handler.
+func (r *fetchManifestResolver) Resolve(ctx context.Context, handler directive.ResolverHandler) error {
+	traceCtx, task := startuptrace.NewTask(ctx, "bldr/manifest-fetch-world/resolve")
+	defer task.End()
+	return r.resolve(traceCtx, handler)
+}

--- a/bldr/manifest/fetch/world/res-fetch-manifest_startup_trace.go
+++ b/bldr/manifest/fetch/world/res-fetch-manifest_startup_trace.go
@@ -7,11 +7,30 @@ import (
 
 	"github.com/aperturerobotics/controllerbus/directive"
 	startuptrace "github.com/s4wave/spacewave/db/traceutil/startup"
+	"github.com/s4wave/spacewave/db/world"
+	"github.com/sirupsen/logrus"
 )
 
-// Resolve resolves the values, emitting them to the handler.
-func (r *fetchManifestResolver) Resolve(ctx context.Context, handler directive.ResolverHandler) error {
+// reconcileManifests re-collects and emits the manifests for this directive.
+//
+// The task covers one reconciliation rather than the resolver as a whole. The
+// resolver blocks in its watch loop until the directive is released, so a task
+// scoped to it stays open past the end of the startup capture and contributes
+// no duration.
+func (r *fetchManifestResolver) reconcileManifests(
+	ctx context.Context,
+	le *logrus.Entry,
+	handler directive.ResolverHandler,
+	ws world.WorldState,
+) (bool, error) {
 	traceCtx, task := startuptrace.NewTask(ctx, "bldr/manifest-fetch-world/resolve")
 	defer task.End()
-	return r.resolve(traceCtx, handler)
+	startuptrace.Log(traceCtx, "manifest-id", r.dir.GetManifestId())
+	waitForChanges, err := r.reconcileManifestsCore(traceCtx, le, handler, ws)
+	if err != nil {
+		startuptrace.Log(traceCtx, "outcome", "error")
+		return waitForChanges, err
+	}
+	startuptrace.Log(traceCtx, "outcome", "ok")
+	return waitForChanges, nil
 }

--- a/bldr/manifest/world/startup-eligibility.go
+++ b/bldr/manifest/world/startup-eligibility.go
@@ -54,9 +54,9 @@ type StartupManifestCandidateEligibility struct {
 	ManifestRef *bucket.ObjectRef
 }
 
-// CollectStartupManifestEligibilityForManifestID classifies startup manifest
+// collectStartupManifestEligibilityForManifestID classifies startup manifest
 // candidates without mutating the Manifest graph or candidate objects.
-func CollectStartupManifestEligibilityForManifestID(
+func collectStartupManifestEligibilityForManifestID(
 	ctx context.Context,
 	ws world.WorldState,
 	manifestID string,

--- a/bldr/manifest/world/startup-eligibility_disabled.go
+++ b/bldr/manifest/world/startup-eligibility_disabled.go
@@ -1,0 +1,21 @@
+//go:build !bldr_startup_trace || tinygo
+
+package bldr_manifest_world
+
+import (
+	"context"
+
+	"github.com/s4wave/spacewave/db/world"
+)
+
+// CollectStartupManifestEligibilityForManifestID classifies startup manifest
+// candidates without mutating the Manifest graph or candidate objects.
+func CollectStartupManifestEligibilityForManifestID(
+	ctx context.Context,
+	ws world.WorldState,
+	manifestID string,
+	filterPlatformIDs []string,
+	objKeys ...string,
+) ([]*StartupManifestCandidateEligibility, error) {
+	return collectStartupManifestEligibilityForManifestID(ctx, ws, manifestID, filterPlatformIDs, objKeys...)
+}

--- a/bldr/manifest/world/startup-eligibility_startup_trace.go
+++ b/bldr/manifest/world/startup-eligibility_startup_trace.go
@@ -1,0 +1,32 @@
+//go:build bldr_startup_trace && !tinygo
+
+package bldr_manifest_world
+
+import (
+	"context"
+
+	startuptrace "github.com/s4wave/spacewave/db/traceutil/startup"
+	"github.com/s4wave/spacewave/db/world"
+)
+
+// CollectStartupManifestEligibilityForManifestID classifies startup manifest
+// candidates without mutating the Manifest graph or candidate objects.
+func CollectStartupManifestEligibilityForManifestID(
+	ctx context.Context,
+	ws world.WorldState,
+	manifestID string,
+	filterPlatformIDs []string,
+	objKeys ...string,
+) ([]*StartupManifestCandidateEligibility, error) {
+	traceCtx, task := startuptrace.NewTask(ctx, "bldr/manifest-world/eligibility/collect")
+	defer task.End()
+	startuptrace.Log(traceCtx, "manifest-id", manifestID)
+	candidates, err := collectStartupManifestEligibilityForManifestID(traceCtx, ws, manifestID, filterPlatformIDs, objKeys...)
+	if err != nil {
+		startuptrace.Log(traceCtx, "outcome", "error")
+		return nil, err
+	}
+	startuptrace.Logf(traceCtx, "candidate-count", "%d", len(candidates))
+	startuptrace.Log(traceCtx, "outcome", "ok")
+	return candidates, nil
+}

--- a/bldr/manifest/world/startup-graph-dump.go
+++ b/bldr/manifest/world/startup-graph-dump.go
@@ -20,9 +20,9 @@ type startupManifestGraphEdge struct {
 	label string
 }
 
-// DumpStartupManifestGraphForManifestID builds a non-mutating diagnostic dump
+// dumpStartupManifestGraphForManifestID builds a non-mutating diagnostic dump
 // of the retained manifest graph followed during startup selection.
-func DumpStartupManifestGraphForManifestID(
+func dumpStartupManifestGraphForManifestID(
 	ctx context.Context,
 	ws world.WorldState,
 	manifestID string,

--- a/bldr/manifest/world/startup-graph-dump_disabled.go
+++ b/bldr/manifest/world/startup-graph-dump_disabled.go
@@ -1,0 +1,21 @@
+//go:build !bldr_startup_trace || tinygo
+
+package bldr_manifest_world
+
+import (
+	"context"
+
+	"github.com/s4wave/spacewave/db/world"
+)
+
+// DumpStartupManifestGraphForManifestID builds a non-mutating diagnostic dump
+// of the retained manifest graph followed during startup selection.
+func DumpStartupManifestGraphForManifestID(
+	ctx context.Context,
+	ws world.WorldState,
+	manifestID string,
+	filterPlatformIDs []string,
+	objKeys ...string,
+) (string, error) {
+	return dumpStartupManifestGraphForManifestID(ctx, ws, manifestID, filterPlatformIDs, objKeys...)
+}

--- a/bldr/manifest/world/startup-graph-dump_startup_trace.go
+++ b/bldr/manifest/world/startup-graph-dump_startup_trace.go
@@ -1,0 +1,31 @@
+//go:build bldr_startup_trace && !tinygo
+
+package bldr_manifest_world
+
+import (
+	"context"
+
+	startuptrace "github.com/s4wave/spacewave/db/traceutil/startup"
+	"github.com/s4wave/spacewave/db/world"
+)
+
+// DumpStartupManifestGraphForManifestID builds a non-mutating diagnostic dump
+// of the retained manifest graph followed during startup selection.
+func DumpStartupManifestGraphForManifestID(
+	ctx context.Context,
+	ws world.WorldState,
+	manifestID string,
+	filterPlatformIDs []string,
+	objKeys ...string,
+) (string, error) {
+	traceCtx, task := startuptrace.NewTask(ctx, "bldr/manifest-world/eligibility/graph-dump")
+	defer task.End()
+	startuptrace.Log(traceCtx, "manifest-id", manifestID)
+	dump, err := dumpStartupManifestGraphForManifestID(traceCtx, ws, manifestID, filterPlatformIDs, objKeys...)
+	if err != nil {
+		startuptrace.Log(traceCtx, "outcome", "error")
+		return "", err
+	}
+	startuptrace.Log(traceCtx, "outcome", "ok")
+	return dump, nil
+}

--- a/bldr/plugin/host/scheduler/fetch-world-manifest.go
+++ b/bldr/plugin/host/scheduler/fetch-world-manifest.go
@@ -28,7 +28,7 @@ type directFetchCandidate struct {
 }
 
 // execute executes the tracker.
-func (t *pluginInstance) execFetchWorldManifest(ctx context.Context, hosts *pluginHostSet) (rerr error) {
+func (t *pluginInstance) execFetchWorldManifestCore(ctx context.Context, hosts *pluginHostSet) (rerr error) {
 	defer func() {
 		t.c.recordPluginStatusError(t.pluginID, t.instanceKey, "fetch plugin manifest", rerr)
 	}()
@@ -139,7 +139,7 @@ func (t *pluginInstance) newManifestFetchValueStorer(key storeFetchedManifestsKe
 }
 
 // execFetchManifestValueStorer executes storing the FetchManifest value in storage.
-func (t *fetchManifestValueStorer) execFetchManifestValueStorer(ctx context.Context) (rerr error) {
+func (t *fetchManifestValueStorer) execFetchManifestValueStorerCore(ctx context.Context) (rerr error) {
 	defer func() {
 		t.pi.c.recordPluginStatusError(
 			t.pi.pluginID,

--- a/bldr/plugin/host/scheduler/fetch-world-manifest_disabled.go
+++ b/bldr/plugin/host/scheduler/fetch-world-manifest_disabled.go
@@ -1,0 +1,15 @@
+//go:build !bldr_startup_trace || tinygo
+
+package plugin_host_scheduler
+
+import "context"
+
+// execFetchWorldManifest executes the world manifest fetch tracker.
+func (t *pluginInstance) execFetchWorldManifest(ctx context.Context, hosts *pluginHostSet) error {
+	return t.execFetchWorldManifestCore(ctx, hosts)
+}
+
+// execFetchManifestValueStorer executes storing the FetchManifest value in storage.
+func (t *fetchManifestValueStorer) execFetchManifestValueStorer(ctx context.Context) error {
+	return t.execFetchManifestValueStorerCore(ctx)
+}

--- a/bldr/plugin/host/scheduler/fetch-world-manifest_startup_trace.go
+++ b/bldr/plugin/host/scheduler/fetch-world-manifest_startup_trace.go
@@ -1,0 +1,23 @@
+//go:build bldr_startup_trace && !tinygo
+
+package plugin_host_scheduler
+
+import (
+	"context"
+
+	startuptrace "github.com/s4wave/spacewave/db/traceutil/startup"
+)
+
+// execFetchWorldManifest executes the world manifest fetch tracker.
+func (t *pluginInstance) execFetchWorldManifest(ctx context.Context, hosts *pluginHostSet) error {
+	traceCtx, task := startuptrace.NewTask(ctx, "bldr/plugin-host-scheduler/fetch-world-manifest")
+	defer task.End()
+	return t.execFetchWorldManifestCore(traceCtx, hosts)
+}
+
+// execFetchManifestValueStorer executes storing the FetchManifest value in storage.
+func (t *fetchManifestValueStorer) execFetchManifestValueStorer(ctx context.Context) error {
+	traceCtx, task := startuptrace.NewTask(ctx, "bldr/plugin-host-scheduler/store-manifest")
+	defer task.End()
+	return t.execFetchManifestValueStorerCore(traceCtx)
+}

--- a/bldr/plugin/host/scheduler/watch-world-manifest.go
+++ b/bldr/plugin/host/scheduler/watch-world-manifest.go
@@ -46,7 +46,7 @@ func (t *pluginInstance) execWatchWorldManifest(ctx context.Context, hosts *plug
 }
 
 // processManifestWorldState processes the state for the PluginManifest.
-func (t *pluginInstance) processManifestWorldState(
+func (t *pluginInstance) processManifestWorldStateCore(
 	ctx context.Context,
 	le *logrus.Entry,
 	hosts *pluginHostSet,

--- a/bldr/plugin/host/scheduler/watch-world-manifest_disabled.go
+++ b/bldr/plugin/host/scheduler/watch-world-manifest_disabled.go
@@ -1,0 +1,21 @@
+//go:build !bldr_startup_trace || tinygo
+
+package plugin_host_scheduler
+
+import (
+	"context"
+
+	"github.com/s4wave/spacewave/db/world"
+	"github.com/sirupsen/logrus"
+)
+
+// processManifestWorldState processes the state for the PluginManifest.
+func (t *pluginInstance) processManifestWorldState(
+	ctx context.Context,
+	le *logrus.Entry,
+	hosts *pluginHostSet,
+	ws world.WorldState,
+	obj world.ObjectState,
+) (bool, error) {
+	return t.processManifestWorldStateCore(ctx, le, hosts, ws, obj)
+}

--- a/bldr/plugin/host/scheduler/watch-world-manifest_startup_trace.go
+++ b/bldr/plugin/host/scheduler/watch-world-manifest_startup_trace.go
@@ -1,0 +1,32 @@
+//go:build bldr_startup_trace && !tinygo
+
+package plugin_host_scheduler
+
+import (
+	"context"
+
+	startuptrace "github.com/s4wave/spacewave/db/traceutil/startup"
+	"github.com/s4wave/spacewave/db/world"
+	"github.com/sirupsen/logrus"
+)
+
+// processManifestWorldState processes the state for the PluginManifest.
+func (t *pluginInstance) processManifestWorldState(
+	ctx context.Context,
+	le *logrus.Entry,
+	hosts *pluginHostSet,
+	ws world.WorldState,
+	obj world.ObjectState,
+) (waitForChanges bool, err error) {
+	traceCtx, task := startuptrace.NewTask(ctx, "bldr/plugin-host-scheduler/eligibility-collect")
+	outcome := "error"
+	defer func() {
+		startuptrace.Log(traceCtx, "outcome", outcome)
+		task.End()
+	}()
+	waitForChanges, err = t.processManifestWorldStateCore(traceCtx, le, hosts, ws, obj)
+	if err == nil {
+		outcome = "ok"
+	}
+	return waitForChanges, err
+}

--- a/bldr/util/gocompiler/runtime-startup-trace.go
+++ b/bldr/util/gocompiler/runtime-startup-trace.go
@@ -1,0 +1,27 @@
+package gocompiler
+
+import "os"
+
+const (
+	// RuntimeStartupTraceEnv enables the opt-in browser runtime startup trace.
+	RuntimeStartupTraceEnv = "BLDR_RUNTIME_STARTUP_TRACE"
+	// RuntimeStartupTraceBuildTag includes the browser startup trace hook.
+	RuntimeStartupTraceBuildTag = "bldr_startup_trace"
+)
+
+// RuntimeStartupTraceBuildTags returns the opt-in startup trace build tag.
+func RuntimeStartupTraceBuildTags() []string {
+	if os.Getenv(RuntimeStartupTraceEnv) == "" {
+		return nil
+	}
+	return []string{RuntimeStartupTraceBuildTag}
+}
+
+// RuntimeStartupTraceBuildTagsForWebWasm returns the opt-in startup trace tag
+// only for the supported non-TinyGo browser compiler.
+func RuntimeStartupTraceBuildTagsForWebWasm(isWebPlatform, useTinygo bool) []string {
+	if !isWebPlatform || useTinygo {
+		return nil
+	}
+	return RuntimeStartupTraceBuildTags()
+}

--- a/bldr/util/gocompiler/runtime-startup-trace_test.go
+++ b/bldr/util/gocompiler/runtime-startup-trace_test.go
@@ -1,0 +1,33 @@
+package gocompiler
+
+import (
+	"slices"
+	"testing"
+)
+
+// TestRuntimeStartupTraceBuildTags verifies environment-gated startup trace tags.
+func TestRuntimeStartupTraceBuildTags(t *testing.T) {
+	t.Setenv(RuntimeStartupTraceEnv, "")
+	if tags := RuntimeStartupTraceBuildTags(); len(tags) != 0 {
+		t.Fatalf("startup trace tags = %v, want none", tags)
+	}
+
+	t.Setenv(RuntimeStartupTraceEnv, "1")
+	if tags := RuntimeStartupTraceBuildTags(); !slices.Equal(tags, []string{RuntimeStartupTraceBuildTag}) {
+		t.Fatalf("startup trace tags = %v, want %s tag", tags, RuntimeStartupTraceBuildTag)
+	}
+}
+
+// TestRuntimeStartupTraceBuildTagsForWebWasm verifies unsupported compiler modes receive no hook.
+func TestRuntimeStartupTraceBuildTagsForWebWasm(t *testing.T) {
+	t.Setenv(RuntimeStartupTraceEnv, "1")
+	if tags := RuntimeStartupTraceBuildTagsForWebWasm(false, false); len(tags) != 0 {
+		t.Fatalf("native startup trace tags = %v, want none", tags)
+	}
+	if tags := RuntimeStartupTraceBuildTagsForWebWasm(true, true); len(tags) != 0 {
+		t.Fatalf("TinyGo startup trace tags = %v, want none", tags)
+	}
+	if tags := RuntimeStartupTraceBuildTagsForWebWasm(true, false); !slices.Equal(tags, []string{RuntimeStartupTraceBuildTag}) {
+		t.Fatalf("Go WASM startup trace tags = %v, want %s tag", tags, RuntimeStartupTraceBuildTag)
+	}
+}

--- a/bldr/web/entrypoint/startuptrace/startup-trace_js.go
+++ b/bldr/web/entrypoint/startuptrace/startup-trace_js.go
@@ -1,0 +1,104 @@
+//go:build js && bldr_startup_trace
+
+// Package startuptrace installs the opt-in browser runtime startup trace.
+package startuptrace
+
+import (
+	"bytes"
+	"encoding/base64"
+	"runtime/trace"
+	"sync"
+	"syscall/js"
+)
+
+type startupTrace struct {
+	mu       sync.Mutex
+	buffer   bytes.Buffer
+	encoded  string
+	stopped  bool
+	cleaned  bool
+	stopFunc js.Func
+	readFunc js.Func
+}
+
+// Install starts the runtime trace and exposes chunked stop and read callbacks.
+func Install() {
+	owner := &startupTrace{}
+	if err := trace.Start(&owner.buffer); err != nil {
+		owner.buffer.Reset()
+		return
+	}
+	owner.stopFunc = js.FuncOf(owner.stop)
+	owner.readFunc = js.FuncOf(owner.read)
+	js.Global().Set("BLDR_STOP_STARTUP_TRACE", owner.stopFunc)
+	js.Global().Set("BLDR_READ_STARTUP_TRACE", owner.readFunc)
+}
+
+func (t *startupTrace) stop(_ js.Value, _ []js.Value) any {
+	t.mu.Lock()
+	if t.cleaned {
+		t.mu.Unlock()
+		return "error:startup trace unavailable"
+	}
+	if !t.stopped {
+		trace.Stop()
+		t.stopped = true
+		t.encoded = base64.StdEncoding.EncodeToString(t.buffer.Bytes())
+	}
+	if t.encoded == "" {
+		t.mu.Unlock()
+		t.cleanup()
+		return "error:startup trace is empty"
+	}
+	length := len(t.encoded)
+	t.mu.Unlock()
+	return length
+}
+
+func (t *startupTrace) read(_ js.Value, args []js.Value) any {
+	if len(args) != 2 {
+		t.cleanup()
+		return ""
+	}
+
+	offset, size := args[0].Int(), args[1].Int()
+	t.mu.Lock()
+	if t.cleaned || !t.stopped || offset < 0 || size <= 0 || offset >= len(t.encoded) || size > len(t.encoded)-offset {
+		t.mu.Unlock()
+		t.cleanup()
+		return ""
+	}
+	end := offset + size
+	chunk := t.encoded[offset:end]
+	final := end == len(t.encoded)
+	t.mu.Unlock()
+	if final {
+		t.cleanup()
+	}
+	return chunk
+}
+
+func (t *startupTrace) cleanup() {
+	t.mu.Lock()
+	if t.cleaned {
+		t.mu.Unlock()
+		return
+	}
+	if !t.stopped {
+		trace.Stop()
+		t.stopped = true
+	}
+	t.cleaned = true
+	stopFunc := t.stopFunc
+	readFunc := t.readFunc
+	t.stopFunc = js.Func{}
+	t.readFunc = js.Func{}
+	t.buffer.Reset()
+	t.encoded = ""
+	t.mu.Unlock()
+
+	js.Global().Delete("BLDR_STOP_STARTUP_TRACE")
+	js.Global().Delete("BLDR_READ_STARTUP_TRACE")
+	stopFunc.Release()
+	readFunc.Release()
+}

--- a/bldr/web/entrypoint/startuptrace/startup-trace_stub.go
+++ b/bldr/web/entrypoint/startuptrace/startup-trace_stub.go
@@ -1,0 +1,4 @@
+//go:build !js || !bldr_startup_trace
+
+// Package startuptrace installs the opt-in browser runtime startup trace.
+package startuptrace

--- a/db/traceutil/startup/trace_disabled.go
+++ b/db/traceutil/startup/trace_disabled.go
@@ -1,0 +1,25 @@
+//go:build !bldr_startup_trace || tinygo
+
+// Package startuptrace provides compile-time gated startup attribution tracing.
+package startuptrace
+
+import "context"
+
+const buildTagged = false
+
+// Task is a no-op startup attribution trace task.
+type Task struct{}
+
+// NewTask returns ctx and a no-op startup attribution trace task.
+func NewTask(ctx context.Context, _ string) (context.Context, Task) {
+	return ctx, Task{}
+}
+
+// End ends the no-op startup attribution trace task.
+func (t Task) End() {}
+
+// Log is a no-op startup attribution trace log.
+func Log(_ context.Context, _ string, _ string) {}
+
+// Logf is a no-op formatted startup attribution trace log.
+func Logf(_ context.Context, _ string, _ string, _ ...any) {}

--- a/db/traceutil/startup/trace_disabled_test.go
+++ b/db/traceutil/startup/trace_disabled_test.go
@@ -1,0 +1,12 @@
+//go:build !bldr_startup_trace || tinygo
+
+package startuptrace
+
+import "testing"
+
+// TestStartupTraceBuildDisabled verifies the production owner is no-op without the opt-in tag.
+func TestStartupTraceBuildDisabled(t *testing.T) {
+	if buildTagged {
+		t.Fatal("startup trace owner unexpectedly enabled")
+	}
+}

--- a/db/traceutil/startup/trace_enabled.go
+++ b/db/traceutil/startup/trace_enabled.go
@@ -1,0 +1,37 @@
+//go:build bldr_startup_trace && !tinygo
+
+// Package startuptrace provides compile-time gated startup attribution tracing.
+package startuptrace
+
+import (
+	"context"
+	"runtime/trace"
+)
+
+const buildTagged = true
+
+// Task is a startup attribution trace task.
+type Task struct {
+	task *trace.Task
+}
+
+// NewTask creates a startup attribution trace task rooted at ctx.
+func NewTask(ctx context.Context, taskType string) (context.Context, Task) {
+	ctx, task := trace.NewTask(ctx, taskType)
+	return ctx, Task{task: task}
+}
+
+// End ends the startup attribution trace task.
+func (t Task) End() {
+	t.task.End()
+}
+
+// Log emits a startup attribution trace log message.
+func Log(ctx context.Context, category string, message string) {
+	trace.Log(ctx, category, message)
+}
+
+// Logf emits a formatted startup attribution trace log message.
+func Logf(ctx context.Context, category string, format string, args ...any) {
+	trace.Logf(ctx, category, format, args...)
+}

--- a/db/traceutil/startup/trace_enabled_test.go
+++ b/db/traceutil/startup/trace_enabled_test.go
@@ -1,0 +1,12 @@
+//go:build bldr_startup_trace && !tinygo
+
+package startuptrace
+
+import "testing"
+
+// TestStartupTraceBuildEnabled verifies the opt-in owner is selected with the build tag.
+func TestStartupTraceBuildEnabled(t *testing.T) {
+	if !buildTagged {
+		t.Fatal("startup trace owner unexpectedly disabled")
+	}
+}

--- a/db/world/block/tx-graph.go
+++ b/db/world/block/tx-graph.go
@@ -10,7 +10,7 @@ import (
 // All accesses of the handle should complete before returning cb.
 // Try to make access (queries) as short as possible.
 // Write operations will fail if the store is read-only.
-func (t *Tx) AccessCayleyGraph(ctx context.Context, write bool, cb func(ctx context.Context, h world.CayleyHandle) error) error {
+func (t *Tx) accessCayleyGraph(ctx context.Context, write bool, cb func(ctx context.Context, h world.CayleyHandle) error) error {
 	unlock, err := t.rmtx.Lock(ctx, false)
 	if err != nil {
 		return err
@@ -21,7 +21,7 @@ func (t *Tx) AccessCayleyGraph(ctx context.Context, write bool, cb func(ctx cont
 }
 
 // LookupGraphQuads searches for graph quads in the store.
-func (t *Tx) LookupGraphQuads(ctx context.Context, filter world.GraphQuad, limit uint32) ([]world.GraphQuad, error) {
+func (t *Tx) lookupGraphQuads(ctx context.Context, filter world.GraphQuad, limit uint32) ([]world.GraphQuad, error) {
 	unlock, err := t.rmtx.Lock(ctx, false)
 	if err != nil {
 		return nil, err
@@ -32,7 +32,7 @@ func (t *Tx) LookupGraphQuads(ctx context.Context, filter world.GraphQuad, limit
 }
 
 // LookupGraphQuadsBatch searches for graph quads for each filter in one locked read.
-func (t *Tx) LookupGraphQuadsBatch(ctx context.Context, filters []world.GraphQuad, limitPerFilter uint32) ([][]world.GraphQuad, error) {
+func (t *Tx) lookupGraphQuadsBatch(ctx context.Context, filters []world.GraphQuad, limitPerFilter uint32) ([][]world.GraphQuad, error) {
 	unlock, err := t.rmtx.Lock(ctx, false)
 	if err != nil {
 		return nil, err
@@ -43,7 +43,7 @@ func (t *Tx) LookupGraphQuadsBatch(ctx context.Context, filters []world.GraphQua
 }
 
 // QueryGraphPath executes a bounded graph traversal.
-func (t *Tx) QueryGraphPath(ctx context.Context, query *world.GraphPathQuery) (*world.GraphPathQueryResult, error) {
+func (t *Tx) queryGraphPath(ctx context.Context, query *world.GraphPathQuery) (*world.GraphPathQueryResult, error) {
 	unlock, err := t.rmtx.Lock(ctx, false)
 	if err != nil {
 		return nil, err
@@ -58,7 +58,7 @@ func (t *Tx) QueryGraphPath(ctx context.Context, query *world.GraphPathQuery) (*
 // Predicate: a predicate string, e.x. IRI: <ref>
 // Object: an existing object IRI: <object-key>
 // If already exists, returns nil.
-func (t *Tx) SetGraphQuad(ctx context.Context, q world.GraphQuad) error {
+func (t *Tx) setGraphQuad(ctx context.Context, q world.GraphQuad) error {
 	unlock, err := t.rmtx.Lock(ctx, true)
 	if err != nil {
 		return err
@@ -70,7 +70,7 @@ func (t *Tx) SetGraphQuad(ctx context.Context, q world.GraphQuad) error {
 
 // DeleteGraphQuad deletes a quad from the graph store.
 // Note: if quad did not exist, returns nil.
-func (t *Tx) DeleteGraphQuad(ctx context.Context, q world.GraphQuad) error {
+func (t *Tx) deleteGraphQuad(ctx context.Context, q world.GraphQuad) error {
 	unlock, err := t.rmtx.Lock(ctx, true)
 	if err != nil {
 		return err
@@ -82,7 +82,7 @@ func (t *Tx) DeleteGraphQuad(ctx context.Context, q world.GraphQuad) error {
 
 // DeleteGraphObject deletes all quads with Subject or Object set to value.
 // May also remove objects with <predicate> or <value> set to the value.
-func (t *Tx) DeleteGraphObject(ctx context.Context, value string) error {
+func (t *Tx) deleteGraphObject(ctx context.Context, value string) error {
 	unlock, err := t.rmtx.Lock(ctx, true)
 	if err != nil {
 		return err
@@ -90,6 +90,37 @@ func (t *Tx) DeleteGraphObject(ctx context.Context, value string) error {
 	defer unlock()
 
 	return t.state.DeleteGraphObject(ctx, value)
+}
+
+// AccessCayleyGraph calls a callback with a temporary Cayley graph handle.
+func (t *Tx) AccessCayleyGraph(ctx context.Context, write bool, cb func(ctx context.Context, h world.CayleyHandle) error) error {
+	return t.accessCayleyGraph(ctx, write, cb)
+}
+
+// LookupGraphQuadsBatch searches for graph quads for each filter in one locked read.
+func (t *Tx) LookupGraphQuadsBatch(ctx context.Context, filters []world.GraphQuad, limitPerFilter uint32) ([][]world.GraphQuad, error) {
+	return t.lookupGraphQuadsBatch(ctx, filters, limitPerFilter)
+}
+
+// QueryGraphPath executes a bounded graph traversal.
+func (t *Tx) QueryGraphPath(ctx context.Context, query *world.GraphPathQuery) (*world.GraphPathQueryResult, error) {
+	return t.queryGraphPath(ctx, query)
+}
+
+// SetGraphQuad sets a quad in the graph store.
+func (t *Tx) SetGraphQuad(ctx context.Context, q world.GraphQuad) error {
+	return t.setGraphQuad(ctx, q)
+}
+
+// DeleteGraphQuad deletes a quad from the graph store.
+// Note: if quad did not exist, returns nil.
+func (t *Tx) DeleteGraphQuad(ctx context.Context, q world.GraphQuad) error {
+	return t.deleteGraphQuad(ctx, q)
+}
+
+// DeleteGraphObject deletes all quads with Subject or Object set to value.
+func (t *Tx) DeleteGraphObject(ctx context.Context, value string) error {
+	return t.deleteGraphObject(ctx, value)
 }
 
 // _ is a type assertion

--- a/db/world/block/tx-graph_disabled.go
+++ b/db/world/block/tx-graph_disabled.go
@@ -1,0 +1,14 @@
+//go:build !bldr_startup_trace || tinygo
+
+package world_block
+
+import (
+	"context"
+
+	"github.com/s4wave/spacewave/db/world"
+)
+
+// LookupGraphQuads searches for graph quads in the store.
+func (t *Tx) LookupGraphQuads(ctx context.Context, filter world.GraphQuad, limit uint32) ([]world.GraphQuad, error) {
+	return t.lookupGraphQuads(ctx, filter, limit)
+}

--- a/db/world/block/tx-graph_startup_trace.go
+++ b/db/world/block/tx-graph_startup_trace.go
@@ -1,0 +1,17 @@
+//go:build bldr_startup_trace && !tinygo
+
+package world_block
+
+import (
+	"context"
+
+	startuptrace "github.com/s4wave/spacewave/db/traceutil/startup"
+	"github.com/s4wave/spacewave/db/world"
+)
+
+// LookupGraphQuads searches for graph quads in the store.
+func (t *Tx) LookupGraphQuads(ctx context.Context, filter world.GraphQuad, limit uint32) ([]world.GraphQuad, error) {
+	traceCtx, task := startuptrace.NewTask(ctx, "hydra/world-block/tx/lookup-graph-quads")
+	defer task.End()
+	return t.lookupGraphQuads(traceCtx, filter, limit)
+}

--- a/db/world/block/world-graph.go
+++ b/db/world/block/world-graph.go
@@ -15,7 +15,7 @@ import (
 // All accesses of the handle should complete before returning cb.
 // Try to make access (queries) as short as possible.
 // Write operations will fail if the store is read-only.
-func (t *WorldState) AccessCayleyGraph(ctx context.Context, write bool, cb func(ctx context.Context, h world.CayleyHandle) error) error {
+func (t *WorldState) accessCayleyGraph(ctx context.Context, write bool, cb func(ctx context.Context, h world.CayleyHandle) error) error {
 	if t.discarded.Load() {
 		return tx.ErrDiscarded
 	}
@@ -26,7 +26,7 @@ func (t *WorldState) AccessCayleyGraph(ctx context.Context, write bool, cb func(
 }
 
 // LookupGraphQuads searches for graph quads in the store.
-func (t *WorldState) LookupGraphQuads(ctx context.Context, filter world.GraphQuad, limit uint32) ([]world.GraphQuad, error) {
+func (t *WorldState) lookupGraphQuadsOnWorld(ctx context.Context, filter world.GraphQuad, limit uint32) ([]world.GraphQuad, error) {
 	if t.discarded.Load() {
 		return nil, tx.ErrDiscarded
 	}
@@ -45,7 +45,7 @@ func (t *WorldState) LookupGraphQuads(ctx context.Context, filter world.GraphQua
 }
 
 // LookupGraphQuadsBatch searches for graph quads for each filter in one graph read.
-func (t *WorldState) LookupGraphQuadsBatch(ctx context.Context, filters []world.GraphQuad, limitPerFilter uint32) ([][]world.GraphQuad, error) {
+func (t *WorldState) lookupGraphQuadsBatchOnWorld(ctx context.Context, filters []world.GraphQuad, limitPerFilter uint32) ([][]world.GraphQuad, error) {
 	if t.discarded.Load() {
 		return nil, tx.ErrDiscarded
 	}
@@ -138,7 +138,7 @@ func (t *WorldState) graphQuadExists(ctx context.Context, cq quad.Quad) (bool, e
 }
 
 // QueryGraphPath executes a bounded graph traversal.
-func (t *WorldState) QueryGraphPath(ctx context.Context, query *world.GraphPathQuery) (*world.GraphPathQueryResult, error) {
+func (t *WorldState) queryGraphPathOnWorld(ctx context.Context, query *world.GraphPathQuery) (*world.GraphPathQueryResult, error) {
 	if t.discarded.Load() {
 		return nil, tx.ErrDiscarded
 	}
@@ -189,7 +189,7 @@ func (g *graphPathReadOperation) QueryGraphPath(ctx context.Context, query *worl
 
 // SetGraphQuad sets a quad in the graph store.
 // If already exists, returns nil.
-func (t *WorldState) SetGraphQuad(ctx context.Context, q world.GraphQuad) error {
+func (t *WorldState) setGraphQuad(ctx context.Context, q world.GraphQuad) error {
 	if !t.write {
 		return tx.ErrNotWrite
 	}
@@ -257,7 +257,7 @@ func (t *WorldState) SetGraphQuad(ctx context.Context, q world.GraphQuad) error 
 
 // DeleteGraphQuad deletes a quad from the graph store.
 // Note: if quad did not exist, returns nil.
-func (t *WorldState) DeleteGraphQuad(ctx context.Context, q world.GraphQuad) error {
+func (t *WorldState) deleteGraphQuadEntry(ctx context.Context, q world.GraphQuad) error {
 	return t.deleteGraphQuad(ctx, q, true)
 }
 
@@ -320,7 +320,7 @@ func (t *WorldState) deleteGraphQuad(ctx context.Context, q world.GraphQuad, val
 }
 
 // DeleteGraphObject deletes all quads with Subject or Object set to value.
-func (t *WorldState) DeleteGraphObject(ctx context.Context, objKey string) error {
+func (t *WorldState) deleteGraphObject(ctx context.Context, objKey string) error {
 	if !t.write {
 		return tx.ErrNotWrite
 	}
@@ -367,6 +367,37 @@ func (t *WorldState) DeleteGraphObject(ctx context.Context, objKey string) error
 	}
 
 	return nil
+}
+
+// AccessCayleyGraph calls a callback with a temporary Cayley graph handle.
+func (t *WorldState) AccessCayleyGraph(ctx context.Context, write bool, cb func(ctx context.Context, h world.CayleyHandle) error) error {
+	return t.accessCayleyGraph(ctx, write, cb)
+}
+
+// LookupGraphQuadsBatch searches for graph quads for each filter in one graph read.
+func (t *WorldState) LookupGraphQuadsBatch(ctx context.Context, filters []world.GraphQuad, limitPerFilter uint32) ([][]world.GraphQuad, error) {
+	return t.lookupGraphQuadsBatchOnWorld(ctx, filters, limitPerFilter)
+}
+
+// QueryGraphPath executes a bounded graph traversal.
+func (t *WorldState) QueryGraphPath(ctx context.Context, query *world.GraphPathQuery) (*world.GraphPathQueryResult, error) {
+	return t.queryGraphPathOnWorld(ctx, query)
+}
+
+// SetGraphQuad sets a quad in the graph store.
+func (t *WorldState) SetGraphQuad(ctx context.Context, q world.GraphQuad) error {
+	return t.setGraphQuad(ctx, q)
+}
+
+// DeleteGraphQuad deletes a quad from the graph store.
+// Note: if quad did not exist, returns nil.
+func (t *WorldState) DeleteGraphQuad(ctx context.Context, q world.GraphQuad) error {
+	return t.deleteGraphQuadEntry(ctx, q)
+}
+
+// DeleteGraphObject deletes all quads with Subject or Object set to value.
+func (t *WorldState) DeleteGraphObject(ctx context.Context, objKey string) error {
+	return t.deleteGraphObject(ctx, objKey)
 }
 
 // _ is a type assertion

--- a/db/world/block/world-graph_disabled.go
+++ b/db/world/block/world-graph_disabled.go
@@ -1,0 +1,14 @@
+//go:build !bldr_startup_trace || tinygo
+
+package world_block
+
+import (
+	"context"
+
+	"github.com/s4wave/spacewave/db/world"
+)
+
+// LookupGraphQuads searches for graph quads in the store.
+func (t *WorldState) LookupGraphQuads(ctx context.Context, filter world.GraphQuad, limit uint32) ([]world.GraphQuad, error) {
+	return t.lookupGraphQuadsOnWorld(ctx, filter, limit)
+}

--- a/db/world/block/world-graph_startup_trace.go
+++ b/db/world/block/world-graph_startup_trace.go
@@ -1,0 +1,17 @@
+//go:build bldr_startup_trace && !tinygo
+
+package world_block
+
+import (
+	"context"
+
+	startuptrace "github.com/s4wave/spacewave/db/traceutil/startup"
+	"github.com/s4wave/spacewave/db/world"
+)
+
+// LookupGraphQuads searches for graph quads in the store.
+func (t *WorldState) LookupGraphQuads(ctx context.Context, filter world.GraphQuad, limit uint32) ([]world.GraphQuad, error) {
+	traceCtx, task := startuptrace.NewTask(ctx, "hydra/world-block/world-state/lookup-graph-quads")
+	defer task.End()
+	return t.lookupGraphQuadsOnWorld(traceCtx, filter, limit)
+}

--- a/e2e/drivebench/drivebench.go
+++ b/e2e/drivebench/drivebench.go
@@ -143,10 +143,10 @@ type ResourceConn struct {
 type Trace struct {
 	Bytes            int    `json:"bytes"`
 	RuntimeTracePath string `json:"runtimeTracePath"`
-	TracetoolPath    string `json:"tracetoolPath"`
-	UserTasks        int    `json:"userTasks"`
-	UserRegions      int    `json:"userRegions"`
-	UserLogs         int    `json:"userLogs"`
+	TracetoolPath    string `json:"tracetoolPath,omitempty"`
+	UserTasks        int    `json:"userTasks,omitempty"`
+	UserRegions      int    `json:"userRegions,omitempty"`
+	UserLogs         int    `json:"userLogs,omitempty"`
 	Tasks            []Task `json:"tasks,omitempty"`
 }
 
@@ -419,10 +419,22 @@ func marshalTraceValue(arena *fastjson.Arena, trace Trace) *fastjson.Value {
 	obj := arena.NewObject()
 	obj.Set("bytes", arena.NewNumberInt(trace.Bytes))
 	obj.Set("runtimeTracePath", arena.NewString(trace.RuntimeTracePath))
-	obj.Set("tracetoolPath", arena.NewString(trace.TracetoolPath))
-	obj.Set("userTasks", arena.NewNumberInt(trace.UserTasks))
-	obj.Set("userRegions", arena.NewNumberInt(trace.UserRegions))
-	obj.Set("userLogs", arena.NewNumberInt(trace.UserLogs))
+	// A cell that captured the raw trace without summarizing it has no counts
+	// to report. Emitting them anyway would publish measured zeros for tasks
+	// and logs the capture demonstrably contains, so the summary keys appear
+	// only once something has filled them in.
+	if trace.TracetoolPath != "" {
+		obj.Set("tracetoolPath", arena.NewString(trace.TracetoolPath))
+	}
+	if trace.UserTasks != 0 {
+		obj.Set("userTasks", arena.NewNumberInt(trace.UserTasks))
+	}
+	if trace.UserRegions != 0 {
+		obj.Set("userRegions", arena.NewNumberInt(trace.UserRegions))
+	}
+	if trace.UserLogs != 0 {
+		obj.Set("userLogs", arena.NewNumberInt(trace.UserLogs))
+	}
 	if len(trace.Tasks) != 0 {
 		obj.Set("tasks", marshalTasksValue(arena, trace.Tasks))
 	}

--- a/e2e/drivebench/drivebench.go
+++ b/e2e/drivebench/drivebench.go
@@ -419,23 +419,16 @@ func marshalTraceValue(arena *fastjson.Arena, trace Trace) *fastjson.Value {
 	obj := arena.NewObject()
 	obj.Set("bytes", arena.NewNumberInt(trace.Bytes))
 	obj.Set("runtimeTracePath", arena.NewString(trace.RuntimeTracePath))
-	// A cell that captured the raw trace without summarizing it has no counts
-	// to report. Emitting them anyway would publish measured zeros for tasks
-	// and logs the capture demonstrably contains, so the summary keys appear
-	// only once something has filled them in.
+	// A cell that captured the raw trace without summarizing it has no counts to
+	// report, and the tracetool path is what says whether summarization ran. Key
+	// the whole summary block on it rather than on the counts themselves: a
+	// summarized cell that legitimately saw no user regions must serialize that
+	// zero, or a consumer cannot tell a measured zero from an unsummarized cell.
 	if trace.TracetoolPath != "" {
 		obj.Set("tracetoolPath", arena.NewString(trace.TracetoolPath))
-	}
-	if trace.UserTasks != 0 {
 		obj.Set("userTasks", arena.NewNumberInt(trace.UserTasks))
-	}
-	if trace.UserRegions != 0 {
 		obj.Set("userRegions", arena.NewNumberInt(trace.UserRegions))
-	}
-	if trace.UserLogs != 0 {
 		obj.Set("userLogs", arena.NewNumberInt(trace.UserLogs))
-	}
-	if len(trace.Tasks) != 0 {
 		obj.Set("tasks", marshalTasksValue(arena, trace.Tasks))
 	}
 	return obj

--- a/e2e/drivebench/drivebench.go
+++ b/e2e/drivebench/drivebench.go
@@ -25,8 +25,8 @@ import (
 // quickstart timing, the served bundle size, the Resource SDK connection timing,
 // and optional trace/profile summaries. It is written as run.json per cell so
 // cells compare across runtime states and build modes. The bundled production
-// bench has no Go trace service and no Resource SDK client, so it omits Trace
-// and leaves ResourceConnection zero.
+// bench has no Resource SDK client, so ResourceConnection remains zero; an
+// opt-in startup trace may populate Trace.
 type Run struct {
 	Timestamp          string          `json:"timestamp"`
 	Compiler           string          `json:"compiler"`

--- a/e2e/releasewasm/artifact.go
+++ b/e2e/releasewasm/artifact.go
@@ -38,6 +38,7 @@ var releaseWasmArtifactEnvKeys = []string{
 	gocompiler.TinyGoInterpTimeoutEnv,
 	gocompiler.TinyGoDebugInfoEnv,
 	gocompiler.GoWasmOptimizeEnv,
+	gocompiler.RuntimeStartupTraceEnv,
 	"BINARYEN_CORES",
 	"BINARYEN_VERSION",
 	"CGO_ENABLED",

--- a/e2e/releasewasm/drive-startup-bench_test.go
+++ b/e2e/releasewasm/drive-startup-bench_test.go
@@ -22,9 +22,9 @@ const driveBenchEnv = "E2E_WASM_DRIVE_BENCH"
 // TestGoScriptDriveStartupBenchBundled records the time-to-Drive bench for the
 // production bundled build across three runtime states on one owned
 // BrowserContext, writing the same run.json schema as the unbundled bench so
-// cells compare across harnesses. The bundled production path has no Go trace
-// service and no Resource SDK client, so cells omit Trace and leave
-// ResourceConnection zero. The states mirror the unbundled bench:
+// cells compare across harnesses. The bundled production path has no Resource
+// SDK client. An opt-in root-runtime trace is read directly from its browser
+// SharedWorker target.
 //
 //   - cold: a fresh context boots the bundled SharedWorker runtime over a cold
 //     HTTP cache and empty OPFS Space state.
@@ -46,6 +46,11 @@ func TestGoScriptDriveStartupBenchBundled(t *testing.T) {
 	}
 	if compiler != releaseWasmCompilerGoScript {
 		t.Skipf("bundled drive bench requires %s=true", E2EReleaseWasmGoScriptEnv)
+	}
+	if releaseStartupTraceEnabled() {
+		if err := checkReleaseStartupTraceBrowser(); err != nil {
+			t.Fatalf("startup trace capture: %v", err)
+		}
 	}
 
 	// One run stamp groups every cell's artifacts under a single run directory.
@@ -115,6 +120,11 @@ type bundledDriveBenchCellInput struct {
 func runBundledDriveBenchCell(t *testing.T, page playwright.Page, in bundledDriveBenchCellInput) {
 	t.Helper()
 
+	cellDir, err := drivebench.CellDir(in.runStamp, in.cell)
+	if err != nil {
+		t.Fatalf("resolve cell dir (%s): %v", in.cell, err)
+	}
+
 	navStart := time.Now()
 	if _, err := page.Goto(testHarness.getBaseURL() + "/quickstart/drive"); err != nil {
 		t.Fatalf("goto quickstart drive (%s): %v", in.cell, err)
@@ -127,7 +137,8 @@ func runBundledDriveBenchCell(t *testing.T, page playwright.Page, in bundledDriv
 	liveAppMs := browserNowMs(t, page)
 	waitForQuickstartAppRoute(t, page)
 	routeAcceptedMs := browserNowMs(t, page)
-	completeQuickstartDriveIntroIfPresent(t, page)
+	// The first-run intro overlays the already-mounted viewer; the benchmark
+	// observes readiness without adding an interaction to the startup interval.
 	if err := page.Locator("[data-testid='unixfs-browser']:visible").First().WaitFor(
 		playwright.LocatorWaitForOptions{Timeout: playwright.Float(browserWaitMS)},
 	); err != nil {
@@ -140,6 +151,14 @@ func runBundledDriveBenchCell(t *testing.T, page playwright.Page, in bundledDriv
 		t.Logf("quickstart content-ready not reached (%s): %s", in.cell, contentReadyErr)
 	}
 	logQuickstartTiming(t, page)
+
+	var startupTrace []byte
+	if releaseStartupTraceEnabled() {
+		startupTrace, err = captureReleaseStartupTrace(t.Context(), testHarness.browser)
+		if err != nil {
+			t.Fatalf("capture startup trace (%s): %v", in.cell, err)
+		}
+	}
 
 	distDir := filepath.Join(testHarness.repoRoot, releaseDistRelPath)
 	bundle, err := drivebench.MeasureBundleDir(distDir)
@@ -167,14 +186,20 @@ func runBundledDriveBenchCell(t *testing.T, page playwright.Page, in bundledDriv
 		ServedBundle: bundle,
 	}
 	run.Browser.StartupMarks = readBundledStartupMarks(t, page)
+	if len(startupTrace) != 0 {
+		tracePath := filepath.Join(cellDir, "runtime.trace")
+		if err := drivebench.WriteArtifact(tracePath, startupTrace); err != nil {
+			t.Fatalf("write runtime trace (%s): %v", in.cell, err)
+		}
+		run.Trace = &drivebench.Trace{
+			Bytes:            len(startupTrace),
+			RuntimeTracePath: tracePath,
+		}
+	}
 	t.Logf("bundled served bundle (%s): totalBytes=%d wasmBytes=%d fileCount=%d",
 		in.cell, bundle.TotalBytes, bundle.WasmBytes, bundle.FileCount)
 
-	dir, err := drivebench.CellDir(in.runStamp, in.cell)
-	if err != nil {
-		t.Fatalf("resolve cell dir (%s): %v", in.cell, err)
-	}
-	runPath, err := drivebench.WriteRun(dir, run)
+	runPath, err := drivebench.WriteRun(cellDir, run)
 	if err != nil {
 		t.Fatalf("write run.json (%s): %v", in.cell, err)
 	}

--- a/e2e/releasewasm/drive-startup-bench_test.go
+++ b/e2e/releasewasm/drive-startup-bench_test.go
@@ -47,12 +47,6 @@ func TestGoScriptDriveStartupBenchBundled(t *testing.T) {
 	if compiler != releaseWasmCompilerGoScript {
 		t.Skipf("bundled drive bench requires %s=true", E2EReleaseWasmGoScriptEnv)
 	}
-	if releaseStartupTraceEnabled() {
-		if err := checkReleaseStartupTraceBrowser(); err != nil {
-			t.Fatalf("startup trace capture: %v", err)
-		}
-	}
-
 	// One run stamp groups every cell's artifacts under a single run directory.
 	runStamp := time.Now().UTC().Format("20060102-150405")
 

--- a/e2e/releasewasm/releasewasm_test.go
+++ b/e2e/releasewasm/releasewasm_test.go
@@ -67,6 +67,10 @@ func TestMain(m *testing.M) {
 		os.Exit(0)
 	}
 
+	if err := applyReleaseStartupTraceEnv(); err != nil {
+		le.WithError(err).Fatal("apply release wasm startup trace env")
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
 	defer cancel()
 

--- a/e2e/releasewasm/startup-trace.go
+++ b/e2e/releasewasm/startup-trace.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aperturerobotics/fastjson"
 	playwright "github.com/mxschmitt/playwright-go"
 	"github.com/pkg/errors"
+	"github.com/s4wave/spacewave/bldr/util/gocompiler"
 )
 
 const releaseWasmStartupTraceEnv = "E2E_RELEASE_WASM_MANIFEST_STARTUP_TRACE"
@@ -27,11 +28,19 @@ func releaseStartupTraceEnabled() bool {
 	return os.Getenv(releaseWasmStartupTraceEnv) == "1"
 }
 
-// checkReleaseStartupTraceBrowser rejects a trace run on a browser that cannot
-// serve it. The capture reads the SharedWorker target through a browser-level
-// CDP session, which Playwright provides for Chromium only, so firefox and
-// webkit would boot the whole cell and then fail at the capture.
-func checkReleaseStartupTraceBrowser() error {
+// applyReleaseStartupTraceEnv prepares the process for a trace run, before the
+// harness builds anything.
+//
+// The capture reads the SharedWorker target through a browser-level CDP
+// session, which Playwright provides for Chromium only, so firefox and webkit
+// are rejected here rather than after a full build and boot. The instrumented
+// build itself is selected by gocompiler.RuntimeStartupTraceEnv, so the capture
+// opt-in sets it: an operator who asks for a trace gets a bundle that carries
+// the callback instead of one that reports it missing.
+func applyReleaseStartupTraceEnv() error {
+	if !releaseStartupTraceEnabled() {
+		return nil
+	}
 	name, err := releaseWasmBrowserName()
 	if err != nil {
 		return err
@@ -41,6 +50,9 @@ func checkReleaseStartupTraceBrowser() error {
 			"%s=1 needs a browser CDP session, which only chromium provides; E2E_RELEASE_WASM_BROWSER is %s",
 			releaseWasmStartupTraceEnv, name,
 		)
+	}
+	if err := os.Setenv(gocompiler.RuntimeStartupTraceEnv, "1"); err != nil {
+		return errors.Wrapf(err, "set %s from %s", gocompiler.RuntimeStartupTraceEnv, releaseWasmStartupTraceEnv)
 	}
 	return nil
 }

--- a/e2e/releasewasm/startup-trace.go
+++ b/e2e/releasewasm/startup-trace.go
@@ -1,0 +1,297 @@
+//go:build !js
+
+package releasewasm
+
+import (
+	"context"
+	"encoding/base64"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/aperturerobotics/fastjson"
+	playwright "github.com/mxschmitt/playwright-go"
+	"github.com/pkg/errors"
+)
+
+const releaseWasmStartupTraceEnv = "E2E_RELEASE_WASM_MANIFEST_STARTUP_TRACE"
+
+const (
+	startupTraceChunkSize = 256 * 1024
+	startupTraceMissing   = "missing"
+)
+
+// releaseStartupTraceEnabled reports whether this run opted into capturing the
+// startup trace.
+func releaseStartupTraceEnabled() bool {
+	return os.Getenv(releaseWasmStartupTraceEnv) == "1"
+}
+
+// checkReleaseStartupTraceBrowser rejects a trace run on a browser that cannot
+// serve it. The capture reads the SharedWorker target through a browser-level
+// CDP session, which Playwright provides for Chromium only, so firefox and
+// webkit would boot the whole cell and then fail at the capture.
+func checkReleaseStartupTraceBrowser() error {
+	name, err := releaseWasmBrowserName()
+	if err != nil {
+		return err
+	}
+	if name != "chromium" {
+		return errors.Errorf(
+			"%s=1 needs a browser CDP session, which only chromium provides; E2E_RELEASE_WASM_BROWSER is %s",
+			releaseWasmStartupTraceEnv, name,
+		)
+	}
+	return nil
+}
+
+// captureReleaseStartupTrace stops and reads the root distribution runtime
+// trace from the SharedWorker target that owns the browser plugin host.
+func captureReleaseStartupTrace(ctx context.Context, browser playwright.Browser) (_ []byte, retErr error) {
+	cdp, err := browser.NewBrowserCDPSession()
+	if err != nil {
+		return nil, errors.Wrap(err, "create browser CDP session")
+	}
+	defer func() {
+		if err := cdp.Detach(); err != nil {
+			if retErr == nil {
+				retErr = errors.Wrap(err, "detach browser CDP session")
+			} else {
+				retErr = errors.Wrapf(retErr, "detach browser CDP session: %v", err)
+			}
+		}
+	}()
+
+	raw, err := cdp.Send("Target.getTargets", map[string]any{})
+	if err != nil {
+		return nil, errors.Wrap(err, "list browser targets")
+	}
+	targets, err := startupTraceTargets(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	var checked []string
+	for _, target := range targets {
+		data, found, err := captureStartupTraceTarget(ctx, cdp, target)
+		if err != nil {
+			return nil, errors.Wrapf(err, "capture startup trace from %s %s", target.kind, target.url)
+		}
+		checked = append(checked, target.kind+":"+target.url)
+		if found {
+			return data, nil
+		}
+	}
+	return nil, errors.Errorf("startup trace callback not found; targets=%v", checked)
+}
+
+type startupTraceTarget struct {
+	id   string
+	kind string
+	url  string
+}
+
+func startupTraceTargets(raw any) ([]startupTraceTarget, error) {
+	result, ok := raw.(map[string]any)
+	if !ok {
+		return nil, errors.Errorf("browser targets result has type %T", raw)
+	}
+	infos, ok := result["targetInfos"].([]any)
+	if !ok {
+		return nil, errors.Errorf("browser target infos has type %T", result["targetInfos"])
+	}
+
+	targets := make([]startupTraceTarget, 0, len(infos))
+	for _, rawInfo := range infos {
+		info, ok := rawInfo.(map[string]any)
+		if !ok {
+			return nil, errors.Errorf("browser target info has type %T", rawInfo)
+		}
+		kind, _ := info["type"].(string)
+		if kind != "shared_worker" && kind != "worker" {
+			continue
+		}
+		id, _ := info["targetId"].(string)
+		url, _ := info["url"].(string)
+		if id == "" {
+			return nil, errors.Errorf("%s target has no targetId: %v", kind, info)
+		}
+		targets = append(targets, startupTraceTarget{id: id, kind: kind, url: url})
+	}
+	return targets, nil
+}
+
+func captureStartupTraceTarget(
+	ctx context.Context,
+	cdp playwright.CDPSession,
+	target startupTraceTarget,
+) (_ []byte, _ bool, retErr error) {
+	raw, err := cdp.Send("Target.attachToTarget", map[string]any{
+		"targetId": target.id,
+		"flatten":  false,
+	})
+	if err != nil {
+		return nil, false, errors.Wrap(err, "attach to browser target")
+	}
+	result, ok := raw.(map[string]any)
+	if !ok {
+		return nil, false, errors.Errorf("attach target result has type %T", raw)
+	}
+	sessionID, _ := result["sessionId"].(string)
+	if sessionID == "" {
+		return nil, false, errors.Errorf("attach target result has no sessionId: %v", result)
+	}
+	defer func() {
+		_, err := cdp.Send("Target.detachFromTarget", map[string]any{"sessionId": sessionID})
+		if err == nil {
+			return
+		}
+		if retErr == nil {
+			retErr = errors.Wrap(err, "detach from browser target")
+		} else {
+			retErr = errors.Wrapf(retErr, "detach from browser target: %v", err)
+		}
+	}()
+
+	traceStopped := true
+	traceCompleted := false
+	defer func() {
+		if traceStopped && !traceCompleted {
+			abortStartupTraceTarget(cdp, sessionID)
+		}
+	}()
+
+	encodedLength, err := evaluateStartupTraceTarget(ctx, cdp, sessionID, 1, `(async () => {
+		const stop = globalThis.BLDR_STOP_STARTUP_TRACE
+		if (typeof stop !== 'function') return 'missing'
+		const value = await stop()
+		return value == null ? 'missing' : String(value)
+	})()`)
+	if err != nil {
+		return nil, false, err
+	}
+	if encodedLength == startupTraceMissing {
+		return nil, false, nil
+	}
+	length, err := strconv.Atoi(encodedLength)
+	if err != nil || length <= 0 {
+		return nil, false, errors.Errorf("startup trace encoded length %q is invalid", encodedLength)
+	}
+
+	var encoded strings.Builder
+	encoded.Grow(length)
+	requestID := 2
+	for offset := 0; offset < length; offset += startupTraceChunkSize {
+		size := min(startupTraceChunkSize, length-offset)
+		expression := "globalThis.BLDR_READ_STARTUP_TRACE(" + strconv.Itoa(offset) + "," + strconv.Itoa(size) + ")"
+		chunk, err := evaluateStartupTraceTarget(ctx, cdp, sessionID, requestID, expression)
+		if err != nil {
+			return nil, false, errors.Wrapf(err, "read startup trace at %d", offset)
+		}
+		if len(chunk) != size {
+			return nil, false, errors.Errorf("startup trace chunk at %d has %d bytes, want %d", offset, len(chunk), size)
+		}
+		encoded.WriteString(chunk)
+		requestID++
+	}
+	traceCompleted = true
+	data, err := base64.StdEncoding.DecodeString(encoded.String())
+	if err != nil {
+		return nil, false, errors.Wrap(err, "decode startup trace")
+	}
+	if len(data) == 0 {
+		return nil, false, errors.New("startup trace is empty")
+	}
+	return data, true, nil
+}
+
+func abortStartupTraceTarget(cdp playwright.CDPSession, sessionID string) {
+	const expression = `(() => {
+		const read = globalThis.BLDR_READ_STARTUP_TRACE
+		if (typeof read === 'function') read(-1, 0)
+	})()`
+	_, _ = cdp.Send("Target.sendMessageToTarget", map[string]any{
+		"sessionId": sessionID,
+		"message":   startupTraceEvaluateMessage(0, expression),
+	})
+}
+
+func evaluateStartupTraceTarget(
+	ctx context.Context,
+	cdp playwright.CDPSession,
+	sessionID string,
+	requestID int,
+	expression string,
+) (string, error) {
+	responses := make(chan string, 1)
+	handler := func(params map[string]any) {
+		if got, _ := params["sessionId"].(string); got != sessionID {
+			return
+		}
+		message, _ := params["message"].(string)
+		if startupTraceResponseID(message) == requestID {
+			responses <- message
+		}
+	}
+	cdp.On("Target.receivedMessageFromTarget", handler)
+	defer cdp.RemoveListener("Target.receivedMessageFromTarget", handler)
+
+	message := startupTraceEvaluateMessage(requestID, expression)
+	if _, err := cdp.Send("Target.sendMessageToTarget", map[string]any{
+		"sessionId": sessionID,
+		"message":   message,
+	}); err != nil {
+		return "", errors.Wrap(err, "send Runtime.evaluate to browser target")
+	}
+
+	select {
+	case response := <-responses:
+		return parseStartupTraceEvaluation(response)
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+}
+
+func startupTraceEvaluateMessage(requestID int, expression string) string {
+	var arena fastjson.Arena
+	root := arena.NewObject()
+	root.Set("id", arena.NewNumberInt(requestID))
+	root.Set("method", arena.NewString("Runtime.evaluate"))
+	params := arena.NewObject()
+	params.Set("expression", arena.NewString(expression))
+	params.Set("returnByValue", arena.NewTrue())
+	params.Set("awaitPromise", arena.NewTrue())
+	root.Set("params", params)
+	return string(root.MarshalTo(nil))
+}
+
+func startupTraceResponseID(message string) int {
+	var parser fastjson.Parser
+	value, err := parser.Parse(message)
+	if err != nil {
+		return 0
+	}
+	return value.GetInt("id")
+}
+
+func parseStartupTraceEvaluation(message string) (string, error) {
+	var parser fastjson.Parser
+	value, err := parser.Parse(message)
+	if err != nil {
+		return "", errors.Wrap(err, "parse Runtime.evaluate response")
+	}
+	if remoteErr := value.Get("error"); remoteErr != nil {
+		return "", errors.Errorf("Runtime.evaluate failed: %s", remoteErr.String())
+	}
+	if exception := value.Get("result", "exceptionDetails"); exception != nil {
+		return "", errors.Errorf("Runtime.evaluate exception: %s", exception.String())
+	}
+	result := value.Get("result", "result")
+	if result == nil {
+		return "", errors.Errorf("Runtime.evaluate response has no result: %s", message)
+	}
+	if resultType := string(result.GetStringBytes("type")); resultType != "string" {
+		return "", errors.Errorf("Runtime.evaluate returned %q: %s", resultType, result.String())
+	}
+	return string(result.GetStringBytes("value")), nil
+}

--- a/e2e/wasm/harness_test.go
+++ b/e2e/wasm/harness_test.go
@@ -81,6 +81,14 @@ func harness(t testing.TB) *Harness {
 	return sharedHarness
 }
 
+// sharedHarnessBooted reports whether the package harness has already been
+// built. A test that needs the harness compiled a particular way checks this
+// before configuring the build environment, since harnessOnce will not rebuild
+// what an earlier test in the same slice already built.
+func sharedHarnessBooted() bool {
+	return sharedHarness != nil || harnessBootErr != nil
+}
+
 // bootSharedHarness boots the harness, launches the browser, and compiles the
 // e2e test scripts. It runs once, guarded by harnessOnce.
 func bootSharedHarness() (*Harness, error) {

--- a/e2e/wasm/manifest-startup-trace-goscript_test.go
+++ b/e2e/wasm/manifest-startup-trace-goscript_test.go
@@ -26,6 +26,17 @@ func TestGoScriptManifestStartupTrace(t *testing.T) {
 	if compiler != E2EWasmCompilerGoScript {
 		t.Skipf("GoScript-only Manifest startup trace; compiler=%s", compiler)
 	}
+	workerMode, err := ResolveE2EWasmWorkerMode("")
+	if err != nil {
+		t.Fatalf("resolve e2e wasm worker mode: %v", err)
+	}
+	// sess.Workers() is populated from page.OnWorker, which reports dedicated
+	// workers only. In shared-worker mode the instrumented root runtime lives in
+	// a SharedWorker the scan never reaches, so the capture would fail looking
+	// for a callback that is running somewhere it cannot see.
+	if workerMode != WorkerModeDedicated {
+		t.Skipf("Manifest startup trace captures through page workers; worker mode=%s, want %s", workerMode, WorkerModeDedicated)
+	}
 
 	// The trace hook is a build tag, so the shared harness has to be compiled
 	// with it. Once an earlier test in this slice has booted that harness there

--- a/e2e/wasm/manifest-startup-trace-goscript_test.go
+++ b/e2e/wasm/manifest-startup-trace-goscript_test.go
@@ -1,0 +1,126 @@
+//go:build !skip_e2e && !js
+
+package wasm
+
+import (
+	"encoding/base64"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/s4wave/spacewave/bldr/util/gocompiler"
+)
+
+const e2eWasmManifestStartupTraceEnv = "E2E_WASM_MANIFEST_STARTUP_TRACE"
+
+// TestGoScriptManifestStartupTrace captures and writes the root browser runtime
+// from process initialization through configured startup completion.
+func TestGoScriptManifestStartupTrace(t *testing.T) {
+	if os.Getenv(e2eWasmManifestStartupTraceEnv) == "" {
+		t.Skip("set " + e2eWasmManifestStartupTraceEnv + "=1 to capture the Manifest startup trace")
+	}
+	compiler, err := ResolveE2EWasmCompiler()
+	if err != nil {
+		t.Fatalf("resolve e2e wasm compiler: %v", err)
+	}
+	if compiler != E2EWasmCompilerGoScript {
+		t.Skipf("GoScript-only Manifest startup trace; compiler=%s", compiler)
+	}
+
+	t.Setenv(gocompiler.RuntimeStartupTraceEnv, "1")
+	t.Setenv("E2E_WASM_STARTUP_BUILD_CACHE", "false")
+	h := harness(t)
+	sess := h.NewCleanBlankSession(t)
+	if err := h.loadAppPageURL(sess, h.baseURL+"/#/pair/00000000"); err != nil {
+		t.Fatalf("load Pairing startup route: %v", err)
+	}
+	WaitForApp(t, sess.Page())
+	AssertBrowserStartupDone(t, h, sess.Page())
+
+	data := stopStartupTrace(t, sess)
+	tracePath := TraceArtifactPath(t)
+	if err := WriteTraceArtifact(tracePath, data); err != nil {
+		t.Fatalf("write startup trace: %v", err)
+	}
+	assertTraceParses(t, data)
+	t.Logf("wrote %d trace bytes to %s", len(data), tracePath)
+}
+
+func stopStartupTrace(t testing.TB, sess *TestSession) []byte {
+	t.Helper()
+	const (
+		stopScript = `() => {
+			const stop = globalThis.BLDR_STOP_STARTUP_TRACE
+			return typeof stop === 'function' ? stop() : null
+		}`
+		readScript  = `(arg) => globalThis.BLDR_READ_STARTUP_TRACE(arg.offset, arg.size)`
+		abortScript = `() => {
+			const read = globalThis.BLDR_READ_STARTUP_TRACE
+			if (typeof read === 'function') read({ offset: -1, size: 0 })
+		}`
+		chunkSize = 256 * 1024
+	)
+	var workerResults []string
+	for _, worker := range sess.Workers() {
+		raw, err := worker.Evaluate(stopScript)
+		if err != nil {
+			workerResults = append(workerResults, worker.URL()+": "+err.Error())
+			continue
+		}
+		if raw == nil {
+			workerResults = append(workerResults, worker.URL()+": no callback")
+			continue
+		}
+		traceCompleted := false
+		defer func() {
+			if !traceCompleted {
+				_, _ = worker.Evaluate(abortScript)
+			}
+		}()
+		if encodedErr, ok := raw.(string); ok {
+			if after, ok := strings.CutPrefix(encodedErr, "error:"); ok {
+				t.Fatalf("startup trace callback failed: %s", after)
+			}
+			t.Fatalf("startup trace callback returned unexpected string %q from %s", encodedErr, worker.URL())
+		}
+		var encodedLength int
+		switch v := raw.(type) {
+		case int:
+			encodedLength = v
+		case float64:
+			encodedLength = int(v)
+		}
+		if encodedLength <= 0 {
+			t.Fatalf("startup trace callback returned %T(%v) from %s", raw, raw, worker.URL())
+		}
+
+		var encoded strings.Builder
+		encoded.Grow(encodedLength)
+		for offset := 0; offset < encodedLength; offset += chunkSize {
+			size := min(chunkSize, encodedLength-offset)
+			chunkRaw, err := worker.Evaluate(readScript, map[string]any{
+				"offset": offset,
+				"size":   size,
+			})
+			if err != nil {
+				t.Fatalf("read startup trace from %s at %d: %v", worker.URL(), offset, err)
+			}
+			chunk, ok := chunkRaw.(string)
+			if !ok || len(chunk) != size {
+				t.Fatalf("startup trace chunk from %s at %d = %T bytes=%d, want %d", worker.URL(), offset, chunkRaw, len(chunk), size)
+			}
+			encoded.WriteString(chunk)
+		}
+		traceCompleted = true
+		data, err := base64.StdEncoding.DecodeString(encoded.String())
+		if err != nil {
+			t.Fatalf("decode startup trace from %s: %v", worker.URL(), err)
+		}
+		if len(data) == 0 {
+			t.Fatalf("startup trace from %s is empty", worker.URL())
+		}
+		return data
+	}
+	t.Fatalf("root startup trace callback not found; workers=%v", workerResults)
+	return nil
+}

--- a/e2e/wasm/manifest-startup-trace-goscript_test.go
+++ b/e2e/wasm/manifest-startup-trace-goscript_test.go
@@ -27,6 +27,14 @@ func TestGoScriptManifestStartupTrace(t *testing.T) {
 		t.Skipf("GoScript-only Manifest startup trace; compiler=%s", compiler)
 	}
 
+	// The trace hook is a build tag, so the shared harness has to be compiled
+	// with it. Once an earlier test in this slice has booted that harness there
+	// is nothing left to configure, and the run would quietly measure an
+	// uninstrumented worker and then fail looking for the callback.
+	if sharedHarnessBooted() {
+		t.Fatalf("shared harness already built without the trace tag; run this test alone with -run %s", t.Name())
+	}
+
 	t.Setenv(gocompiler.RuntimeStartupTraceEnv, "1")
 	t.Setenv("E2E_WASM_STARTUP_BUILD_CACHE", "false")
 	h := harness(t)

--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
     "bldr:lint:go": "bun run go:aptre -- lint ./bldr/...",
     "lint:js:oxlint": "oxlint .",
     "lint:js:oxlint:type-aware": "oxlint -c .oxlintrc.type-aware.json --type-aware ./app ./web ./core ./sdk ./cmd",
+    "check:go:startup-trace": "cross-env GOFLAGS=-mod=mod go build -tags bldr_startup_trace,purego ./bldr/... ./db/...",
     "lint:go:db": "bun run go:aptre -- lint ./db/...",
     "lint:go:e2e": "bun run go:aptre -- lint ./e2e/...",
     "lint:go:forge": "bun run go:aptre -- lint ./forge/...",


### PR DESCRIPTION
Browser startup had no trace that connected generated runtime work to manifest selection and World operations, so the startup review could not establish a current attribution baseline. This change adds an opt-in browser runtime trace hook, build-tag propagation through GoScript release entrypoints, and trace tasks and logs around manifest eligibility, manifest storage, demand reads, World graph work, root updates, block writes, and OPFS Sync barriers. The existing runtime path and benchmark schema remain unchanged when tracing is disabled.

Tracing is off by default. Disabled production builds do not include the browser hook or trace build tag, and the normal hot paths do not allocate trace state or acquire an instrumentation lock. Enabled runs write the standard Go runtime trace and expose a bounded browser callback for the release harness to capture it.

Focused package builds and tests pass for the changed Bldr, storage, manifest, scheduler, and drivebench packages. The instrumented GoScript release Drive startup benchmark also passes across cold, warm, and cache-hot bundled cells on the rebased branch.