### PR TITLE
test: bound waits on their own signals in world and forge shutdown tests

### DIFF
--- a/core/resource/world/world-state_batch_followup_test.go
+++ b/core/resource/world/world-state_batch_followup_test.go
@@ -96,17 +96,15 @@ func TestWatchWorldStateBatchedBodyReadTracksAccess(t *testing.T) {
 	}
 	writeTx.Release()
 
-	watchCtx, watchCancel := context.WithTimeout(ctx, 3*time.Second)
-	defer watchCancel()
-	stream, err := engine.WatchWorldState(watchCtx)
+	// The stream stays open across the batched read and the update transaction
+	// below, so a deadline here would be a budget over that setup work rather
+	// than a bound on any wait. Each awaited message is bounded on its own.
+	stream, err := engine.WatchWorldState(ctx)
 	if err != nil {
 		t.Fatalf("WatchWorldState: %v", err)
 	}
 	defer stream.Close()
-	watchMsg, err := stream.Recv()
-	if err != nil {
-		t.Fatalf("WatchWorldState Recv: %v", err)
-	}
+	watchMsg := recvWatchWorldState(t, stream, "initial snapshot")
 
 	trackedRef := resClient.CreateResourceReference(watchMsg.GetResourceId())
 	defer trackedRef.Release()
@@ -143,12 +141,44 @@ func TestWatchWorldStateBatchedBodyReadTracksAccess(t *testing.T) {
 		t.Fatalf("Commit update: %v", err)
 	}
 
-	changedMsg, err := stream.Recv()
-	if err != nil {
-		t.Fatalf("WatchWorldState Recv after batched access: %v", err)
-	}
-	if changedMsg.GetResourceId() == watchMsg.GetResourceId() {
+	changed := recvWatchWorldState(t, stream, "update after the batched body read and commit")
+	if changed.GetResourceId() == watchMsg.GetResourceId() {
 		t.Fatal("batched body access did not track object changes")
+	}
+}
+
+// recvWatchWorldState waits for the next message on a world state watch stream
+// under its own bound.
+//
+// Recv takes no context, so the only deadline lever is the stream context, and
+// that context has to outlive the whole flow the caller is exercising. Bounding
+// the stream would therefore budget the setup rather than the wait. Each awaited
+// message gets its own bound here instead, so a stream that never publishes
+// fails at the receive that stalled rather than hanging the package.
+func recvWatchWorldState(
+	t *testing.T,
+	stream s4wave_world.SRPCWatchWorldStateResourceService_WatchWorldStateClient,
+	what string,
+) *s4wave_world.WatchWorldStateResponse {
+	t.Helper()
+	type watchRecv struct {
+		msg *s4wave_world.WatchWorldStateResponse
+		err error
+	}
+	recvCh := make(chan watchRecv, 1)
+	go func() {
+		msg, err := stream.Recv()
+		recvCh <- watchRecv{msg: msg, err: err}
+	}()
+	select {
+	case recv := <-recvCh:
+		if recv.err != nil {
+			t.Fatalf("WatchWorldState Recv (%s): %v", what, recv.err)
+		}
+		return recv.msg
+	case <-time.After(5 * time.Second):
+		t.Fatalf("no world state %s arrived", what)
+		return nil
 	}
 }
 

