### PR TITLE
Assert the plugin relay survives DedicatedWorker failover, not its schedule

### DIFF
--- a/e2e/wasm/dedicated-worker-host-fallback_test.go
+++ b/e2e/wasm/dedicated-worker-host-fallback_test.go
@@ -104,7 +104,6 @@ func TestDedicatedWorkerHostMultiTab(t *testing.T) {
 	waitForDriveEntry(t, rightPage, dedicatedMultiTabLeft)
 	pluginAssetURL := dedicatedWorkerPluginAssetURL(t, leftPage)
 	startDedicatedWorkerPluginAssetFetch(t, rightPage, pluginAssetURL)
-	markDedicatedWorkerFailoverCloseStart(t, rightPage)
 	if err := leftPage.Close(); err != nil {
 		t.Fatalf("close elected DedicatedWorker host document: %v", err)
 	}
@@ -114,6 +113,7 @@ func TestDedicatedWorkerHostMultiTab(t *testing.T) {
 	assertDedicatedWorkerHostTopology(t, rightPage, dedicatedHostRoleHost)
 	assertNoDedicatedWorkerFailoverReload(t, rightPage)
 	assertDedicatedWorkerPluginAssetFetch(t, rightPage, pluginAssetURL)
+	assertPluginAssetFetchSucceeds(t, rightPage, pluginAssetURL, "after DedicatedWorker failover")
 	assertDirectOpfsMarkers(t, rightPage)
 	waitForDriveEntry(t, rightPage, dedicatedMultiTabLeft)
 	createDriveFolder(t, rightPage, dedicatedMultiTabRight)
@@ -404,20 +404,16 @@ func startDedicatedWorkerPluginAssetFetch(
 	t.Helper()
 	if _, err := page.Evaluate(`(arg) => {
 		const url = Array.isArray(arg) ? arg[0] : arg
-		globalThis.__dedicatedHostFailoverPluginFetchSettledAt = null
 		globalThis.__dedicatedHostFailoverPluginFetch = fetch(url, { cache: 'no-store' })
 			.then(async (resp) => {
-				const result = {
+				return {
 					url,
 					ok: resp.ok,
 					status: resp.status,
 					body: (await resp.text()).slice(0, 120),
 				}
-				globalThis.__dedicatedHostFailoverPluginFetchSettledAt = performance.now()
-				return result
 			})
 			.catch((err) => {
-				globalThis.__dedicatedHostFailoverPluginFetchSettledAt = performance.now()
 				return {
 					url,
 					error: err instanceof Error ? err.message : String(err),
@@ -426,16 +422,6 @@ func startDedicatedWorkerPluginAssetFetch(
 		return true
 	}`, []any{url}); err != nil {
 		t.Fatalf("start in-flight plugin asset fetch: %v", err)
-	}
-}
-
-func markDedicatedWorkerFailoverCloseStart(t testing.TB, page playwright.Page) {
-	t.Helper()
-	if _, err := page.Evaluate(`() => {
-		globalThis.__dedicatedHostFailoverCloseStartedAt = performance.now()
-		return true
-	}`, nil); err != nil {
-		t.Fatalf("mark DedicatedWorker failover close start: %v", err)
 	}
 }
 
@@ -460,6 +446,12 @@ func assertNoDedicatedWorkerFailoverReload(t testing.TB, page playwright.Page) {
 	}
 }
 
+// assertDedicatedWorkerPluginAssetFetch awaits the fetch started before the
+// elected host closed. The fetch may settle on either side of the close: the
+// runtime relay promises that the request completes, not that it is still
+// pending at any chosen instant, and on a fast machine the response arrives
+// before the two round trips that follow it. Asserting the instant would fail
+// exactly when the system did the right thing.
 func assertDedicatedWorkerPluginAssetFetch(t testing.TB, page playwright.Page, url string) {
 	t.Helper()
 	raw, err := page.Evaluate(`async (arg) => {
@@ -472,8 +464,6 @@ func assertDedicatedWorkerPluginAssetFetch(t testing.TB, page playwright.Page, u
 		return {
 			...result,
 			wantURL,
-			closeStartedAt: globalThis.__dedicatedHostFailoverCloseStartedAt ?? null,
-			settledAt: globalThis.__dedicatedHostFailoverPluginFetchSettledAt ?? null,
 		}
 	}`, []any{url})
 	if err != nil {
@@ -482,9 +472,6 @@ func assertDedicatedWorkerPluginAssetFetch(t testing.TB, page playwright.Page, u
 	result, ok := raw.(map[string]any)
 	if !ok {
 		t.Fatalf("unexpected plugin asset fetch proof %T: %#v", raw, raw)
-	}
-	if intField(result, "settledAt") < intField(result, "closeStartedAt") {
-		t.Fatalf("plugin asset fetch settled before host close; result=%#v", result)
 	}
 	if gotURL := stringField(result, "url"); gotURL != url {
 		t.Fatalf("plugin asset fetch URL=%q want %q; result=%#v", gotURL, url, result)

--- a/e2e/wasm/service-worker-restart_test.go
+++ b/e2e/wasm/service-worker-restart_test.go
@@ -73,14 +73,14 @@ func TestServiceWorkerRestartRecoversBldrWebHarness(t *testing.T) {
 	createDriveFolder(t, leftPage, serviceWorkerRestartPreFolder)
 	waitForDriveEntry(t, rightPage, serviceWorkerRestartPreFolder)
 	pluginAssetURL := serviceWorkerRestartPluginAssetURL(t, leftPage)
-	assertServiceWorkerRestartPluginFetch(t, leftPage, pluginAssetURL, "before ServiceWorker restart")
+	assertPluginAssetFetchSucceeds(t, leftPage, pluginAssetURL, "before ServiceWorker restart")
 
 	control := newServiceWorkerRestartCDPControl(t, rightPage)
 	defer control.Close()
 	active := control.WaitForRunning(t)
 	stopped := control.Stop(t, active)
 	control.Drain()
-	assertServiceWorkerRestartPluginFetch(t, rightPage, pluginAssetURL, "after ServiceWorker restart")
+	assertPluginAssetFetchSucceeds(t, rightPage, pluginAssetURL, "after ServiceWorker restart")
 	restarted := control.WaitForRunning(t)
 	if restarted.VersionID != stopped.VersionID {
 		t.Fatalf("ServiceWorker restarted unexpected version: stopped=%#v running=%#v", stopped, restarted)
@@ -315,7 +315,11 @@ func serviceWorkerRestartPluginAssetURL(t testing.TB, page playwright.Page) stri
 	return url
 }
 
-func assertServiceWorkerRestartPluginFetch(
+// assertPluginAssetFetchSucceeds fetches a plugin asset through the runtime
+// relay and asserts it returns HTTP 200. Every test that disturbs the relay,
+// by restarting the ServiceWorker or by failing the DedicatedWorker host over
+// to a survivor document, uses this to prove the relay serves again afterwards.
+func assertPluginAssetFetchSucceeds(
 	t testing.TB,
 	page playwright.Page,
 	url string,


### PR DESCRIPTION
TestDedicatedWorkerHostMultiTab has been failing intermittently in the wasm browser suite. It started a plugin asset fetch on the survivor document, stamped a timestamp, closed the elected DedicatedWorker host, and then failed if the fetch had settled before that stamp. The asset comes back from the runtime relay in a few milliseconds, well inside the two Playwright round trips that follow the fetch call, so on a fast machine the response arrived first and the test failed while the system under test did exactly the right thing.

The relay promises that a request completes across a host handover. It promises nothing about the request still being pending at any chosen instant, so no arrangement of timestamps can assert that contract. The fetch started before the close keeps its success assertion and loses the ordering check, and a second fetch after the survivor takes the host role proves the relay serves again once the handover is done. The test causes that second fetch rather than racing it, so it holds on a fast machine and a loaded one alike.

The ServiceWorker restart test already proved its relay the same way, with a fetch before and a fetch after the disturbance. Its helper is renamed to say what it checks rather than which test first needed it, and both tests share it now instead of carrying two mechanisms for one assertion.

Route interception was the obvious alternative and it cannot work here: plugin assets are served by the ServiceWorker through the runtime relay, and Playwright does not intercept requests a ServiceWorker answers. Verification is go build and go vet on e2e/wasm plus the wasm slice in CI.