### PR TITLE
fix(provider): narrow P2P sync mutex scope

### DIFF
--- a/core/provider/local/account.go
+++ b/core/provider/local/account.go
@@ -58,7 +58,7 @@ type ProviderAccount struct {
 	soListCtr *ccontainer.CContainer[*sobject.SharedObjectList]
 	// p2pSyncMtx guards p2pSync lifecycle.
 	p2pSyncMtx sync.Mutex
-	// p2pSync holds running P2P sync state, nil when not active.
+	// p2pSync holds current P2P sync startup or running state, nil when inactive.
 	p2pSync *p2pSyncState
 	// sessionTransport is the running session transport, nil when not active.
 	sessionTransport *sessionTransportState

--- a/core/provider/local/account.go
+++ b/core/provider/local/account.go
@@ -2,7 +2,6 @@ package provider_local
 
 import (
 	"context"
-	"sync"
 
 	"github.com/aperturerobotics/controllerbus/bus"
 	"github.com/aperturerobotics/controllerbus/controller/loader"
@@ -56,8 +55,8 @@ type ProviderAccount struct {
 	mtx csync.Mutex
 	// soListCtr is the list of shared objects.
 	soListCtr *ccontainer.CContainer[*sobject.SharedObjectList]
-	// p2pSyncMtx guards p2pSync lifecycle.
-	p2pSyncMtx sync.Mutex
+	// p2pSyncBcast guards p2pSync lifecycle and wakes status watchers.
+	p2pSyncBcast broadcast.Broadcast
 	// p2pSync holds current P2P sync startup or running state, nil when inactive.
 	p2pSync *p2pSyncState
 	// sessionTransport is the running session transport, nil when not active.

--- a/core/provider/local/p2p-sync-lifecycle_test.go
+++ b/core/provider/local/p2p-sync-lifecycle_test.go
@@ -1,0 +1,16 @@
+package provider_local
+
+import "testing"
+
+func TestP2PSyncStateStartCompletionIsIdempotent(t *testing.T) {
+	state := &p2pSyncState{startDone: make(chan struct{})}
+
+	state.completeStart()
+	state.completeStart()
+
+	select {
+	case <-state.startDone:
+	default:
+		t.Fatal("expected startup completion signal to be closed")
+	}
+}

--- a/core/provider/local/p2p-sync.go
+++ b/core/provider/local/p2p-sync.go
@@ -20,20 +20,32 @@ import (
 	"github.com/s4wave/spacewave/net/peer"
 )
 
-// p2pSyncState holds running P2P sync and DEX stores for a provider account.
+// p2pSyncState holds P2P sync startup or running state and DEX stores.
 type p2pSyncState struct {
-	cancel context.CancelFunc
-	wg     sync.WaitGroup
-	refs   []directive.Reference
-	relFns []func()
-	stores map[string]block.StoreOps
+	cancel    context.CancelFunc
+	startDone chan struct{}
+	stopOnce  sync.Once
+	wg        sync.WaitGroup
+	mtx       sync.Mutex
+	refs      []directive.Reference
+	relFns    []func()
+	stores    map[string]block.StoreOps
 }
 
 func (s *p2pSyncState) addStore(bucketID string, store block.StoreOps) {
+	s.mtx.Lock()
 	if s.stores == nil {
 		s.stores = make(map[string]block.StoreOps)
 	}
 	s.stores[bucketID] = store
+	s.mtx.Unlock()
+}
+
+func (s *p2pSyncState) getStore(bucketID string) block.StoreOps {
+	s.mtx.Lock()
+	store := s.stores[bucketID]
+	s.mtx.Unlock()
+	return store
 }
 
 // StartP2PSync starts SO sync and DEX block exchange for all mounted
@@ -42,7 +54,7 @@ func (s *p2pSyncState) addStore(bucketID string, store block.StoreOps) {
 // childBus is the session transport's child bus where solicit
 // controllers run. The session transport must be running before
 // calling this method.
-func (a *ProviderAccount) StartP2PSync(ctx context.Context, sessionTransport *transport.SessionTransport) error {
+func (a *ProviderAccount) StartP2PSync(ctx context.Context, sessionTransport *transport.SessionTransport) (rerr error) {
 	if err := sessionTransport.AwaitReady(ctx); err != nil {
 		return err
 	}
@@ -52,13 +64,42 @@ func (a *ProviderAccount) StartP2PSync(ctx context.Context, sessionTransport *tr
 	}
 
 	a.p2pSyncMtx.Lock()
-	defer a.p2pSyncMtx.Unlock()
-
-	a.stopP2PSyncLocked()
+	previous := a.p2pSync
+	if previous != nil {
+		select {
+		case <-previous.startDone:
+		default:
+			a.p2pSyncMtx.Unlock()
+			return nil
+		}
+	}
 
 	syncCtx, syncCancel := context.WithCancel(ctx)
-	state := &p2pSyncState{cancel: syncCancel}
+	state := &p2pSyncState{
+		cancel:    syncCancel,
+		startDone: make(chan struct{}),
+	}
 	a.p2pSync = state
+	defer func() {
+		if rerr == nil {
+			close(state.startDone)
+			return
+		}
+
+		a.p2pSyncMtx.Lock()
+		cleanup := a.p2pSync == state
+		if cleanup {
+			a.p2pSync = nil
+		}
+		a.p2pSyncMtx.Unlock()
+		close(state.startDone)
+		if cleanup {
+			a.stopP2PSyncState(state)
+		}
+	}()
+	a.p2pSyncMtx.Unlock()
+
+	a.stopP2PSyncState(previous)
 
 	soList := a.soListCtr.GetValue()
 	for _, entry := range soList.GetSharedObjects() {
@@ -71,19 +112,15 @@ func (a *ProviderAccount) StartP2PSync(ctx context.Context, sessionTransport *tr
 		providerAccountID := provRef.GetProviderAccountId()
 		bucketID := BlockStoreBucketID(providerID, providerAccountID, blockStoreID)
 		if err := a.startDEXSolicit(syncCtx, childBus, bucketID, state); err != nil {
-			if ctx.Err() != nil {
-				a.p2pSync = nil
-				a.stopP2PSyncState(state)
-				return ctx.Err()
+			if syncCtx.Err() != nil {
+				return syncCtx.Err()
 			}
 			a.le.WithError(err).WithField("bucket-id", bucketID).Warn("failed to start dex solicit")
 		}
 
 		if err := a.startSOSync(syncCtx, childBus, ref, soID, state); err != nil {
-			if ctx.Err() != nil {
-				a.p2pSync = nil
-				a.stopP2PSyncState(state)
-				return ctx.Err()
+			if syncCtx.Err() != nil {
+				return syncCtx.Err()
 			}
 			a.le.WithError(err).WithField("so-id", soID).Warn("failed to start so sync")
 		}
@@ -91,61 +128,66 @@ func (a *ProviderAccount) StartP2PSync(ctx context.Context, sessionTransport *tr
 
 	// Start the SO invite server so invitees can join via alpha/so-invite.
 	if err := a.startInviteServer(syncCtx, childBus, sessionTransport, state); err != nil {
+		if syncCtx.Err() != nil {
+			return syncCtx.Err()
+		}
 		a.le.WithError(err).Warn("failed to start invite server")
 	}
-	return nil
+	return syncCtx.Err()
 }
 
 // IsP2PSyncRunning returns whether P2P sync is currently active.
 // Safe to call from any goroutine.
 func (a *ProviderAccount) IsP2PSyncRunning() bool {
 	a.p2pSyncMtx.Lock()
-	running := a.p2pSync != nil
-	a.p2pSyncMtx.Unlock()
-	return running
+	defer a.p2pSyncMtx.Unlock()
+	if a.p2pSync == nil {
+		return false
+	}
+	select {
+	case <-a.p2pSync.startDone:
+		return true
+	default:
+		return false
+	}
 }
 
 // StopP2PSync stops all P2P sync controllers, waits for goroutines
 // to finish, and releases references.
 func (a *ProviderAccount) StopP2PSync() {
 	a.p2pSyncMtx.Lock()
-	defer a.p2pSyncMtx.Unlock()
+	state := a.p2pSync
+	a.p2pSync = nil
+	a.p2pSyncMtx.Unlock()
 
-	a.stopP2PSyncLocked()
+	a.stopP2PSyncState(state)
 }
 
 func (a *ProviderAccount) getP2PStore(bucketID string) block.StoreOps {
 	a.p2pSyncMtx.Lock()
 	state := a.p2pSync
-	var store block.StoreOps
-	if state != nil {
-		store = state.stores[bucketID]
-	}
 	a.p2pSyncMtx.Unlock()
-	return store
-}
-
-func (a *ProviderAccount) stopP2PSyncLocked() {
-	state := a.p2pSync
 	if state == nil {
-		return
+		return nil
 	}
-	a.p2pSync = nil
-	a.stopP2PSyncState(state)
+	return state.getStore(bucketID)
 }
 
 func (a *ProviderAccount) stopP2PSyncState(state *p2pSyncState) {
 	if state == nil {
 		return
 	}
-	state.cancel()
-	state.wg.Wait()
-	for _, ref := range state.refs {
-		ref.Release()
-	}
-	for _, rel := range state.relFns {
-		rel()
-	}
+	state.stopOnce.Do(func() {
+		state.cancel()
+		<-state.startDone
+		state.wg.Wait()
+		for _, ref := range state.refs {
+			ref.Release()
+		}
+		for _, rel := range state.relFns {
+			rel()
+		}
+	})
 }
 
 // startSOSync mounts the shared object and starts an SOSync instance for it.

--- a/core/provider/local/p2p-sync.go
+++ b/core/provider/local/p2p-sync.go
@@ -22,16 +22,63 @@ import (
 
 // p2pSyncState holds P2P sync startup or running state and DEX stores.
 type p2pSyncState struct {
+	ctx            context.Context
 	cancel         context.CancelFunc
 	startDone      chan struct{}
+	startOnce      sync.Once
+	stopDone       chan struct{}
 	stopOnce       sync.Once
 	wg             sync.WaitGroup
 	mtx            sync.Mutex
+	owners         int
 	restartPending bool
 	refs           []directive.Reference
 	relFns         []func()
 	stores         map[string]block.StoreOps
 	soIDs          map[string]struct{}
+}
+
+func (s *p2pSyncState) completeStart() {
+	s.startOnce.Do(func() {
+		close(s.startDone)
+	})
+}
+
+func (s *p2pSyncState) retain(ctx context.Context) bool {
+	if ctx.Err() != nil {
+		return false
+	}
+
+	s.mtx.Lock()
+	if s.ctx.Err() != nil {
+		s.mtx.Unlock()
+		return false
+	}
+	s.owners++
+	s.mtx.Unlock()
+
+	if ctx.Done() == nil {
+		return true
+	}
+	go func() {
+		select {
+		case <-ctx.Done():
+			s.release()
+		case <-s.stopDone:
+		}
+	}()
+	return true
+}
+
+func (s *p2pSyncState) release() {
+	s.mtx.Lock()
+	if s.owners > 0 {
+		s.owners--
+		if s.owners == 0 {
+			s.cancel()
+		}
+	}
+	s.mtx.Unlock()
 }
 
 func (s *p2pSyncState) addStore(bucketID string, store block.StoreOps) {
@@ -89,9 +136,10 @@ func (a *ProviderAccount) StartP2PSync(ctx context.Context, sessionTransport *tr
 	}
 
 	var (
-		previous *p2pSyncState
-		syncCtx  context.Context
-		state    *p2pSyncState
+		previous  *p2pSyncState
+		waitState *p2pSyncState
+		syncCtx   context.Context
+		state     *p2pSyncState
 	)
 	a.p2pSyncBcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
 		previous = a.p2pSync
@@ -99,22 +147,50 @@ func (a *ProviderAccount) StartP2PSync(ctx context.Context, sessionTransport *tr
 			select {
 			case <-previous.startDone:
 			default:
-				previous.restartPending = true
-				return
+				if previous.ctx.Err() == nil && previous.retain(ctx) {
+					previous.restartPending = true
+					waitState = previous
+					return
+				}
 			}
 		}
 
 		var syncCancel context.CancelFunc
-		syncCtx, syncCancel = context.WithCancel(ctx)
+		syncCtx, syncCancel = context.WithCancel(context.WithoutCancel(ctx))
 		state = &p2pSyncState{
+			ctx:       syncCtx,
 			cancel:    syncCancel,
 			startDone: make(chan struct{}),
+			stopDone:  make(chan struct{}),
+		}
+		if !state.retain(ctx) {
+			syncCancel()
+			state = nil
+			return
 		}
 		a.p2pSync = state
 		bcast()
 	})
 	if state == nil {
-		return nil
+		if waitState == nil {
+			return ctx.Err()
+		}
+		select {
+		case <-waitState.startDone:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		running := false
+		a.p2pSyncBcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+			running = a.p2pSync == waitState
+		})
+		if running {
+			return nil
+		}
+		if err := waitState.ctx.Err(); err != nil {
+			return err
+		}
+		return errors.New("P2P sync stopped during startup")
 	}
 	defer func() {
 		if rerr == nil {
@@ -127,7 +203,7 @@ func (a *ProviderAccount) StartP2PSync(ctx context.Context, sessionTransport *tr
 			if cleanup {
 				a.p2pSync = nil
 			}
-			close(state.startDone)
+			state.completeStart()
 			bcast()
 		})
 		if cleanup {
@@ -189,7 +265,7 @@ func (a *ProviderAccount) StartP2PSync(ctx context.Context, sessionTransport *tr
 				restart = true
 				return
 			}
-			close(state.startDone)
+			state.completeStart()
 			bcast()
 		})
 		if !restart {
@@ -253,7 +329,9 @@ func (a *ProviderAccount) stopP2PSyncState(state *p2pSyncState) {
 		return
 	}
 	state.stopOnce.Do(func() {
+		close(state.stopDone)
 		state.cancel()
+		state.completeStart()
 		<-state.startDone
 		state.wg.Wait()
 		for _, ref := range state.refs {

--- a/core/provider/local/p2p-sync.go
+++ b/core/provider/local/p2p-sync.go
@@ -32,6 +32,7 @@ type p2pSyncState struct {
 	cancel           context.CancelFunc
 	startDone        chan struct{}
 	startOnce        sync.Once
+	runDone          chan struct{}
 	stopDone         chan struct{}
 	stopOnce         sync.Once
 	wg               sync.WaitGroup
@@ -53,18 +54,21 @@ func (s *p2pSyncState) completeStart() {
 	})
 }
 
-func (s *p2pSyncState) retain(ctx context.Context) bool {
+// retainP2PSyncState is called with the account sync lock held before it takes
+// state.mtx. The release path drops state.mtx before reacquiring the account
+// lock to retire the state, so the locks are never held in reverse order.
+func (a *ProviderAccount) retainP2PSyncState(ctx context.Context, state *p2pSyncState) bool {
 	if ctx.Err() != nil {
 		return false
 	}
 
-	s.mtx.Lock()
-	if s.ctx.Err() != nil {
-		s.mtx.Unlock()
+	state.mtx.Lock()
+	if state.ctx.Err() != nil {
+		state.mtx.Unlock()
 		return false
 	}
-	s.owners++
-	s.mtx.Unlock()
+	state.owners++
+	state.mtx.Unlock()
 
 	if ctx.Done() == nil {
 		return true
@@ -72,22 +76,28 @@ func (s *p2pSyncState) retain(ctx context.Context) bool {
 	go func() {
 		select {
 		case <-ctx.Done():
-			s.release()
-		case <-s.stopDone:
+			a.releaseP2PSyncState(state)
+		case <-state.stopDone:
 		}
 	}()
 	return true
 }
 
-func (s *p2pSyncState) release() {
-	s.mtx.Lock()
-	if s.owners > 0 {
-		s.owners--
-		if s.owners == 0 {
-			s.cancel()
+func (a *ProviderAccount) releaseP2PSyncState(state *p2pSyncState) {
+	retire := false
+	state.mtx.Lock()
+	if state.owners > 0 {
+		state.owners--
+		if state.owners == 0 {
+			state.cancel()
+			retire = true
 		}
 	}
-	s.mtx.Unlock()
+	state.mtx.Unlock()
+
+	if retire {
+		a.retireP2PSyncState(state)
+	}
 }
 
 func (s *p2pSyncState) addStore(bucketID string, store block.StoreOps) {
@@ -155,7 +165,7 @@ func (a *ProviderAccount) StartP2PSync(ctx context.Context, sessionTransport *tr
 			select {
 			case <-previous.startDone:
 			default:
-				if previous.ctx.Err() == nil && previous.retain(ctx) {
+				if previous.ctx.Err() == nil && a.retainP2PSyncState(ctx, previous) {
 					previous.restartPending = true
 					waitState = previous
 					return
@@ -169,9 +179,10 @@ func (a *ProviderAccount) StartP2PSync(ctx context.Context, sessionTransport *tr
 			sessionTransport: sessionTransport,
 			cancel:           syncCancel,
 			startDone:        make(chan struct{}),
+			runDone:          make(chan struct{}),
 			stopDone:         make(chan struct{}),
 		}
-		if !state.retain(ctx) {
+		if !a.retainP2PSyncState(ctx, state) {
 			syncCancel()
 			state = nil
 			return
@@ -232,20 +243,15 @@ func (a *ProviderAccount) runP2PSyncStart(
 ) {
 	err := a.startP2PSyncControllers(state, previous, sessionTransport, childBus)
 
-	cleanup := false
 	a.p2pSyncBcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
-		if err != nil {
-			state.startErr = err
-			cleanup = a.p2pSync == state
-			if cleanup {
-				a.p2pSync = nil
-			}
-		}
+		state.startErr = err
 		state.completeStart()
 		bcast()
 	})
-	if cleanup {
-		a.stopP2PSyncState(state)
+	close(state.runDone)
+
+	if err != nil {
+		a.retireP2PSyncState(state)
 	}
 }
 
@@ -255,7 +261,11 @@ func (a *ProviderAccount) startP2PSyncControllers(
 	sessionTransport *transport.SessionTransport,
 	childBus bus.Bus,
 ) error {
-	a.stopP2PSyncState(previous)
+	if previous != nil {
+		// The replacement has its own transport, so its startup can proceed
+		// while the prior state's lifecycle owner waits for detached startup.
+		go a.retireP2PSyncState(previous)
+	}
 
 	syncCtx := state.ctx
 	inviteStarted := false
@@ -345,14 +355,7 @@ func (a *ProviderAccount) IsP2PSyncRunning() bool {
 // StopP2PSync stops all P2P sync controllers, waits for goroutines
 // to finish, and releases references.
 func (a *ProviderAccount) StopP2PSync() {
-	var state *p2pSyncState
-	a.p2pSyncBcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
-		state = a.p2pSync
-		a.p2pSync = nil
-		bcast()
-	})
-
-	a.stopP2PSyncState(state)
+	a.retireP2PSyncState(nil)
 }
 
 func (a *ProviderAccount) getP2PStore(bucketID string) block.StoreOps {
@@ -366,6 +369,25 @@ func (a *ProviderAccount) getP2PStore(bucketID string) block.StoreOps {
 	return state.getStore(bucketID)
 }
 
+// retireP2PSyncState removes one state from the account lifecycle and releases
+// its resources. A nil state selects the current state atomically with removal.
+//
+// Callers never hold state.mtx here: the account lock may nest state.mtx while
+// retaining an owner, so retirement acquires only the account lock. Resource
+// cleanup waits outside both locks.
+func (a *ProviderAccount) retireP2PSyncState(state *p2pSyncState) {
+	a.p2pSyncBcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
+		if state == nil {
+			state = a.p2pSync
+		}
+		if state != nil && a.p2pSync == state {
+			a.p2pSync = nil
+			bcast()
+		}
+	})
+	a.stopP2PSyncState(state)
+}
+
 func (a *ProviderAccount) stopP2PSyncState(state *p2pSyncState) {
 	if state == nil {
 		return
@@ -374,7 +396,7 @@ func (a *ProviderAccount) stopP2PSyncState(state *p2pSyncState) {
 		close(state.stopDone)
 		state.cancel()
 		state.completeStart()
-		<-state.startDone
+		<-state.runDone
 		state.wg.Wait()
 		for _, ref := range state.refs {
 			ref.Release()

--- a/core/provider/local/p2p-sync.go
+++ b/core/provider/local/p2p-sync.go
@@ -22,20 +22,29 @@ import (
 
 // p2pSyncState holds P2P sync startup or running state and DEX stores.
 type p2pSyncState struct {
-	ctx            context.Context
-	cancel         context.CancelFunc
-	startDone      chan struct{}
-	startOnce      sync.Once
-	stopDone       chan struct{}
-	stopOnce       sync.Once
-	wg             sync.WaitGroup
-	mtx            sync.Mutex
-	owners         int
-	restartPending bool
-	refs           []directive.Reference
-	relFns         []func()
-	stores         map[string]block.StoreOps
-	soIDs          map[string]struct{}
+	ctx context.Context
+	// sessionTransport is the transport this state's controllers run on. A
+	// start for a different transport cannot join this one: the startup pass
+	// loads controllers onto the child bus of the transport it began with, so
+	// coalescing across transports would leave the newer transport without
+	// them while its caller was told sync had started.
+	sessionTransport *transport.SessionTransport
+	cancel           context.CancelFunc
+	startDone        chan struct{}
+	startOnce        sync.Once
+	stopDone         chan struct{}
+	stopOnce         sync.Once
+	wg               sync.WaitGroup
+	mtx              sync.Mutex
+	owners           int
+	restartPending   bool
+	// startErr is the failure that ended startup, published to every waiter
+	// under the account's sync lock before startDone closes.
+	startErr error
+	refs     []directive.Reference
+	relFns   []func()
+	stores   map[string]block.StoreOps
+	soIDs    map[string]struct{}
 }
 
 func (s *p2pSyncState) completeStart() {
@@ -126,7 +135,7 @@ func (s *p2pSyncState) getStore(bucketID string) block.StoreOps {
 // childBus is the session transport's child bus where solicit
 // controllers run. The session transport must be running before
 // calling this method.
-func (a *ProviderAccount) StartP2PSync(ctx context.Context, sessionTransport *transport.SessionTransport) (rerr error) {
+func (a *ProviderAccount) StartP2PSync(ctx context.Context, sessionTransport *transport.SessionTransport) error {
 	if err := sessionTransport.AwaitReady(ctx); err != nil {
 		return err
 	}
@@ -138,12 +147,11 @@ func (a *ProviderAccount) StartP2PSync(ctx context.Context, sessionTransport *tr
 	var (
 		previous  *p2pSyncState
 		waitState *p2pSyncState
-		syncCtx   context.Context
 		state     *p2pSyncState
 	)
 	a.p2pSyncBcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
 		previous = a.p2pSync
-		if previous != nil {
+		if previous != nil && previous.sessionTransport == sessionTransport {
 			select {
 			case <-previous.startDone:
 			default:
@@ -155,13 +163,13 @@ func (a *ProviderAccount) StartP2PSync(ctx context.Context, sessionTransport *tr
 			}
 		}
 
-		var syncCancel context.CancelFunc
-		syncCtx, syncCancel = context.WithCancel(context.WithoutCancel(ctx))
+		syncCtx, syncCancel := context.WithCancel(context.WithoutCancel(ctx))
 		state = &p2pSyncState{
-			ctx:       syncCtx,
-			cancel:    syncCancel,
-			startDone: make(chan struct{}),
-			stopDone:  make(chan struct{}),
+			ctx:              syncCtx,
+			sessionTransport: sessionTransport,
+			cancel:           syncCancel,
+			startDone:        make(chan struct{}),
+			stopDone:         make(chan struct{}),
 		}
 		if !state.retain(ctx) {
 			syncCancel()
@@ -175,44 +183,81 @@ func (a *ProviderAccount) StartP2PSync(ctx context.Context, sessionTransport *tr
 		if waitState == nil {
 			return ctx.Err()
 		}
-		select {
-		case <-waitState.startDone:
-		case <-ctx.Done():
-			return ctx.Err()
-		}
-		running := false
-		a.p2pSyncBcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
-			running = a.p2pSync == waitState
-		})
-		if running {
-			return nil
-		}
-		if err := waitState.ctx.Err(); err != nil {
-			return err
-		}
-		return errors.New("P2P sync stopped during startup")
+		return a.awaitP2PSyncStart(ctx, waitState)
 	}
-	defer func() {
-		if rerr == nil {
-			return
-		}
 
-		cleanup := false
-		a.p2pSyncBcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
+	// Startup belongs to every owner of the state, not to the caller that
+	// happened to create it. Running it here would tie it to that caller's
+	// goroutine, so a caller whose context is canceled while later owners keep
+	// the state alive could not return until startup finished on its own.
+	go a.runP2PSyncStart(state, previous, sessionTransport, childBus)
+	return a.awaitP2PSyncStart(ctx, state)
+}
+
+// awaitP2PSyncStart waits for the shared startup to finish or for the caller's
+// own context to end, whichever comes first. Giving up releases this caller's
+// ownership without stopping the run; it ends only when the last owner leaves.
+func (a *ProviderAccount) awaitP2PSyncStart(ctx context.Context, state *p2pSyncState) error {
+	select {
+	case <-state.startDone:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	var running bool
+	var startErr error
+	a.p2pSyncBcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		running = a.p2pSync == state
+		startErr = state.startErr
+	})
+	if startErr != nil {
+		return startErr
+	}
+	if running {
+		return nil
+	}
+	if err := state.ctx.Err(); err != nil {
+		return err
+	}
+	return errors.New("P2P sync stopped during startup")
+}
+
+// runP2PSyncStart performs the startup pass and publishes its outcome to every
+// caller waiting on the state.
+func (a *ProviderAccount) runP2PSyncStart(
+	state *p2pSyncState,
+	previous *p2pSyncState,
+	sessionTransport *transport.SessionTransport,
+	childBus bus.Bus,
+) {
+	err := a.startP2PSyncControllers(state, previous, sessionTransport, childBus)
+
+	cleanup := false
+	a.p2pSyncBcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
+		if err != nil {
+			state.startErr = err
 			cleanup = a.p2pSync == state
 			if cleanup {
 				a.p2pSync = nil
 			}
-			state.completeStart()
-			bcast()
-		})
-		if cleanup {
-			a.stopP2PSyncState(state)
 		}
-	}()
+		state.completeStart()
+		bcast()
+	})
+	if cleanup {
+		a.stopP2PSyncState(state)
+	}
+}
 
+func (a *ProviderAccount) startP2PSyncControllers(
+	state *p2pSyncState,
+	previous *p2pSyncState,
+	sessionTransport *transport.SessionTransport,
+	childBus bus.Bus,
+) error {
 	a.stopP2PSyncState(previous)
 
+	syncCtx := state.ctx
 	inviteStarted := false
 	for {
 		soList := a.soListCtr.GetValue()
@@ -259,14 +304,11 @@ func (a *ProviderAccount) StartP2PSync(ctx context.Context, sessionTransport *tr
 		}
 
 		restart := false
-		a.p2pSyncBcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
+		a.p2pSyncBcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
 			if a.p2pSync == state && state.restartPending {
 				state.restartPending = false
 				restart = true
-				return
 			}
-			state.completeStart()
-			bcast()
 		})
 		if !restart {
 			return syncCtx.Err()

--- a/core/provider/local/p2p-sync.go
+++ b/core/provider/local/p2p-sync.go
@@ -22,14 +22,16 @@ import (
 
 // p2pSyncState holds P2P sync startup or running state and DEX stores.
 type p2pSyncState struct {
-	cancel    context.CancelFunc
-	startDone chan struct{}
-	stopOnce  sync.Once
-	wg        sync.WaitGroup
-	mtx       sync.Mutex
-	refs      []directive.Reference
-	relFns    []func()
-	stores    map[string]block.StoreOps
+	cancel         context.CancelFunc
+	startDone      chan struct{}
+	stopOnce       sync.Once
+	wg             sync.WaitGroup
+	mtx            sync.Mutex
+	restartPending bool
+	refs           []directive.Reference
+	relFns         []func()
+	stores         map[string]block.StoreOps
+	soIDs          map[string]struct{}
 }
 
 func (s *p2pSyncState) addStore(bucketID string, store block.StoreOps) {
@@ -38,6 +40,29 @@ func (s *p2pSyncState) addStore(bucketID string, store block.StoreOps) {
 		s.stores = make(map[string]block.StoreOps)
 	}
 	s.stores[bucketID] = store
+	s.mtx.Unlock()
+}
+
+func (s *p2pSyncState) hasStore(bucketID string) bool {
+	s.mtx.Lock()
+	_, ok := s.stores[bucketID]
+	s.mtx.Unlock()
+	return ok
+}
+
+func (s *p2pSyncState) hasSO(soID string) bool {
+	s.mtx.Lock()
+	_, ok := s.soIDs[soID]
+	s.mtx.Unlock()
+	return ok
+}
+
+func (s *p2pSyncState) addSO(soID string) {
+	s.mtx.Lock()
+	if s.soIDs == nil {
+		s.soIDs = make(map[string]struct{})
+	}
+	s.soIDs[soID] = struct{}{}
 	s.mtx.Unlock()
 }
 
@@ -63,110 +88,160 @@ func (a *ProviderAccount) StartP2PSync(ctx context.Context, sessionTransport *tr
 		return errors.New("session transport child bus is not ready")
 	}
 
-	a.p2pSyncMtx.Lock()
-	previous := a.p2pSync
-	if previous != nil {
-		select {
-		case <-previous.startDone:
-		default:
-			a.p2pSyncMtx.Unlock()
-			return nil
+	var (
+		previous *p2pSyncState
+		syncCtx  context.Context
+		state    *p2pSyncState
+	)
+	a.p2pSyncBcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
+		previous = a.p2pSync
+		if previous != nil {
+			select {
+			case <-previous.startDone:
+			default:
+				previous.restartPending = true
+				return
+			}
 		}
-	}
 
-	syncCtx, syncCancel := context.WithCancel(ctx)
-	state := &p2pSyncState{
-		cancel:    syncCancel,
-		startDone: make(chan struct{}),
+		var syncCancel context.CancelFunc
+		syncCtx, syncCancel = context.WithCancel(ctx)
+		state = &p2pSyncState{
+			cancel:    syncCancel,
+			startDone: make(chan struct{}),
+		}
+		a.p2pSync = state
+		bcast()
+	})
+	if state == nil {
+		return nil
 	}
-	a.p2pSync = state
 	defer func() {
 		if rerr == nil {
-			close(state.startDone)
 			return
 		}
 
-		a.p2pSyncMtx.Lock()
-		cleanup := a.p2pSync == state
-		if cleanup {
-			a.p2pSync = nil
-		}
-		a.p2pSyncMtx.Unlock()
-		close(state.startDone)
+		cleanup := false
+		a.p2pSyncBcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
+			cleanup = a.p2pSync == state
+			if cleanup {
+				a.p2pSync = nil
+			}
+			close(state.startDone)
+			bcast()
+		})
 		if cleanup {
 			a.stopP2PSyncState(state)
 		}
 	}()
-	a.p2pSyncMtx.Unlock()
 
 	a.stopP2PSyncState(previous)
 
-	soList := a.soListCtr.GetValue()
-	for _, entry := range soList.GetSharedObjects() {
-		ref := entry.GetRef()
-		provRef := ref.GetProviderResourceRef()
-		soID := provRef.GetId()
-		blockStoreID := ref.GetBlockStoreId()
+	inviteStarted := false
+	for {
+		soList := a.soListCtr.GetValue()
+		for _, entry := range soList.GetSharedObjects() {
+			ref := entry.GetRef()
+			provRef := ref.GetProviderResourceRef()
+			soID := provRef.GetId()
+			blockStoreID := ref.GetBlockStoreId()
 
-		providerID := provRef.GetProviderId()
-		providerAccountID := provRef.GetProviderAccountId()
-		bucketID := BlockStoreBucketID(providerID, providerAccountID, blockStoreID)
-		if err := a.startDEXSolicit(syncCtx, childBus, bucketID, state); err != nil {
-			if syncCtx.Err() != nil {
-				return syncCtx.Err()
+			providerID := provRef.GetProviderId()
+			providerAccountID := provRef.GetProviderAccountId()
+			bucketID := BlockStoreBucketID(providerID, providerAccountID, blockStoreID)
+			if !state.hasStore(bucketID) {
+				if err := a.startDEXSolicit(syncCtx, childBus, bucketID, state); err != nil {
+					if syncCtx.Err() != nil {
+						return syncCtx.Err()
+					}
+					a.le.WithError(err).WithField("bucket-id", bucketID).Warn("failed to start dex solicit")
+				}
 			}
-			a.le.WithError(err).WithField("bucket-id", bucketID).Warn("failed to start dex solicit")
+
+			if !state.hasSO(soID) {
+				if err := a.startSOSync(syncCtx, childBus, ref, soID, state); err != nil {
+					if syncCtx.Err() != nil {
+						return syncCtx.Err()
+					}
+					a.le.WithError(err).WithField("so-id", soID).Warn("failed to start so sync")
+				} else {
+					state.addSO(soID)
+				}
+			}
 		}
 
-		if err := a.startSOSync(syncCtx, childBus, ref, soID, state); err != nil {
-			if syncCtx.Err() != nil {
-				return syncCtx.Err()
+		// Start the SO invite server so invitees can join via alpha/so-invite.
+		if !inviteStarted {
+			if err := a.startInviteServer(syncCtx, childBus, sessionTransport, state); err != nil {
+				if syncCtx.Err() != nil {
+					return syncCtx.Err()
+				}
+				a.le.WithError(err).Warn("failed to start invite server")
+			} else {
+				inviteStarted = true
 			}
-			a.le.WithError(err).WithField("so-id", soID).Warn("failed to start so sync")
 		}
-	}
 
-	// Start the SO invite server so invitees can join via alpha/so-invite.
-	if err := a.startInviteServer(syncCtx, childBus, sessionTransport, state); err != nil {
-		if syncCtx.Err() != nil {
+		restart := false
+		a.p2pSyncBcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
+			if a.p2pSync == state && state.restartPending {
+				state.restartPending = false
+				restart = true
+				return
+			}
+			close(state.startDone)
+			bcast()
+		})
+		if !restart {
 			return syncCtx.Err()
 		}
-		a.le.WithError(err).Warn("failed to start invite server")
 	}
-	return syncCtx.Err()
+}
+
+// GetP2PSyncSnapshotWithWait returns whether P2P sync is running and a channel
+// that closes when its lifecycle changes.
+func (a *ProviderAccount) GetP2PSyncSnapshotWithWait() (bool, <-chan struct{}) {
+	var running bool
+	var ch <-chan struct{}
+	a.p2pSyncBcast.HoldLock(func(_ func(), getWaitCh func() <-chan struct{}) {
+		ch = getWaitCh()
+		if a.p2pSync == nil {
+			return
+		}
+		select {
+		case <-a.p2pSync.startDone:
+			running = true
+		default:
+		}
+	})
+	return running, ch
 }
 
 // IsP2PSyncRunning returns whether P2P sync is currently active.
 // Safe to call from any goroutine.
 func (a *ProviderAccount) IsP2PSyncRunning() bool {
-	a.p2pSyncMtx.Lock()
-	defer a.p2pSyncMtx.Unlock()
-	if a.p2pSync == nil {
-		return false
-	}
-	select {
-	case <-a.p2pSync.startDone:
-		return true
-	default:
-		return false
-	}
+	running, _ := a.GetP2PSyncSnapshotWithWait()
+	return running
 }
 
 // StopP2PSync stops all P2P sync controllers, waits for goroutines
 // to finish, and releases references.
 func (a *ProviderAccount) StopP2PSync() {
-	a.p2pSyncMtx.Lock()
-	state := a.p2pSync
-	a.p2pSync = nil
-	a.p2pSyncMtx.Unlock()
+	var state *p2pSyncState
+	a.p2pSyncBcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
+		state = a.p2pSync
+		a.p2pSync = nil
+		bcast()
+	})
 
 	a.stopP2PSyncState(state)
 }
 
 func (a *ProviderAccount) getP2PStore(bucketID string) block.StoreOps {
-	a.p2pSyncMtx.Lock()
-	state := a.p2pSync
-	a.p2pSyncMtx.Unlock()
+	var state *p2pSyncState
+	a.p2pSyncBcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		state = a.p2pSync
+	})
 	if state == nil {
 		return nil
 	}

--- a/core/provider/local/p2p-sync_test.go
+++ b/core/provider/local/p2p-sync_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/aperturerobotics/controllerbus/bus"
+	"github.com/aperturerobotics/controllerbus/controller"
+	"github.com/aperturerobotics/controllerbus/controller/loader"
 	"github.com/aperturerobotics/controllerbus/controller/resolver"
 	"github.com/aperturerobotics/controllerbus/directive"
 	account_settings "github.com/s4wave/spacewave/core/account/settings"
@@ -699,6 +701,185 @@ func TestStartP2PSyncDoesNotCoalesceAcrossTransports(t *testing.T) {
 	case <-ctx.Done():
 		t.Fatal("the replacement transport never received its DEX solicit controller")
 	}
+}
+
+func TestP2PSyncRetiresWhenFinalOwnerExits(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	tb, sessRef, acc, sess, release := setupProviderAndSession(ctx, t)
+	defer release()
+
+	accountID := sessRef.GetProviderResourceRef().GetProviderAccountId()
+	_, soRelease := mountAccountSettingsSO(ctx, t, tb.Bus, accountID)
+	soRelease()
+
+	if err := acc.CreateSessionTransport(ctx, sess.GetPrivKey(), ""); err != nil {
+		t.Fatal(err)
+	}
+	defer acc.StopSessionTransport()
+	defer acc.StopP2PSync()
+
+	st := acc.GetSessionTransport()
+	ownerCtx, ownerCancel := context.WithCancel(ctx)
+	if err := acc.StartP2PSync(ownerCtx, st); err != nil {
+		t.Fatal(err)
+	}
+
+	running, lifecycleChanged := acc.GetP2PSyncSnapshotWithWait()
+	if !running {
+		t.Fatal("expected P2P sync to be running before its final owner exits")
+	}
+	ownerCancel()
+
+	select {
+	case <-lifecycleChanged:
+	case <-ctx.Done():
+		t.Fatal("P2P sync did not retire after its final owner exited")
+	}
+	if running, _ := acc.GetP2PSyncSnapshotWithWait(); running {
+		t.Fatal("expected P2P sync to stop after its final owner exited")
+	}
+}
+
+func TestStopP2PSyncReleasesResourceRegisteredDuringStartup(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	tb, sessRef, acc, sess, release := setupProviderAndSession(ctx, t)
+	defer release()
+
+	accountID := sessRef.GetProviderResourceRef().GetProviderAccountId()
+	_, soRelease := mountAccountSettingsSO(ctx, t, tb.Bus, accountID)
+	soRelease()
+
+	if err := acc.CreateSessionTransport(ctx, sess.GetPrivKey(), ""); err != nil {
+		t.Fatal(err)
+	}
+	defer acc.StopSessionTransport()
+
+	st := acc.GetSessionTransport()
+	childBus := st.GetChildBus()
+	var factoryResolver controller.Controller
+	for _, ctrl := range childBus.GetControllers() {
+		if _, ok := ctrl.(*resolver.Controller); ok {
+			childBus.RemoveController(ctrl)
+			factoryResolver = ctrl
+			break
+		}
+	}
+	if factoryResolver == nil {
+		t.Fatal("expected the transport child bus factory resolver")
+	}
+	defer func() {
+		if err := factoryResolver.Close(); err != nil {
+			t.Errorf("close transport child bus factory resolver: %v", err)
+		}
+	}()
+
+	controllerSelected := make(chan struct{})
+	allowRegistration := make(chan struct{})
+	resourceReleased := make(chan struct{})
+	var selectedOnce, releasedOnce sync.Once
+	removeHandler, err := childBus.AddHandler(directive.NewFuncHandler(
+		func(_ context.Context, di directive.Instance) ([]directive.Resolver, error) {
+			load, ok := di.GetDirective().(resolver.LoadControllerWithConfig)
+			if !ok {
+				return nil, nil
+			}
+			loadConfig, ok := load.GetLoadControllerConfig().(*dex_solicit.Config)
+			if !ok {
+				return nil, nil
+			}
+			ctrl, err := dex_solicit.NewController(logrus.NewEntry(logrus.New()), childBus, loadConfig)
+			if err != nil {
+				return nil, err
+			}
+			value := &gatedP2PSyncExecValue{
+				ExecControllerValue: loader.NewExecControllerValue(time.Now(), time.Time{}, ctrl, nil),
+				ctrl:                ctrl,
+				selected:            controllerSelected,
+				allow:               allowRegistration,
+				selectedOnce:        &selectedOnce,
+			}
+			return directive.Resolvers(directive.NewFuncResolver(
+				func(resolverCtx context.Context, handler directive.ResolverHandler) error {
+					if _, accepted := handler.AddValue(value); !accepted {
+						return errors.New("P2P startup resource was rejected")
+					}
+					<-resolverCtx.Done()
+					releasedOnce.Do(func() {
+						close(resourceReleased)
+					})
+					return resolverCtx.Err()
+				},
+			)), nil
+		},
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer removeHandler()
+
+	startDone := make(chan error, 1)
+	go func() {
+		startDone <- acc.StartP2PSync(ctx, st)
+	}()
+	select {
+	case <-controllerSelected:
+	case <-ctx.Done():
+		t.Fatal("P2P startup did not select the gated controller resource")
+	}
+
+	_, lifecycleChanged := acc.GetP2PSyncSnapshotWithWait()
+	stopDone := make(chan struct{})
+	go func() {
+		acc.StopP2PSync()
+		close(stopDone)
+	}()
+	select {
+	case <-lifecycleChanged:
+	case <-ctx.Done():
+		t.Fatal("P2P stop did not retire the starting state")
+	}
+
+	// Registration proceeds only after stop has retired the state. Cleanup must
+	// wait for the startup pass to retain this reference before releasing it.
+	close(allowRegistration)
+	select {
+	case <-resourceReleased:
+	case <-ctx.Done():
+		t.Fatal("P2P startup resource registered after stop began was not released")
+	}
+	select {
+	case <-stopDone:
+	case <-ctx.Done():
+		t.Fatal("P2P stop did not finish after releasing the startup resource")
+	}
+	select {
+	case err := <-startDone:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected stopped P2P startup to return context.Canceled, got %v", err)
+		}
+	case <-ctx.Done():
+		t.Fatal("stopped P2P startup did not return")
+	}
+}
+
+type gatedP2PSyncExecValue struct {
+	loader.ExecControllerValue
+	ctrl         controller.Controller
+	selected     chan struct{}
+	allow        chan struct{}
+	selectedOnce *sync.Once
+}
+
+func (v *gatedP2PSyncExecValue) GetController() controller.Controller {
+	v.selectedOnce.Do(func() {
+		close(v.selected)
+	})
+	<-v.allow
+	return v.ctrl
 }
 
 type observedP2PStartContext struct {

--- a/core/provider/local/p2p-sync_test.go
+++ b/core/provider/local/p2p-sync_test.go
@@ -379,6 +379,7 @@ func TestStartP2PSyncStartsDEXSolicit(t *testing.T) {
 
 	loadStarted := make(chan struct{})
 	releaseLoad := make(chan struct{})
+	dexLoads := make(chan string, 8)
 	var gate sync.Once
 	removeHandler, err := st.GetChildBus().AddHandler(directive.NewFuncHandler(
 		func(handlerCtx context.Context, di directive.Instance) ([]directive.Resolver, error) {
@@ -386,8 +387,13 @@ func TestStartP2PSyncStartsDEXSolicit(t *testing.T) {
 			if !ok {
 				return nil, nil
 			}
-			if _, ok := load.GetLoadControllerConfig().(*dex_solicit.Config); !ok {
+			loadConfig, ok := load.GetLoadControllerConfig().(*dex_solicit.Config)
+			if !ok {
 				return nil, nil
+			}
+			select {
+			case dexLoads <- loadConfig.GetBucketId():
+			default:
 			}
 			gate.Do(func() {
 				close(loadStarted)
@@ -438,18 +444,54 @@ func TestStartP2PSyncStartsDEXSolicit(t *testing.T) {
 		)
 	}
 
+	newRef, err := acc.CreateSharedObject(
+		ctx,
+		"pending-start-space",
+		&sobject.SharedObjectMeta{BodyType: "space"},
+		"",
+		"",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newBucketID := provider_local.BlockStoreBucketID(
+		newRef.GetProviderResourceRef().GetProviderId(),
+		newRef.GetProviderResourceRef().GetProviderAccountId(),
+		newRef.GetBlockStoreId(),
+	)
+
 	if acc.IsP2PSyncRunning() {
 		t.Fatal("expected P2P sync to remain starting while DEX controller load is blocked")
 	}
+	_, p2pWaitCh := acc.GetP2PSyncSnapshotWithWait()
 
 	close(releaseLoad)
 	if err := <-firstDone; err != nil {
 		t.Fatal(err)
 	}
+	select {
+	case <-p2pWaitCh:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for P2P startup broadcast")
+	}
+	if running, _ := acc.GetP2PSyncSnapshotWithWait(); !running {
+		t.Fatal("expected P2P sync running after startup broadcast")
+	}
+
 	defer acc.StopP2PSync()
 
-	if !acc.IsP2PSyncRunning() {
-		t.Fatal("expected P2P sync running after direct start")
+	for {
+		select {
+		case bucketID := <-dexLoads:
+			if bucketID == newBucketID {
+				if !acc.IsP2PSyncRunning() {
+					t.Fatal("expected P2P sync running after pending shared object start")
+				}
+				return
+			}
+		case <-ctx.Done():
+			t.Fatalf("timed out waiting for DEX solicit controller for %s", newBucketID)
+		}
 	}
 }
 

--- a/core/provider/local/p2p-sync_test.go
+++ b/core/provider/local/p2p-sync_test.go
@@ -2,6 +2,7 @@ package provider_local_test
 
 import (
 	"context"
+	"errors"
 	"runtime"
 	"sync"
 	"testing"
@@ -562,10 +563,20 @@ func TestStartP2PSyncCoalescedCallerOwnsLifecycle(t *testing.T) {
 		t.Fatal("coalesced P2P caller did not retain the lifecycle")
 	}
 
+	// Cancel the first caller while its startup is still gated. The startup
+	// belongs to whoever owns the state, so a caller that gives up returns on
+	// its own context instead of finishing work it no longer has a stake in.
 	firstCancel()
+	select {
+	case err := <-firstDone:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected the canceled first caller to return context.Canceled, got %v", err)
+		}
+	case <-ctx.Done():
+		t.Fatal("canceled first P2P caller did not return while startup was still gated")
+	}
 	close(releaseLoad)
 
-	<-firstDone
 	select {
 	case err := <-secondDone:
 		if err != nil {
@@ -577,6 +588,116 @@ func TestStartP2PSyncCoalescedCallerOwnsLifecycle(t *testing.T) {
 	defer acc.StopP2PSync()
 	if !acc.IsP2PSyncRunning() {
 		t.Fatal("expected P2P sync to remain running under the coalesced caller")
+	}
+}
+
+// TestStartP2PSyncDoesNotCoalesceAcrossTransports checks that a start for a
+// replacement session transport gets its own controllers.
+//
+// A startup pass loads controllers onto the child bus of the transport it began
+// with. A start for a different transport that joined an in-flight one would be
+// told sync had started while its own transport carried no DEX solicit, SO
+// sync, or invite controllers at all.
+func TestStartP2PSyncDoesNotCoalesceAcrossTransports(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	tb, sessRef, acc, sess, release := setupProviderAndSession(ctx, t)
+	defer release()
+
+	accountID := sessRef.GetProviderResourceRef().GetProviderAccountId()
+	_, soRelease := mountAccountSettingsSO(ctx, t, tb.Bus, accountID)
+	soRelease()
+
+	if err := acc.CreateSessionTransport(ctx, sess.GetPrivKey(), ""); err != nil {
+		t.Fatal(err)
+	}
+	defer acc.StopSessionTransport()
+	first := acc.GetSessionTransport()
+	if first == nil {
+		t.Fatal("expected non-nil session transport")
+	}
+
+	firstLoadStarted := make(chan struct{})
+	releaseFirstLoad := make(chan struct{})
+	var gate sync.Once
+	removeFirst, err := first.GetChildBus().AddHandler(directive.NewFuncHandler(
+		func(_ context.Context, di directive.Instance) ([]directive.Resolver, error) {
+			load, ok := di.GetDirective().(resolver.LoadControllerWithConfig)
+			if !ok {
+				return nil, nil
+			}
+			if _, ok := load.GetLoadControllerConfig().(*dex_solicit.Config); !ok {
+				return nil, nil
+			}
+			// Hold the first startup open past the replacement of its own
+			// transport, so the second start meets a startup genuinely in
+			// flight rather than one that already finished.
+			gate.Do(func() {
+				close(firstLoadStarted)
+				<-releaseFirstLoad
+			})
+			return nil, nil
+		},
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer removeFirst()
+	defer close(releaseFirstLoad)
+
+	firstDone := make(chan error, 1)
+	go func() {
+		firstDone <- acc.StartP2PSync(ctx, first)
+	}()
+	select {
+	case <-firstLoadStarted:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for the first P2P startup load")
+	}
+
+	if err := acc.CreateSessionTransport(ctx, sess.GetPrivKey(), ""); err != nil {
+		t.Fatal(err)
+	}
+	second := acc.GetSessionTransport()
+	if second == first {
+		t.Fatal("expected a replacement session transport")
+	}
+
+	secondLoads := make(chan struct{}, 1)
+	removeSecond, err := second.GetChildBus().AddHandler(directive.NewFuncHandler(
+		func(_ context.Context, di directive.Instance) ([]directive.Resolver, error) {
+			load, ok := di.GetDirective().(resolver.LoadControllerWithConfig)
+			if !ok {
+				return nil, nil
+			}
+			if _, ok := load.GetLoadControllerConfig().(*dex_solicit.Config); !ok {
+				return nil, nil
+			}
+			select {
+			case secondLoads <- struct{}{}:
+			default:
+			}
+			return nil, nil
+		},
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer removeSecond()
+
+	secondDone := make(chan error, 1)
+	go func() {
+		secondDone <- acc.StartP2PSync(ctx, second)
+	}()
+	defer acc.StopP2PSync()
+
+	select {
+	case <-secondLoads:
+	case err := <-secondDone:
+		t.Fatalf("start for the replacement transport finished without loading controllers on it: %v", err)
+	case <-ctx.Done():
+		t.Fatal("the replacement transport never received its DEX solicit controller")
 	}
 }
 

--- a/core/provider/local/p2p-sync_test.go
+++ b/core/provider/local/p2p-sync_test.go
@@ -3,14 +3,18 @@ package provider_local_test
 import (
 	"context"
 	"runtime"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/aperturerobotics/controllerbus/bus"
+	"github.com/aperturerobotics/controllerbus/controller/resolver"
+	"github.com/aperturerobotics/controllerbus/directive"
 	account_settings "github.com/s4wave/spacewave/core/account/settings"
 	provider_local "github.com/s4wave/spacewave/core/provider/local"
 	"github.com/s4wave/spacewave/core/sobject"
 	"github.com/s4wave/spacewave/core/transport"
+	dex_solicit "github.com/s4wave/spacewave/db/dex/solicit"
 	"github.com/s4wave/spacewave/net/link"
 	"github.com/s4wave/spacewave/net/peer"
 	"github.com/s4wave/spacewave/net/transport/common/dialer"
@@ -353,14 +357,14 @@ func TestBlockSyncDEX(t *testing.T) {
 }
 
 func TestStartP2PSyncStartsDEXSolicit(t *testing.T) {
-	ctx := t.Context()
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
 
 	tb, sessRef, acc, sess, release := setupProviderAndSession(ctx, t)
 	defer release()
 
 	accountID := sessRef.GetProviderResourceRef().GetProviderAccountId()
-	so, soRelease := mountAccountSettingsSO(ctx, t, tb.Bus, accountID)
-	addPairedDeviceAndWait(ctx, t, so, sess.GetPeerId().String(), "GoScript DEX Test Device")
+	_, soRelease := mountAccountSettingsSO(ctx, t, tb.Bus, accountID)
 	soRelease()
 
 	if err := acc.CreateSessionTransport(ctx, sess.GetPrivKey(), ""); err != nil {
@@ -372,7 +376,74 @@ func TestStartP2PSyncStartsDEXSolicit(t *testing.T) {
 	if st == nil {
 		t.Fatal("expected non-nil session transport")
 	}
-	if err := acc.StartP2PSync(ctx, st); err != nil {
+
+	loadStarted := make(chan struct{})
+	releaseLoad := make(chan struct{})
+	var gate sync.Once
+	removeHandler, err := st.GetChildBus().AddHandler(directive.NewFuncHandler(
+		func(handlerCtx context.Context, di directive.Instance) ([]directive.Resolver, error) {
+			load, ok := di.GetDirective().(resolver.LoadControllerWithConfig)
+			if !ok {
+				return nil, nil
+			}
+			if _, ok := load.GetLoadControllerConfig().(*dex_solicit.Config); !ok {
+				return nil, nil
+			}
+			gate.Do(func() {
+				close(loadStarted)
+				select {
+				case <-releaseLoad:
+				case <-handlerCtx.Done():
+				}
+			})
+			return nil, nil
+		},
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer removeHandler()
+
+	firstDone := make(chan error, 1)
+	go func() {
+		firstDone <- acc.StartP2PSync(ctx, st)
+	}()
+
+	select {
+	case <-loadStarted:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for DEX solicit controller load")
+	}
+
+	secondDone := make(chan error, 1)
+	go func() {
+		secondDone <- acc.StartP2PSync(ctx, st)
+	}()
+
+	secondCtx, secondCancel := context.WithTimeout(ctx, time.Second)
+	defer secondCancel()
+	select {
+	case err := <-secondDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-secondCtx.Done():
+		close(releaseLoad)
+		firstErr := <-firstDone
+		secondErr := <-secondDone
+		t.Fatalf(
+			"concurrent start blocked behind DEX controller load: first=%v second=%v",
+			firstErr,
+			secondErr,
+		)
+	}
+
+	if acc.IsP2PSyncRunning() {
+		t.Fatal("expected P2P sync to remain starting while DEX controller load is blocked")
+	}
+
+	close(releaseLoad)
+	if err := <-firstDone; err != nil {
 		t.Fatal(err)
 	}
 	defer acc.StopP2PSync()

--- a/core/provider/local/p2p-sync_test.go
+++ b/core/provider/local/p2p-sync_test.go
@@ -426,24 +426,6 @@ func TestStartP2PSyncStartsDEXSolicit(t *testing.T) {
 		secondDone <- acc.StartP2PSync(ctx, st)
 	}()
 
-	secondCtx, secondCancel := context.WithTimeout(ctx, time.Second)
-	defer secondCancel()
-	select {
-	case err := <-secondDone:
-		if err != nil {
-			t.Fatal(err)
-		}
-	case <-secondCtx.Done():
-		close(releaseLoad)
-		firstErr := <-firstDone
-		secondErr := <-secondDone
-		t.Fatalf(
-			"concurrent start blocked behind DEX controller load: first=%v second=%v",
-			firstErr,
-			secondErr,
-		)
-	}
-
 	newRef, err := acc.CreateSharedObject(
 		ctx,
 		"pending-start-space",
@@ -467,6 +449,9 @@ func TestStartP2PSyncStartsDEXSolicit(t *testing.T) {
 
 	close(releaseLoad)
 	if err := <-firstDone; err != nil {
+		t.Fatal(err)
+	}
+	if err := <-secondDone; err != nil {
 		t.Fatal(err)
 	}
 	select {
@@ -493,6 +478,126 @@ func TestStartP2PSyncStartsDEXSolicit(t *testing.T) {
 			t.Fatalf("timed out waiting for DEX solicit controller for %s", newBucketID)
 		}
 	}
+}
+
+func TestStartP2PSyncCoalescedCallerOwnsLifecycle(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	tb, sessRef, acc, sess, release := setupProviderAndSession(ctx, t)
+	defer release()
+
+	accountID := sessRef.GetProviderResourceRef().GetProviderAccountId()
+	_, soRelease := mountAccountSettingsSO(ctx, t, tb.Bus, accountID)
+	soRelease()
+
+	if err := acc.CreateSessionTransport(ctx, sess.GetPrivKey(), ""); err != nil {
+		t.Fatal(err)
+	}
+	defer acc.StopSessionTransport()
+
+	st := acc.GetSessionTransport()
+	loadStarted := make(chan struct{})
+	releaseLoad := make(chan struct{})
+	var gate sync.Once
+	removeHandler, err := st.GetChildBus().AddHandler(directive.NewFuncHandler(
+		func(handlerCtx context.Context, di directive.Instance) ([]directive.Resolver, error) {
+			load, ok := di.GetDirective().(resolver.LoadControllerWithConfig)
+			if !ok {
+				return nil, nil
+			}
+			if _, ok := load.GetLoadControllerConfig().(*dex_solicit.Config); !ok {
+				return nil, nil
+			}
+			gate.Do(func() {
+				close(loadStarted)
+				select {
+				case <-releaseLoad:
+				case <-handlerCtx.Done():
+				}
+			})
+			return nil, nil
+		},
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer removeHandler()
+
+	firstCtx, firstCancel := context.WithCancel(ctx)
+	defer firstCancel()
+	firstDone := make(chan error, 1)
+	go func() {
+		firstDone <- acc.StartP2PSync(firstCtx, st)
+	}()
+
+	select {
+	case <-loadStarted:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for first P2P startup load")
+	}
+
+	secondBaseCtx, secondCancel := context.WithCancel(ctx)
+	defer secondCancel()
+	secondCtx := &observedP2PStartContext{
+		Context:         secondBaseCtx,
+		awaitReady:      make(chan struct{}),
+		allowAwait:      make(chan struct{}),
+		ownerRegistered: make(chan struct{}),
+	}
+	secondDone := make(chan error, 1)
+	go func() {
+		secondDone <- acc.StartP2PSync(secondCtx, st)
+	}()
+
+	select {
+	case <-secondCtx.awaitReady:
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for coalesced P2P caller readiness")
+	}
+	close(secondCtx.allowAwait)
+	select {
+	case <-secondCtx.ownerRegistered:
+	case <-ctx.Done():
+		t.Fatal("coalesced P2P caller did not retain the lifecycle")
+	}
+
+	firstCancel()
+	close(releaseLoad)
+
+	<-firstDone
+	select {
+	case err := <-secondDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for coalesced P2P start")
+	}
+	defer acc.StopP2PSync()
+	if !acc.IsP2PSyncRunning() {
+		t.Fatal("expected P2P sync to remain running under the coalesced caller")
+	}
+}
+
+type observedP2PStartContext struct {
+	context.Context
+	awaitReady      chan struct{}
+	allowAwait      chan struct{}
+	ownerRegistered chan struct{}
+	awaitOnce       sync.Once
+	ownerOnce       sync.Once
+}
+
+func (c *observedP2PStartContext) Done() <-chan struct{} {
+	c.awaitOnce.Do(func() {
+		close(c.awaitReady)
+		<-c.allowAwait
+	})
+	c.ownerOnce.Do(func() {
+		close(c.ownerRegistered)
+	})
+	return c.Context.Done()
 }
 
 func skipFullP2PSyncUnderGoScript(t *testing.T) {

--- a/core/resource/session/sync-status-rpc.go
+++ b/core/resource/session/sync-status-rpc.go
@@ -109,8 +109,9 @@ func (r *SessionResource) buildLocalSyncStatusSnapshot(
 		pairing = acc.GetPairingSnapshot()
 	})
 	transportRunning, transportCh := acc.GetTransportSnapshotWithWait()
-	return syncStatusFromLocalState(pairing, transportRunning, acc.IsP2PSyncRunning()),
-		[]<-chan struct{}{pairingCh, transportCh}
+	p2pRunning, p2pCh := acc.GetP2PSyncSnapshotWithWait()
+	return syncStatusFromLocalState(pairing, transportRunning, p2pRunning),
+		[]<-chan struct{}{pairingCh, transportCh, p2pCh}
 }
 
 func syncStatusFromSpacewaveTelemetry(

--- a/core/resource/session/sync-status-rpc_test.go
+++ b/core/resource/session/sync-status-rpc_test.go
@@ -200,6 +200,20 @@ func TestWatchSyncStatusInitialSnapshots(t *testing.T) {
 	}
 }
 
+func TestBuildLocalSyncStatusSnapshotWaitsForP2P(t *testing.T) {
+	t.Parallel()
+
+	acc := &provider_local.ProviderAccount{}
+	res := &SessionResource{
+		session: &testSyncStatusSession{acc: acc},
+	}
+
+	_, waitChs := res.buildLocalSyncStatusSnapshot(acc)
+	if len(waitChs) != 3 {
+		t.Fatalf("wait channel count = %d, want 3", len(waitChs))
+	}
+}
+
 func TestWaitSyncStatusWaitsForEverySource(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
StartP2PSync held p2pSyncMtx while the ControllerBus loader waited for the DEX solicit controller to report running. A concurrent start could not inspect the published state, so the direct start path could sit behind the load until the package timeout.

The Provider Account now publishes startup state under the mutex and performs controller loading after unlocking. A duplicate call that races unfinished startup returns without issuing another load, while sequential starts still replace completed state. Cleanup waits for startup completion and remains safe when cancellation races startup.

A causal regression fails against the unfixed code in 1.01 seconds and passes in 20 consecutive runs after the fix. The focused race run passed five times, and go test ./core/provider/local -count=1 -timeout=90s passed.
