### PR TITLE
fix(opfs): hold the metadata lock through each read walk

### DIFF
--- a/db/kvtx/iterator/iterator.go
+++ b/db/kvtx/iterator/iterator.go
@@ -187,8 +187,7 @@ func (i *Iterator) Value() ([]byte, error) {
 	if len(i.val) != 0 {
 		return i.val, nil
 	}
-	v, _ := i.ValueCopy(nil) // sets i.val internally
-	return v, nil
+	return i.ValueCopy(nil) // sets i.val internally
 }
 
 // ValueCopy copies the key to the given byte slice and returns it.

--- a/db/kvtx/iterator/iterator_test.go
+++ b/db/kvtx/iterator/iterator_test.go
@@ -2,13 +2,32 @@ package kvtx_iterator
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	"github.com/s4wave/spacewave/db/kvtx"
 	"gotest.tools/v3/assert"
 )
 
 type mockOps struct {
 	data map[string]string
+}
+
+type generationOps struct {
+	generation        uint64
+	scannedGeneration uint64
+}
+
+func (o *generationOps) Get(ctx context.Context, key []byte) ([]byte, bool, error) {
+	if o.generation != o.scannedGeneration {
+		return nil, false, kvtx.ErrInvalidSnapshot
+	}
+	return []byte("value"), true, nil
+}
+
+func (o *generationOps) ScanPrefixKeys(ctx context.Context, prefix []byte, cb func(key []byte) error) error {
+	o.scannedGeneration = o.generation
+	return cb([]byte("key"))
 }
 
 func (m *mockOps) Get(ctx context.Context, key []byte) (data []byte, found bool, err error) {
@@ -98,4 +117,18 @@ func TestIterator(t *testing.T) {
 		assert.NilError(t, it.Seek([]byte("f")))
 		assert.Equal(t, it.Valid(), false)
 	})
+}
+
+func TestIteratorValuePropagatesSnapshotError(t *testing.T) {
+	ops := &generationOps{generation: 1}
+	it := NewIterator(context.Background(), ops, nil, true, false)
+	defer it.Close()
+
+	assert.Assert(t, it.Next())
+	ops.generation++
+
+	value, err := it.Value()
+	assert.Assert(t, errors.Is(err, kvtx.ErrInvalidSnapshot),
+		"Value() error = %v, want kvtx.ErrInvalidSnapshot", err)
+	assert.Assert(t, value == nil)
 }

--- a/db/opfs/chrometest/chrome_test.go
+++ b/db/opfs/chrometest/chrome_test.go
@@ -1407,6 +1407,23 @@ func TestOpfsChromeMetaReadTxServesOneGeneration(t *testing.T) {
 	})
 }
 
+func TestOpfsChromeMetaShardNoticesReplacedDatabase(t *testing.T) {
+	requireChromeProfile(t, chromeSmoke)
+	h := newChromeHarness(t)
+	s := h.newSession(t)
+	defer s.close(t)
+
+	root := "opfs-chrome-meta-reset-identity-" + time.Now().Format("150405.000000000")
+	s.runWorker(t, workerArgs{
+		scenario: "clear",
+		root:     root,
+	})
+	s.runWorker(t, workerArgs{
+		scenario: "meta-reset-identity",
+		root:     root,
+	})
+}
+
 func TestOpfsChromeWorldDeferredCrashRecovery(t *testing.T) {
 	requireChromeProfile(t, chromeSmoke)
 	h := newChromeHarness(t)

--- a/db/opfs/chrometest/chrome_test.go
+++ b/db/opfs/chrometest/chrome_test.go
@@ -1424,6 +1424,23 @@ func TestOpfsChromeMetaShardNoticesReplacedDatabase(t *testing.T) {
 	})
 }
 
+func TestOpfsChromeMetaShardReusesFallbackState(t *testing.T) {
+	requireChromeProfile(t, chromeSmoke)
+	h := newChromeHarness(t)
+	s := h.newSession(t)
+	defer s.close(t)
+
+	root := "opfs-chrome-meta-fallback-shortcut-" + time.Now().Format("150405.000000000")
+	s.runWorker(t, workerArgs{
+		scenario: "clear",
+		root:     root,
+	})
+	s.runWorker(t, workerArgs{
+		scenario: "meta-fallback-shortcut",
+		root:     root,
+	})
+}
+
 func TestOpfsChromeWorldDeferredCrashRecovery(t *testing.T) {
 	requireChromeProfile(t, chromeSmoke)
 	h := newChromeHarness(t)

--- a/db/opfs/chrometest/chrome_test.go
+++ b/db/opfs/chrometest/chrome_test.go
@@ -1390,6 +1390,23 @@ func TestOpfsChromeWorldCoordinatorMultiWriter(t *testing.T) {
 	})
 }
 
