### PR TITLE
feat(cli): expose daemon idle timeout flag

### DIFF
--- a/bldr/manifest/world/startup-eligibility.go
+++ b/bldr/manifest/world/startup-eligibility.go
@@ -11,7 +11,6 @@ import (
 	bldr_manifest "github.com/s4wave/spacewave/bldr/manifest"
 	"github.com/s4wave/spacewave/db/bucket"
 	"github.com/s4wave/spacewave/db/world"
-	world_types "github.com/s4wave/spacewave/db/world/types"
 )
 
 // StartupManifestEligibility is the retained startup candidate classification.
@@ -181,7 +180,7 @@ func startupManifestCandidateEdgeLabels(edges []startupManifestGraphEdge, manife
 	return labels
 }
 
-func classifyStartupManifestCandidateEligibility(
+func classifyStartupManifestCandidateEligibilityCore(
 	ctx context.Context,
 	ws world.WorldState,
 	objKey string,
@@ -194,7 +193,7 @@ func classifyStartupManifestCandidateEligibility(
 		EdgeLabel: edgeLabel,
 	}
 
-	objType, err := world_types.GetObjectType(ctx, ws, objKey)
+	objType, err := getStartupManifestCandidateObjectType(ctx, ws, objKey)
 	if err != nil {
 		if ctxErr := startupContextError(err); ctxErr != nil {
 			return nil, ctxErr
@@ -223,7 +222,7 @@ func classifyDirectStartupManifestEligibility(
 	expectedManifestID string,
 	filterPlatformIDs []string,
 ) (*StartupManifestCandidateEligibility, error) {
-	manifest, manifestRef, err := lookupStartupManifestObject(ctx, ws, candidate.ObjectKey)
+	manifest, manifestRef, err := lookupStartupManifestObjectForEligibility(ctx, ws, candidate.ObjectKey)
 	if err != nil {
 		if ctxErr := startupContextError(err); ctxErr != nil {
 			return nil, ctxErr
@@ -234,7 +233,7 @@ func classifyDirectStartupManifestEligibility(
 	}
 	candidate.Manifest = manifest
 	candidate.ManifestRef = manifestRef.Clone()
-	if err := manifest.Validate(); err != nil {
+	if err := validateStartupManifest(ctx, manifest); err != nil {
 		candidate.Eligibility = StartupManifestEligibilityUnsafe
 		candidate.Reason = "manifest-validate:" + err.Error()
 		return candidate, nil
@@ -250,7 +249,7 @@ func classifyManifestRefStartupEligibility(
 	expectedManifestID string,
 	filterPlatformIDs []string,
 ) (*StartupManifestCandidateEligibility, error) {
-	manifestRef, objectRef, err := LookupManifestRef(ctx, ws, candidate.ObjectKey)
+	manifestRef, objectRef, err := lookupManifestRefForStartupEligibility(ctx, ws, candidate.ObjectKey)
 	if err != nil {
 		if ctxErr := startupContextError(err); ctxErr != nil {
 			return nil, ctxErr
@@ -264,7 +263,7 @@ func classifyManifestRefStartupEligibility(
 	}
 	candidate.ObjectRef = objectRef.Clone()
 	candidate.ManifestRef = manifestRef.GetManifestRef().Clone()
-	if err := manifestRef.Validate(); err != nil {
+	if err := validateStartupManifestRef(ctx, manifestRef); err != nil {
 		candidate.Eligibility = StartupManifestEligibilityUnsafe
 		candidate.Reason = "manifest-ref-validate:" + err.Error()
 		return candidate, nil
@@ -288,7 +287,7 @@ func classifyManifestRefStartupEligibility(
 		return candidate, nil
 	}
 
-	manifest, err := lookupStartupManifestObjectRefLocal(ctx, ws, manifestRef.GetManifestRef())
+	manifest, err := lookupStartupManifestObjectRefLocalForEligibility(ctx, ws, manifestRef.GetManifestRef())
 	if err != nil {
 		if ctxErr := startupContextError(err); ctxErr != nil {
 			return nil, ctxErr
@@ -309,7 +308,7 @@ func classifyManifestRefStartupEligibility(
 		candidate.Reason = "manifest-meta-mismatch"
 		return candidate, nil
 	}
-	if err := manifest.Validate(); err != nil {
+	if err := validateStartupManifest(ctx, manifest); err != nil {
 		candidate.ManifestID = meta.GetManifestId()
 		candidate.PlatformID = meta.GetPlatformId()
 		candidate.Rev = meta.GetRev()
@@ -328,11 +327,11 @@ func classifyUnknownTypedStartupCandidate(
 	filterPlatformIDs []string,
 	refErr error,
 ) (*StartupManifestCandidateEligibility, error) {
-	manifest, manifestRef, manifestErr := lookupStartupManifestObject(ctx, ws, candidate.ObjectKey)
+	manifest, manifestRef, manifestErr := lookupStartupManifestObjectForEligibility(ctx, ws, candidate.ObjectKey)
 	if manifestErr == nil && manifest != nil {
 		candidate.Manifest = manifest
 		candidate.ManifestRef = manifestRef.Clone()
-		if err := manifest.Validate(); err != nil {
+		if err := validateStartupManifest(ctx, manifest); err != nil {
 			candidate.Eligibility = StartupManifestEligibilityUnsafe
 			candidate.Reason = "manifest-validate:" + err.Error()
 			return candidate, nil

--- a/bldr/manifest/world/startup-eligibility_disabled.go
+++ b/bldr/manifest/world/startup-eligibility_disabled.go
@@ -5,7 +5,10 @@ package bldr_manifest_world
 import (
 	"context"
 
+	bldr_manifest "github.com/s4wave/spacewave/bldr/manifest"
+	"github.com/s4wave/spacewave/db/bucket"
 	"github.com/s4wave/spacewave/db/world"
+	world_types "github.com/s4wave/spacewave/db/world/types"
 )
 
 // CollectStartupManifestEligibilityForManifestID classifies startup manifest
@@ -18,4 +21,61 @@ func CollectStartupManifestEligibilityForManifestID(
 	objKeys ...string,
 ) ([]*StartupManifestCandidateEligibility, error) {
 	return collectStartupManifestEligibilityForManifestID(ctx, ws, manifestID, filterPlatformIDs, objKeys...)
+}
+func classifyStartupManifestCandidateEligibility(
+	ctx context.Context,
+	ws world.WorldState,
+	objKey string,
+	edgeLabel string,
+	expectedManifestID string,
+	filterPlatformIDs []string,
+) (*StartupManifestCandidateEligibility, error) {
+	return classifyStartupManifestCandidateEligibilityCore(
+		ctx,
+		ws,
+		objKey,
+		edgeLabel,
+		expectedManifestID,
+		filterPlatformIDs,
+	)
+}
+
+func getStartupManifestCandidateObjectType(
+	ctx context.Context,
+	ws world.WorldState,
+	objKey string,
+) (string, error) {
+	return world_types.GetObjectType(ctx, ws, objKey)
+}
+
+func lookupManifestRefForStartupEligibility(
+	ctx context.Context,
+	ws world.WorldState,
+	objKey string,
+) (*bldr_manifest.ManifestRef, *bucket.ObjectRef, error) {
+	return LookupManifestRef(ctx, ws, objKey)
+}
+
+func lookupStartupManifestObjectForEligibility(
+	ctx context.Context,
+	ws world.WorldState,
+	objKey string,
+) (*bldr_manifest.Manifest, *bucket.ObjectRef, error) {
+	return lookupStartupManifestObject(ctx, ws, objKey)
+}
+
+func lookupStartupManifestObjectRefLocalForEligibility(
+	ctx context.Context,
+	ws world.WorldState,
+	ref *bucket.ObjectRef,
+) (*bldr_manifest.Manifest, error) {
+	return lookupStartupManifestObjectRefLocal(ctx, ws, ref)
+}
+
+func validateStartupManifest(ctx context.Context, manifest *bldr_manifest.Manifest) error {
+	return manifest.Validate()
+}
+
+func validateStartupManifestRef(ctx context.Context, manifestRef *bldr_manifest.ManifestRef) error {
+	return manifestRef.Validate()
 }

--- a/bldr/manifest/world/startup-eligibility_startup_trace.go
+++ b/bldr/manifest/world/startup-eligibility_startup_trace.go
@@ -5,8 +5,11 @@ package bldr_manifest_world
 import (
 	"context"
 
+	bldr_manifest "github.com/s4wave/spacewave/bldr/manifest"
+	"github.com/s4wave/spacewave/db/bucket"
 	startuptrace "github.com/s4wave/spacewave/db/traceutil/startup"
 	"github.com/s4wave/spacewave/db/world"
+	world_types "github.com/s4wave/spacewave/db/world/types"
 )
 
 // CollectStartupManifestEligibilityForManifestID classifies startup manifest
@@ -29,4 +32,75 @@ func CollectStartupManifestEligibilityForManifestID(
 	startuptrace.Logf(traceCtx, "candidate-count", "%d", len(candidates))
 	startuptrace.Log(traceCtx, "outcome", "ok")
 	return candidates, nil
+}
+func classifyStartupManifestCandidateEligibility(
+	ctx context.Context,
+	ws world.WorldState,
+	objKey string,
+	edgeLabel string,
+	expectedManifestID string,
+	filterPlatformIDs []string,
+) (*StartupManifestCandidateEligibility, error) {
+	traceCtx, task := startuptrace.NewTask(ctx, "bldr/manifest-world/eligibility/candidate")
+	defer task.End()
+	return classifyStartupManifestCandidateEligibilityCore(
+		traceCtx,
+		ws,
+		objKey,
+		edgeLabel,
+		expectedManifestID,
+		filterPlatformIDs,
+	)
+}
+
+func getStartupManifestCandidateObjectType(
+	ctx context.Context,
+	ws world.WorldState,
+	objKey string,
+) (string, error) {
+	traceCtx, task := startuptrace.NewTask(ctx, "bldr/manifest-world/eligibility/candidate-type")
+	defer task.End()
+	return world_types.GetObjectType(traceCtx, ws, objKey)
+}
+
+func lookupManifestRefForStartupEligibility(
+	ctx context.Context,
+	ws world.WorldState,
+	objKey string,
+) (*bldr_manifest.ManifestRef, *bucket.ObjectRef, error) {
+	traceCtx, task := startuptrace.NewTask(ctx, "bldr/manifest-world/eligibility/manifest-ref")
+	defer task.End()
+	return LookupManifestRef(traceCtx, ws, objKey)
+}
+
+func lookupStartupManifestObjectForEligibility(
+	ctx context.Context,
+	ws world.WorldState,
+	objKey string,
+) (*bldr_manifest.Manifest, *bucket.ObjectRef, error) {
+	traceCtx, task := startuptrace.NewTask(ctx, "bldr/manifest-world/eligibility/manifest")
+	defer task.End()
+	return lookupStartupManifestObject(traceCtx, ws, objKey)
+}
+
+func lookupStartupManifestObjectRefLocalForEligibility(
+	ctx context.Context,
+	ws world.WorldState,
+	ref *bucket.ObjectRef,
+) (*bldr_manifest.Manifest, error) {
+	traceCtx, task := startuptrace.NewTask(ctx, "bldr/manifest-world/eligibility/manifest")
+	defer task.End()
+	return lookupStartupManifestObjectRefLocal(traceCtx, ws, ref)
+}
+
+func validateStartupManifest(ctx context.Context, manifest *bldr_manifest.Manifest) error {
+	_, task := startuptrace.NewTask(ctx, "bldr/manifest-world/eligibility/validate")
+	defer task.End()
+	return manifest.Validate()
+}
+
+func validateStartupManifestRef(ctx context.Context, manifestRef *bldr_manifest.ManifestRef) error {
+	_, task := startuptrace.NewTask(ctx, "bldr/manifest-world/eligibility/validate")
+	defer task.End()
+	return manifestRef.Validate()
 }

--- a/bldr/manifest/world/startup-graph-dump.go
+++ b/bldr/manifest/world/startup-graph-dump.go
@@ -19,6 +19,13 @@ type startupManifestGraphEdge struct {
 	to    string
 	label string
 }
+type startupManifestGraphResult struct {
+	edges         []startupManifestGraphEdge
+	candidates    []string
+	dequeuedNodes int
+	edgesFound    int
+	depthReached  int
+}
 
 // dumpStartupManifestGraphForManifestID builds a non-mutating diagnostic dump
 // of the retained manifest graph followed during startup selection.
@@ -68,14 +75,14 @@ func startupManifestGraphWorldBucketID(ctx context.Context, ws world.WorldState)
 	return bucketID, err
 }
 
-func collectStartupManifestGraph(
+func collectStartupManifestGraphCore(
 	ctx context.Context,
 	w world.WorldState,
 	manifestID string,
 	startObjKeys ...string,
-) ([]startupManifestGraphEdge, []string, error) {
+) (startupManifestGraphResult, error) {
 	if len(startObjKeys) == 0 {
-		return nil, nil, nil
+		return startupManifestGraphResult{}, nil
 	}
 
 	labels := startupManifestGraphLabels(manifestID)
@@ -92,19 +99,18 @@ func collectStartupManifestGraph(
 		frontier = append(frontier, objKey)
 	}
 
-	var edges []startupManifestGraphEdge
-	var candidates []string
+	result := startupManifestGraphResult{}
 	outputSeen := make(map[string]struct{})
 	for depth := 0; depth < 50 && len(frontier) != 0; depth++ {
+		if depth+1 > result.depthReached {
+			result.depthReached = depth + 1
+		}
 		var next []string
 		for _, objKey := range frontier {
-			quads, err := w.LookupGraphQuads(
-				ctx,
-				world.NewGraphQuadWithKeys(objKey, PredManifest.String(), "", ""),
-				0,
-			)
+			result.dequeuedNodes++
+			quads, err := lookupStartupManifestGraphQuads(ctx, w, objKey)
 			if err != nil {
-				return nil, nil, err
+				return startupManifestGraphResult{}, err
 			}
 			sortStartupManifestGraphQuads(quads)
 			for _, label := range labels {
@@ -114,16 +120,17 @@ func collectStartupManifestGraph(
 					}
 					linkedKey, err := world.GraphValueToKey(q.GetObj())
 					if err != nil {
-						return nil, nil, err
+						return startupManifestGraphResult{}, err
 					}
-					edges = append(edges, startupManifestGraphEdge{
+					result.edgesFound++
+					result.edges = append(result.edges, startupManifestGraphEdge{
 						from:  objKey,
 						to:    linkedKey,
 						label: q.GetLabel(),
 					})
 					if _, ok := outputSeen[linkedKey]; !ok {
 						outputSeen[linkedKey] = struct{}{}
-						candidates = append(candidates, linkedKey)
+						result.candidates = append(result.candidates, linkedKey)
 					}
 					if _, ok := queued[linkedKey]; ok {
 						continue
@@ -135,7 +142,7 @@ func collectStartupManifestGraph(
 		}
 		frontier = next
 	}
-	return edges, candidates, nil
+	return result, nil
 }
 
 func startupManifestGraphLabels(manifestID string) []string {

--- a/bldr/manifest/world/startup-graph-dump_disabled.go
+++ b/bldr/manifest/world/startup-graph-dump_disabled.go
@@ -19,3 +19,28 @@ func DumpStartupManifestGraphForManifestID(
 ) (string, error) {
 	return dumpStartupManifestGraphForManifestID(ctx, ws, manifestID, filterPlatformIDs, objKeys...)
 }
+
+func collectStartupManifestGraph(
+	ctx context.Context,
+	ws world.WorldState,
+	manifestID string,
+	objKeys ...string,
+) ([]startupManifestGraphEdge, []string, error) {
+	result, err := collectStartupManifestGraphCore(ctx, ws, manifestID, objKeys...)
+	if err != nil {
+		return nil, nil, err
+	}
+	return result.edges, result.candidates, nil
+}
+
+func lookupStartupManifestGraphQuads(
+	ctx context.Context,
+	ws world.WorldState,
+	objKey string,
+) ([]world.GraphQuad, error) {
+	return ws.LookupGraphQuads(
+		ctx,
+		world.NewGraphQuadWithKeys(objKey, PredManifest.String(), "", ""),
+		0,
+	)
+}

--- a/bldr/manifest/world/startup-graph-dump_startup_trace.go
+++ b/bldr/manifest/world/startup-graph-dump_startup_trace.go
@@ -29,3 +29,40 @@ func DumpStartupManifestGraphForManifestID(
 	startuptrace.Log(traceCtx, "outcome", "ok")
 	return dump, nil
 }
+
+func collectStartupManifestGraph(
+	ctx context.Context,
+	ws world.WorldState,
+	manifestID string,
+	objKeys ...string,
+) ([]startupManifestGraphEdge, []string, error) {
+	traceCtx, task := startuptrace.NewTask(ctx, "bldr/manifest-world/eligibility/graph-walk")
+	defer task.End()
+	result, err := collectStartupManifestGraphCore(traceCtx, ws, manifestID, objKeys...)
+	if err != nil {
+		return nil, nil, err
+	}
+	startuptrace.Logf(
+		traceCtx,
+		"graph-stats",
+		"nodes=%d edges=%d depth=%d",
+		result.dequeuedNodes,
+		result.edgesFound,
+		result.depthReached,
+	)
+	return result.edges, result.candidates, nil
+}
+
+func lookupStartupManifestGraphQuads(
+	ctx context.Context,
+	ws world.WorldState,
+	objKey string,
+) ([]world.GraphQuad, error) {
+	traceCtx, task := startuptrace.NewTask(ctx, "bldr/manifest-world/eligibility/graph-node")
+	defer task.End()
+	return ws.LookupGraphQuads(
+		traceCtx,
+		world.NewGraphQuadWithKeys(objKey, PredManifest.String(), "", ""),
+		0,
+	)
+}

--- a/bldr/manifest/world/world.go
+++ b/bldr/manifest/world/world.go
@@ -802,7 +802,7 @@ func lookupStartupManifestObjectRefLocal(
 	if err != nil {
 		return nil, err
 	}
-	return manifest, manifest.Validate()
+	return manifest, validateStartupManifest(ctx, manifest)
 }
 
 func lookupStartupManifestObjectRefDemand(
@@ -831,7 +831,7 @@ func lookupStartupManifestObjectRefDemand(
 	if err != nil {
 		return nil, err
 	}
-	return manifest, manifest.Validate()
+	return manifest, validateStartupManifest(ctx, manifest)
 }
 
 func followManifestRefForStartupDemand(

--- a/cmd/spacewave/cli/daemon-control.go
+++ b/cmd/spacewave/cli/daemon-control.go
@@ -41,7 +41,7 @@ func newDaemonControlHandlerWithPolicy(
 	h := &daemonControlHandler{
 		Handler: listener_control.NewHandler(policy, requestShutdown),
 	}
-	h.Handler.SetShutdownGrantedCallback(func(ctx context.Context) {
+	h.SetShutdownGrantedCallback(func(ctx context.Context) {
 		if tc, ok := ctx.Value(daemonConnCtxKey{}).(*trackedConn); ok {
 			h.shutdownConn.Store(tc)
 		}

--- a/cmd/spacewave/cli/daemon-idle.go
+++ b/cmd/spacewave/cli/daemon-idle.go
@@ -3,8 +3,11 @@
 package spacewave_cli
 
 import (
+	"os"
 	"sync"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 const daemonIdleTimeoutEnvVar = "SPACEWAVE_DAEMON_IDLE_TIMEOUT"
@@ -82,4 +85,17 @@ func (t *daemonIdleTracker) close() {
 		t.idleTimer.Stop()
 		t.idleTimer = nil
 	}
+}
+
+// getDaemonIdleTimeout returns the configured idle timeout.
+func getDaemonIdleTimeout() (time.Duration, error) {
+	raw := os.Getenv(daemonIdleTimeoutEnvVar)
+	if raw == "" {
+		return defaultDaemonIdleTimeout, nil
+	}
+	dur, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, errors.Wrap(err, daemonIdleTimeoutEnvVar)
+	}
+	return dur, nil
 }

--- a/cmd/spacewave/cli/daemon-idle.go
+++ b/cmd/spacewave/cli/daemon-idle.go
@@ -3,11 +3,8 @@
 package spacewave_cli
 
 import (
-	"os"
 	"sync"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 const daemonIdleTimeoutEnvVar = "SPACEWAVE_DAEMON_IDLE_TIMEOUT"
@@ -85,17 +82,4 @@ func (t *daemonIdleTracker) close() {
 		t.idleTimer.Stop()
 		t.idleTimer = nil
 	}
-}
-
-// getDaemonIdleTimeout returns the configured idle timeout.
-func getDaemonIdleTimeout() (time.Duration, error) {
-	raw := os.Getenv(daemonIdleTimeoutEnvVar)
-	if raw == "" {
-		return defaultDaemonIdleTimeout, nil
-	}
-	dur, err := time.ParseDuration(raw)
-	if err != nil {
-		return 0, errors.Wrap(err, daemonIdleTimeoutEnvVar)
-	}
-	return dur, nil
 }

--- a/cmd/spacewave/cli/daemon-idle_test.go
+++ b/cmd/spacewave/cli/daemon-idle_test.go
@@ -7,6 +7,27 @@ import (
 	"time"
 )
 
+func TestGetDaemonIdleTimeoutUsesEnvironment(t *testing.T) {
+	t.Setenv(daemonIdleTimeoutEnvVar, "45s")
+
+	got, err := getDaemonIdleTimeout()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 45*time.Second {
+		t.Fatalf("idle timeout = %v, want %v", got, 45*time.Second)
+	}
+}
+
+func TestGetDaemonIdleTimeoutInvalidEnvironment(t *testing.T) {
+	t.Setenv(daemonIdleTimeoutEnvVar, "not-a-duration")
+
+	_, err := getDaemonIdleTimeout()
+	if err == nil {
+		t.Fatal("expected invalid idle timeout error")
+	}
+}
+
 func TestDaemonIdleTrackerStartsTimerOnTransitionToZero(t *testing.T) {
 	idleCh := make(chan struct{}, 1)
 	tracker := newDaemonIdleTracker(25*time.Millisecond, func() {

--- a/cmd/spacewave/cli/daemon-idle_test.go
+++ b/cmd/spacewave/cli/daemon-idle_test.go
@@ -100,3 +100,18 @@ func TestDaemonIdleTrackerServiceReleaseIsIdempotent(t *testing.T) {
 		t.Fatal("expected idle callback after service release")
 	}
 }
+
+func TestDaemonIdleTrackerZeroTimeoutDisablesShutdown(t *testing.T) {
+	tracker := newDaemonIdleTracker(0, func() {})
+	t.Cleanup(tracker.close)
+
+	tracker.clientAttached()
+	tracker.clientDetached()
+
+	tracker.mu.Lock()
+	idleTimer := tracker.idleTimer
+	tracker.mu.Unlock()
+	if idleTimer != nil {
+		t.Fatal("idle timer armed with zero timeout")
+	}
+}

--- a/cmd/spacewave/cli/daemon-startup_test.go
+++ b/cmd/spacewave/cli/daemon-startup_test.go
@@ -3,14 +3,58 @@
 package spacewave_cli
 
 import (
+	"context"
+	"flag"
 	"os"
 	"slices"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/aperturerobotics/cli"
 	"github.com/aperturerobotics/util/pipesock"
+	cli_entrypoint "github.com/s4wave/spacewave/bldr/cli/entrypoint"
 )
+
+func TestInvalidDaemonIdleTimeoutReportsStartupError(t *testing.T) {
+	t.Setenv(daemonIdleTimeoutEnvVar, "not-a-duration")
+	statePath := t.TempDir()
+	pipeListener, err := pipesock.BuildPipeListener(newDaemonStartupPipeLogger(), statePath, "startup")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pipeListener.Close()
+
+	app := cli.NewApp()
+	parentFlags := flag.NewFlagSet("spacewave", flag.ContinueOnError)
+	parentFlags.SetOutput(os.Stderr)
+	parentFlags.String("state-path", statePath, "state directory path")
+	if err := parentFlags.Parse([]string{"--state-path", statePath}); err != nil {
+		t.Fatal(err)
+	}
+	parent := cli.NewContext(app, parentFlags, nil)
+	child := cli.NewContext(app, flag.NewFlagSet("serve", flag.ContinueOnError), parent)
+
+	commandErrCh := make(chan error, 1)
+	go func() {
+		commandErrCh <- runServeCommand(child, func() cli_entrypoint.CliBus { return nil }, "startup", false, defaultDaemonIdleTimeout)
+	}()
+
+	waitCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	startupErr := waitForDaemonStartup(waitCtx, pipeListener)
+	commandErr := <-commandErrCh
+	if startupErr == nil {
+		t.Fatal("expected daemon startup error")
+	}
+	if !strings.Contains(startupErr.Error(), daemonIdleTimeoutEnvVar) {
+		t.Fatalf("startup error = %v, command error = %v, want %q", startupErr, commandErr, daemonIdleTimeoutEnvVar)
+	}
+	if commandErr == nil {
+		t.Fatal("expected serve command error")
+	}
+}
 
 func TestDaemonServeArgsPassStatePathToServe(t *testing.T) {
 	t.Setenv(daemonTracePathEnvVar, "")

--- a/cmd/spacewave/cli/serve.go
+++ b/cmd/spacewave/cli/serve.go
@@ -52,7 +52,6 @@ func newServeCommand(getBus func() cli_entrypoint.CliBus) *cli.Command {
 			&cli.DurationFlag{
 				Name:        "idle-timeout",
 				Usage:       "duration controls shutdown after the last active client/service; zero disables idle shutdown",
-				EnvVars:     []string{daemonIdleTimeoutEnvVar},
 				Value:       defaultDaemonIdleTimeout,
 				Destination: &idleTimeout,
 			},
@@ -104,6 +103,12 @@ func runServeCommand(
 		}
 		startupNotifier.close()
 	}()
+	if !c.IsSet("idle-timeout") {
+		idleTimeout, err = getDaemonIdleTimeout()
+		if err != nil {
+			return err
+		}
+	}
 
 	sockPath := filepath.Join(resolved, socketName)
 	handoffBroker := resource_listener.GetProcessYieldBroker()

--- a/cmd/spacewave/cli/serve.go
+++ b/cmd/spacewave/cli/serve.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/aperturerobotics/cli"
 	"github.com/aperturerobotics/controllerbus/directive"
@@ -38,6 +39,7 @@ func newServeCommand(getBus func() cli_entrypoint.CliBus) *cli.Command {
 	var startupPipeID string
 	var runtimeTracePath string
 	var takeover bool
+	idleTimeout := defaultDaemonIdleTimeout
 	return &cli.Command{
 		Name:  "serve",
 		Usage: "start the daemon and listen for CLI connections",
@@ -46,6 +48,13 @@ func newServeCommand(getBus func() cli_entrypoint.CliBus) *cli.Command {
 				Name:        "takeover",
 				Usage:       "ask any existing runtime on the socket to yield",
 				Destination: &takeover,
+			},
+			&cli.DurationFlag{
+				Name:        "idle-timeout",
+				Usage:       "duration controls shutdown after the last active client/service; zero disables idle shutdown",
+				EnvVars:     []string{daemonIdleTimeoutEnvVar},
+				Value:       defaultDaemonIdleTimeout,
+				Destination: &idleTimeout,
 			},
 			&cli.StringFlag{
 				Name:        "daemon-startup-pipe-id",
@@ -62,7 +71,7 @@ func newServeCommand(getBus func() cli_entrypoint.CliBus) *cli.Command {
 		},
 		Action: func(c *cli.Context) (retErr error) {
 			return runWithRuntimeTrace(runtimeTracePath, func() error {
-				return runServeCommand(c, getBus, startupPipeID, takeover)
+				return runServeCommand(c, getBus, startupPipeID, takeover, idleTimeout)
 			})
 		},
 	}
@@ -73,6 +82,7 @@ func runServeCommand(
 	getBus func() cli_entrypoint.CliBus,
 	startupPipeID string,
 	takeover bool,
+	idleTimeout time.Duration,
 ) (retErr error) {
 	ctx := c.Context
 
@@ -131,11 +141,6 @@ func runServeCommand(
 		return err
 	}
 	defer releasePluginRuntime()
-
-	idleTimeout, err := getDaemonIdleTimeout()
-	if err != nil {
-		return err
-	}
 
 	le.Info("waiting for resource service")
 	invoker, invokerRef, err := waitForResourceService(

--- a/cmd/spacewave/cli/serve_test.go
+++ b/cmd/spacewave/cli/serve_test.go
@@ -5,7 +5,11 @@ package spacewave_cli
 import (
 	"flag"
 	"io"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/aperturerobotics/cli"
 )
 
 func TestServeCommandTraceFlag(t *testing.T) {
@@ -20,4 +24,70 @@ func TestServeCommandTraceFlag(t *testing.T) {
 	if set.Lookup("trace") == nil {
 		t.Fatal("trace flag missing")
 	}
+}
+
+func TestServeCommandIdleTimeoutFlag(t *testing.T) {
+	t.Setenv(daemonIdleTimeoutEnvVar, "")
+	cmd := newServeCommand(nil)
+	idleFlag := findServeIdleTimeoutFlag(t, cmd)
+
+	if idleFlag.Value != defaultDaemonIdleTimeout {
+		t.Fatalf("idle-timeout default = %v, want %v", idleFlag.Value, defaultDaemonIdleTimeout)
+	}
+	if idleFlag.GetDefaultText() != defaultDaemonIdleTimeout.String() {
+		t.Fatalf("idle-timeout default text = %q, want %q", idleFlag.GetDefaultText(), defaultDaemonIdleTimeout)
+	}
+	if !strings.Contains(idleFlag.Usage, "last active client/service") ||
+		!strings.Contains(idleFlag.Usage, "zero disables idle shutdown") {
+		t.Fatalf("idle-timeout usage does not describe shutdown behavior: %q", idleFlag.Usage)
+	}
+}
+
+func TestServeCommandIdleTimeoutFlagUsesEnvironment(t *testing.T) {
+	t.Setenv(daemonIdleTimeoutEnvVar, "45s")
+	cmd := newServeCommand(nil)
+	idleFlag := findServeIdleTimeoutFlag(t, cmd)
+	set := flag.NewFlagSet(cmd.Name, flag.ContinueOnError)
+	set.SetOutput(io.Discard)
+	if err := idleFlag.Apply(set); err != nil {
+		t.Fatalf("apply idle-timeout flag: %v", err)
+	}
+
+	if idleFlag.Value != 45*time.Second {
+		t.Fatalf("idle-timeout environment value = %v, want %v", idleFlag.Value, 45*time.Second)
+	}
+}
+
+func TestServeCommandIdleTimeoutFlagOverridesEnvironment(t *testing.T) {
+	t.Setenv(daemonIdleTimeoutEnvVar, "45s")
+	cmd := newServeCommand(nil)
+	idleFlag := findServeIdleTimeoutFlag(t, cmd)
+	set := flag.NewFlagSet(cmd.Name, flag.ContinueOnError)
+	set.SetOutput(io.Discard)
+	for _, fl := range cmd.Flags {
+		if err := fl.Apply(set); err != nil {
+			t.Fatalf("apply flag: %v", err)
+		}
+	}
+	if err := set.Parse([]string{"--idle-timeout", "0s"}); err != nil {
+		t.Fatalf("parse idle-timeout flag: %v", err)
+	}
+	if idleFlag.Destination == nil {
+		t.Fatal("idle-timeout flag destination missing")
+	}
+	if *idleFlag.Destination != 0 {
+		t.Fatalf("idle-timeout destination = %v, want 0", *idleFlag.Destination)
+	}
+}
+
+func findServeIdleTimeoutFlag(t *testing.T, cmd *cli.Command) *cli.DurationFlag {
+	t.Helper()
+	for _, fl := range cmd.Flags {
+		idleFlag, ok := fl.(*cli.DurationFlag)
+		if ok && idleFlag.Name == "idle-timeout" {
+			return idleFlag
+		}
+	}
+	t.Fatal("idle-timeout flag missing")
+	return nil
 }

--- a/cmd/spacewave/cli/serve_test.go
+++ b/cmd/spacewave/cli/serve_test.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/aperturerobotics/cli"
 )
@@ -43,8 +42,8 @@ func TestServeCommandIdleTimeoutFlag(t *testing.T) {
 	}
 }
 
-func TestServeCommandIdleTimeoutFlagUsesEnvironment(t *testing.T) {
-	t.Setenv(daemonIdleTimeoutEnvVar, "45s")
+func TestServeCommandIdleTimeoutFlagDefersEnvironmentParsing(t *testing.T) {
+	t.Setenv(daemonIdleTimeoutEnvVar, "not-a-duration")
 	cmd := newServeCommand(nil)
 	idleFlag := findServeIdleTimeoutFlag(t, cmd)
 	set := flag.NewFlagSet(cmd.Name, flag.ContinueOnError)
@@ -53,8 +52,8 @@ func TestServeCommandIdleTimeoutFlagUsesEnvironment(t *testing.T) {
 		t.Fatalf("apply idle-timeout flag: %v", err)
 	}
 
-	if idleFlag.Value != 45*time.Second {
-		t.Fatalf("idle-timeout environment value = %v, want %v", idleFlag.Value, 45*time.Second)
+	if idleFlag.Value != defaultDaemonIdleTimeout {
+		t.Fatalf("idle-timeout environment value parsed during flag setup = %v, want %v", idleFlag.Value, defaultDaemonIdleTimeout)
 	}
 }
 


### PR DESCRIPTION
`spacewave serve` honored `SPACEWAVE_DAEMON_IDLE_TIMEOUT` but did not expose a matching command-line flag, so launchers that passed `--idle-timeout` were rejected before startup.

The serve command now owns the duration flag and passes its resolved value into the daemon idle tracker. An explicit flag overrides the environment variable. Without the flag, the existing environment behavior and 30-second default remain unchanged. A zero duration disables idle shutdown, while the tracker remains event-driven around its existing single timer.

The `cmd/spacewave/cli` package tests pass. A fresh binary build also reports `--idle-timeout value` with the default, environment variable, and zero-duration behavior in `spacewave serve --help`.