### PR TITLE
fix(e2e): match the ellipsis character the placeholders actually render

### DIFF
--- a/e2e/wasm/blog-coexistence_test.go
+++ b/e2e/wasm/blog-coexistence_test.go
@@ -95,7 +95,7 @@ func waitForNotebookReady(t testing.TB, page playwright.Page, noteTitle string) 
 	t.Helper()
 
 	wait := playwright.LocatorWaitForOptions{Timeout: playwright.Float(blogCoexistenceWaitMS)}
-	if err := page.Locator("input[placeholder='Search notes...']").First().WaitFor(wait); err != nil {
+	if err := page.Locator("input[placeholder='Search notes…']").First().WaitFor(wait); err != nil {
 		debug, debugErr := page.Evaluate(`() => JSON.stringify({
 			url: window.location.href,
 			hash: window.location.hash,

--- a/e2e/wasm/chat-quickstart-goscript_test.go
+++ b/e2e/wasm/chat-quickstart-goscript_test.go
@@ -112,7 +112,7 @@ func collectChatQuickstartDebug(page playwright.Page) any {
 		hash: window.location.hash,
 		timing: globalThis.__s4waveQuickstartTiming ?? globalThis.__s4wave_debug?.quickstartTiming ?? null,
 		text: document.querySelector('#bldr-root')?.textContent?.replace(/\s+/g, ' ').slice(0, 2200) ?? '',
-		hasInput: !!document.querySelector('textarea[placeholder="Type a message..."]'),
+		hasInput: !!document.querySelector('textarea[placeholder="Type a message…"]'),
 	})`)
 	if err != nil {
 		return map[string]any{"error": err.Error()}

--- a/e2e/wasm/chat-quickstart-goscript_test.go
+++ b/e2e/wasm/chat-quickstart-goscript_test.go
@@ -3,6 +3,7 @@
 package wasm
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 
@@ -10,6 +11,12 @@ import (
 )
 
 const chatQuickstartWaitMS = 240000
+
+// chatMessageInputSelector matches the composer textarea rendered by the Chat
+// viewer. The placeholder ends in a single ellipsis character, and a CSS
+// attribute selector compares exactly, so every query for this element shares
+// one owner rather than repeating a string that has already drifted once.
+const chatMessageInputSelector = "textarea[placeholder=\"Type a message…\"]"
 
 func TestGoScriptChatQuickstartMessagingParity(t *testing.T) {
 	compiler, err := ResolveE2EWasmCompiler()
@@ -68,7 +75,7 @@ func TestGoScriptChatQuickstartMessagingParity(t *testing.T) {
 func waitForChatRoute(t testing.TB, page playwright.Page) {
 	t.Helper()
 
-	locator := page.Locator("textarea[placeholder=\"Type a message...\"]")
+	locator := page.Locator(chatMessageInputSelector)
 	if err := locator.WaitFor(playwright.LocatorWaitForOptions{
 		Timeout: playwright.Float(chatQuickstartWaitMS),
 	}); err != nil {
@@ -84,7 +91,7 @@ func waitForChatRoute(t testing.TB, page playwright.Page) {
 func sendChatMessage(t testing.TB, page playwright.Page, message string) {
 	t.Helper()
 
-	input := page.Locator("textarea[placeholder=\"Type a message...\"]")
+	input := page.Locator(chatMessageInputSelector)
 	if err := input.Fill(message, playwright.LocatorFillOptions{
 		Timeout: playwright.Float(chatQuickstartWaitMS),
 	}); err != nil {
@@ -112,7 +119,7 @@ func collectChatQuickstartDebug(page playwright.Page) any {
 		hash: window.location.hash,
 		timing: globalThis.__s4waveQuickstartTiming ?? globalThis.__s4wave_debug?.quickstartTiming ?? null,
 		text: document.querySelector('#bldr-root')?.textContent?.replace(/\s+/g, ' ').slice(0, 2200) ?? '',
-		hasInput: !!document.querySelector('textarea[placeholder="Type a message…"]'),
+		hasInput: !!document.querySelector(` + strconv.Quote(chatMessageInputSelector) + `),
 	})`)
 	if err != nil {
 		return map[string]any{"error": err.Error()}

--- a/e2e/wasm/harness_test.go
+++ b/e2e/wasm/harness_test.go
@@ -2145,7 +2145,13 @@ func TestForgeWorkerExecution(t *testing.T) {
 
 	// Start the completion budget after setup has observed the approved worker.
 	// Browser/plugin startup and World mounting must not consume wait time.
-	waitCtx, cancel := context.WithTimeout(ctx, 3*time.Minute)
+	// The alternate browser compilers run every pass an order slower, so they
+	// take the same doubled budget WaitForApp gives app readiness.
+	jobBudget := 3 * time.Minute
+	if E2EWasmSlowCompilerEnabled() {
+		jobBudget = 6 * time.Minute
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, jobBudget)
 	defer cancel()
 	job, err := forge_job.WaitJobComplete(waitCtx, h.le, mounted.engWs, jobKey)
 	if err != nil {

--- a/e2e/wasm/notes-dynamic-quickstart-goscript_test.go
+++ b/e2e/wasm/notes-dynamic-quickstart-goscript_test.go
@@ -162,7 +162,7 @@ func waitForNotesQuickstartSpaceRoute(t testing.TB, page playwright.Page, quicks
 		if (quickstartID === 'blog') {
 			return document.querySelector("button[title='Reading mode']") !== null
 		}
-		return document.querySelector("input[placeholder='Search notes...']") !== null
+		return document.querySelector("input[placeholder='Search notes…']") !== null
 	}`, []any{quickstartID}, playwright.PageWaitForFunctionOptions{
 		Timeout: playwright.Float(notesDynamicQuickstartWaitMS),
 	})


### PR DESCRIPTION
Three browser selectors in the wasm e2e suite still ask for "Search notes..." and "Type a message..." with three periods, but the components render a single ellipsis character. A CSS attribute selector compares the value exactly, so those locators match nothing and each wait runs to its full timeout against a page that has already rendered correctly.

TestBlogCoexistenceScenario paid for that twice. Its first subtest spent four minutes waiting for the notebook search input and then left the document without the post its second subtest looks for, so that one spent four minutes as well. The eight minutes pushed the forge-blog slice past its job budget and the slice was killed before its remaining cases ran, which is why the aggregate wasm check has been red on master reporting a cancellation instead of a defect.

With the selectors corrected the slice reaches TestForgeWorkerExecution for the first time in days, and that test misses its three minute job budget by seconds under the alternate browser compilers: link and test passes complete and compile is still checking when the context expires. Every pass runs an order slower there, the same cost WaitForApp already covers by doubling its app readiness budget, so the forge job wait now takes the same doubling under the same condition.

Verified against the forge-blog slice log for the previous head: blog coexistence passed and the package reached the forge case, which it had not done in any recent run.