### PR TITLE
test(e2e): record the startup trace test as deliberately unenrolled

### DIFF
--- a/e2e/wasm/slicecoverage/slice_coverage_test.go
+++ b/e2e/wasm/slicecoverage/slice_coverage_test.go
@@ -55,6 +55,7 @@ var notEnrolledInAnySlice = []string{
 	"TestGoScriptDriveStartupBench",
 	"TestGoScriptFSHandleBrowserResourceOperations",
 	"TestGoScriptGitQuickstartLocalCreateReloadParity",
+	"TestGoScriptManifestStartupTrace",
 	"TestGoScriptNotesDynamicQuickstartsParity",
 	"TestGoScriptObjectLayoutRuntimeParity",
 	"TestGoScriptObjectLayoutSeedModelParity",


### PR DESCRIPTION
The wasm slice coverage check inventories every test declared under the wasm end-to-end directory and fails when one is selected by no CI slice and carries no deliberate exception. The opt-in startup trace test landed in neither set, so that check has been failing on master and on every branch built from it since. It is a source inventory check with no browser, timing, or concurrency path, so it fails the same way every time, and while it stands no end-to-end result on any branch carries information.

The test cannot go into an ordinary slice. It skips unless its environment variable is set and it requires running alone, so a slice that selected it would either skip it on every run or serialize the whole slice around it. The exception list is the right home: an entry there is a decision a reviewer sees in the diff, and it comes back out when the test becomes enrollable.

Verified by running the coverage package directly against this change, which passes in 0.21 seconds. The same package on master reports the failure verbatim in run 30316821889.