### PR TITLE
fix(docs): rank title matches before content results

### DIFF
--- a/app/docs/DocsPageRoute.tsx
+++ b/app/docs/DocsPageRoute.tsx
@@ -22,7 +22,7 @@ export function DocsPageRoute() {
   const docs = useMemo(() => loadDocs(), [])
   const allSections = useMemo(() => getSections(), [])
 
-  // Filter docs and sections to the current site for scoped navigation.
+  // Keep sections scoped to the current site while search spans the corpus.
   const siteDocs = useMemo(
     () => docs.filter((d) => d.site === site),
     [docs, site],
@@ -53,7 +53,7 @@ export function DocsPageRoute() {
   const sidebar = (
     <div className="flex min-h-full flex-col gap-3">
       <div className="px-4 pt-4">
-        <DocsSearch docs={siteDocs} onSelect={handleSearchSelect} />
+        <DocsSearch docs={docs} onSelect={handleSearchSelect} />
       </div>
       <DocsSidebar sections={sections} currentDoc={doc} />
     </div>

--- a/app/docs/DocsSearch.test.tsx
+++ b/app/docs/DocsSearch.test.tsx
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import type { DocPage } from './types.js'
+import { DocsSearch } from './DocsSearch.js'
+
+const docs: DocPage[] = [
+  {
+    slug: 'cli-reference',
+    url: '/docs/developers/cli/cli-reference',
+    title: 'CLI Reference',
+    site: 'developers',
+    section: 'cli',
+    order: 1,
+    summary: 'Reference the command tree.',
+    body: 'The auth backup command writes a recovery key.',
+    filename: '01-cli-reference.md',
+  },
+  {
+    slug: 'backup-and-recovery',
+    url: '/docs/self-hosters/storage/backup-and-recovery',
+    title: 'Backup and Recovery',
+    site: 'self-hosters',
+    section: 'storage',
+    order: 2,
+    summary: 'Recovery paths for stored data.',
+    body: 'Keep the recovery material somewhere safe.',
+    filename: '02-backup-and-recovery.md',
+  },
+]
+
+describe('DocsSearch', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('ranks a title match above a body-only match through the search input', async () => {
+    const user = userEvent.setup()
+    render(<DocsSearch docs={docs} onSelect={() => {}} />)
+
+    await user.type(screen.getByPlaceholderText('Search docs…'), 'backup')
+
+    const results = screen.getAllByRole('button')
+    expect(results).toHaveLength(2)
+    expect(results[0].textContent).toContain('Backup and Recovery')
+    expect(results[1].textContent).toContain('CLI Reference')
+  })
+})

--- a/app/docs/DocsSearch.tsx
+++ b/app/docs/DocsSearch.tsx
@@ -18,12 +18,25 @@ export function DocsSearch({ docs, onSelect }: DocsSearchProps) {
   const results = useMemo(() => {
     if (!query.trim()) return []
     const q = query.toLowerCase()
-    return docs.filter(
-      (d) =>
-        d.title.toLowerCase().includes(q) ||
-        d.body.toLowerCase().includes(q) ||
-        d.summary.toLowerCase().includes(q),
-    )
+    return docs
+      .flatMap((doc, index) => {
+        const title = doc.title.toLowerCase()
+        const titleMatch = title.includes(q)
+        const contentMatch =
+          doc.body.toLowerCase().includes(q) ||
+          doc.summary.toLowerCase().includes(q)
+        if (!titleMatch && !contentMatch) return []
+
+        return [
+          {
+            doc,
+            index,
+            score: title === q ? 3 : titleMatch ? 2 : 1,
+          },
+        ]
+      })
+      .sort((a, b) => b.score - a.score || a.index - b.index)
+      .map(({ doc }) => doc)
   }, [query, docs])
 
   const handleSelect = useCallback(

--- a/app/docs/DocsSiteRoute.tsx
+++ b/app/docs/DocsSiteRoute.tsx
@@ -21,10 +21,6 @@ export function DocsSiteRoute() {
     () => allSections.filter((s) => s.site === site),
     [allSections, site],
   )
-  const siteDocs = useMemo(
-    () => docs.filter((d) => d.site === site),
-    [docs, site],
-  )
 
   const validSite = useMemo(() => siteDefs.some((s) => s.id === site), [site])
 
@@ -42,7 +38,7 @@ export function DocsSiteRoute() {
   const sidebar = (
     <div className="flex min-h-full flex-col gap-3">
       <div className="px-4 pt-4">
-        <DocsSearch docs={siteDocs} onSelect={handleSearchSelect} />
+        <DocsSearch docs={docs} onSelect={handleSearchSelect} />
       </div>
       <DocsSidebar sections={sections} />
     </div>

--- a/app/docs/content/users/start/01-start-here.md
+++ b/app/docs/content/users/start/01-start-here.md
@@ -41,7 +41,7 @@ Press Cmd/Ctrl+K, or click the Spacewave logo, to open the command palette. Type
 what you want to do. What you see there depends on where you are and which Space
 is open.
 
-## Check it stuck
+## Verify your data persisted
 
 Once your first Space opens, add a file or a folder, then reload the page. Still
 there? Everything is set up correctly.


### PR DESCRIPTION
Documentation search previously searched only the current audience site, so searching from Developer docs could not show Backup and Recovery from Self-Hosters. Matching pages also stayed in corpus order, so body text could outrank a direct title match.

Both docs routes now pass the full corpus to DocsSearch. The component scores exact titles above partial titles and content matches, while article navigation remains scoped to the current site. Selecting a result can navigate across documentation sites. The Start Here heading now reads Verify your data persisted.

The focused rendered search test fails when title scoring is removed and passes with the targeted documentation tests: 4 files and 10 tests. Targeted Oxlint passes with no output.