### PR TITLE
fix(e2e): report why a prebuilt release artifact was not reused

### DIFF
--- a/e2e/releasewasm/artifact-resolve.go
+++ b/e2e/releasewasm/artifact-resolve.go
@@ -18,6 +18,16 @@ type releaseArtifact struct {
 	prerenderDir string
 }
 
+// identityFields carries every digest that determines an artifact identity into
+// one log entry.
+func identityFields(identity *artifact.Identity) logrus.Fields {
+	fields := make(logrus.Fields, 8)
+	for key, value := range identity.Summary() {
+		fields[key] = value
+	}
+	return fields
+}
+
 type releaseShape struct {
 	le       *logrus.Entry
 	repoRoot string
@@ -41,6 +51,21 @@ func (s *releaseShape) Lookup(ctx context.Context, key string) ([]e2eharness.Gen
 	if err != nil {
 		return nil, err
 	}
+	if len(generations) == 0 {
+		// A miss here is the whole cost of the run: the caller rebuilds, and in
+		// CI the job that consumes a prebuilt artifact has no compiler to
+		// rebuild with. Report the identity being looked for and the
+		// generations that were actually present, because the two digests
+		// together name the input that differs.
+		present, err := artifact.GenerationIDs(s.storeDir)
+		if err != nil {
+			return nil, err
+		}
+		s.le.WithFields(identityFields(s.identity)).
+			WithField("store", s.storeDir).
+			WithField("present", present).
+			Warn("no published release artifact matches the current identity")
+	}
 	results := make([]e2eharness.Generation[releaseArtifact], 0, len(generations))
 	for _, generation := range generations {
 		results = append(results, e2eharness.Generation[releaseArtifact]{
@@ -62,7 +87,7 @@ func (s *releaseShape) Build(ctx context.Context, key string) (e2eharness.Genera
 		return e2eharness.Generation[releaseArtifact]{}, errors.Wrap(err, "clean release dist state")
 	}
 
-	s.le.Info("building release web bundle")
+	s.le.WithFields(identityFields(s.identity)).Info("building release web bundle")
 	if err := buildReleaseWeb(ctx, s.repoRoot); err != nil {
 		return e2eharness.Generation[releaseArtifact]{}, errors.Wrap(err, "build release web bundle")
 	}

--- a/e2e/releasewasm/artifact-resolve.go
+++ b/e2e/releasewasm/artifact-resolve.go
@@ -52,11 +52,10 @@ func (s *releaseShape) Lookup(ctx context.Context, key string) ([]e2eharness.Gen
 		return nil, err
 	}
 	if len(generations) == 0 {
-		// A miss here is the whole cost of the run: the caller rebuilds, and in
-		// CI the job that consumes a prebuilt artifact has no compiler to
-		// rebuild with. Report the identity being looked for and the
-		// generations that were actually present, because the two digests
-		// together name the input that differs.
+		// A miss makes the caller rebuild, which is the expensive path and is
+		// impossible wherever no compiler is available. Report the identity
+		// being looked for alongside the generations that were present, since
+		// the two digests together name the input that differs.
 		present, err := artifact.GenerationIDs(s.storeDir)
 		if err != nil {
 			return nil, err

--- a/e2e/releasewasm/artifact.go
+++ b/e2e/releasewasm/artifact.go
@@ -65,9 +65,9 @@ func PublishReleaseWasmArtifact(ctx context.Context, le *logrus.Entry, repoRoot 
 	if err != nil {
 		return err
 	}
-	// The consumer of this artifact computes the same identity in its own
-	// process, and when the two disagree it silently rebuilds. Print the
-	// producing side's digests so the pair can be compared from two job logs.
+	// The consumer computes the same identity in its own process and rebuilds
+	// whenever the two disagree. Print the producing side's digests so both
+	// sides of that comparison are recoverable from their separate logs.
 	le.WithFields(identityFields(identity)).Info("published release artifact")
 	return nil
 }

--- a/e2e/releasewasm/artifact.go
+++ b/e2e/releasewasm/artifact.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/s4wave/spacewave/bldr/util/gocompiler"
 	"github.com/s4wave/spacewave/e2e/releasewasm/artifact"
+	"github.com/sirupsen/logrus"
 )
 
 const releaseWasmArtifactStoreRelPath = ".bldr/e2e-releasewasm/release-artifacts"
@@ -50,7 +51,7 @@ var releaseWasmArtifactEnvKeys = []string{
 
 // PublishReleaseWasmArtifact publishes the existing release and prerender build
 // outputs under their current source and build identity.
-func PublishReleaseWasmArtifact(ctx context.Context, repoRoot string) error {
+func PublishReleaseWasmArtifact(ctx context.Context, le *logrus.Entry, repoRoot string) error {
 	identity, err := computeReleaseWasmArtifactIdentity(ctx, repoRoot)
 	if err != nil {
 		return err
@@ -61,7 +62,14 @@ func PublishReleaseWasmArtifact(ctx context.Context, repoRoot string) error {
 		filepath.Join(repoRoot, prerenderDistRelPath),
 		identity,
 	)
-	return err
+	if err != nil {
+		return err
+	}
+	// The consumer of this artifact computes the same identity in its own
+	// process, and when the two disagree it silently rebuilds. Print the
+	// producing side's digests so the pair can be compared from two job logs.
+	le.WithFields(identityFields(identity)).Info("published release artifact")
+	return nil
 }
 
 func computeReleaseWasmArtifactIdentity(ctx context.Context, repoRoot string) (*artifact.Identity, error) {

--- a/e2e/releasewasm/artifact/identity.go
+++ b/e2e/releasewasm/artifact/identity.go
@@ -95,6 +95,7 @@ func ComputeIdentity(repoRoot string, inputs *BuildInputs) (*Identity, error) {
 func (i *Identity) Summary() map[string]string {
 	return map[string]string{
 		"identity":        i.Digest,
+		"schema":          strconv.Itoa(i.SchemaVersion),
 		"compiler":        i.Compiler,
 		"mode":            i.Mode,
 		"source":          i.SourceDigest,

--- a/e2e/releasewasm/artifact/identity.go
+++ b/e2e/releasewasm/artifact/identity.go
@@ -89,6 +89,22 @@ func ComputeIdentity(repoRoot string, inputs *BuildInputs) (*Identity, error) {
 	return identity, nil
 }
 
+// Summary returns every digest that determines the identity, so two processes
+// that disagree about which artifact they want can be compared field by field
+// from their logs alone.
+func (i *Identity) Summary() map[string]string {
+	return map[string]string{
+		"identity":        i.Digest,
+		"compiler":        i.Compiler,
+		"mode":            i.Mode,
+		"source":          i.SourceDigest,
+		"build":           i.BuildDigest,
+		"lockfiles":       i.LockfileDigest,
+		"bldr":            i.BldrDigest,
+		"prerenderInputs": i.PrerenderInputsDigest,
+	}
+}
+
 // Differences returns the current inputs that do not match the artifact.
 func (i *Identity) Differences(artifact *Identity) []string {
 	if artifact == nil {

--- a/e2e/releasewasm/artifact/store.go
+++ b/e2e/releasewasm/artifact/store.go
@@ -202,6 +202,24 @@ func ValidGenerations(storeDir string, expected *Identity) ([]Generation, error)
 	return generations, nil
 }
 
+// GenerationIDs returns the name of every generation directory in the store,
+// whatever identity it carries. A caller that found no usable generation uses
+// this to report what the store did hold.
+func GenerationIDs(storeDir string) ([]string, error) {
+	entries, err := os.ReadDir(filepath.Join(storeDir, generationsDir))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, errors.Wrap(err, "read release artifact generations")
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	return names, nil
+}
+
 // Validate rejects incomplete, modified, or stale artifact directory pairs.
 func Validate(releaseDir, prerenderDir string, expected *Identity) error {
 	if expected == nil {

--- a/e2e/releasewasm/artifact/store_test.go
+++ b/e2e/releasewasm/artifact/store_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -115,6 +116,39 @@ func TestValidateRejectsStaleIdentity(t *testing.T) {
 	changedIdentity := computeTestIdentity(t, repoRoot, changedInputs)
 	if err := Validate(publishedRelease, publishedPrerender, changedIdentity); err == nil {
 		t.Fatal("stale artifact identity validated")
+	}
+}
+
+func TestForeignIdentityMissesSilentlyAndStaysReportable(t *testing.T) {
+	repoRoot := newIdentityTestRepo(t)
+	identity := computeTestIdentity(t, repoRoot, testBuildInputs())
+	storeDir := filepath.Join(t.TempDir(), "store")
+
+	releaseDir, prerenderDir := newArtifactFixture(t, "published")
+	if _, _, err := Publish(storeDir, releaseDir, prerenderDir, identity); err != nil {
+		t.Fatal(err)
+	}
+
+	changedInputs := testBuildInputs()
+	changedInputs.Environment["BLDR_GO_WASM_OPTIMIZE"] = "false"
+	changedIdentity := computeTestIdentity(t, repoRoot, changedInputs)
+
+	// A store holding only another identity's work is a miss, not a failure:
+	// the caller rebuilds. The caller can only say why it rebuilt if the names
+	// it did not match stay readable.
+	generations, err := ValidGenerations(storeDir, changedIdentity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(generations) != 0 {
+		t.Fatalf("foreign identity matched %d generation(s)", len(generations))
+	}
+	names, err := GenerationIDs(storeDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(names) != 1 || !strings.HasPrefix(names[0], identity.Digest) {
+		t.Fatalf("store reported generations %v, want one named for %s", names, identity.Digest)
 	}
 }
 

--- a/e2e/releasewasm/cmd/publish-artifact/main.go
+++ b/e2e/releasewasm/cmd/publish-artifact/main.go
@@ -9,12 +9,14 @@ import (
 
 	"github.com/aperturerobotics/util/gitroot"
 	"github.com/s4wave/spacewave/e2e/releasewasm"
+	"github.com/sirupsen/logrus"
 )
 
 func main() {
+	le := logrus.NewEntry(logrus.New())
 	repoRoot, err := gitroot.FindRepoRoot()
 	if err == nil {
-		err = releasewasm.PublishReleaseWasmArtifact(context.Background(), repoRoot)
+		err = releasewasm.PublishReleaseWasmArtifact(context.Background(), le, repoRoot)
 	}
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())


### PR DESCRIPTION
The nightly release-wasm smoke job downloads the build job's prebuilt browser artifact, verifies its digest, and then rebuilds the whole bundle from source anyway. It has no TinyGo installed, so the rebuild fails immediately and the job has been red every night since July 5. Nothing in either job's log explains the discard.

The store is content addressed. The publisher writes a generation named for an identity digest computed from the working tree, the build environment, and tool versions; the consumer recomputes that digest and looks for a matching generation. A disagreement is an ordinary cache miss to the resolver, so it rebuilds silently, and neither side ever printed the digest it computed. That leaves no way to tell which of the seven component digests differed short of reproducing both stores by hand.

Both sides now report the identity. The publisher prints the digest and its components after publishing, the resolver prints the same fields plus the generation names that were actually present whenever nothing matched, and the build message carries the digest it is building for. The next nightly run should name the differing input directly.

This changes diagnostics only. The reuse decision, the store layout, and the build path are unchanged.