### PR TITLE
ci: name the wasm E2E slice that failed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,14 +388,35 @@ jobs:
     needs: e2e-wasm
     if: ${{ always() }}
     timeout-minutes: 5
+    permissions:
+      actions: read
     steps:
       - name: Check wasm E2E slices
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          if [ "${{ needs.e2e-wasm.result }}" != "success" ]; then
-            echo "wasm E2E slices completed with result: ${{ needs.e2e-wasm.result }}"
-            exit 1
+          if [ "${{ needs.e2e-wasm.result }}" = "success" ]; then
+            echo "wasm E2E slices passed"
+            exit 0
           fi
-          echo "wasm E2E slices passed"
+          # The matrix result on its own says only that something went wrong,
+          # and a slice killed by its own timeout-minutes reports as cancelled,
+          # which reads as a slow runner rather than as a defect. Name the
+          # slices that did not pass and the step each one stopped on.
+          echo "wasm E2E slices completed with result: ${{ needs.e2e-wasm.result }}"
+          echo
+          gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${GITHUB_RUN_ATTEMPT}/jobs?per_page=100" \
+            --jq '.jobs[]
+              | select(.name | startswith("E2E (wasm / "))
+              | select(.conclusion != "success")
+              | . as $job
+              | (($job.steps // [])
+                  | map(select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out"))
+                  | first) as $step
+              | "\($job.conclusion)\t\($job.name)\tstopped on: \($step.name // "unknown")\n  \($job.html_url)"' \
+            || echo "could not list the slice jobs; open the run to see which slice failed"
+          exit 1
 
   e2e-playwright:
     name: E2E (${{ matrix.suite.name }})


### PR DESCRIPTION
When the browser suite goes red, the aggregate gate prints "wasm E2E slices completed with result: failure" and stops there, so you have to open the run and click through nine slices to find out which one broke. A slice killed by its own timeout-minutes is worse: it reports as cancelled, and a cancelled matrix reads like a preempted runner rather than a defect. A real regression sat on master for days behind exactly that reading.

The aggregate job already runs after every slice and already knows the run id, so it is the natural place to turn the matrix result into a report. It now lists the run's jobs for the current attempt, picks out the `E2E (wasm / *)` jobs that did not pass, and prints each one's conclusion, the first step that failed or was cancelled or timed out, and a link straight to it. The step filter deliberately skips `skipped` steps, which would otherwise name a setup step that never ran instead of the slice itself. The job needs `actions: read` to list its own run, and it still exits non-zero, so a failing suite fails the gate exactly as before.

I ran the jq filter against two real historical runs before proposing it: run 30266226821 prints `failure  E2E (wasm / forge-blog)  stopped on: Run wasm E2E slice`, and master run 30265860162 prints `cancelled  E2E (wasm / forge-blog)  stopped on: Run wasm E2E slice`, which is the case that hid the defect.
