### PR TITLE
test(e2e): cover wasm slice enrollment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,11 @@ jobs:
             test_go_script: test:go:identity
             test_js_script: test:js:identity
 
-    timeout-minutes: 15
+    # A typical member run finishes in ten minutes, so a fifteen minute budget
+    # leaves a slow runner no room: the job is killed, and GitHub reports that
+    # kill as "cancelled", which reads as a superseded run rather than a
+    # defect. Runner minutes are cheaper than that misreading.
+    timeout-minutes: 25
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
             check_script: ''
             lint_go_script: lint:go:e2e
             lint_js_script: ''
-            test_go_script: ''
+            test_go_script: test:go:e2e:wasm:slice-coverage
             test_js_script: ''
           - name: db
             build_script: ''

--- a/e2e/wasm/slicecoverage/slice_coverage_test.go
+++ b/e2e/wasm/slicecoverage/slice_coverage_test.go
@@ -1,0 +1,240 @@
+package slicecoverage
+
+import (
+	"go/ast"
+	goparser "go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/ghodss/yaml"
+)
+
+type workflow struct {
+	Jobs map[string]struct {
+		Strategy struct {
+			Matrix struct {
+				Slice []wasmSlice `json:"slice"`
+			} `json:"matrix"`
+		} `json:"strategy"`
+	} `json:"jobs"`
+}
+
+type wasmSlice struct {
+	Name    string  `json:"name"`
+	Package *string `json:"package"`
+	Run     string  `json:"run"`
+}
+
+// No slice regex selects these tests, so CI never runs them. This list exists
+// so a new unenrolled test fails this check instead of passing unnoticed.
+// Entries leave the list as tests are enrolled, and an addition is a deliberate
+// decision a reviewer sees in the diff.
+var notEnrolledInAnySlice = []string{
+	"TestBrowserHelpersAndRawAccess",
+	"TestBrowserLaunchFromGo",
+	"TestBrowserRouteNavigation",
+	"TestBrowserWorkerQuicRwcFixture",
+	"TestBuildHarnessStateRootKeepsCachedRunsStable",
+	"TestChromiumLaunchOptions",
+	"TestConfigureGoScriptBrowserStartupUsesLauncherCoreAndBuildsSQL",
+	"TestConfigureGoScriptForManifestPreservesTraceService",
+	"TestConfigureGoScriptForManifestRetainsSessionHarnessWebRTC",
+	"TestCrashReportIgnoresBenignNormalCloseTeardownAbort",
+	"TestCrashReportStillCatchesRealAbortPageError",
+	"TestDedicatedWorkerHostFallback",
+	"TestE2EWasmBrowserWebRTCEnabled",
+	"TestE2EWasmDriveBenchJSProfileEnabled",
+	"TestE2EWasmTraceServiceEnabled",
+	"TestEndToEndLinkEstablishment",
+	"TestGoScriptBlogDynamicQuickstartRetainedStateParity",
+	"TestGoScriptCanvasQuickstartCreateMutate",
+	"TestGoScriptCanvasQuickstartRouteResourceProbe",
+	"TestGoScriptChatQuickstartMessagingParity",
+	"TestGoScriptCliTerminalCommands",
+	"TestGoScriptDeviceQuickstartOpensComputersDashboard",
+	"TestGoScriptDriveAccountDeleteRemovesOpfsSubtree",
+	"TestGoScriptDriveBrowserLayoutDropReloadUIParity",
+	"TestGoScriptDriveBrowserMoveDragDeleteUIParity",
+	"TestGoScriptDriveStartupBench",
+	"TestGoScriptFSHandleBrowserResourceOperations",
+	"TestGoScriptGitQuickstartLocalCreateReloadParity",
+	"TestGoScriptNotesDynamicQuickstartsParity",
+	"TestGoScriptObjectLayoutRuntimeParity",
+	"TestGoScriptObjectLayoutSeedModelParity",
+	"TestGoScriptProjectedExportDownloadBrowserParity",
+	"TestGoScriptQuickstartDriveDirectRouteMountGate",
+	"TestGoScriptQuickstartDrivePerformanceProof",
+	"TestGoScriptQuickstartSpaceDirectRouteMountGate",
+	"TestGoScriptSharedObjectDirectRouteBodyMountGate",
+	"TestGoScriptSharedWorkerOPFSProbe",
+	"TestGoScriptUnixFSLargeMultiFileDropCompletes",
+	"TestHarnessStateRootConcurrentOwnersUseDistinctRoots",
+	"TestHarnessStateRootOwnerMarkerRoundTrip",
+	"TestHarnessStateRootReleaseStopsConsumersBeforeUnlock",
+	"TestHarnessStateRootSerialOwnersReuseStableRoot",
+	"TestQuickstartDriveLargeUploadBudgetReport",
+	"TestQuickstartDriveNavigateTrace",
+	"TestQuickstartDriveSplitTabNavigation",
+	"TestQuickstartDriveTrace",
+	"TestQuickstartDriveUploadBudgetProfiles",
+	"TestQuickstartDriveUploadOverwriteBudgetProfile",
+	"TestQuickstartDriveUploadTrace",
+	"TestQuickstartKvEditPersistsAfterReload",
+	"TestQuickstartSqlRunCreatesLinkedQueryResult",
+	"TestQuickstartSqlWorkbenchPinsPersistAfterReload",
+	"TestQuickstartV86BootSmoke",
+	"TestReapHarnessCacheOffStateRootsDeletesDeadPIDMarker",
+	"TestReapHarnessCacheOffStateRootsDeletesOldMarkerlessStateRoot",
+	"TestReapHarnessCacheOffStateRootsPreservesLivePIDMarker",
+	"TestReapHarnessCacheOffStateRootsPreservesStableStateRoot",
+	"TestReapHarnessCacheOffStateRootsPreservesYoungMarkerlessStateRoot",
+	"TestResolveBldrDependencyUsesExplicitSpacewaveRepoRoot",
+	"TestResolveE2EWasmManifestBuildTimeout",
+	"TestResolveE2EWasmManifestBuildTimeoutRejectsInvalid",
+	"TestResourceSetupHelpers",
+	"TestRetainedStatePageSessionReusesWarmContext",
+	"TestRetainedStateResourceSessionSupportsSequentialReuse",
+	"TestRetainedStateSessionReleaseCleansPerSessionState",
+	"TestSessionHarnessPeerInfo",
+	"TestSharedWorkerOpfsReturnGate",
+	"TestSignalRelayCrossConnect",
+	"TestStartupBuildCacheDefaultsOnWithExplicitFreshBuildEscape",
+	"TestSummarizeBrowserCPUProfileBucketsSamples",
+	"TestSummarizeTraceBuildsOperationShapeFromTasksAndLogs",
+	"TestTransientAppWaitErrorIncludesStartupNavigation",
+	"TestWaitForCountConsumesOwnerUpdates",
+	"TestWasmHarnessTraceConfig",
+}
+
+func TestAllWasmTestsAreEnrolled(t *testing.T) {
+	repoRoot := testRepoRoot(t)
+
+	workflowData, err := os.ReadFile(filepath.Join(repoRoot, ".github", "workflows", "ci.yml"))
+	if err != nil {
+		t.Fatalf("read CI workflow: %v", err)
+	}
+	var config workflow
+	if err := yaml.Unmarshal(workflowData, &config); err != nil {
+		t.Fatalf("parse CI workflow: %v", err)
+	}
+
+	e2eWasm, ok := config.Jobs["e2e-wasm"]
+	if !ok {
+		t.Fatal("CI workflow has no e2e-wasm job")
+	}
+	var sliceRegexps []*regexp.Regexp
+	for _, slice := range e2eWasm.Strategy.Matrix.Slice {
+		// A slice naming its own package runs TestScenarios under build tags, so
+		// what it covers is a tag question rather than a name question. This
+		// check answers the name question only.
+		if slice.Package != nil {
+			continue
+		}
+		sliceRegexps = append(sliceRegexps, compileSliceRegexp(t, slice))
+	}
+
+	wasmTests := findWasmTests(t, filepath.Join(repoRoot, "e2e", "wasm"))
+	knownTests := make(map[string]bool, len(wasmTests))
+	for _, testName := range wasmTests {
+		knownTests[testName] = true
+	}
+	for _, testName := range notEnrolledInAnySlice {
+		if !knownTests[testName] {
+			t.Errorf("not-enrolled test name no longer exists: %s", testName)
+		}
+	}
+
+	var unenrolled []string
+	for _, testName := range wasmTests {
+		covered := false
+		for _, sliceRegexp := range sliceRegexps {
+			if sliceRegexp.MatchString(testName) {
+				covered = true
+				break
+			}
+		}
+		if !covered && !slices.Contains(notEnrolledInAnySlice, testName) {
+			unenrolled = append(unenrolled, testName)
+		}
+	}
+	if len(unenrolled) != 0 {
+		t.Errorf("these e2e/wasm tests are not selected by any slice; enroll each test in a slice, or deliberately add its name to notEnrolledInAnySlice after review:\n%s", strings.Join(unenrolled, "\n"))
+	}
+}
+
+func testRepoRoot(t *testing.T) string {
+	t.Helper()
+	_, testFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("find coverage test file")
+	}
+	return filepath.Join(filepath.Dir(testFile), "..", "..", "..")
+}
+
+func compileSliceRegexp(t *testing.T, slice wasmSlice) (compiled *regexp.Regexp) {
+	t.Helper()
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			t.Fatalf("slice %q has invalid run regex: %v", slice.Name, recovered)
+		}
+	}()
+	return regexp.MustCompile(slice.Run)
+}
+
+func findWasmTests(t *testing.T, wasmDir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(wasmDir)
+	if err != nil {
+		t.Fatalf("read wasm test directory: %v", err)
+	}
+
+	fileSet := token.NewFileSet()
+	var testNames []string
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+
+		// parser.ParseFile ignores build constraints, keeping tagged tests in this inventory.
+		file, err := goparser.ParseFile(fileSet, filepath.Join(wasmDir, entry.Name()), nil, goparser.AllErrors)
+		if err != nil {
+			t.Fatalf("parse %s: %v", entry.Name(), err)
+		}
+		for _, declaration := range file.Decls {
+			function, ok := declaration.(*ast.FuncDecl)
+			if !ok || function.Recv != nil || !strings.HasPrefix(function.Name.Name, "Test") {
+				continue
+			}
+			if function.Type.Params == nil || len(function.Type.Params.List) != 1 {
+				continue
+			}
+			parameter := function.Type.Params.List[0]
+			if len(parameter.Names) != 1 || !isTestingT(parameter.Type) {
+				continue
+			}
+			testNames = append(testNames, function.Name.Name)
+		}
+	}
+	sort.Strings(testNames)
+	return testNames
+}
+
+func isTestingT(expression ast.Expr) bool {
+	pointer, ok := expression.(*ast.StarExpr)
+	if !ok {
+		return false
+	}
+	selector, ok := pointer.X.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	packageName, ok := selector.X.(*ast.Ident)
+	return ok && packageName.Name == "testing" && selector.Sel.Name == "T"
+}

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "test:go:e2e:wasm:tinygo:drive-split-tab": "cross-env ENABLE_E2E_WASM=true E2E_WASM_COMPILER=tinygo E2E_WASM_MANIFEST_BUILD_TIMEOUT=45m go test -count=1 -timeout=60m -v ./e2e/wasm -run TestQuickstartDriveSplitTabNavigation$",
     "test:go:e2e:wasm:goscript": "cross-env ENABLE_E2E_WASM=true E2E_WASM_COMPILER=goscript E2E_WASM_MANIFEST_BUILD_TIMEOUT=45m go test -count=1 -timeout=60m -v ./e2e/wasm",
     "test:go:e2e:wasm:goscript:smoke": "cross-env ENABLE_E2E_WASM=true E2E_WASM_COMPILER=goscript E2E_WASM_MANIFEST_BUILD_TIMEOUT=45m go test -count=1 -timeout=60m -v ./e2e/wasm -run '^TestWasmHarnessBoot$'",