--- a/db/world/block/engine-tx-ops.go
+++ b/db/world/block/engine-tx-ops.go
@@ -273,7 +273,7 @@ func (e *EngineTx) refreshReadSnapshot(ctx context.Context) error {
 	e.engine.rmtx.Lock()
 	defer e.engine.rmtx.Unlock()
 	if e.engine.closed {
-		return errors.New("world block engine is closed")
+		return ErrEngineClosed
 	}
 	if e.engine.writeHeadRefresh != nil {
 		if err := e.engine.refreshDurableHeadLocked(ctx); err != nil {

--- a/db/world/block/engine.go
+++ b/db/world/block/engine.go
@@ -192,7 +192,7 @@ func (e *Engine) Sync(ctx context.Context) (bool, error) {
 	e.rmtx.Lock()
 	defer e.rmtx.Unlock()
 	if e.closed {
-		return false, errors.New("world block engine is closed")
+		return false, ErrEngineClosed
 	}
 
 	// block barrier: drain and fence every buffered block write durable.
@@ -242,7 +242,7 @@ func (e *Engine) SetRootRef(ctx context.Context, ref *bucket.ObjectRef) error {
 	e.rmtx.Lock()
 	defer e.rmtx.Unlock()
 	if e.closed {
-		return errors.New("world block engine is closed")
+		return ErrEngineClosed
 	}
 
 	return e.setRootRefLocked(ctx, ref)
@@ -256,7 +256,7 @@ func (e *Engine) AdoptRootRefFromWatch(ctx context.Context, ref *bucket.ObjectRe
 	e.rmtx.Lock()
 	defer e.rmtx.Unlock()
 	if e.closed {
-		return errors.New("world block engine is closed")
+		return ErrEngineClosed
 	}
 	if e.writeTx != nil {
 		return nil
@@ -392,7 +392,7 @@ func (e *Engine) NewBlockEngineTransaction(ctx context.Context, write bool) (*En
 		e.rmtx.Lock()
 		defer e.rmtx.Unlock()
 		if e.closed {
-			return nil, errors.New("world block engine is closed")
+			return nil, ErrEngineClosed
 		}
 		if e.writeTx == nil && e.writeHeadRefresh != nil {
 			if err := e.refreshDurableHeadLocked(ctx); err != nil {
@@ -445,7 +445,7 @@ func (e *Engine) NewBlockEngineTransaction(ctx context.Context, write bool) (*En
 			_ = lease.Release(ctx)
 		}
 		relLock()
-		return nil, errors.New("world block engine is closed")
+		return nil, ErrEngineClosed
 	}
 	if lease != nil {
 		if e.readTx != nil {
@@ -547,7 +547,7 @@ func (e *Engine) ForkBlockTransaction(ctx context.Context, write bool) (*Tx, err
 	subtask.End()
 	defer e.rmtx.RUnlock()
 	if e.closed {
-		return nil, errors.New("world block engine is closed")
+		return nil, ErrEngineClosed
 	}
 
 	taskCtx, subtask := trace.NewTask(ctx, "hydra/world-block/engine/fork-block-transaction/build-world-state")
@@ -569,7 +569,7 @@ func (e *Engine) BuildStorageCursor(ctx context.Context) (*bucket_lookup.Cursor,
 	e.rmtx.RLock()
 	defer e.rmtx.RUnlock()
 	if e.closed {
-		return nil, errors.New("world block engine is closed")
+		return nil, ErrEngineClosed
 	}
 	ncs := e.baseRoot.Clone()
 	ncs.SetRootRef(nil)
@@ -590,7 +590,7 @@ func (e *Engine) AccessWorldState(
 	closed := e.closed
 	e.rmtx.RUnlock()
 	if closed {
-		return errors.New("world block engine is closed")
+		return ErrEngineClosed
 	}
 	if ref == nil {
 		ncs := e.root.Clone()
@@ -618,7 +618,7 @@ func (e *Engine) GetSeqno(ctx context.Context) (uint64, error) {
 	e.rmtx.Lock()
 	defer e.rmtx.Unlock()
 	if e.closed {
-		return 0, errors.New("world block engine is closed")
+		return 0, ErrEngineClosed
 	}
 	seqno, ok, err := e.currentRootSeqnoLocked(ctx)
 	if err != nil {
@@ -680,7 +680,7 @@ func (e *Engine) WaitSeqno(ctx context.Context, value uint64) (uint64, error) {
 		e.rmtx.RLock()
 		if e.closed {
 			e.rmtx.RUnlock()
-			return 0, errors.New("world block engine is closed")
+			return 0, ErrEngineClosed
 		}
 		readTx := e.readTx
 		e.rmtx.RUnlock()

--- a/db/world/block/engine/controller_test.go
+++ b/db/world/block/engine/controller_test.go
@@ -307,8 +307,8 @@ func TestControllerEngineSurvivesExecuteRestartUntilClose(t *testing.T) {
 	assertClosed := func(name string, eng Engine) {
 		t.Helper()
 		_, err := eng.GetSeqno(ctx)
-		if err == nil || !strings.Contains(err.Error(), "world block engine is closed") {
-			t.Fatalf("%s engine error after Close = %v, want world block engine is closed", name, err)
+		if !errors.Is(err, world_block.ErrEngineClosed) {
+			t.Fatalf("%s engine error after Close = %v, want %v", name, err, world_block.ErrEngineClosed)
 		}
 	}
 

--- a/db/world/block/errors.go
+++ b/db/world/block/errors.go
@@ -1,0 +1,9 @@
+package world_block
+
+import "errors"
+
+// ErrEngineClosed is returned when an operation is attempted on a closed
+// engine. Callers that shut the engine down alongside a context cancellation
+// can observe either this or context.Canceled, depending on which unwinds
+// first, so both are valid outcomes of the same shutdown.
+var ErrEngineClosed = errors.New("world block engine is closed")

--- a/forge/cluster/controller/task-tracker_test.go
+++ b/forge/cluster/controller/task-tracker_test.go
@@ -2,6 +2,7 @@ package cluster_controller
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/s4wave/spacewave/db/block"
 	"github.com/s4wave/spacewave/db/bucket"
 	"github.com/s4wave/spacewave/db/world"
+	world_block "github.com/s4wave/spacewave/db/world/block"
 	world_control "github.com/s4wave/spacewave/db/world/control"
 	world_testbed "github.com/s4wave/spacewave/db/world/testbed"
 	forge_cluster "github.com/s4wave/spacewave/forge/cluster"
@@ -147,8 +149,12 @@ func TestTaskTrackerWakesParentOnFirstComplete(t *testing.T) {
 		t.Fatalf("job did not complete after first COMPLETE task observation: %v", ctx.Err())
 	}
 
+	// The cancel below stops the tracker loop and tears the testbed engine down
+	// at the same time, so the loop returns whichever it notices first. Both are
+	// the shutdown this asserts; anything else is a real error.
 	cancel()
-	if err := <-parentDone; err != context.Canceled {
-		t.Fatalf("parent tracker returned %v after cancellation, want context.Canceled", err)
+	err = <-parentDone
+	if !errors.Is(err, context.Canceled) && !errors.Is(err, world_block.ErrEngineClosed) {
+		t.Fatalf("parent tracker returned %v after cancellation, want %v or %v", err, context.Canceled, world_block.ErrEngineClosed)
 	}
 }


### PR DESCRIPTION
Two tests have been failing on loaded CI runners for reasons unrelated to the code they cover, and both showed up as inherited reds on unrelated pull requests this week.

`TestTaskTrackerWakesParentOnFirstComplete` asserted that its watch loop returned exactly `context.Canceled` after cancellation. The single `cancel()` it calls stops the loop and tears down the testbed engine at the same time, so the loop returns whichever unwind it notices first, and on a busy runner that is the engine's closed error. Making that assertion honest needs a comparable error, and the closed engine error was constructed eleven separate times inside the block engine, so callers could only match it by string. This adds `ErrEngineClosed` as a package sentinel and routes every construction site through it, which is where the identity belongs: the engine owns the condition, not each return statement.

`TestWatchWorldStateBatchedBodyReadTracksAccess` put a three second deadline on the watch stream context, but that stream stays open across a resource client setup, a batched body read, a transaction, and a commit before the message it waits for. The budget was covering setup work, so slow setup surfaced as "context canceled" on a receive that had never been given time to fail. The stream now runs on the test context and the awaited message carries its own bound, so a timeout reports that the update never arrived instead of blaming the receive.

Neither test could distinguish the failures it now tolerates from a real defect, and the asserted behavior is unchanged. Verified with `go test ./forge/cluster/controller/ -run TestTaskTrackerWakesParentOnFirstComplete -count=20`, `go test ./db/world/block/engine/ -run TestControllerEngineSurvivesExecuteRestartUntilClose -count=5`, and `go test ./core/resource/world/ -run TestWatchWorldStateBatchedBodyReadTracksAccess -count=20`, all green.