### PR TITLE
fix(pairing): hide relay transport errors

### DIFF
--- a/app/pair/PairCodePage.test.tsx
+++ b/app/pair/PairCodePage.test.tsx
@@ -31,6 +31,55 @@ describe('PairCodePage', () => {
   afterEach(() => {
     cleanup()
     vi.clearAllMocks()
+    mockUseParams.mockReturnValue({ code: 'direct' })
+  })
+  it('shows the missing or expired message for a rejected pairing code', async () => {
+    mockUseParams.mockReturnValue({ code: '' })
+    const session = {
+      completePairing: vi.fn(async () => {
+        throw new Error(
+          'pairing relay returned 404: {"code":"not_found","message":"Pairing code not found or expired"}',
+        )
+      }),
+    }
+
+    render(<PairCodePage session={session as never} />)
+    fireEvent.change(screen.getByPlaceholderText('XXXX XXXX'), {
+      target: { value: 'AAAA AAAA' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Connect' }))
+
+    expect(
+      await screen.findByText(
+        'That pairing code was not found or has expired. Check the code and try again.',
+      ),
+    ).toBeDefined()
+    expect(screen.queryByText(/pairing relay returned/)).toBeNull()
+    expect(screen.getByDisplayValue('AAAA AAAA')).toBeDefined()
+  })
+
+  it('shows the fallback for an unmapped relay failure', async () => {
+    mockUseParams.mockReturnValue({ code: '' })
+    const session = {
+      completePairing: vi.fn(async () => {
+        throw new Error(
+          'pairing relay returned 418: {"code":"teapot","message":"Unexpected relay response"}',
+        )
+      }),
+    }
+
+    render(<PairCodePage session={session as never} />)
+    fireEvent.change(screen.getByPlaceholderText('XXXX XXXX'), {
+      target: { value: 'AAAA AAAA' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Connect' }))
+
+    expect(
+      await screen.findByText(
+        'Could not complete pairing. Check the code and try again.',
+      ),
+    ).toBeDefined()
+    expect(screen.queryByText(/pairing relay returned/)).toBeNull()
   })
 
   it('surfaces PAIRING_FAILED from the PairVerifyStep status watch', async () => {

--- a/app/pair/PairCodePage.tsx
+++ b/app/pair/PairCodePage.tsx
@@ -19,6 +19,7 @@ import type { RegisterCleanup } from '@aptre/bldr-sdk/hooks/useResource.js'
 import { useResourceValue } from '@aptre/bldr-sdk/hooks/useResource.js'
 import { createLocalSession } from '@s4wave/app/quickstart/create.js'
 import { PairingChannelProgress } from '@s4wave/app/session/setup/PairingChannelProgress.js'
+import { pairingErrorMessage } from '@s4wave/app/session/setup/pairing-copy.js'
 import { PairingStatus } from '@s4wave/sdk/session/session.pb.js'
 import { pairingStatusReachedPeer } from '@s4wave/app/session/pairing-status.js'
 import { pairingStatusIsTerminalFailure } from '@s4wave/app/loading/status/pairing.js'
@@ -150,9 +151,9 @@ export function PairCodePage(props: PairCodePageProps) {
         setStep('verify')
       }
     } catch (err) {
-      setError(
-        err instanceof Error ? err.message : 'Failed to complete pairing',
-      )
+      const message =
+        err instanceof Error ? err.message : 'Failed to complete pairing'
+      setError(pairingErrorMessage(message))
     } finally {
       setLoading(false)
     }

--- a/app/session/setup/LinkDeviceWizard.test.tsx
+++ b/app/session/setup/LinkDeviceWizard.test.tsx
@@ -135,6 +135,33 @@ describe('LinkDeviceWizard', () => {
     ).toBeDefined()
   })
 
+  it('maps a local relay not-found error in the EnterCodeStep submit path', async () => {
+    const session = {
+      completePairing: vi
+        .fn()
+        .mockRejectedValue(
+          new Error(
+            'pairing relay returned 404: {"code":"not_found","message":"Pairing code not found or expired"}',
+          ),
+        ),
+    }
+    mockUseResourceValue.mockReturnValue(session)
+
+    render(<LinkDeviceWizard />)
+    fireEvent.click(screen.getByText('Enter a code from another device'))
+    fireEvent.change(screen.getByPlaceholderText('XXXX XXXX'), {
+      target: { value: 'ABCD1234' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Connect' }))
+
+    expect(
+      await screen.findByText(
+        'That pairing code was not found or has expired. Check the code and try again.',
+      ),
+    ).toBeDefined()
+    expect(screen.queryByText(/pairing relay returned/i)).toBeNull()
+  })
+
   it('starts watching pairing status after the generated code resolves', async () => {
     const watchPairingStatus = vi.fn(async function* () {})
     const session = {

--- a/app/session/setup/LinkDeviceWizard.tsx
+++ b/app/session/setup/LinkDeviceWizard.tsx
@@ -886,7 +886,7 @@ function EnterCodeStep({
     } catch (err) {
       const message =
         err instanceof Error ? err.message : 'Failed to complete pairing'
-      setError(message)
+      setError(pairingErrorMessage(message))
       // Surface via toast too: a failed submit can re-render or navigate the
       // settings pane away from this card before the inline error is seen.
       toast.error(pairingErrorMessage(message))
@@ -961,11 +961,7 @@ function EnterCodeStep({
         <span className="text-foreground-alt text-xs">Scan QR code</span>
       </button>
 
-      {error && (
-        <p className="text-destructive text-center text-xs">
-          {pairingErrorMessage(error)}
-        </p>
-      )}
+      {error && <p className="text-destructive text-center text-xs">{error}</p>}
 
       <div className="flex gap-2">
         <button

--- a/app/session/setup/pairing-copy.test.ts
+++ b/app/session/setup/pairing-copy.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  PAIRING_CODE_NOT_FOUND,
+  PAIRING_FAILED,
   PAIRING_SERVICE_UNREACHABLE,
   pairingCodeInstructions,
   pairingErrorMessage,
@@ -23,9 +25,9 @@ describe('pairingCodeInstructions', () => {
 
 describe('pairingErrorMessage', () => {
   it('collapses relay 5xx and fetch failures to the reachability message', () => {
-    expect(pairingErrorMessage('pairing relay returned 500: Failed to fetch')).toBe(
-      PAIRING_SERVICE_UNREACHABLE,
-    )
+    expect(
+      pairingErrorMessage('pairing relay returned 500: Failed to fetch'),
+    ).toBe(PAIRING_SERVICE_UNREACHABLE)
     expect(pairingErrorMessage('Failed to fetch')).toBe(
       PAIRING_SERVICE_UNREACHABLE,
     )
@@ -39,12 +41,32 @@ describe('pairingErrorMessage', () => {
     expect(pairingErrorMessage('')).toBe(PAIRING_SERVICE_UNREACHABLE)
   })
 
-  it('passes through user-actionable errors', () => {
-    expect(pairingErrorMessage('pairing code conflict, retry with new code')).toBe(
-      'pairing code conflict, retry with new code',
-    )
-    expect(pairingErrorMessage('pairing relay returned 404: not found')).toBe(
-      'pairing relay returned 404: not found',
+  it('maps relay responses without exposing their details', () => {
+    expect(
+      pairingErrorMessage(
+        'pairing relay returned 404: {"code":"not_found","message":"Pairing code not found or expired"}',
+      ),
+    ).toBe(PAIRING_CODE_NOT_FOUND)
+    expect(
+      pairingErrorMessage(
+        'get pairing code: 404 not_found: Pairing code not found or expired',
+      ),
+    ).toBe(PAIRING_CODE_NOT_FOUND)
+    expect(
+      pairingErrorMessage(
+        'get pairing code: 418 teapot: Unexpected relay response',
+      ),
+    ).toBe(PAIRING_FAILED)
+    expect(
+      pairingErrorMessage(
+        'pairing relay returned 418: {"code":"teapot","message":"Unexpected relay response"}',
+      ),
+    ).toBe(PAIRING_FAILED)
+    expect(
+      pairingErrorMessage('pairing code conflict, retry with new code'),
+    ).toBe('pairing code conflict, retry with new code')
+    expect(pairingErrorMessage('unexpected pairing failure')).toBe(
+      PAIRING_FAILED,
     )
   })
 })

--- a/app/session/setup/pairing-copy.ts
+++ b/app/session/setup/pairing-copy.ts
@@ -30,20 +30,42 @@ export function pairingCodeInstructions(
 export const PAIRING_SERVICE_UNREACHABLE =
   'Could not reach the pairing service. Check your connection and try again.'
 
+// PAIRING_CODE_NOT_FOUND is the recovery message for an expired or unknown
+// pairing code.
+export const PAIRING_CODE_NOT_FOUND =
+  'That pairing code was not found or has expired. Check the code and try again.'
+
+// PAIRING_FAILED is the fallback for a relay error without a known code.
+export const PAIRING_FAILED =
+  'Could not complete pairing. Check the code and try again.'
+
 // pairingErrorMessage maps a raw pairing error into user-facing copy. Relay
-// transport failures (a raw fetch failure or a relay 5xx surfaced as "pairing
-// relay returned 5xx") collapse to a single reachability message; other errors,
-// which are user-actionable (code conflict, rejected pairing), pass through.
+// transport failures stay behind the reachability message, known relay error
+// codes get recovery copy, and unknown relay responses use one honest fallback.
 export function pairingErrorMessage(raw: string | null | undefined): string {
   if (!raw) {
     return PAIRING_SERVICE_UNREACHABLE
   }
+  const relayStatus = raw.match(
+    /(?:pairing relay returned\s+|(?:get|post) pairing code:\s*)(\d{3})(?=\s|:)/i,
+  )
   if (
     /failed to fetch/i.test(raw) ||
-    /pairing relay returned 5\d\d/i.test(raw) ||
     /network(?:error)?|load failed|could not reach|err_network/i.test(raw)
   ) {
     return PAIRING_SERVICE_UNREACHABLE
   }
-  return raw
+  if (relayStatus) {
+    if (relayStatus[1].startsWith('5')) {
+      return PAIRING_SERVICE_UNREACHABLE
+    }
+    if (/"code"\s*:\s*"not_found"/i.test(raw) || /\bnot_found\s*:/i.test(raw)) {
+      return PAIRING_CODE_NOT_FOUND
+    }
+    return PAIRING_FAILED
+  }
+  if (/^pairing code conflict, retry with new code$/i.test(raw)) {
+    return raw
+  }
+  return PAIRING_FAILED
 }


### PR DESCRIPTION
Submitting an invalid pairing code exposed the relay HTTP status and JSON response below the form. An ordinary mistyped or expired code therefore showed implementation details instead of a recovery action.

The pairing copy module now recognizes the observed not_found response and the cloud provider equivalent, maps network and server failures, and sends unknown failures to one recovery message. Both pairing forms map errors before rendering, preserve the entered code, and leave their retry controls available.

The focused pairing command passed 3 test files and 16 tests. Targeted oxlint and git diff --check also passed.