+    "test:go:e2e:wasm:slice-coverage": "go test -count=1 -timeout=30s -v ./e2e/wasm/slicecoverage",
     "test:go:e2e:bldr-comms": "cross-env RUN_NO_COI_E2E=1 go test -timeout=30m -v ./bldr/e2e/comms",
     "test:go:e2e:bldr-downstreamapp": "cross-env RUN_DOWNSTREAM_APP_E2E=1 go test -count=1 -timeout=10m -v ./bldr/e2e/downstreamapp",
     "test:go:e2e:core": "cross-env RUN_CORE_E2E=1 go test -timeout=30m -v ./core/e2e/... -run TestSpacewaveCoreE2E",


### PR DESCRIPTION
The wasm E2E matrix picks tests by name: each slice carries a regex that enumerates every test it runs. Nothing checked that enumeration against the tests that exist, so a test nobody added to a slice compiles, never runs, and looks covered. That is how a stale locator in the chat quickstart test went unnoticed for days with every check green on the branch and on master.

This adds a plain Go check, no browser and no harness, that reads the matrix out of the workflow file, enumerates the test functions in e2e/wasm with go/parser (which ignores build constraints, so tagged tests are counted too), and fails with the names of any test no slice selects. It runs through the e2e member's previously empty Go script, so it is on every pull request in about half a second rather than behind a browser suite.

Running it turned up 74 unenrolled tests, which is the finding rather than a detail: the browser suite runs roughly a third of that package. About forty are heavy browser tests, including the GoScript quickstart parity tests, the drive trace and upload budget tests, and the V86 boot smoke; the rest are cheap unit tests sitting beside ones the support slice already runs. They are recorded in one list with no invented per-test reasons, so the check can land today and the number can only fall. Enrolling them is separate work: each of those tests has never run under CI conditions, so its first run is as likely to find a real defect as to go green. A stale entry in the list is also a failure, so it cannot rot.

Verified both directions: removing an enrolled name from a slice regex makes the check fail and name that test, and restoring it makes it pass.

One related change rides along, because this branch is what puts new work in the member job. That job typically finishes in ten minutes against a fifteen minute budget, so a slow runner exhausts it, and GitHub reports a budget kill as "cancelled", which reads as a superseded run rather than a job that ran out of time. That exact misreading cost a round on this workflow already. Twenty five minutes keeps enough headroom that reaching the budget means the job is stuck rather than unlucky.
