### PR TITLE
test(provider): bound the pairing signaling test by the test context

### DIFF
--- a/core/provider/local/pairing_test.go
+++ b/core/provider/local/pairing_test.go
@@ -3,7 +3,6 @@
 package provider_local_test
 
 import (
-	"context"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
@@ -13,7 +12,6 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"testing"
-	"time"
 
 	websocket "github.com/aperturerobotics/go-websocket"
 	provider_local "github.com/s4wave/spacewave/core/provider/local"
@@ -356,8 +354,7 @@ func TestCompletePairingWaitsForLink(t *testing.T) {
 // TestCompletePairingReplacesEmptyTransportWithSignaling verifies that the
 // deployed short-code path starts signaling after accepting a code.
 func TestCompletePairingReplacesEmptyTransportWithSignaling(t *testing.T) {
-	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
-	defer cancel()
+	ctx := t.Context()
 
 	_, _, acc, sess, release := setupProviderAndSession(ctx, t)
 	defer release()
@@ -411,9 +408,13 @@ func TestCompletePairingReplacesEmptyTransportWithSignaling(t *testing.T) {
 		t.Fatalf("got peer %s, want %s", got.String(), remotePeerID.String())
 	}
 
+	// CompletePairing starts signaling in the background, so the ticket request
+	// lands after it returns. Wait on the test context rather than a private
+	// deadline: the test timeout already bounds a hang, and a second stopwatch
+	// only decides how loaded a runner has to be before a correct run fails.
 	select {
 	case <-signalTickets:
-	case <-time.After(time.Second):
+	case <-ctx.Done():
 		t.Fatal("expected CompletePairing to request a signaling ticket")
 	}
 }


### PR DESCRIPTION
TestCompletePairingReplacesEmptyTransportWithSignaling has been one of the alpha job's intermittents. That matters more than its size suggests: three unrelated intermittents in one job is how a check stops carrying information, and this is the one that was still unowned.

It was also the only test in the file carrying its own deadlines, a five second context around the whole test and a one second stopwatch on the signaling ticket, where the four tests around it take t.Context() directly. Neither deadline says anything about what the pairing code promises. Shrinking that context to thirty milliseconds does not make the test fail, so nothing it exercises actually enforces it; the five seconds only tells a reader the test is bounded when it is not. The one second wait is the bet that can fire, and it is the same shape as the packfile retry test fixed earlier this week: a fixed wait on work that starts after the call returns, which holds on an idle machine and loses on a loaded runner.

Both are gone and the ticket wait blocks on the test context, so the assertion is now that CompletePairing starts signaling rather than how fast a particular machine gets there. A real hang is bounded by the package test timeout, and its goroutine dump names the blocked call, which is more than an expired deadline ever said.

Verified with twenty race-enabled runs of this test and its neighbours in core/provider/local, plus the thirty millisecond probe above that established the context was not load bearing.