### PR TITLE
fix(trace/service): give each test its own build directory

### DIFF
--- a/core/trace/service/discovery_test.go
+++ b/core/trace/service/discovery_test.go
@@ -55,15 +55,11 @@ func setupPluginClients(
 		t.Fatal(err)
 	}
 	repoRoot := filepath.Join(wd, "../../..")
-	workDir := filepath.Join(wd, ".bldr")
-	buildDir := filepath.Join(workDir, "build")
+	workDir := t.TempDir()
 	distDir := filepath.Join(workDir, "src")
 	pluginStateDir := filepath.Join(workDir, "plugin", "state")
 	pluginDistDir := filepath.Join(workDir, "plugin", "dist")
 
-	if err := fsutil.CleanCreateDir(buildDir); err != nil {
-		t.Fatal(err)
-	}
 	if err := fsutil.CleanCreateDir(pluginStateDir); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Both trace service discovery tests rooted their build state at core/trace/service/.bldr and wiped the shared build directory at the start of every fixture. The scheduler builds two platforms, and the first test returns once the desktop half completes while the js half is still writing, so the second test could delete files mid-write and fail with "unlinkat .bldr/build/js/spacewave-core: directory not empty". On a faster runner the js compile lands first and nothing goes wrong, which is why this showed up as an intermittent rather than a break.

The fixture owns its working state, so the fix belongs there: setupPluginClients now takes t.TempDir() as its working directory and the shared path is gone entirely. Waiting for the js platform would have kept the shared directory and added a contract every future platform has to honour. Nothing was cached across runs, since the old code cleaned the directory at each setup, so no build reuse is lost.

The trace service E2E suite runs in CI only; it compiles two platforms and takes several minutes per test.