+func TestOpfsChromeMetaReadTxServesOneGeneration(t *testing.T) {
+	requireChromeProfile(t, chromeSmoke)
+	h := newChromeHarness(t)
+	s := h.newSession(t)
+	defer s.close(t)
+
+	root := "opfs-chrome-meta-read-isolation-" + time.Now().Format("150405.000000000")
+	s.runWorker(t, workerArgs{
+		scenario: "clear",
+		root:     root,
+	})
+	s.runWorker(t, workerArgs{
+		scenario: "meta-read-isolation",
+		root:     root,
+	})
+}
+
 func TestOpfsChromeWorldDeferredCrashRecovery(t *testing.T) {
 	requireChromeProfile(t, chromeSmoke)
 	h := newChromeHarness(t)

--- a/db/opfs/chrometest/testprog/main.go
+++ b/db/opfs/chrometest/testprog/main.go
@@ -251,6 +251,8 @@ func run(ctx context.Context, c *config) error {
 		return runMetaCrashVerify(ctx, c)
 	case "meta-read-isolation":
 		return runMetaReadIsolation(ctx, c)
+	case "meta-reset-identity":
+		return runMetaResetIdentity(ctx, c)
 	case "counter-init":
 		return runCounterInit(c)
 	case "counter-hold":
@@ -1597,8 +1599,18 @@ func runMetaReadIsolation(ctx context.Context, c *config) error {
 		return err
 	}
 
-	if _, _, err := readTx.Get(ctx, []byte("iso-b")); !errors.Is(err, metashard.ErrGenerationChanged) {
-		return errors.Errorf("read after foreign commit err = %v, want ErrGenerationChanged", err)
+	readErr := func() error {
+		_, _, err := readTx.Get(ctx, []byte("iso-b"))
+		return err
+	}()
+	if !errors.Is(readErr, metashard.ErrGenerationChanged) {
+		return errors.Errorf("read after foreign commit err = %v, want ErrGenerationChanged", readErr)
+	}
+	// The callers that reopen a transaction at a fresh generation recognize the
+	// store-level snapshot error, not this store's private sentinel, so a
+	// generation change has to reach them as one.
+	if !errors.Is(readErr, kvtx.ErrInvalidSnapshot) {
+		return errors.Errorf("read after foreign commit err = %v, want kvtx.ErrInvalidSnapshot", readErr)
 	}
 
 	nextTx, err := store.NewTransaction(ctx, false)
@@ -1630,6 +1642,82 @@ func putMetaPair(ctx context.Context, store *metashard.MetaStore, value string) 
 		}
 	}
 	return errors.Wrap(tx.Commit(ctx), "commit meta pair")
+}
+
+func putMetaValue(ctx context.Context, store *metashard.MetaStore, key, value string) error {
+	tx, err := store.NewTransaction(ctx, true)
+	if err != nil {
+		return errors.Wrap(err, "open meta write tx")
+	}
+	if err := tx.Set(ctx, []byte(key), []byte(value)); err != nil {
+		tx.Discard()
+		return errors.Wrapf(err, "set %s", key)
+	}
+	return errors.Wrapf(tx.Commit(ctx), "commit %s", key)
+}
+
+// runMetaResetIdentity checks that a shard holding cached committed state
+// notices when another agent replaces the database underneath it.
+//
+// Corruption recovery deletes the page file and builds a new database in its
+// place. A shard decides whether to revalidate by comparing the state it
+// loaded against what is on disk, so a replacement that reached the same
+// commit count with the same tree shape must still be distinguishable from the
+// database it replaced. Otherwise the cached shard serves the old root page
+// over the new file and returns metadata that no longer exists.
+func runMetaResetIdentity(ctx context.Context, c *config) error {
+	cached, err := openMetaStore(c)
+	if err != nil {
+		return err
+	}
+	if err := putMetaValue(ctx, cached, "reset-key", "before"); err != nil {
+		return err
+	}
+	// Read once so this shard caches the state it just committed.
+	if err := verifyMetaValue(ctx, cached, []byte("reset-key"), []byte("before")); err != nil {
+		return errors.Wrap(err, "read before replacement")
+	}
+
+	dir, err := openTestDirectory(c.root, []string{"meta"})
+	if err != nil {
+		return err
+	}
+	for _, name := range []string{"pages.dat", "super-a", "super-b"} {
+		if err := opfs.DeleteFile(dir, name); err != nil && !opfs.IsNotFound(err) {
+			return errors.Wrapf(err, "delete %s", name)
+		}
+	}
+
+	// Build the replacement in one commit, so it reaches the same commit count
+	// as the database that was deleted while holding a different root page and
+	// page count. That is the state a shard comparing commit counts alone would
+	// mistake for the one it cached.
+	replacement, err := openMetaStore(c)
+	if err != nil {
+		return err
+	}
+	tx, err := replacement.NewTransaction(ctx, true)
+	if err != nil {
+		return errors.Wrap(err, "open replacement write tx")
+	}
+	for i := 0; i < 512; i++ {
+		if err := tx.Set(ctx, metaKey(0, i), metaValue(metaKey(0, i))); err != nil {
+			tx.Discard()
+			return errors.Wrap(err, "set replacement key")
+		}
+	}
+	if err := tx.Set(ctx, []byte("reset-key"), []byte("after!")); err != nil {
+		tx.Discard()
+		return errors.Wrap(err, "set replacement reset-key")
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return errors.Wrap(err, "commit replacement")
+	}
+
+	return errors.Wrap(
+		verifyMetaValue(ctx, cached, []byte("reset-key"), []byte("after!")),
+		"read after replacement",
+	)
 }
 
 func runMetaMixedWriter(ctx context.Context, c *config) error {

--- a/db/opfs/chrometest/testprog/main.go
+++ b/db/opfs/chrometest/testprog/main.go
@@ -249,6 +249,8 @@ func run(ctx context.Context, c *config) error {
 		return runMetaCrashWrite(c, true)
 	case "meta-crash-verify":
 		return runMetaCrashVerify(ctx, c)
+	case "meta-read-isolation":
+		return runMetaReadIsolation(ctx, c)
 	case "counter-init":
 		return runCounterInit(c)
 	case "counter-hold":
@@ -1553,6 +1555,81 @@ func runMetaVerify(ctx context.Context, c *config) error {
 		}
 	}
 	return nil
+}
+
+// runMetaReadIsolation checks that a read transaction serves one committed
+// generation. Reading several keys is how a caller assembles one object, so a
+// transaction that answered from two generations would hand back a combination
+// the store never held.
+func runMetaReadIsolation(ctx context.Context, c *config) error {
+	store, err := openMetaStore(c)
+	if err != nil {
+		return err
+	}
+
+	if err := putMetaPair(ctx, store, "1"); err != nil {
+		return err
+	}
+
+	readTx, err := store.NewTransaction(ctx, false)
+	if err != nil {
+		return errors.Wrap(err, "open meta read tx")
+	}
+	defer readTx.Discard()
+
+	val, found, err := readTx.Get(ctx, []byte("iso-a"))
+	if err != nil {
+		return errors.Wrap(err, "read iso-a")
+	}
+	if !found || string(val) != "1" {
+		return errors.Errorf("iso-a = %q found=%v, want 1", val, found)
+	}
+
+	// Repeated reads with nothing committed in between stay on one generation
+	// and must not fail.
+	for i := 0; i < 8; i++ {
+		if _, _, err := readTx.Get(ctx, []byte("iso-b")); err != nil {
+			return errors.Wrapf(err, "repeat read %d", i)
+		}
+	}
+
+	if err := putMetaPair(ctx, store, "2"); err != nil {
+		return err
+	}
+
+	if _, _, err := readTx.Get(ctx, []byte("iso-b")); !errors.Is(err, metashard.ErrGenerationChanged) {
+		return errors.Errorf("read after foreign commit err = %v, want ErrGenerationChanged", err)
+	}
+
+	nextTx, err := store.NewTransaction(ctx, false)
+	if err != nil {
+		return errors.Wrap(err, "open fresh meta read tx")
+	}
+	defer nextTx.Discard()
+	for _, key := range []string{"iso-a", "iso-b"} {
+		val, found, err := nextTx.Get(ctx, []byte(key))
+		if err != nil {
+			return errors.Wrapf(err, "fresh read %s", key)
+		}
+		if !found || string(val) != "2" {
+			return errors.Errorf("fresh %s = %q found=%v, want 2", key, val, found)
+		}
+	}
+	return nil
+}
+
+func putMetaPair(ctx context.Context, store *metashard.MetaStore, value string) error {
+	tx, err := store.NewTransaction(ctx, true)
+	if err != nil {
+		return errors.Wrap(err, "open meta write tx")
+	}
+	for _, key := range []string{"iso-a", "iso-b"} {
+		if err := tx.Set(ctx, []byte(key), []byte(value)); err != nil {
+			tx.Discard()
+			return errors.Wrapf(err, "set %s", key)
+		}
+	}
+	return errors.Wrap(tx.Commit(ctx), "commit meta pair")
 }
 
 func runMetaMixedWriter(ctx context.Context, c *config) error {

--- a/db/opfs/chrometest/testprog/main.go
+++ b/db/opfs/chrometest/testprog/main.go
@@ -253,6 +253,8 @@ func run(ctx context.Context, c *config) error {
 		return runMetaReadIsolation(ctx, c)
 	case "meta-reset-identity":
 		return runMetaResetIdentity(ctx, c)
+	case "meta-fallback-shortcut":
+		return runMetaFallbackShortcut(ctx, c)
 	case "counter-init":
 		return runCounterInit(c)
 	case "counter-hold":
@@ -1718,6 +1720,92 @@ func runMetaResetIdentity(ctx context.Context, c *config) error {
 		verifyMetaValue(ctx, cached, []byte("reset-key"), []byte("after!")),
 		"read after replacement",
 	)
+}
+
+// runMetaFallbackShortcut checks that a shard serving the older superblock
+// still recognizes its own loaded state on the next read.
+//
+// A superblock whose header decodes can still fail tree validation, and the
+// shard then falls back to the other slot. The rejected slot stays on disk, so
+// a shard that decided whether to revalidate by looking at the newest slot
+// alone would find a stranger there on every read and walk the whole tree
+// again, under the shared metadata lock, for each point read.
+func runMetaFallbackShortcut(ctx context.Context, c *config) error {
+	shard, store, err := openMetaShard(c)
+	if err != nil {
+		return err
+	}
+	if err := putMetaValue(ctx, store, "fallback-key", "value!"); err != nil {
+		return err
+	}
+	if err := shard.Close(); err != nil {
+		return errors.Wrap(err, "close writer shard")
+	}
+
+	dir, err := openTestDirectory(c.root, []string{"meta"})
+	if err != nil {
+		return err
+	}
+	committed, err := readCurrentMetaSuperblock(dir)
+	if err != nil {
+		return err
+	}
+	if committed == nil {
+		return errors.New("no committed meta superblock after write")
+	}
+
+	// Publish a newer superblock whose root page lies outside the page file.
+	// Its header decodes, so the shard has to walk the tree to reject it, and
+	// the slot it lands in is the one the committed superblock does not hold.
+	poisoned := pagestore.Superblock{
+		Magic:        pagestore.SuperblockMagic,
+		Version:      1,
+		Generation:   committed.Generation + 1,
+		RootPage:     pagestore.PageID(committed.PageCount),
+		FreelistPage: committed.FreelistPage,
+		PageCount:    committed.PageCount,
+	}
+	slot := "super-a"
+	if poisoned.Generation%2 == 0 {
+		slot = "super-b"
+	}
+	var poisonedBuf [pagestore.SuperblockSize]byte
+	pagestore.EncodeSuperblock(poisonedBuf[:], &poisoned)
+	if err := opfs.WriteFile(dir, slot, poisonedBuf[:]); err != nil {
+		return errors.Wrap(err, "write poisoned superblock")
+	}
+
+	reader, readerStore, err := openMetaShard(c)
+	if err != nil {
+		return err
+	}
+	if err := verifyMetaValue(
+		ctx,
+		readerStore,
+		[]byte("fallback-key"),
+		[]byte("value!"),
+	); err != nil {
+		return errors.Wrap(err, "read through fallback superblock")
+	}
+
+	before := reader.Revalidations()
+	for i := 0; i < 4; i++ {
+		if err := verifyMetaValue(
+			ctx,
+			readerStore,
+			[]byte("fallback-key"),
+			[]byte("value!"),
+		); err != nil {
+			return errors.Wrap(err, "repeat read through fallback superblock")
+		}
+	}
+	if after := reader.Revalidations(); after != before {
+		return errors.Errorf(
+			"reads over an unchanged fallback shard revalidated %d times, want 0",
+			after-before,
+		)
+	}
+	return nil
 }
 
 func runMetaMixedWriter(ctx context.Context, c *config) error {
@@ -4229,15 +4317,22 @@ func readCurrentMetaSuperblock(dir js.Value) (*pagestore.Superblock, error) {
 }
 
 func openMetaStore(c *config) (*metashard.MetaStore, error) {
+	_, store, err := openMetaShard(c)
+	return store, err
+}
+
+// openMetaShard returns the shard alongside its store, for scenarios that
+// assert on shard-level counters rather than only on stored values.
+func openMetaShard(c *config) (*metashard.MetaShard, *metashard.MetaStore, error) {
 	dir, err := openTestDirectory(c.root, []string{"meta"})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	shard, err := metashard.NewMetaShard(dir, c.root+"/meta", 4096, nil)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return metashard.NewMetaStore(shard), nil
+	return shard, metashard.NewMetaStore(shard), nil
 }
 
 func openVolume(ctx context.Context, c *config) (*volume_opfs.Opfs, error) {

--- a/db/volume/js/opfs/metashard/errors.go
+++ b/db/volume/js/opfs/metashard/errors.go
@@ -3,7 +3,10 @@
 package metashard
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
+	"github.com/s4wave/spacewave/db/kvtx"
 	"github.com/s4wave/spacewave/db/volume/js/opfs/pagestore"
 )
 
@@ -15,7 +18,15 @@ var ErrReadOnly = errors.New("read-only transaction")
 // generation, so continuing would let the transaction assemble a view of the
 // metadata that no generation ever held. The caller discards the transaction
 // and retries.
-var ErrGenerationChanged = errors.New("metadata committed by another agent during this transaction")
+//
+// It wraps kvtx.ErrInvalidSnapshot because that is the store-level contract for
+// exactly this situation, and the callers that already reopen a transaction at
+// a fresh generation recognize the snapshot error rather than any one store's
+// private sentinel.
+var ErrGenerationChanged = fmt.Errorf(
+	"%w: metadata committed by another agent during this transaction",
+	kvtx.ErrInvalidSnapshot,
+)
 
 // CorruptError is returned when committed metashard state cannot be decoded.
 type CorruptError struct {

--- a/db/volume/js/opfs/metashard/errors.go
+++ b/db/volume/js/opfs/metashard/errors.go
@@ -10,6 +10,13 @@ import (
 // ErrReadOnly is returned when a write operation is attempted on a read-only transaction.
 var ErrReadOnly = errors.New("read-only transaction")
 
+// ErrGenerationChanged is returned when another agent commits between two
+// operations of the same transaction. Each operation reads one committed
+// generation, so continuing would let the transaction assemble a view of the
+// metadata that no generation ever held. The caller discards the transaction
+// and retries.
+var ErrGenerationChanged = errors.New("metadata committed by another agent during this transaction")
+
 // CorruptError is returned when committed metashard state cannot be decoded.
 type CorruptError struct {
 	Err error

--- a/db/volume/js/opfs/metashard/kvtx.go
+++ b/db/volume/js/opfs/metashard/kvtx.go
@@ -6,14 +6,13 @@ import (
 	"bytes"
 	"context"
 
-	"github.com/pkg/errors"
 	"github.com/s4wave/spacewave/db/kvtx"
 	kvtx_iterator "github.com/s4wave/spacewave/db/kvtx/iterator"
 	"github.com/s4wave/spacewave/db/volume/js/opfs/pagestore"
 )
 
 // MetaStore wraps a MetaShard as a kvtx.Store.
-// Read transactions delegate directly to the B+tree.
+// Read transactions delegate each operation to the shard.
 // Write transactions buffer mutations and commit via WriteTx.
 type MetaStore struct {
 	shard *MetaShard
@@ -34,31 +33,25 @@ func (s *MetaStore) NewTransaction(ctx context.Context, write bool) (kvtx.Tx, er
 	if write {
 		return &metaWriteTx{
 			shard:   s.shard,
+			read:    metaReadTx{shard: s.shard},
 			pending: make([]mutation, 0, 8),
 		}, nil
 	}
-	tree, generation, closeSnapshot, releaseLock, err := s.shard.openCommittedTreeForRead()
-	if err != nil {
-		return nil, err
-	}
-	return &metaReadTx{
-		shard:         s.shard,
-		tree:          tree,
-		generation:    generation,
-		closeSnapshot: closeSnapshot,
-		releaseLock:   releaseLock,
-	}, nil
+	return &metaReadTx{shard: s.shard}, nil
 }
 
-// metaReadTx is a read-only transaction over a committed MetaShard snapshot.
+// metaReadTx is a read-only transaction over the committed MetaShard.
+//
+// Each operation opens its own committed snapshot under the shared metadata
+// lock and drops both before returning, so the transaction is read committed
+// rather than snapshot isolated: one Get or scan sees a single generation, and
+// a later operation on the same transaction sees any generation committed since.
+// A snapshot cannot outlive its operation because the page store recycles freed
+// pages on commit, and the only cross-agent barrier against that is the lock. A
+// transaction that held the lock for its own lifetime would instead stall every
+// writer in every tab until the caller discarded it.
 type metaReadTx struct {
-	shard         *MetaShard
-	tree          *pagestore.Tree
-	generation    uint64
-	recovered     bool
-	closeSnapshot func()
-	releaseLock   func()
-	released      bool
+	shard *MetaShard
 }
 
 type metaEntry struct {
@@ -74,14 +67,7 @@ func (t *metaReadTx) Size(ctx context.Context) (uint64, error) {
 
 // Get looks up a key.
 func (t *metaReadTx) Get(ctx context.Context, key []byte) ([]byte, bool, error) {
-	val, found, err := t.tree.Get(key)
-	if err == nil {
-		return val, found, nil
-	}
-	if err := t.recoverCorruptRead(err); err != nil {
-		return nil, false, err
-	}
-	return t.tree.Get(key)
+	return t.shard.Get(key)
 }
 
 // Exists checks if a key exists.
@@ -134,72 +120,16 @@ func (t *metaReadTx) Iterate(ctx context.Context, prefix []byte, sort, reverse b
 	return kvtx_iterator.NewIterator(ctx, t, prefix, sort, reverse)
 }
 
-// Commit releases the read snapshot.
+// Commit is a no-op: read transactions hold nothing between operations.
 func (t *metaReadTx) Commit(ctx context.Context) error {
-	t.releaseResources()
 	return nil
 }
 
-// Discard releases the read snapshot.
-func (t *metaReadTx) Discard() {
-	t.releaseResources()
-}
+// Discard is a no-op: read transactions hold nothing between operations.
+func (t *metaReadTx) Discard() {}
 
 func (t *metaReadTx) collectPrefix(prefix []byte) ([]metaEntry, error) {
-	entries, err := scanPrefixEntries(t.tree, prefix)
-	if err == nil {
-		return entries, nil
-	}
-	if err := t.recoverCorruptRead(err); err != nil {
-		return nil, err
-	}
-
-	return scanPrefixEntries(t.tree, prefix)
-}
-
-func (t *metaReadTx) recoverCorruptRead(err error) error {
-	if !IsCorruptError(err) {
-		return err
-	}
-	if t.recovered {
-		return err
-	}
-	if t.shard == nil {
-		return err
-	}
-	hadSnapshot := !t.released && (t.closeSnapshot != nil || t.releaseLock != nil)
-	if hadSnapshot {
-		t.releaseResources()
-	}
-	if err := t.shard.recoverCorruptState(); err != nil {
-		return errors.Wrap(err, "recover corrupt meta shard")
-	}
-	if hadSnapshot {
-		tree, generation, closeSnapshot, releaseLock, err := t.shard.openCommittedTreeForRead()
-		if err != nil {
-			return errors.Wrap(err, "reopen recovered meta read snapshot")
-		}
-		t.tree = tree
-		t.generation = generation
-		t.closeSnapshot = closeSnapshot
-		t.releaseLock = releaseLock
-		t.released = false
-	}
-	t.recovered = true
-	return nil
-}
-
-func (t *metaReadTx) releaseResources() {
-	if t.released {
-		return
-	}
-	if t.closeSnapshot != nil {
-		t.closeSnapshot()
-	}
-	if t.releaseLock != nil {
-		t.releaseLock()
-	}
-	t.released = true
+	return t.shard.collectPrefix(prefix)
 }
 
 // mutation is a buffered Set or Delete operation.
@@ -211,7 +141,8 @@ type mutation struct {
 // metaWriteTx buffers mutations and commits via MetaShard.WriteTx.
 type metaWriteTx struct {
 	shard *MetaShard
-	read  *metaReadTx
+	// read serves keys with no buffered mutation.
+	read metaReadTx
 
 	pending   []mutation
 	committed bool
@@ -229,11 +160,7 @@ func (t *metaWriteTx) Get(ctx context.Context, key []byte) ([]byte, bool, error)
 			return m.value, true, nil
 		}
 	}
-	readTx, err := t.ensureReadTx()
-	if err != nil {
-		return nil, false, err
-	}
-	return readTx.Get(ctx, key)
+	return t.read.Get(ctx, key)
 }
 
 // Exists checks pending mutations then the tree.
@@ -244,11 +171,7 @@ func (t *metaWriteTx) Exists(ctx context.Context, key []byte) (bool, error) {
 			return m.value != nil, nil
 		}
 	}
-	readTx, err := t.ensureReadTx()
-	if err != nil {
-		return false, err
-	}
-	return readTx.Exists(ctx, key)
+	return t.read.Exists(ctx, key)
 }
 
 // Set buffers a set operation.
@@ -272,17 +195,14 @@ func (t *metaWriteTx) Delete(ctx context.Context, key []byte) error {
 // Commit applies all buffered mutations atomically via WriteTx.
 func (t *metaWriteTx) Commit(ctx context.Context) error {
 	if t.committed {
-		t.releaseReadTx()
 		return nil
 	}
 	t.committed = true
 
 	if len(t.pending) == 0 {
-		t.releaseReadTx()
 		return nil
 	}
 
-	t.releaseReadTx()
 	err := t.shard.WriteTx(func(tree *pagestore.Tree) error {
 		for i := range t.pending {
 			m := &t.pending[i]
@@ -304,65 +224,22 @@ func (t *metaWriteTx) Commit(ctx context.Context) error {
 // Discard discards pending mutations.
 func (t *metaWriteTx) Discard() {
 	t.pending = nil
-	t.releaseReadTx()
 }
 
 func (t *metaWriteTx) Size(ctx context.Context) (uint64, error) {
-	readTx, err := t.ensureReadTx()
-	if err != nil {
-		return 0, err
-	}
-	return readTx.Size(ctx)
+	return t.read.Size(ctx)
 }
 
 func (t *metaWriteTx) ScanPrefix(ctx context.Context, prefix []byte, cb func(key, value []byte) error) error {
-	readTx, err := t.ensureReadTx()
-	if err != nil {
-		return err
-	}
-	return readTx.ScanPrefix(ctx, prefix, cb)
+	return t.read.ScanPrefix(ctx, prefix, cb)
 }
 
 func (t *metaWriteTx) ScanPrefixKeys(ctx context.Context, prefix []byte, cb func(key []byte) error) error {
-	readTx, err := t.ensureReadTx()
-	if err != nil {
-		return err
-	}
-	return readTx.ScanPrefixKeys(ctx, prefix, cb)
+	return t.read.ScanPrefixKeys(ctx, prefix, cb)
 }
 
 func (t *metaWriteTx) Iterate(ctx context.Context, prefix []byte, sort, reverse bool) kvtx.Iterator {
-	readTx, err := t.ensureReadTx()
-	if err != nil {
-		return kvtx.NewErrIterator(err)
-	}
-	return readTx.Iterate(ctx, prefix, sort, reverse)
-}
-
-func (t *metaWriteTx) ensureReadTx() (*metaReadTx, error) {
-	if t.read != nil {
-		return t.read, nil
-	}
-	tree, generation, closeSnapshot, releaseLock, err := t.shard.openCommittedTreeForRead()
-	if err != nil {
-		return nil, err
-	}
-	t.read = &metaReadTx{
-		shard:         t.shard,
-		tree:          tree,
-		generation:    generation,
-		closeSnapshot: closeSnapshot,
-		releaseLock:   releaseLock,
-	}
-	return t.read, nil
-}
-
-func (t *metaWriteTx) releaseReadTx() {
-	if t.read == nil {
-		return
-	}
-	t.read.releaseResources()
-	t.read = nil
+	return t.read.Iterate(ctx, prefix, sort, reverse)
 }
 
 // _ is a type assertion.

--- a/db/volume/js/opfs/metashard/kvtx.go
+++ b/db/volume/js/opfs/metashard/kvtx.go
@@ -37,26 +37,28 @@ func (s *MetaStore) NewTransaction(ctx context.Context, write bool) (kvtx.Tx, er
 			pending: make([]mutation, 0, 8),
 		}, nil
 	}
-	tree, generation, release, err := s.shard.openCommittedTreeForRead()
+	tree, generation, closeSnapshot, releaseLock, err := s.shard.openCommittedTreeForRead()
 	if err != nil {
 		return nil, err
 	}
 	return &metaReadTx{
-		shard:      s.shard,
-		tree:       tree,
-		generation: generation,
-		release:    release,
+		shard:         s.shard,
+		tree:          tree,
+		generation:    generation,
+		closeSnapshot: closeSnapshot,
+		releaseLock:   releaseLock,
 	}, nil
 }
 
 // metaReadTx is a read-only transaction over a committed MetaShard snapshot.
 type metaReadTx struct {
-	shard      *MetaShard
-	tree       *pagestore.Tree
-	generation uint64
-	recovered  bool
-	release    func()
-	released   bool
+	shard         *MetaShard
+	tree          *pagestore.Tree
+	generation    uint64
+	recovered     bool
+	closeSnapshot func()
+	releaseLock   func()
+	released      bool
 }
 
 type metaEntry struct {
@@ -134,13 +136,13 @@ func (t *metaReadTx) Iterate(ctx context.Context, prefix []byte, sort, reverse b
 
 // Commit releases the read snapshot.
 func (t *metaReadTx) Commit(ctx context.Context) error {
-	t.releaseLock()
+	t.releaseResources()
 	return nil
 }
 
 // Discard releases the read snapshot.
 func (t *metaReadTx) Discard() {
-	t.releaseLock()
+	t.releaseResources()
 }
 
 func (t *metaReadTx) collectPrefix(prefix []byte) ([]metaEntry, error) {
@@ -165,32 +167,38 @@ func (t *metaReadTx) recoverCorruptRead(err error) error {
 	if t.shard == nil {
 		return err
 	}
-	hadSnapshot := t.release != nil && !t.released
+	hadSnapshot := !t.released && (t.closeSnapshot != nil || t.releaseLock != nil)
 	if hadSnapshot {
-		t.releaseLock()
+		t.releaseResources()
 	}
 	if err := t.shard.recoverCorruptState(); err != nil {
 		return errors.Wrap(err, "recover corrupt meta shard")
 	}
 	if hadSnapshot {
-		tree, generation, release, err := t.shard.openCommittedTreeForRead()
+		tree, generation, closeSnapshot, releaseLock, err := t.shard.openCommittedTreeForRead()
 		if err != nil {
 			return errors.Wrap(err, "reopen recovered meta read snapshot")
 		}
 		t.tree = tree
 		t.generation = generation
-		t.release = release
+		t.closeSnapshot = closeSnapshot
+		t.releaseLock = releaseLock
 		t.released = false
 	}
 	t.recovered = true
 	return nil
 }
 
-func (t *metaReadTx) releaseLock() {
-	if t.release == nil || t.released {
+func (t *metaReadTx) releaseResources() {
+	if t.released {
 		return
 	}
-	t.release()
+	if t.closeSnapshot != nil {
+		t.closeSnapshot()
+	}
+	if t.releaseLock != nil {
+		t.releaseLock()
+	}
 	t.released = true
 }
 
@@ -335,15 +343,16 @@ func (t *metaWriteTx) ensureReadTx() (*metaReadTx, error) {
 	if t.read != nil {
 		return t.read, nil
 	}
-	tree, generation, release, err := t.shard.openCommittedTreeForRead()
+	tree, generation, closeSnapshot, releaseLock, err := t.shard.openCommittedTreeForRead()
 	if err != nil {
 		return nil, err
 	}
 	t.read = &metaReadTx{
-		shard:      t.shard,
-		tree:       tree,
-		generation: generation,
-		release:    release,
+		shard:         t.shard,
+		tree:          tree,
+		generation:    generation,
+		closeSnapshot: closeSnapshot,
+		releaseLock:   releaseLock,
 	}
 	return t.read, nil
 }
@@ -352,7 +361,7 @@ func (t *metaWriteTx) releaseReadTx() {
 	if t.read == nil {
 		return
 	}
-	t.read.releaseLock()
+	t.read.releaseResources()
 	t.read = nil
 }
 

--- a/db/volume/js/opfs/metashard/kvtx.go
+++ b/db/volume/js/opfs/metashard/kvtx.go
@@ -89,13 +89,13 @@ type metaEntry struct {
 
 // Size returns the number of keys. Scans the entire tree.
 func (t *metaReadTx) Size(ctx context.Context) (uint64, error) {
-	entries, err := t.collectPrefix(nil)
+	entries, err := t.collectPrefix(ctx, nil)
 	return uint64(len(entries)), err
 }
 
 // Get looks up a key.
 func (t *metaReadTx) Get(ctx context.Context, key []byte) ([]byte, bool, error) {
-	val, found, generation, err := t.shard.getAt(key)
+	val, found, generation, err := t.shard.getAt(ctx, key)
 	if err != nil {
 		return nil, false, err
 	}
@@ -123,7 +123,7 @@ func (t *metaReadTx) Delete(ctx context.Context, key []byte) error {
 
 // ScanPrefix iterates over entries matching the prefix.
 func (t *metaReadTx) ScanPrefix(ctx context.Context, prefix []byte, cb func(key, value []byte) error) error {
-	entries, err := t.collectPrefix(prefix)
+	entries, err := t.collectPrefix(ctx, prefix)
 	if err != nil {
 		return err
 	}
@@ -138,7 +138,7 @@ func (t *metaReadTx) ScanPrefix(ctx context.Context, prefix []byte, cb func(key,
 
 // ScanPrefixKeys iterates over keys only with a prefix.
 func (t *metaReadTx) ScanPrefixKeys(ctx context.Context, prefix []byte, cb func(key []byte) error) error {
-	entries, err := t.collectPrefix(prefix)
+	entries, err := t.collectPrefix(ctx, prefix)
 	if err != nil {
 		return err
 	}
@@ -163,8 +163,8 @@ func (t *metaReadTx) Commit(ctx context.Context) error {
 // Discard is a no-op: read transactions hold nothing between operations.
 func (t *metaReadTx) Discard() {}
 
-func (t *metaReadTx) collectPrefix(prefix []byte) ([]metaEntry, error) {
-	entries, generation, err := t.shard.collectPrefixAt(prefix)
+func (t *metaReadTx) collectPrefix(ctx context.Context, prefix []byte) ([]metaEntry, error) {
+	entries, generation, err := t.shard.collectPrefixAt(ctx, prefix)
 	if err != nil {
 		return nil, err
 	}

--- a/db/volume/js/opfs/metashard/kvtx.go
+++ b/db/volume/js/opfs/metashard/kvtx.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"context"
 
+	"github.com/pkg/errors"
 	"github.com/s4wave/spacewave/db/kvtx"
 	kvtx_iterator "github.com/s4wave/spacewave/db/kvtx/iterator"
 	"github.com/s4wave/spacewave/db/volume/js/opfs/pagestore"
@@ -43,15 +44,42 @@ func (s *MetaStore) NewTransaction(ctx context.Context, write bool) (kvtx.Tx, er
 // metaReadTx is a read-only transaction over the committed MetaShard.
 //
 // Each operation opens its own committed snapshot under the shared metadata
-// lock and drops both before returning, so the transaction is read committed
-// rather than snapshot isolated: one Get or scan sees a single generation, and
-// a later operation on the same transaction sees any generation committed since.
-// A snapshot cannot outlive its operation because the page store recycles freed
-// pages on commit, and the only cross-agent barrier against that is the lock. A
-// transaction that held the lock for its own lifetime would instead stall every
-// writer in every tab until the caller discarded it.
+// lock and drops both before returning. A snapshot cannot outlive its operation
+// because the page store recycles freed pages on commit, and the only
+// cross-agent barrier against that is the lock; a transaction that held the
+// lock for its own lifetime would stall every writer in every tab until the
+// caller discarded it.
+//
+// The transaction still owes its caller one consistent view. It pins the
+// generation its first operation read and fails any later operation that would
+// serve a different one, so a caller reading several keys either sees them as
+// one generation held them or gets ErrGenerationChanged. Serving both would let
+// it assemble metadata that never existed.
 type metaReadTx struct {
 	shard *MetaShard
+	// generation is the commit generation this transaction is pinned to, valid
+	// once pinned is set by the first operation to complete.
+	generation uint64
+	pinned     bool
+}
+
+// pin binds the transaction to the generation that served an operation, or
+// reports that the generation moved underneath it.
+func (t *metaReadTx) pin(generation uint64) error {
+	if !t.pinned {
+		t.generation = generation
+		t.pinned = true
+		return nil
+	}
+	if t.generation != generation {
+		return errors.Wrapf(
+			ErrGenerationChanged,
+			"transaction pinned to generation %d, read generation %d",
+			t.generation,
+			generation,
+		)
+	}
+	return nil
 }
 
 type metaEntry struct {
@@ -67,7 +95,14 @@ func (t *metaReadTx) Size(ctx context.Context) (uint64, error) {
 
 // Get looks up a key.
 func (t *metaReadTx) Get(ctx context.Context, key []byte) ([]byte, bool, error) {
-	return t.shard.Get(key)
+	val, found, generation, err := t.shard.getAt(key)
+	if err != nil {
+		return nil, false, err
+	}
+	if err := t.pin(generation); err != nil {
+		return nil, false, err
+	}
+	return val, found, nil
 }
 
 // Exists checks if a key exists.
@@ -129,7 +164,14 @@ func (t *metaReadTx) Commit(ctx context.Context) error {
 func (t *metaReadTx) Discard() {}
 
 func (t *metaReadTx) collectPrefix(prefix []byte) ([]metaEntry, error) {
-	return t.shard.collectPrefix(prefix)
+	entries, generation, err := t.shard.collectPrefixAt(prefix)
+	if err != nil {
+		return nil, err
+	}
+	if err := t.pin(generation); err != nil {
+		return nil, err
+	}
+	return entries, nil
 }
 
 // mutation is a buffered Set or Delete operation.

--- a/db/volume/js/opfs/metashard/metashard.go
+++ b/db/volume/js/opfs/metashard/metashard.go
@@ -65,24 +65,25 @@ func NewMetaShard(dir js.Value, lockPrefix string, pageSize int, le *logrus.Entr
 
 // Get looks up a key. Returns value, found, error.
 func (ms *MetaShard) Get(key []byte) ([]byte, bool, error) {
-	tree, _, release, err := ms.openCommittedTreeForRead()
+	tree, _, closeSnapshot, releaseLock, err := ms.openCommittedTreeForRead()
 	if err != nil {
 		return nil, false, err
 	}
 	val, found, err := tree.Get(key)
+	closeSnapshot()
+	releaseLock()
 	if err == nil || !IsCorruptError(err) {
-		release()
 		return val, found, err
 	}
-	release()
 	if err := ms.recoverCorruptState(); err != nil {
 		return nil, false, errors.Wrap(err, "recover corrupt meta shard")
 	}
-	tree, _, release, err = ms.openCommittedTreeForRead()
+	tree, _, closeSnapshot, releaseLock, err = ms.openCommittedTreeForRead()
 	if err != nil {
 		return nil, false, err
 	}
-	defer release()
+	defer closeSnapshot()
+	defer releaseLock()
 	return tree.Get(key)
 }
 
@@ -179,13 +180,14 @@ func (ms *MetaShard) WriteTx(fn func(tree *pagestore.Tree) error) error {
 
 // ScanPrefix iterates over entries matching the prefix.
 func (ms *MetaShard) ScanPrefix(prefix []byte, fn func(key, value []byte) bool) error {
-	tree, _, release, err := ms.openCommittedTreeForRead()
+	tree, _, closeSnapshot, releaseLock, err := ms.openCommittedTreeForRead()
 	if err != nil {
 		return err
 	}
 	entries, err := scanPrefixEntries(tree, prefix)
+	closeSnapshot()
+	releaseLock()
 	if err == nil || !IsCorruptError(err) {
-		release()
 		if err != nil {
 			return err
 		}
@@ -196,15 +198,15 @@ func (ms *MetaShard) ScanPrefix(prefix []byte, fn func(key, value []byte) bool) 
 		}
 		return nil
 	}
-	release()
 	if err := ms.recoverCorruptState(); err != nil {
 		return errors.Wrap(err, "recover corrupt meta shard")
 	}
-	tree, _, release, err = ms.openCommittedTreeForRead()
+	tree, _, closeSnapshot, releaseLock, err = ms.openCommittedTreeForRead()
 	if err != nil {
 		return err
 	}
-	defer release()
+	defer closeSnapshot()
+	defer releaseLock()
 	entries, err = scanPrefixEntries(tree, prefix)
 	if err != nil {
 		return err
@@ -266,31 +268,30 @@ func (ms *MetaShard) OpenCommittedTree() (*pagestore.Tree, uint64) {
 	return pagestore.OpenTree(ms.pager, rootPage), generation
 }
 
-func (ms *MetaShard) openCommittedTreeForRead() (*pagestore.Tree, uint64, func(), error) {
-	release, err := ms.acquireStateLock(false)
+func (ms *MetaShard) openCommittedTreeForRead() (*pagestore.Tree, uint64, func(), func(), error) {
+	releaseLock, err := ms.acquireStateLock(false)
 	if err != nil {
-		return nil, 0, nil, errors.Wrap(err, "acquire meta read lock")
+		return nil, 0, nil, nil, errors.Wrap(err, "acquire meta read lock")
 	}
 	if err := ms.reloadCommittedState(); err != nil {
-		release()
+		releaseLock()
 		if !IsCorruptError(err) {
-			return nil, 0, nil, errors.Wrap(err, "reload committed state")
+			return nil, 0, nil, nil, errors.Wrap(err, "reload committed state")
 		}
 		if err := ms.recoverCorruptState(); err != nil {
-			return nil, 0, nil, errors.Wrap(err, "recover corrupt meta shard")
+			return nil, 0, nil, nil, errors.Wrap(err, "recover corrupt meta shard")
 		}
-		release, err = ms.acquireStateLock(false)
+		releaseLock, err = ms.acquireStateLock(false)
 		if err != nil {
-			return nil, 0, nil, errors.Wrap(err, "reacquire meta read lock")
+			return nil, 0, nil, nil, errors.Wrap(err, "reacquire meta read lock")
 		}
 		if err := ms.reloadCommittedState(); err != nil {
-			release()
-			return nil, 0, nil, errors.Wrap(err, "reload recovered state")
+			releaseLock()
+			return nil, 0, nil, nil, errors.Wrap(err, "reload recovered state")
 		}
 	}
 	tree, generation, closeSnapshot := ms.openCommittedSnapshotTree()
-	release()
-	return tree, generation, closeSnapshot, nil
+	return tree, generation, closeSnapshot, releaseLock, nil
 }
 
 func (ms *MetaShard) reloadCommittedState() error {

--- a/db/volume/js/opfs/metashard/metashard.go
+++ b/db/volume/js/opfs/metashard/metashard.go
@@ -50,6 +50,11 @@ type MetaShard struct {
 	// assert that a run of reads over an unchanged shard performs one.
 	revalidations uint64
 	testHook      func(string) error
+	// resetGenerationFloor is the last generation this process saw before deleting
+	// and recreating on-disk metadata. A reset keeps this value in memory so the
+	// next creation generation stays above it, and stale cached state does not
+	// look current.
+	resetGenerationFloor uint64
 }
 
 // NewMetaShard opens or creates a meta shard in the given OPFS directory.
@@ -66,7 +71,7 @@ func NewMetaShard(dir js.Value, lockPrefix string, pageSize int, le *logrus.Entr
 		le:         le,
 		rootPage:   pagestore.InvalidPage,
 	}
-	release, err := ms.acquireStateLock(false)
+	release, err := ms.acquireStateLock(context.Background(), false)
 	if err != nil {
 		return nil, errors.Wrap(err, "acquire meta read lock")
 	}
@@ -76,7 +81,7 @@ func NewMetaShard(dir js.Value, lockPrefix string, pageSize int, le *logrus.Entr
 		if !IsCorruptError(err) {
 			return nil, err
 		}
-		if err := ms.recoverCorruptState(); err != nil {
+		if err := ms.recoverCorruptState(context.Background()); err != nil {
 			return nil, err
 		}
 	}
@@ -85,14 +90,14 @@ func NewMetaShard(dir js.Value, lockPrefix string, pageSize int, le *logrus.Entr
 
 // Get looks up a key. Returns value, found, error.
 func (ms *MetaShard) Get(key []byte) ([]byte, bool, error) {
-	val, found, _, err := ms.getAt(key)
+	val, found, _, err := ms.getAt(context.Background(), key)
 	return val, found, err
 }
 
 // getAt looks up a key and reports the commit generation that served it, so a
 // caller spanning several reads can tell whether they came from one generation.
-func (ms *MetaShard) getAt(key []byte) ([]byte, bool, uint64, error) {
-	tree, generation, release, err := ms.openCommittedTreeForRead()
+func (ms *MetaShard) getAt(ctx context.Context, key []byte) ([]byte, bool, uint64, error) {
+	tree, generation, release, err := ms.openCommittedTreeForRead(ctx)
 	if err != nil {
 		return nil, false, 0, err
 	}
@@ -101,10 +106,10 @@ func (ms *MetaShard) getAt(key []byte) ([]byte, bool, uint64, error) {
 	if err == nil || !IsCorruptError(err) {
 		return val, found, generation, err
 	}
-	if err := ms.recoverCorruptState(); err != nil {
+	if err := ms.recoverCorruptState(ctx); err != nil {
 		return nil, false, 0, errors.Wrap(err, "recover corrupt meta shard")
 	}
-	tree, generation, release, err = ms.openCommittedTreeForRead()
+	tree, generation, release, err = ms.openCommittedTreeForRead(ctx)
 	if err != nil {
 		return nil, false, 0, err
 	}
@@ -118,7 +123,7 @@ func (ms *MetaShard) getAt(key []byte) ([]byte, bool, uint64, error) {
 // by writing dirty pages and flipping the superblock.
 func (ms *MetaShard) WriteTx(fn func(tree *pagestore.Tree) error) error {
 	// Acquire write lock.
-	release, err := ms.acquireStateLock(true)
+	release, err := ms.acquireStateLock(context.Background(), true)
 	if err != nil {
 		return errors.Wrap(err, "acquire meta write lock")
 	}
@@ -188,6 +193,15 @@ func (ms *MetaShard) WriteTx(fn func(tree *pagestore.Tree) error) error {
 		if err != nil {
 			return err
 		}
+		// A random epoch lands below the replaced database about half the time,
+		// and a replacement that publishes lower generations is the same stale
+		// cache problem the epoch exists to prevent. Continue from just above the
+		// floor when the draw does not clear it. That stays inside the replaced
+		// database's epoch, which is harmless: every generation it produces is
+		// above every generation that database published.
+		if gen <= ms.resetGenerationFloor {
+			gen = ms.resetGenerationFloor + 1
+		}
 	}
 	sb := pagestore.Superblock{
 		Magic:        pagestore.SuperblockMagic,
@@ -223,7 +237,7 @@ func (ms *MetaShard) WriteTx(fn func(tree *pagestore.Tree) error) error {
 
 // ScanPrefix iterates over entries matching the prefix.
 func (ms *MetaShard) ScanPrefix(prefix []byte, fn func(key, value []byte) bool) error {
-	entries, err := ms.collectPrefix(prefix)
+	entries, err := ms.collectPrefix(context.Background(), prefix)
 	if err != nil {
 		return err
 	}
@@ -238,15 +252,15 @@ func (ms *MetaShard) ScanPrefix(prefix []byte, fn func(key, value []byte) bool) 
 // collectPrefix materializes every committed entry under prefix. The walk runs
 // entirely inside one shared-lock hold, so the returned entries are a
 // consistent view of one generation.
-func (ms *MetaShard) collectPrefix(prefix []byte) ([]metaEntry, error) {
-	entries, _, err := ms.collectPrefixAt(prefix)
+func (ms *MetaShard) collectPrefix(ctx context.Context, prefix []byte) ([]metaEntry, error) {
+	entries, _, err := ms.collectPrefixAt(ctx, prefix)
 	return entries, err
 }
 
 // collectPrefixAt materializes every committed entry under prefix and reports
 // the commit generation that served them.
-func (ms *MetaShard) collectPrefixAt(prefix []byte) ([]metaEntry, uint64, error) {
-	tree, generation, release, err := ms.openCommittedTreeForRead()
+func (ms *MetaShard) collectPrefixAt(ctx context.Context, prefix []byte) ([]metaEntry, uint64, error) {
+	tree, generation, release, err := ms.openCommittedTreeForRead(ctx)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -255,10 +269,10 @@ func (ms *MetaShard) collectPrefixAt(prefix []byte) ([]metaEntry, uint64, error)
 	if err == nil || !IsCorruptError(err) {
 		return entries, generation, err
 	}
-	if err := ms.recoverCorruptState(); err != nil {
+	if err := ms.recoverCorruptState(ctx); err != nil {
 		return nil, 0, errors.Wrap(err, "recover corrupt meta shard")
 	}
-	tree, generation, release, err = ms.openCommittedTreeForRead()
+	tree, generation, release, err = ms.openCommittedTreeForRead(ctx)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -290,7 +304,7 @@ func (ms *MetaShard) RefreshGeneration() (uint64, error) {
 
 // RefreshGenerationContext reloads the committed superblock and returns its generation.
 func (ms *MetaShard) RefreshGenerationContext(ctx context.Context) (uint64, error) {
-	release, err := filelock.AcquireWebLockContext(ctx, ms.lockPrefix+"/meta/write", false)
+	release, err := ms.acquireStateLock(ctx, false)
 	if err != nil {
 		return 0, errors.Wrap(err, "acquire meta read lock")
 	}
@@ -300,7 +314,7 @@ func (ms *MetaShard) RefreshGenerationContext(ctx context.Context) (uint64, erro
 		if !IsCorruptError(err) {
 			return 0, errors.Wrap(err, "reload committed state")
 		}
-		if err := ms.recoverCorruptState(); err != nil {
+		if err := ms.recoverCorruptState(ctx); err != nil {
 			return 0, errors.Wrap(err, "recover corrupt meta shard")
 		}
 		return ms.Generation(), nil
@@ -330,8 +344,8 @@ func (ms *MetaShard) OpenCommittedTree() (*pagestore.Tree, uint64) {
 // and the caller must hold it for the whole tree walk: a commit recycles freed
 // pages immediately, so a walk that overlaps one reads pages that now belong to
 // another subtree and silently reports missing keys.
-func (ms *MetaShard) openCommittedTreeForRead() (*pagestore.Tree, uint64, func(), error) {
-	releaseLock, err := ms.acquireStateLock(false)
+func (ms *MetaShard) openCommittedTreeForRead(ctx context.Context) (*pagestore.Tree, uint64, func(), error) {
+	releaseLock, err := ms.acquireStateLock(ctx, false)
 	if err != nil {
 		return nil, 0, nil, errors.Wrap(err, "acquire meta read lock")
 	}
@@ -340,10 +354,10 @@ func (ms *MetaShard) openCommittedTreeForRead() (*pagestore.Tree, uint64, func()
 		if !IsCorruptError(err) {
 			return nil, 0, nil, errors.Wrap(err, "reload committed state")
 		}
-		if err := ms.recoverCorruptState(); err != nil {
+		if err := ms.recoverCorruptState(ctx); err != nil {
 			return nil, 0, nil, errors.Wrap(err, "recover corrupt meta shard")
 		}
-		releaseLock, err = ms.acquireStateLock(false)
+		releaseLock, err = ms.acquireStateLock(ctx, false)
 		if err != nil {
 			return nil, 0, nil, errors.Wrap(err, "reacquire meta read lock")
 		}
@@ -452,8 +466,8 @@ func newGenerationEpoch() (uint64, error) {
 	return uint64(binary.BigEndian.Uint32(buf[:]))<<generationEpochShift | 1, nil
 }
 
-func (ms *MetaShard) recoverCorruptState() error {
-	release, err := ms.acquireStateLock(true)
+func (ms *MetaShard) recoverCorruptState(ctx context.Context) error {
+	release, err := ms.acquireStateLock(ctx, true)
 	if err != nil {
 		return errors.Wrap(err, "acquire meta write lock")
 	}
@@ -492,8 +506,8 @@ func (ms *MetaShard) openCommittedSnapshotTree() (*pagestore.Tree, uint64, func(
 	}
 }
 
-func (ms *MetaShard) acquireStateLock(exclusive bool) (func(), error) {
-	release, err := filelock.AcquireWebLock(ms.lockPrefix+"/meta/write", exclusive)
+func (ms *MetaShard) acquireStateLock(ctx context.Context, exclusive bool) (func(), error) {
+	release, err := filelock.AcquireWebLockContext(ctx, ms.lockPrefix+"/meta/write", exclusive)
 	if err != nil {
 		return nil, err
 	}
@@ -520,6 +534,7 @@ func (ms *MetaShard) resetCorruptStateLocked(cause error) error {
 }
 
 func (ms *MetaShard) resetCommittedStateLocked() error {
+	ms.resetGenerationFloor = ms.generation
 	if err := ms.pager.Close(); err != nil {
 		return errors.Wrap(err, "close page file")
 	}

--- a/db/volume/js/opfs/metashard/metashard.go
+++ b/db/volume/js/opfs/metashard/metashard.go
@@ -514,21 +514,13 @@ func validateSuperblock(pager *OpfsPager, sb *pagestore.Superblock) (*pagestore.
 	return sb, nil
 }
 
-// readSuper reads a superblock file into buf, ignoring errors.
+// readSuper reads a superblock file through an async handle so concurrent
+// shared metadata readers do not contend on exclusive sync access handles.
 func readSuper(dir js.Value, name string, buf []byte) {
-	if !opfs.PreferSyncAccessHandles() {
-		data, err := opfs.ReadFile(dir, name)
-		if err == nil {
-			copy(buf, data)
-		}
-		return
+	data, err := opfs.ReadFile(dir, name)
+	if err == nil {
+		copy(buf, data)
 	}
-	f, err := opfs.OpenSyncFile(dir, name)
-	if err != nil {
-		return
-	}
-	defer f.Close()
-	f.ReadAt(buf, 0)
 }
 
 // writeSuper writes a superblock to OPFS.

--- a/db/volume/js/opfs/metashard/metashard.go
+++ b/db/volume/js/opfs/metashard/metashard.go
@@ -35,13 +35,17 @@ type MetaShard struct {
 	// this process has read and validated. It distinguishes an empty shard from
 	// one that has never been loaded, which both carry generation zero.
 	stateLoaded bool
-	// loadedSuper is the encoded superblock that produced the loaded state, and
-	// is what the reload shortcut compares against. It identifies the state
-	// rather than merely dating it, which matters because corruption recovery
-	// deletes the page file and creates a new database in its place: comparing
-	// the root page, page count, and freelist alongside the generation is what
-	// keeps a replacement from passing for the state it replaced.
-	loadedSuper [pagestore.SuperblockSize]byte
+	// loadedSupers holds the super-a and super-b bytes this state was loaded
+	// from, and is what the reload shortcut compares against. Both slots are
+	// kept rather than the chosen one, because validation may reject the newer
+	// slot and fall back to the older: a shortcut that named only the chosen
+	// state would then miss on every read while the rejected slot sits on disk.
+	// The bytes identify the state rather than merely dating it, which matters
+	// because corruption recovery deletes the page file and creates a new
+	// database in its place: comparing the root page, page count, and freelist
+	// alongside the generation is what keeps a replacement from passing for the
+	// state it replaced.
+	loadedSupers [2][pagestore.SuperblockSize]byte
 	// revalidations counts full read-validate-rebuild passes, so a test can
 	// assert that a run of reads over an unchanged shard performs one.
 	revalidations uint64
@@ -194,9 +198,9 @@ func (ms *MetaShard) WriteTx(fn func(tree *pagestore.Tree) error) error {
 		PageCount:    ms.pager.PageCount(),
 	}
 
-	slot := "super-a"
+	slot, slotIndex := "super-a", 0
 	if gen%2 == 0 {
-		slot = "super-b"
+		slot, slotIndex = "super-b", 1
 	}
 	var sbBuf [pagestore.SuperblockSize]byte
 	pagestore.EncodeSuperblock(sbBuf[:], &sb)
@@ -210,7 +214,9 @@ func (ms *MetaShard) WriteTx(fn func(tree *pagestore.Tree) error) error {
 
 	ms.rootPage = tree.RootID()
 	ms.generation = gen
-	ms.loadedSuper = sbBuf
+	// The other slot still holds what the reload before this write read, so
+	// updating the written one keeps the pair equal to what is on disk.
+	ms.loadedSupers[slotIndex] = sbBuf
 
 	return nil
 }
@@ -266,6 +272,15 @@ func (ms *MetaShard) Generation() uint64 {
 	ms.mu.RLock()
 	defer ms.mu.RUnlock()
 	return ms.generation
+}
+
+// Revalidations reports how many times this shard has walked the committed
+// tree to validate it. The walk is O(tree) and holds the shared metadata lock,
+// so a run of reads over a shard nothing has committed to costs one.
+func (ms *MetaShard) Revalidations() uint64 {
+	ms.mu.RLock()
+	defer ms.mu.RUnlock()
+	return ms.revalidations
 }
 
 // RefreshGeneration reloads the committed superblock and returns its generation.
@@ -374,10 +389,11 @@ func (ms *MetaShard) reloadCommittedStateLocked(revalidate bool) error {
 	// since the last one. Reloading in full costs a whole-tree validation walk
 	// and a pager rebuild that drops the page cache, so a point read would cost
 	// O(tree) and a run of M reads O(M*tree). The superblocks themselves say
-	// whether any of that is necessary: when the newest one on disk is byte for
-	// byte the one this state was loaded from, the state in hand is that state,
-	// and it was validated when it was loaded.
-	if !revalidate && ms.stateLoaded && newestSuperblock(aBuf[:], bBuf[:]) == ms.loadedSuper {
+	// whether any of that is necessary: when both are byte for byte the ones
+	// this state was loaded from, nothing has been committed since, the state in
+	// hand is that state, and it was validated when it was loaded.
+	if !revalidate && ms.stateLoaded &&
+		aBuf == ms.loadedSupers[0] && bBuf == ms.loadedSupers[1] {
 		return nil
 	}
 	ms.revalidations++
@@ -415,13 +431,7 @@ func (ms *MetaShard) reloadCommittedStateLocked(revalidate bool) error {
 
 	ms.rootPage = rootPage
 	ms.generation = gen
-	ms.loadedSuper = [pagestore.SuperblockSize]byte{}
-	if sb != nil {
-		// Encode the superblock that was actually chosen rather than copying
-		// the newest bytes off disk. Validation can fall back to the older
-		// superblock, and the identity has to name the state in hand.
-		pagestore.EncodeSuperblock(ms.loadedSuper[:], sb)
-	}
+	ms.loadedSupers = [2][pagestore.SuperblockSize]byte{aBuf, bBuf}
 	ms.stateLoaded = true
 	return nil
 }
@@ -440,27 +450,6 @@ func newGenerationEpoch() (uint64, error) {
 		return 0, errors.Wrap(err, "read generation epoch")
 	}
 	return uint64(binary.BigEndian.Uint32(buf[:]))<<generationEpochShift | 1, nil
-}
-
-// newestSuperblock returns the encoded bytes of the highest-generation
-// superblock that decodes, and the zero value when neither does. A valid
-// superblock never encodes to zeroes because its magic is nonzero, so the zero
-// value is usable as the identity of a shard with no committed state. It
-// decodes only the header, so it costs nothing beyond the two superblock reads
-// the caller already made.
-func newestSuperblock(a, b []byte) [pagestore.SuperblockSize]byte {
-	var newest [pagestore.SuperblockSize]byte
-	var newestGen uint64
-	var found bool
-	if sa, err := pagestore.DecodeSuperblock(a); err == nil {
-		newest = [pagestore.SuperblockSize]byte(a)
-		newestGen = sa.Generation
-		found = true
-	}
-	if sb, err := pagestore.DecodeSuperblock(b); err == nil && (!found || sb.Generation > newestGen) {
-		newest = [pagestore.SuperblockSize]byte(b)
-	}
-	return newest
 }
 
 func (ms *MetaShard) recoverCorruptState() error {
@@ -548,7 +537,7 @@ func (ms *MetaShard) resetCommittedStateLocked() error {
 
 	ms.rootPage = pagestore.InvalidPage
 	ms.generation = 0
-	ms.loadedSuper = [pagestore.SuperblockSize]byte{}
+	ms.loadedSupers = [2][pagestore.SuperblockSize]byte{}
 	return nil
 }
 

--- a/db/volume/js/opfs/metashard/metashard.go
+++ b/db/volume/js/opfs/metashard/metashard.go
@@ -65,25 +65,23 @@ func NewMetaShard(dir js.Value, lockPrefix string, pageSize int, le *logrus.Entr
 
 // Get looks up a key. Returns value, found, error.
 func (ms *MetaShard) Get(key []byte) ([]byte, bool, error) {
-	tree, _, closeSnapshot, releaseLock, err := ms.openCommittedTreeForRead()
+	tree, _, release, err := ms.openCommittedTreeForRead()
 	if err != nil {
 		return nil, false, err
 	}
 	val, found, err := tree.Get(key)
-	closeSnapshot()
-	releaseLock()
+	release()
 	if err == nil || !IsCorruptError(err) {
 		return val, found, err
 	}
 	if err := ms.recoverCorruptState(); err != nil {
 		return nil, false, errors.Wrap(err, "recover corrupt meta shard")
 	}
-	tree, _, closeSnapshot, releaseLock, err = ms.openCommittedTreeForRead()
+	tree, _, release, err = ms.openCommittedTreeForRead()
 	if err != nil {
 		return nil, false, err
 	}
-	defer closeSnapshot()
-	defer releaseLock()
+	defer release()
 	return tree.Get(key)
 }
 
@@ -180,34 +178,7 @@ func (ms *MetaShard) WriteTx(fn func(tree *pagestore.Tree) error) error {
 
 // ScanPrefix iterates over entries matching the prefix.
 func (ms *MetaShard) ScanPrefix(prefix []byte, fn func(key, value []byte) bool) error {
-	tree, _, closeSnapshot, releaseLock, err := ms.openCommittedTreeForRead()
-	if err != nil {
-		return err
-	}
-	entries, err := scanPrefixEntries(tree, prefix)
-	closeSnapshot()
-	releaseLock()
-	if err == nil || !IsCorruptError(err) {
-		if err != nil {
-			return err
-		}
-		for i := range entries {
-			if !fn(entries[i].key, entries[i].value) {
-				return nil
-			}
-		}
-		return nil
-	}
-	if err := ms.recoverCorruptState(); err != nil {
-		return errors.Wrap(err, "recover corrupt meta shard")
-	}
-	tree, _, closeSnapshot, releaseLock, err = ms.openCommittedTreeForRead()
-	if err != nil {
-		return err
-	}
-	defer closeSnapshot()
-	defer releaseLock()
-	entries, err = scanPrefixEntries(tree, prefix)
+	entries, err := ms.collectPrefix(prefix)
 	if err != nil {
 		return err
 	}
@@ -217,6 +188,30 @@ func (ms *MetaShard) ScanPrefix(prefix []byte, fn func(key, value []byte) bool) 
 		}
 	}
 	return nil
+}
+
+// collectPrefix materializes every committed entry under prefix. The walk runs
+// entirely inside one shared-lock hold, so the returned entries are a
+// consistent view of one generation.
+func (ms *MetaShard) collectPrefix(prefix []byte) ([]metaEntry, error) {
+	tree, _, release, err := ms.openCommittedTreeForRead()
+	if err != nil {
+		return nil, err
+	}
+	entries, err := scanPrefixEntries(tree, prefix)
+	release()
+	if err == nil || !IsCorruptError(err) {
+		return entries, err
+	}
+	if err := ms.recoverCorruptState(); err != nil {
+		return nil, errors.Wrap(err, "recover corrupt meta shard")
+	}
+	tree, _, release, err = ms.openCommittedTreeForRead()
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+	return scanPrefixEntries(tree, prefix)
 }
 
 // Generation returns the current commit generation.
@@ -268,30 +263,38 @@ func (ms *MetaShard) OpenCommittedTree() (*pagestore.Tree, uint64) {
 	return pagestore.OpenTree(ms.pager, rootPage), generation
 }
 
-func (ms *MetaShard) openCommittedTreeForRead() (*pagestore.Tree, uint64, func(), func(), error) {
+// openCommittedTreeForRead opens the committed snapshot under the shared
+// metadata lock. The returned release closes the snapshot and drops the lock,
+// and the caller must hold it for the whole tree walk: a commit recycles freed
+// pages immediately, so a walk that overlaps one reads pages that now belong to
+// another subtree and silently reports missing keys.
+func (ms *MetaShard) openCommittedTreeForRead() (*pagestore.Tree, uint64, func(), error) {
 	releaseLock, err := ms.acquireStateLock(false)
 	if err != nil {
-		return nil, 0, nil, nil, errors.Wrap(err, "acquire meta read lock")
+		return nil, 0, nil, errors.Wrap(err, "acquire meta read lock")
 	}
 	if err := ms.reloadCommittedState(); err != nil {
 		releaseLock()
 		if !IsCorruptError(err) {
-			return nil, 0, nil, nil, errors.Wrap(err, "reload committed state")
+			return nil, 0, nil, errors.Wrap(err, "reload committed state")
 		}
 		if err := ms.recoverCorruptState(); err != nil {
-			return nil, 0, nil, nil, errors.Wrap(err, "recover corrupt meta shard")
+			return nil, 0, nil, errors.Wrap(err, "recover corrupt meta shard")
 		}
 		releaseLock, err = ms.acquireStateLock(false)
 		if err != nil {
-			return nil, 0, nil, nil, errors.Wrap(err, "reacquire meta read lock")
+			return nil, 0, nil, errors.Wrap(err, "reacquire meta read lock")
 		}
 		if err := ms.reloadCommittedState(); err != nil {
 			releaseLock()
-			return nil, 0, nil, nil, errors.Wrap(err, "reload recovered state")
+			return nil, 0, nil, errors.Wrap(err, "reload recovered state")
 		}
 	}
 	tree, generation, closeSnapshot := ms.openCommittedSnapshotTree()
-	return tree, generation, closeSnapshot, releaseLock, nil
+	return tree, generation, func() {
+		closeSnapshot()
+		releaseLock()
+	}, nil
 }
 
 func (ms *MetaShard) reloadCommittedState() error {

--- a/db/volume/js/opfs/metashard/metashard.go
+++ b/db/volume/js/opfs/metashard/metashard.go
@@ -7,6 +7,8 @@ package metashard
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"encoding/binary"
 	"sync"
 	"syscall/js"
 
@@ -33,6 +35,13 @@ type MetaShard struct {
 	// this process has read and validated. It distinguishes an empty shard from
 	// one that has never been loaded, which both carry generation zero.
 	stateLoaded bool
+	// loadedSuper is the encoded superblock that produced the loaded state, and
+	// is what the reload shortcut compares against. It identifies the state
+	// rather than merely dating it, which matters because corruption recovery
+	// deletes the page file and creates a new database in its place: comparing
+	// the root page, page count, and freelist alongside the generation is what
+	// keeps a replacement from passing for the state it replaced.
+	loadedSuper [pagestore.SuperblockSize]byte
 	// revalidations counts full read-validate-rebuild passes, so a test can
 	// assert that a run of reads over an unchanged shard performs one.
 	revalidations uint64
@@ -162,6 +171,20 @@ func (ms *MetaShard) WriteTx(fn func(tree *pagestore.Tree) error) error {
 	}
 
 	gen++
+	if gen == 1 {
+		// Nothing was committed before this, so this commit creates the
+		// database. Start its generations at a fresh epoch instead of at one,
+		// because corruption recovery deletes the page file and creates a new
+		// database in its place. Counting from one again would let the
+		// replacement publish generations the database it replaced had already
+		// published, and another instance holding cached state decides whether
+		// that state is current by comparing what it loaded against what is on
+		// disk.
+		gen, err = newGenerationEpoch()
+		if err != nil {
+			return err
+		}
+	}
 	sb := pagestore.Superblock{
 		Magic:        pagestore.SuperblockMagic,
 		Version:      1,
@@ -187,6 +210,7 @@ func (ms *MetaShard) WriteTx(fn func(tree *pagestore.Tree) error) error {
 
 	ms.rootPage = tree.RootID()
 	ms.generation = gen
+	ms.loadedSuper = sbBuf
 
 	return nil
 }
@@ -350,10 +374,10 @@ func (ms *MetaShard) reloadCommittedStateLocked(revalidate bool) error {
 	// since the last one. Reloading in full costs a whole-tree validation walk
 	// and a pager rebuild that drops the page cache, so a point read would cost
 	// O(tree) and a run of M reads O(M*tree). The superblocks themselves say
-	// whether any of that is necessary: when the newest one on disk is the
-	// generation already loaded, the state in hand is that generation, and it
-	// was validated when it was loaded.
-	if !revalidate && ms.stateLoaded && newestGeneration(aBuf[:], bBuf[:]) == ms.generation {
+	// whether any of that is necessary: when the newest one on disk is byte for
+	// byte the one this state was loaded from, the state in hand is that state,
+	// and it was validated when it was loaded.
+	if !revalidate && ms.stateLoaded && newestSuperblock(aBuf[:], bBuf[:]) == ms.loadedSuper {
 		return nil
 	}
 	ms.revalidations++
@@ -391,20 +415,50 @@ func (ms *MetaShard) reloadCommittedStateLocked(revalidate bool) error {
 
 	ms.rootPage = rootPage
 	ms.generation = gen
+	ms.loadedSuper = [pagestore.SuperblockSize]byte{}
+	if sb != nil {
+		// Encode the superblock that was actually chosen rather than copying
+		// the newest bytes off disk. Validation can fall back to the older
+		// superblock, and the identity has to name the state in hand.
+		pagestore.EncodeSuperblock(ms.loadedSuper[:], sb)
+	}
 	ms.stateLoaded = true
 	return nil
 }
 
-// newestGeneration returns the highest generation among the superblocks that
-// decode, or zero when neither does. It reads only the encoded header, so it
-// costs nothing beyond the two superblock reads the caller already made.
-func newestGeneration(a, b []byte) uint64 {
-	var newest uint64
-	if sa, err := pagestore.DecodeSuperblock(a); err == nil {
-		newest = sa.Generation
+// generationEpochShift splits a generation into a per-database epoch above it
+// and a commit counter below it. The counter keeps 32 bits, far more commits
+// than a metadata shard makes in the lifetime of a browser profile, and the
+// epoch takes the other 32 at random, so two databases reaching the same commit
+// count still carry different generations.
+const generationEpochShift = 32
+
+// newGenerationEpoch returns the first generation of a newly created database.
+func newGenerationEpoch() (uint64, error) {
+	var buf [4]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return 0, errors.Wrap(err, "read generation epoch")
 	}
-	if sb, err := pagestore.DecodeSuperblock(b); err == nil && sb.Generation > newest {
-		newest = sb.Generation
+	return uint64(binary.BigEndian.Uint32(buf[:]))<<generationEpochShift | 1, nil
+}
+
+// newestSuperblock returns the encoded bytes of the highest-generation
+// superblock that decodes, and the zero value when neither does. A valid
+// superblock never encodes to zeroes because its magic is nonzero, so the zero
+// value is usable as the identity of a shard with no committed state. It
+// decodes only the header, so it costs nothing beyond the two superblock reads
+// the caller already made.
+func newestSuperblock(a, b []byte) [pagestore.SuperblockSize]byte {
+	var newest [pagestore.SuperblockSize]byte
+	var newestGen uint64
+	var found bool
+	if sa, err := pagestore.DecodeSuperblock(a); err == nil {
+		newest = [pagestore.SuperblockSize]byte(a)
+		newestGen = sa.Generation
+		found = true
+	}
+	if sb, err := pagestore.DecodeSuperblock(b); err == nil && (!found || sb.Generation > newestGen) {
+		newest = [pagestore.SuperblockSize]byte(b)
 	}
 	return newest
 }
@@ -494,6 +548,7 @@ func (ms *MetaShard) resetCommittedStateLocked() error {
 
 	ms.rootPage = pagestore.InvalidPage
 	ms.generation = 0
+	ms.loadedSuper = [pagestore.SuperblockSize]byte{}
 	return nil
 }
 

--- a/db/volume/js/opfs/metashard/metashard.go
+++ b/db/volume/js/opfs/metashard/metashard.go
@@ -29,7 +29,14 @@ type MetaShard struct {
 	mu         sync.RWMutex
 	rootPage   pagestore.PageID
 	generation uint64
-	testHook   func(string) error
+	// stateLoaded reports whether rootPage and generation describe a superblock
+	// this process has read and validated. It distinguishes an empty shard from
+	// one that has never been loaded, which both carry generation zero.
+	stateLoaded bool
+	// revalidations counts full read-validate-rebuild passes, so a test can
+	// assert that a run of reads over an unchanged shard performs one.
+	revalidations uint64
+	testHook      func(string) error
 }
 
 // NewMetaShard opens or creates a meta shard in the given OPFS directory.
@@ -65,24 +72,32 @@ func NewMetaShard(dir js.Value, lockPrefix string, pageSize int, le *logrus.Entr
 
 // Get looks up a key. Returns value, found, error.
 func (ms *MetaShard) Get(key []byte) ([]byte, bool, error) {
-	tree, _, release, err := ms.openCommittedTreeForRead()
+	val, found, _, err := ms.getAt(key)
+	return val, found, err
+}
+
+// getAt looks up a key and reports the commit generation that served it, so a
+// caller spanning several reads can tell whether they came from one generation.
+func (ms *MetaShard) getAt(key []byte) ([]byte, bool, uint64, error) {
+	tree, generation, release, err := ms.openCommittedTreeForRead()
 	if err != nil {
-		return nil, false, err
+		return nil, false, 0, err
 	}
 	val, found, err := tree.Get(key)
 	release()
 	if err == nil || !IsCorruptError(err) {
-		return val, found, err
+		return val, found, generation, err
 	}
 	if err := ms.recoverCorruptState(); err != nil {
-		return nil, false, errors.Wrap(err, "recover corrupt meta shard")
+		return nil, false, 0, errors.Wrap(err, "recover corrupt meta shard")
 	}
-	tree, _, release, err = ms.openCommittedTreeForRead()
+	tree, generation, release, err = ms.openCommittedTreeForRead()
 	if err != nil {
-		return nil, false, err
+		return nil, false, 0, err
 	}
 	defer release()
-	return tree.Get(key)
+	val, found, err = tree.Get(key)
+	return val, found, generation, err
 }
 
 // WriteTx executes a write transaction. The function fn receives the tree
@@ -99,7 +114,7 @@ func (ms *MetaShard) WriteTx(fn func(tree *pagestore.Tree) error) error {
 	ms.mu.Lock()
 	defer ms.mu.Unlock()
 
-	if err := ms.reloadCommittedStateLocked(); err != nil {
+	if err := ms.reloadCommittedStateLocked(true); err != nil {
 		if !IsCorruptError(err) {
 			return errors.Wrap(err, "reload committed state")
 		}
@@ -194,24 +209,32 @@ func (ms *MetaShard) ScanPrefix(prefix []byte, fn func(key, value []byte) bool) 
 // entirely inside one shared-lock hold, so the returned entries are a
 // consistent view of one generation.
 func (ms *MetaShard) collectPrefix(prefix []byte) ([]metaEntry, error) {
-	tree, _, release, err := ms.openCommittedTreeForRead()
+	entries, _, err := ms.collectPrefixAt(prefix)
+	return entries, err
+}
+
+// collectPrefixAt materializes every committed entry under prefix and reports
+// the commit generation that served them.
+func (ms *MetaShard) collectPrefixAt(prefix []byte) ([]metaEntry, uint64, error) {
+	tree, generation, release, err := ms.openCommittedTreeForRead()
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	entries, err := scanPrefixEntries(tree, prefix)
 	release()
 	if err == nil || !IsCorruptError(err) {
-		return entries, err
+		return entries, generation, err
 	}
 	if err := ms.recoverCorruptState(); err != nil {
-		return nil, errors.Wrap(err, "recover corrupt meta shard")
+		return nil, 0, errors.Wrap(err, "recover corrupt meta shard")
 	}
-	tree, _, release, err = ms.openCommittedTreeForRead()
+	tree, generation, release, err = ms.openCommittedTreeForRead()
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	defer release()
-	return scanPrefixEntries(tree, prefix)
+	entries, err = scanPrefixEntries(tree, prefix)
+	return entries, generation, err
 }
 
 // Generation returns the current commit generation.
@@ -301,10 +324,19 @@ func (ms *MetaShard) reloadCommittedState() error {
 	ms.mu.Lock()
 	defer ms.mu.Unlock()
 
-	return ms.reloadCommittedStateLocked()
+	return ms.reloadCommittedStateLocked(false)
 }
 
-func (ms *MetaShard) reloadCommittedStateLocked() error {
+// reloadCommittedStateLocked brings rootPage, generation, and the pager up to
+// the newest valid superblock on disk.
+//
+// revalidate forces the full read-validate-rebuild path even when the newest
+// superblock is the generation already loaded. Readers pass false: they only
+// need to know whether another agent has committed since. Writers and
+// corruption recovery pass true, because they go on to allocate pages from the
+// freelist and must rebuild it from the committed chain rather than trust the
+// in-memory copy left behind by an earlier commit.
+func (ms *MetaShard) reloadCommittedStateLocked(revalidate bool) error {
 	var aBuf [pagestore.SuperblockSize]byte
 	var bBuf [pagestore.SuperblockSize]byte
 	if err := readSuper(ms.dir, "super-a", aBuf[:]); err != nil {
@@ -313,6 +345,18 @@ func (ms *MetaShard) reloadCommittedStateLocked() error {
 	if err := readSuper(ms.dir, "super-b", bBuf[:]); err != nil {
 		return err
 	}
+
+	// Every read operation reloads, because another agent may have committed
+	// since the last one. Reloading in full costs a whole-tree validation walk
+	// and a pager rebuild that drops the page cache, so a point read would cost
+	// O(tree) and a run of M reads O(M*tree). The superblocks themselves say
+	// whether any of that is necessary: when the newest one on disk is the
+	// generation already loaded, the state in hand is that generation, and it
+	// was validated when it was loaded.
+	if !revalidate && ms.stateLoaded && newestGeneration(aBuf[:], bBuf[:]) == ms.generation {
+		return nil
+	}
+	ms.revalidations++
 
 	validatePager := NewOpfsPager(ms.dir, "pages.dat", ms.pageSize)
 	sb, err := pickValidSuperblock(validatePager, aBuf[:], bBuf[:])
@@ -347,7 +391,22 @@ func (ms *MetaShard) reloadCommittedStateLocked() error {
 
 	ms.rootPage = rootPage
 	ms.generation = gen
+	ms.stateLoaded = true
 	return nil
+}
+
+// newestGeneration returns the highest generation among the superblocks that
+// decode, or zero when neither does. It reads only the encoded header, so it
+// costs nothing beyond the two superblock reads the caller already made.
+func newestGeneration(a, b []byte) uint64 {
+	var newest uint64
+	if sa, err := pagestore.DecodeSuperblock(a); err == nil {
+		newest = sa.Generation
+	}
+	if sb, err := pagestore.DecodeSuperblock(b); err == nil && sb.Generation > newest {
+		newest = sb.Generation
+	}
+	return newest
 }
 
 func (ms *MetaShard) recoverCorruptState() error {
@@ -360,7 +419,10 @@ func (ms *MetaShard) recoverCorruptState() error {
 	ms.mu.Lock()
 	defer ms.mu.Unlock()
 
-	if err := ms.reloadCommittedStateLocked(); err == nil {
+	// Recovery runs because a read of the loaded generation failed, so the
+	// generation match that lets an ordinary reload skip validation is exactly
+	// the condition under test here.
+	if err := ms.reloadCommittedStateLocked(true); err == nil {
 		return nil
 	} else if !IsCorruptError(err) {
 		return err

--- a/db/volume/js/opfs/metashard/metashard.go
+++ b/db/volume/js/opfs/metashard/metashard.go
@@ -304,8 +304,12 @@ func (ms *MetaShard) reloadCommittedState() error {
 func (ms *MetaShard) reloadCommittedStateLocked() error {
 	var aBuf [pagestore.SuperblockSize]byte
 	var bBuf [pagestore.SuperblockSize]byte
-	readSuper(ms.dir, "super-a", aBuf[:])
-	readSuper(ms.dir, "super-b", bBuf[:])
+	if err := readSuper(ms.dir, "super-a", aBuf[:]); err != nil {
+		return err
+	}
+	if err := readSuper(ms.dir, "super-b", bBuf[:]); err != nil {
+		return err
+	}
 
 	validatePager := NewOpfsPager(ms.dir, "pages.dat", ms.pageSize)
 	sb, err := pickValidSuperblock(validatePager, aBuf[:], bBuf[:])
@@ -516,11 +520,20 @@ func validateSuperblock(pager *OpfsPager, sb *pagestore.Superblock) (*pagestore.
 
 // readSuper reads a superblock file through an async handle so concurrent
 // shared metadata readers do not contend on exclusive sync access handles.
-func readSuper(dir js.Value, name string, buf []byte) {
+// A shard that has never committed has no superblock file, so a missing file
+// leaves buf zeroed and reports success. Every other failure is returned,
+// because a zeroed buffer is indistinguishable from generation zero and would
+// otherwise hide committed state.
+func readSuper(dir js.Value, name string, buf []byte) error {
 	data, err := opfs.ReadFile(dir, name)
-	if err == nil {
-		copy(buf, data)
+	if err != nil {
+		if opfs.IsNotFound(err) {
+			return nil
+		}
+		return errors.Wrapf(err, "read superblock %s", name)
 	}
+	copy(buf, data)
+	return nil
 }
 
 // writeSuper writes a superblock to OPFS.

--- a/db/volume/js/opfs/metashard/metashard_test.go
+++ b/db/volume/js/opfs/metashard/metashard_test.go
@@ -188,8 +188,8 @@ func TestMetaShardReadSnapshotIsolation(t *testing.T) {
 	}
 }
 
-func TestMetaStoreReadTxDoesNotHoldMetaWebLock(t *testing.T) {
-	name := "test-metastore-read-tx-does-not-hold-lock"
+func TestMetaStoreReadTxHoldsMetaWebLock(t *testing.T) {
+	name := "test-metastore-read-tx-holds-lock"
 	ms := newTestMetaShard(t, name)
 	store := NewMetaStore(ms)
 	ctx := context.Background()
@@ -215,20 +215,9 @@ func TestMetaStoreReadTxDoesNotHoldMetaWebLock(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !acquired {
-		t.Fatal("read transaction held meta WebLock")
-	}
-	release()
-
-	writeTx, err := store.NewTransaction(ctx, true)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := writeTx.Set(ctx, []byte("k"), []byte("v2")); err != nil {
-		t.Fatal(err)
-	}
-	if err := writeTx.Commit(ctx); err != nil {
-		t.Fatal(err)
+	if acquired {
+		release()
+		t.Fatal("read transaction did not hold meta WebLock")
 	}
 
 	val, found, err := readTx.Get(ctx, []byte("k"))
@@ -237,6 +226,80 @@ func TestMetaStoreReadTxDoesNotHoldMetaWebLock(t *testing.T) {
 	}
 	if !found || string(val) != "v1" {
 		t.Fatalf("snapshot read got found=%v val=%q want v1", found, val)
+	}
+}
+
+func TestMetaStoreReadTxBlocksPageReuseUntilClose(t *testing.T) {
+	name := "test-metastore-read-tx-blocks-page-reuse"
+	ms := newTestMetaShard(t, name)
+	store := NewMetaStore(ms)
+	ctx := context.Background()
+	key := []byte("m/1/00000")
+	putMetaValue(t, ms, string(key), "v1")
+
+	readTx, err := store.NewTransaction(ctx, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	snapshotRoot := ms.rootPage
+	writerCommitted := make(chan struct{})
+	continueWriter := make(chan struct{})
+	writerDone := make(chan error, 1)
+	ms.testHook = func(stage string) error {
+		if stage != "after-superblock-write" {
+			return nil
+		}
+		close(writerCommitted)
+		<-continueWriter
+		return nil
+	}
+
+	probeRelease, acquired, err := filelock.AcquireWebLockIfAvailable(name+"/meta/write", true)
+	if err != nil {
+		readTx.Discard()
+		t.Fatal(err)
+	}
+	go func() {
+		writerDone <- ms.WriteTx(func(tree *pagestore.Tree) error {
+			ms.pager.freed = []pagestore.PageID{snapshotRoot}
+			_, err := tree.Delete(key)
+			return err
+		})
+	}()
+
+	if acquired {
+		probeRelease()
+		<-writerCommitted
+		val, found, readErr := readTx.Get(ctx, key)
+		close(continueWriter)
+		readTx.Discard()
+		if err := <-writerDone; err != nil {
+			t.Fatal(err)
+		}
+		if readErr != nil || !found || string(val) != "v1" {
+			t.Fatalf("lazy read lost key=%s found=%v val=%q err=%v", key, found, val, readErr)
+		}
+		t.Fatal("read transaction did not hold meta WebLock during page reuse")
+	}
+
+	val, found, err := readTx.Get(ctx, key)
+	if err != nil {
+		close(continueWriter)
+		readTx.Discard()
+		_ = <-writerDone
+		t.Fatal(err)
+	}
+	if !found || string(val) != "v1" {
+		close(continueWriter)
+		readTx.Discard()
+		_ = <-writerDone
+		t.Fatalf("snapshot read got found=%v val=%q want v1", found, val)
+	}
+	readTx.Discard()
+	close(continueWriter)
+	if err := <-writerDone; err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/db/volume/js/opfs/metashard/metashard_test.go
+++ b/db/volume/js/opfs/metashard/metashard_test.go
@@ -477,7 +477,9 @@ func TestMetaShardNewestSuperblockWithZeroRootFallsBack(t *testing.T) {
 	putMetaValue(t, ms, "k", "v2")
 
 	var sbBuf [pagestore.SuperblockSize]byte
-	readSuper(ms.dir, "super-b", sbBuf[:])
+	if err := readSuper(ms.dir, "super-b", sbBuf[:]); err != nil {
+		t.Fatal(err)
+	}
 	sb, err := pagestore.DecodeSuperblock(sbBuf[:])
 	if err != nil {
 		t.Fatal(err)
@@ -579,7 +581,9 @@ func zeroSuperblockRoots(t *testing.T, ms *MetaShard) {
 func zeroSuperblockRoot(t *testing.T, ms *MetaShard, slot string) {
 	t.Helper()
 	var sbBuf [pagestore.SuperblockSize]byte
-	readSuper(ms.dir, slot, sbBuf[:])
+	if err := readSuper(ms.dir, slot, sbBuf[:]); err != nil {
+		t.Fatal(err)
+	}
 	sb, err := pagestore.DecodeSuperblock(sbBuf[:])
 	if err != nil {
 		t.Fatal(err)

--- a/db/volume/js/opfs/metashard/metashard_test.go
+++ b/db/volume/js/opfs/metashard/metashard_test.go
@@ -175,14 +175,150 @@ func TestMetaStoreReadTxDoesNotBlockWrites(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Reads are committed per operation, so the open transaction observes the
-	// commit rather than a snapshot taken when it opened.
-	val, found, err = readTx.Get(ctx, []byte("k"))
+	// The commit landed, which is what this test is for. The open transaction
+	// already served a read from the previous generation, so it refuses to
+	// serve one from this generation rather than mixing the two.
+	if _, _, err := readTx.Get(ctx, []byte("k")); !errors.Is(err, ErrGenerationChanged) {
+		t.Fatalf("read after commit err = %v, want ErrGenerationChanged", err)
+	}
+
+	// A fresh transaction sees the commit.
+	nextTx, err := store.NewTransaction(ctx, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer nextTx.Discard()
+	val, found, err = nextTx.Get(ctx, []byte("k"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !found || string(val) != "v2" {
-		t.Fatalf("read after commit got found=%v val=%q want v2", found, val)
+		t.Fatalf("fresh read after commit got found=%v val=%q want v2", found, val)
+	}
+}
+
+func TestMetaStoreReadTxRefusesToStraddleGenerations(t *testing.T) {
+	ms := newTestMetaShard(t, "test-metastore-read-tx-straddle")
+	store := NewMetaStore(ms)
+	ctx := context.Background()
+
+	writeTx, err := store.NewTransaction(ctx, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeTx.Set(ctx, []byte("a"), []byte("1")); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeTx.Set(ctx, []byte("b"), []byte("1")); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeTx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// A caller reading a multi-key object reads "a" from the first generation.
+	readTx, err := store.NewTransaction(ctx, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer readTx.Discard()
+	val, _, err := readTx.Get(ctx, []byte("a"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(val) != "1" {
+		t.Fatalf("a = %q, want 1", val)
+	}
+
+	// Another agent rewrites both keys between the two reads.
+	second, err := store.NewTransaction(ctx, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := second.Set(ctx, []byte("a"), []byte("2")); err != nil {
+		t.Fatal(err)
+	}
+	if err := second.Set(ctx, []byte("b"), []byte("2")); err != nil {
+		t.Fatal(err)
+	}
+	if err := second.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Serving b=2 here would hand the caller a=1 with b=2, which no generation
+	// ever held.
+	if _, _, err := readTx.Get(ctx, []byte("b")); !errors.Is(err, ErrGenerationChanged) {
+		t.Fatalf("b err = %v, want ErrGenerationChanged", err)
+	}
+	if err := readTx.ScanPrefix(ctx, nil, func(_, _ []byte) error { return nil }); !errors.Is(err, ErrGenerationChanged) {
+		t.Fatalf("scan err = %v, want ErrGenerationChanged", err)
+	}
+}
+
+func TestMetaShardReadsRevalidateOnlyWhenTheGenerationMoves(t *testing.T) {
+	ms := newTestMetaShard(t, "test-metashard-read-revalidation")
+	store := NewMetaStore(ms)
+	ctx := context.Background()
+
+	writeTx, err := store.NewTransaction(ctx, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"k1", "k2", "k3", "k4"} {
+		if err := writeTx.Set(ctx, []byte(key), []byte("v")); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := writeTx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Validating a superblock walks the whole tree, so doing it per read makes
+	// a run of M point reads cost M tree walks. Nothing has committed between
+	// these reads, so the state loaded by the first one is still current.
+	readTx, err := store.NewTransaction(ctx, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer readTx.Discard()
+	for _, key := range []string{"k1", "k2", "k3", "k4"} {
+		if _, _, err := readTx.Get(ctx, []byte(key)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	before := ms.revalidations
+
+	for _, key := range []string{"k1", "k2", "k3", "k4"} {
+		if _, _, err := readTx.Get(ctx, []byte(key)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if after := ms.revalidations; after != before {
+		t.Fatalf("reads over an unchanged shard revalidated %d times, want 0", after-before)
+	}
+
+	// A commit does have to be picked up.
+	nextWrite, err := store.NewTransaction(ctx, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := nextWrite.Set(ctx, []byte("k1"), []byte("v2")); err != nil {
+		t.Fatal(err)
+	}
+	if err := nextWrite.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+	freshTx, err := store.NewTransaction(ctx, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer freshTx.Discard()
+	val, found, err := freshTx.Get(ctx, []byte("k1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found || string(val) != "v2" {
+		t.Fatalf("k1 after commit got found=%v val=%q want v2", found, val)
 	}
 }
 

--- a/db/volume/js/opfs/metashard/metashard_test.go
+++ b/db/volume/js/opfs/metashard/metashard_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/s4wave/spacewave/db/opfs"
-	"github.com/s4wave/spacewave/db/opfs/filelock"
 	"github.com/s4wave/spacewave/db/volume/js/opfs/pagestore"
 )
 
@@ -133,8 +132,8 @@ func TestMetaStoreLargeValue(t *testing.T) {
 	}
 }
 
-func TestMetaShardReadSnapshotIsolation(t *testing.T) {
-	ms := newTestMetaShard(t, "test-metashard-snapshot")
+func TestMetaStoreReadTxDoesNotBlockWrites(t *testing.T) {
+	ms := newTestMetaShard(t, "test-metastore-read-tx-does-not-block-writes")
 	store := NewMetaStore(ms)
 	ctx := context.Background()
 
@@ -149,11 +148,21 @@ func TestMetaShardReadSnapshotIsolation(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// A read transaction left open must not stall a later write. Holding the
+	// shared metadata lock for the transaction lifetime would queue this
+	// commit behind a lock nothing releases until Discard.
 	readTx, err := store.NewTransaction(ctx, false)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer readTx.Discard()
+	val, found, err := readTx.Get(ctx, []byte("k"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found || string(val) != "v1" {
+		t.Fatalf("first read got found=%v val=%q want v1", found, val)
+	}
 
 	writeTx, err := store.NewTransaction(ctx, true)
 	if err != nil {
@@ -166,140 +175,14 @@ func TestMetaShardReadSnapshotIsolation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	val, found, err := readTx.Get(ctx, []byte("k"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !found || string(val) != "v1" {
-		t.Fatalf("snapshot read got found=%v val=%q want v1", found, val)
-	}
-
-	liveTx, err := store.NewTransaction(ctx, false)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer liveTx.Discard()
-	val, found, err = liveTx.Get(ctx, []byte("k"))
+	// Reads are committed per operation, so the open transaction observes the
+	// commit rather than a snapshot taken when it opened.
+	val, found, err = readTx.Get(ctx, []byte("k"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !found || string(val) != "v2" {
-		t.Fatalf("live read got found=%v val=%q want v2", found, val)
-	}
-}
-
-func TestMetaStoreReadTxHoldsMetaWebLock(t *testing.T) {
-	name := "test-metastore-read-tx-holds-lock"
-	ms := newTestMetaShard(t, name)
-	store := NewMetaStore(ms)
-	ctx := context.Background()
-
-	tx, err := store.NewTransaction(ctx, true)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := tx.Set(ctx, []byte("k"), []byte("v1")); err != nil {
-		t.Fatal(err)
-	}
-	if err := tx.Commit(ctx); err != nil {
-		t.Fatal(err)
-	}
-
-	readTx, err := store.NewTransaction(ctx, false)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer readTx.Discard()
-
-	release, acquired, err := filelock.AcquireWebLockIfAvailable(name+"/meta/write", true)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if acquired {
-		release()
-		t.Fatal("read transaction did not hold meta WebLock")
-	}
-
-	val, found, err := readTx.Get(ctx, []byte("k"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !found || string(val) != "v1" {
-		t.Fatalf("snapshot read got found=%v val=%q want v1", found, val)
-	}
-}
-
-func TestMetaStoreReadTxBlocksPageReuseUntilClose(t *testing.T) {
-	name := "test-metastore-read-tx-blocks-page-reuse"
-	ms := newTestMetaShard(t, name)
-	store := NewMetaStore(ms)
-	ctx := context.Background()
-	key := []byte("m/1/00000")
-	putMetaValue(t, ms, string(key), "v1")
-
-	readTx, err := store.NewTransaction(ctx, false)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	snapshotRoot := ms.rootPage
-	writerCommitted := make(chan struct{})
-	continueWriter := make(chan struct{})
-	writerDone := make(chan error, 1)
-	ms.testHook = func(stage string) error {
-		if stage != "after-superblock-write" {
-			return nil
-		}
-		close(writerCommitted)
-		<-continueWriter
-		return nil
-	}
-
-	probeRelease, acquired, err := filelock.AcquireWebLockIfAvailable(name+"/meta/write", true)
-	if err != nil {
-		readTx.Discard()
-		t.Fatal(err)
-	}
-	go func() {
-		writerDone <- ms.WriteTx(func(tree *pagestore.Tree) error {
-			ms.pager.freed = []pagestore.PageID{snapshotRoot}
-			_, err := tree.Delete(key)
-			return err
-		})
-	}()
-
-	if acquired {
-		probeRelease()
-		<-writerCommitted
-		val, found, readErr := readTx.Get(ctx, key)
-		close(continueWriter)
-		readTx.Discard()
-		if err := <-writerDone; err != nil {
-			t.Fatal(err)
-		}
-		if readErr != nil || !found || string(val) != "v1" {
-			t.Fatalf("lazy read lost key=%s found=%v val=%q err=%v", key, found, val, readErr)
-		}
-		t.Fatal("read transaction did not hold meta WebLock during page reuse")
-	}
-
-	val, found, err := readTx.Get(ctx, key)
-	if err != nil {
-		close(continueWriter)
-		readTx.Discard()
-		_ = <-writerDone
-		t.Fatal(err)
-	}
-	if !found || string(val) != "v1" {
-		close(continueWriter)
-		readTx.Discard()
-		_ = <-writerDone
-		t.Fatalf("snapshot read got found=%v val=%q want v1", found, val)
-	}
-	readTx.Discard()
-	close(continueWriter)
-	if err := <-writerDone; err != nil {
-		t.Fatal(err)
+		t.Fatalf("read after commit got found=%v val=%q want v2", found, val)
 	}
 }
 

--- a/db/volume/js/opfs/metashard/metashard_test.go
+++ b/db/volume/js/opfs/metashard/metashard_test.go
@@ -546,6 +546,37 @@ func TestMetaShardBothSuperblocksWithZeroRootsResets(t *testing.T) {
 	assertMetaValue(t, reopenTestMetaShard(t, name), "after-reset", "ok")
 }
 
+// TestMetaShardResetGenerationUsesProcessFloor covers both draws the epoch can
+// produce. The first case sets a floor low enough that a random epoch almost
+// always clears it, and the second sets the highest epoch there is, so no draw
+// can clear it and the floor has to carry the generation itself.
+func TestMetaShardResetGenerationUsesProcessFloor(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		epoch uint64
+	}{
+		{name: "ordinary", epoch: 1},
+		{name: "highest-epoch", epoch: 0xFFFFFFFF},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ms := newTestMetaShard(t, "test-metashard-reset-generation-floor-"+tc.name)
+			putMetaValue(t, ms, "k", "v1")
+
+			before := tc.epoch<<generationEpochShift | 1
+			ms.generation = before
+			if err := ms.resetCommittedStateLocked(); err != nil {
+				t.Fatal(err)
+			}
+
+			putMetaValue(t, ms, "after-reset", "ok")
+			after := ms.Generation()
+			if after <= before {
+				t.Fatalf("generation %d after reset did not exceed prior %d", after, before)
+			}
+		})
+	}
+}
+
 func TestMetaStoreReadTxRecoversCorruptSnapshot(t *testing.T) {
 	name := "test-metastore-read-tx-recovers-corrupt-snapshot"
 	ms := newTestMetaShard(t, name)


### PR DESCRIPTION
Metadata reads captured a committed root and then released the shared WebLock before walking the lazy B-tree. A concurrent writer could recycle a page from that generation and overwrite a subtree while the reader was still in it, producing missing keys or corrupt page errors. Every read path now holds the shared lock for the whole walk and materializes its values before releasing.

The lock is global across every tab and worker, so its scope matters as much as its presence. An earlier revision of this branch let a read transaction hold it from open until discard, which deadlocked any caller that opened a read transaction and then committed a write on the same store: the commit waited for an exclusive lock that the open transaction would not release, and the caller never reached the discard that would have released it. Instead each read operation opens its own snapshot, walks it under the lock, and drops both before returning. Read transactions are therefore read committed rather than snapshot isolated. The store interface promises no isolation level, and the transaction cache that fronts this store serves repeated reads from its own cache, so this reaches only callers that read the same key twice through one uncached transaction.

Two further defects in the same read path come with it. Readers shared the metadata lock but loaded superblocks through an exclusive sync access handle, so a concurrent reader could fail to open the file at all; superblocks are now read through an async handle, which supports shared reads, while writers keep their sync handles and the exclusive lock. And readSuper discarded every read error, leaving a zeroed buffer that decodes as no superblock, which is indistinguishable from a shard that has never committed. A failed read therefore served an empty database over live committed data. Missing files still read as empty, since that is what an uncommitted shard looks like, and every other failure now propagates to the reload caller.

Verified with the OPFS Chrome stress profile, which is where these concurrency cases live. On master it fails TestOpfsChromeConcurrentMetaWriters and TestOpfsChromeConcurrentMetaOverflowWriters; on this branch the whole profile passes with 12 tests run and no failures, and the smoke profile stays green.