### PR TITLE
fix(web): latch WebDocument readiness so a late waiter still wakes

### DIFF
--- a/bldr/web/bldr/web-document-tracker.test.ts
+++ b/bldr/web/bldr/web-document-tracker.test.ts
@@ -660,6 +660,71 @@ describe('WebDocumentTracker resume-ready gate', () => {
     documentPort.close()
     runtimeChannel.port1.close()
   })
+  it('retries when runtime readiness is reported before the waiter parks', async () => {
+    const onWebDocumentsExhausted = vi.fn().mockResolvedValue(undefined)
+    const tracker = new WebDocumentTracker(
+      'service-worker',
+      WebRuntimeClientType.WebRuntimeClientType_SERVICE_WORKER,
+      onWebDocumentsExhausted,
+      null,
+    )
+    const { port1: trackerPort, port2: documentPort } = new MessageChannel()
+    tracker.handleWebDocumentMessage({
+      from: 'document-1',
+      initPort: trackerPort,
+    })
+    const connectResolvers: Array<(msg: ClientToWebDocument) => void> = []
+    const nextConnectMsg = () =>
+      new Promise<ClientToWebDocument>((resolve) => {
+        connectResolvers.push(resolve)
+      })
+    documentPort.onmessage = (ev) => {
+      connectResolvers.shift()?.(ev.data)
+    }
+    documentPort.start()
+
+    const firstConnectMsg = nextConnectMsg()
+    const waitConn = tracker.waitConn()
+    const msg = await firstConnectMsg
+    const ackPort = msg.connectWebRuntime?.port
+    if (!ackPort) {
+      throw new Error('connectWebRuntime ack port missing')
+    }
+    trackerPort.onmessage?.call(
+      trackerPort,
+      new MessageEvent('message', {
+        data: {
+          from: 'document-1',
+          runtimeConnected: true,
+        },
+      }),
+    )
+    ackPort.postMessage({
+      from: 'document-1',
+      error: 'webRuntimePort not initialized',
+    })
+
+    const retryMsg = await nextConnectMsg()
+    const retryAckPort = retryMsg.connectWebRuntime?.port
+    if (!retryAckPort) {
+      throw new Error('retry connectWebRuntime ack port missing')
+    }
+    const runtimeChannel = new MessageChannel()
+    retryAckPort.postMessage(
+      {
+        from: 'document-1',
+        webRuntimePort: runtimeChannel.port2,
+      },
+      [runtimeChannel.port2],
+    )
+    runtimeChannel.port1.postMessage({ connected: true })
+
+    await expect(waitConn).resolves.toBeUndefined()
+
+    tracker.close()
+    documentPort.close()
+    runtimeChannel.port1.close()
+  })
 
   it('retries an already-ready replacement WebDocument after a stale pre-ack disconnect', async () => {
     const webLock = installControllableWebLock()

--- a/bldr/web/bldr/web-document-tracker.ts
+++ b/bldr/web/bldr/web-document-tracker.ts
@@ -72,8 +72,10 @@ export class WebDocumentTracker {
   private webDocuments: Record<string, MessagePort> = {}
   // closed records that the tracker is shutting down and should not accept new work.
   private closed = false
-  // webDocumentWaiters are callbacks waiting for the next WebDocument.
+  // webDocumentWaiters are callbacks waiting for a document or readiness event.
   private webDocumentWaiters: WebDocumentWaiter[] = []
+  // webDocumentGeneration changes when a document is added or becomes runtime-connected.
+  private webDocumentGeneration = 0
   // webDocumentResumeReadyIds are WebDocuments that reported foreground readiness.
   private webDocumentResumeReadyIds = new Set<string>()
   // webDocumentRuntimeConnectedIds are WebDocuments with a live runtime channel.
@@ -153,6 +155,7 @@ export class WebDocumentTracker {
     )
 
     this.webDocuments[webDocumentId] = port
+    this.webDocumentGeneration++
     this.lastWebDocumentId = webDocumentId
     port.onmessage = (ev) => {
       const data: WebDocumentToClient = ev.data
@@ -190,6 +193,7 @@ export class WebDocumentTracker {
 
       if (data.runtimeConnected === true) {
         this.webDocumentRuntimeConnectedIds.add(webDocumentId)
+        this.webDocumentGeneration++
         this.resolveRuntimeConnectedWaiters(webDocumentId)
         const waiters = this.webDocumentWaiters.splice(0)
         for (const waiter of waiters) {
@@ -551,6 +555,7 @@ export class WebDocumentTracker {
     excludedWebDocumentId?: string,
     signal?: AbortSignal,
   ): Promise<OpenWebRuntimePortResult> {
+    const webDocumentGeneration = this.webDocumentGeneration
     if (signal?.aborted) {
       throw signal.reason instanceof Error
         ? signal.reason
@@ -726,6 +731,7 @@ export class WebDocumentTracker {
             signal,
           ),
         signal,
+        webDocumentGeneration,
       )
     }
 
@@ -737,6 +743,7 @@ export class WebDocumentTracker {
           signal,
         ),
       signal,
+      webDocumentGeneration,
     )
 
     void waitPromise.catch(() => {})
@@ -752,6 +759,7 @@ export class WebDocumentTracker {
   private waitForWebDocument<T>(
     resume: () => Promise<T>,
     signal?: AbortSignal,
+    webDocumentGeneration = this.webDocumentGeneration,
   ): Promise<T> {
     return new Promise<T>((resolve, reject) => {
       let settled = false
@@ -797,6 +805,10 @@ export class WebDocumentTracker {
         return
       }
       signal?.addEventListener('abort', onAbort, { once: true })
+      if (this.webDocumentGeneration !== webDocumentGeneration) {
+        queueMicrotask(() => waiter.resume())
+        return
+      }
       this.webDocumentWaiters.push(waiter)
     })
   }


### PR DESCRIPTION
The WebDocument tracker woke pending waiters by draining its waiter list when a document was added or reported a live runtime channel, which only works if the waiter is already parked. A caller that entered openWebRuntimePort, negotiated with a document, and got an error ack back could reach waitForWebDocument after the replacement document had already arrived and already reported runtimeConnected. Its wake had come and gone, so it parked on a list nothing would drain again. Both the PluginWorker and the ServiceWorker then sat waiting for a document that was sitting right there, which is what the in-flight reload zero-document test was catching intermittently in CI.

The tracker owns both sides of that handover, so the fix belongs there rather than in a guard at each call site. It now carries a generation counter that advances when a document is added and when one reports a live runtime channel. A caller captures the generation before it starts opening, and waitForWebDocument compares it before parking: if anything changed in between, the waiter resumes on the next microtask instead of registering. Callers that would previously hang now retry against the document that became available, and nothing changes for a caller that parks before its event arrives.

The new tracker test drives the real handover and establishes the race by causation rather than timing: it delivers runtimeConnected before the error ack that forces the retry, then asserts waitConn resolves. Removing the four-line latch makes exactly that one case time out and leaves the other 35 green; restoring it turns all 36 green. The browser regression passed 10 consecutive runs with the fix.