### PR TITLE
fix(forge/exec): tolerate completed v86 execution pipes

### DIFF
--- a/core/forge/exec/v86.go
+++ b/core/forge/exec/v86.go
@@ -91,22 +91,20 @@ func (h *v86Handler) Execute(ctx context.Context) error {
 	}
 
 	client := srpc.NewClient(srpc.NewServerPipe(srpc.NewServer(inv)))
-	strm, err := s4wave_process.NewSRPCPersistentExecutionServiceClient(client).Execute(ctx, &s4wave_process.ExecuteRequest{})
+	strm, err := openV86ExecutionStream(ctx, client)
 	if err != nil {
 		return errors.Wrap(err, "execute v86 resource")
 	}
 	defer strm.Close()
 
 	for {
-		status, err := strm.Recv()
-		if err == io.EOF {
+		status := new(s4wave_process.ExecuteStatus)
+		err := strm.MsgRecv(status)
+		if err == io.EOF || errors.Is(err, io.ErrClosedPipe) {
 			return errors.New("v86 execution stream ended before RUNNING")
 		}
 		if err != nil {
 			return errors.Wrap(err, "receive v86 execution status")
-		}
-		if status == nil {
-			return errors.New("v86 execution stream returned nil status")
 		}
 		switch status.GetState() {
 		case s4wave_process.ExecutionState_ExecutionState_RUNNING:
@@ -127,6 +125,25 @@ func (h *v86Handler) Execute(ctx context.Context) error {
 			}
 		}
 	}
+}
+
+func openV86ExecutionStream(ctx context.Context, client srpc.Client) (srpc.Stream, error) {
+	strm, err := client.NewStream(
+		ctx,
+		s4wave_process.SRPCPersistentExecutionServiceServiceID,
+		"Execute",
+		&s4wave_process.ExecuteRequest{},
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := strm.CloseSend(); err != nil &&
+		!errors.Is(err, io.ErrClosedPipe) &&
+		!errors.Is(err, srpc.ErrCompleted) {
+		_ = strm.Close()
+		return nil, err
+	}
+	return strm, nil
 }
 
 // NewV86Handler constructs a V86 VM object handler factory.

--- a/core/forge/exec/v86_test.go
+++ b/core/forge/exec/v86_test.go
@@ -2,6 +2,7 @@ package space_exec
 
 import (
 	"context"
+	"io"
 	"slices"
 	"strings"
 	"testing"
@@ -173,6 +174,103 @@ func TestV86ExecuteSetsStartingAndStreamsLogs(t *testing.T) {
 			t.Fatalf("log %d = {%q, %q}, want {%q, %q}", i, got.GetLevel(), got.GetMessage(), want.GetLevel(), want.GetMessage())
 		}
 	}
+}
+
+func TestOpenV86ExecutionStreamCloseSend(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		closeSendErr  error
+		wantError     bool
+		wantCloseCall bool
+	}{
+		{name: "closed pipe", closeSendErr: io.ErrClosedPipe},
+		{name: "completed", closeSendErr: srpc.ErrCompleted},
+		{name: "other error", closeSendErr: errors.New("close send failed"), wantError: true, wantCloseCall: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stream := &v86ExecutionStreamFake{closeSendErr: tc.closeSendErr}
+			client := &v86ExecutionClientFake{stream: stream}
+
+			got, err := openV86ExecutionStream(context.Background(), client)
+			if tc.wantError {
+				if err == nil || err.Error() != "close send failed" {
+					t.Fatalf("openV86ExecutionStream error = %v, want close send failed", err)
+				}
+				if got != nil {
+					t.Fatal("openV86ExecutionStream returned a stream on error")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("openV86ExecutionStream: %v", err)
+				}
+				if got != stream {
+					t.Fatal("openV86ExecutionStream returned a different stream")
+				}
+			}
+			if stream.closeCalled != tc.wantCloseCall {
+				t.Fatalf("stream close called = %t, want %t", stream.closeCalled, tc.wantCloseCall)
+			}
+			if client.service != s4wave_process.SRPCPersistentExecutionServiceServiceID {
+				t.Fatalf("service = %q", client.service)
+			}
+			if client.method != "Execute" {
+				t.Fatalf("method = %q", client.method)
+			}
+		})
+	}
+}
+
+type v86ExecutionClientFake struct {
+	stream  srpc.Stream
+	service string
+	method  string
+}
+
+func (f *v86ExecutionClientFake) ExecCall(
+	ctx context.Context,
+	service string,
+	method string,
+	in srpc.Message,
+	out srpc.Message,
+) error {
+	return errors.New("unexpected ExecCall")
+}
+
+func (f *v86ExecutionClientFake) NewStream(
+	ctx context.Context,
+	service string,
+	method string,
+	firstMsg srpc.Message,
+) (srpc.Stream, error) {
+	f.service = service
+	f.method = method
+	return f.stream, nil
+}
+
+type v86ExecutionStreamFake struct {
+	closeSendErr error
+	closeCalled  bool
+}
+
+func (f *v86ExecutionStreamFake) Context() context.Context {
+	return context.Background()
+}
+
+func (f *v86ExecutionStreamFake) MsgSend(msg srpc.Message) error {
+	return nil
+}
+
+func (f *v86ExecutionStreamFake) MsgRecv(msg srpc.Message) error {
+	return io.EOF
+}
+
+func (f *v86ExecutionStreamFake) CloseSend() error {
+	return f.closeSendErr
+}
+
+func (f *v86ExecutionStreamFake) Close() error {
+	f.closeCalled = true
+	return nil
 }
 
 type v86PersistentExecutionServiceFake struct {


### PR DESCRIPTION
The V86 execution handler could report io: read/write on closed pipe when the local SRPC server completed the invocation before the generated Execute client sent CloseSend. The generated client returned the stream only after CloseSend succeeded, so statuses already buffered on the pipe were discarded.

The handler now opens the Execute stream directly, keeps it when CloseSend returns io.ErrClosedPipe or srpc.ErrCompleted, and drains statuses. Other close errors remain failures, and a stream closed before RUNNING remains terminal. The focused test now covers tolerated completion errors and fatal close errors.

Verified with go test -race -run 'Test(OpenV86ExecutionStreamCloseSend|V86ExecuteSetsStartingAndStreamsLogs)$' ./core/forge/exec/, go test -race -count=200 -run TestV86ExecuteSetsStartingAndStreamsLogs ./core/forge/exec/, and go test -race ./core/forge/exec/.