### PR TITLE
fix(gc): retain owner edges for deduplicated blocks

### DIFF
--- a/db/block/gc/gcgraph/batch.go
+++ b/db/block/gc/gcgraph/batch.go
@@ -9,19 +9,88 @@ import (
 	block_gc "github.com/s4wave/spacewave/db/block/gc"
 )
 
-// ApplyRefBatch applies ref graph edge additions followed by removals.
+// ApplyRefBatch applies a ref graph ownership transition while holding the
+// graph-wide ownership lock.
 func (g *GCGraph) ApplyRefBatch(ctx context.Context, adds, removes []block_gc.RefEdge) error {
+	release, err := g.acquireOwnershipLock(ctx)
+	if err != nil {
+		return err
+	}
+	defer release()
+	return g.applyRefBatchLocked(ctx, adds, removes)
+}
+
+func (g *GCGraph) applyRefBatchLocked(
+	ctx context.Context,
+	adds, removes []block_gc.RefEdge,
+) error {
+	adds, removes, err := g.prepareRefBatch(ctx, adds, removes)
+	if err != nil {
+		return err
+	}
 	for _, e := range adds {
-		if err := g.AddRef(ctx, e.Subject, e.Object); err != nil {
+		if err := g.addRef(e.Subject, e.Object); err != nil {
 			return err
 		}
 	}
 	for _, e := range removes {
-		if err := g.RemoveRef(ctx, e.Subject, e.Object); err != nil {
+		if err := g.removeRef(e.Subject, e.Object); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func (g *GCGraph) prepareRefBatch(
+	ctx context.Context,
+	adds, removes []block_gc.RefEdge,
+) ([]block_gc.RefEdge, []block_gc.RefEdge, error) {
+	owners := make(map[string]map[string]struct{})
+	stagingRemoves := make(map[string]struct{})
+	for _, edge := range removes {
+		if edge.Subject == block_gc.NodeUnreferenced {
+			stagingRemoves[edge.Object] = struct{}{}
+			continue
+		}
+		if block_gc.IsPermanentRoot(edge.Object) {
+			continue
+		}
+		if _, ok := owners[edge.Object]; ok {
+			continue
+		}
+		sources, err := g.GetIncomingRefs(ctx, edge.Object)
+		if err != nil {
+			return nil, nil, err
+		}
+		set := make(map[string]struct{}, len(sources))
+		for _, source := range sources {
+			if source != block_gc.NodeUnreferenced {
+				set[source] = struct{}{}
+			}
+		}
+		owners[edge.Object] = set
+	}
+	for _, edge := range removes {
+		if set, ok := owners[edge.Object]; ok {
+			delete(set, edge.Subject)
+		}
+	}
+	for _, edge := range adds {
+		if set, ok := owners[edge.Object]; ok && edge.Subject != block_gc.NodeUnreferenced {
+			set[edge.Subject] = struct{}{}
+		}
+	}
+	for object, set := range owners {
+		if len(set) == 0 {
+			if _, removingStaging := stagingRemoves[object]; !removingStaging {
+				adds = append(adds, block_gc.RefEdge{
+					Subject: block_gc.NodeUnreferenced,
+					Object:  object,
+				})
+			}
+		}
+	}
+	return adds, removes, nil
 }
 
 // RemoveNodeRefs removes all outgoing gc/ref edges for a node.
@@ -29,28 +98,28 @@ func (g *GCGraph) ApplyRefBatch(ctx context.Context, adds, removes []block_gc.Re
 // If markOrphaned is true, targets with no remaining incoming
 // refs get an unreferenced edge.
 func (g *GCGraph) RemoveNodeRefs(ctx context.Context, node string, markOrphaned bool) ([]string, error) {
+	release, err := g.acquireOwnershipLock(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+
 	targets, err := g.GetOutgoingRefs(ctx, node)
 	if err != nil {
 		return nil, err
 	}
-	for _, t := range targets {
-		if err := g.RemoveRef(ctx, node, t); err != nil {
-			return nil, err
-		}
+	removes := make([]block_gc.RefEdge, 0, len(targets))
+	for _, target := range targets {
+		removes = append(removes, block_gc.RefEdge{Subject: node, Object: target})
 	}
 	if markOrphaned {
-		for _, t := range targets {
-			if block_gc.IsPermanentRoot(t) {
-				continue
-			}
-			has, err := g.HasIncomingRefs(ctx, t)
-			if err != nil {
+		if err := g.applyRefBatchLocked(ctx, nil, removes); err != nil {
+			return nil, err
+		}
+	} else {
+		for _, edge := range removes {
+			if err := g.removeRef(edge.Subject, edge.Object); err != nil {
 				return nil, err
-			}
-			if !has {
-				if err := g.AddRef(ctx, block_gc.NodeUnreferenced, t); err != nil {
-					return nil, err
-				}
 			}
 		}
 	}

--- a/db/block/gc/gcgraph/gcgraph.go
+++ b/db/block/gc/gcgraph/gcgraph.go
@@ -2,8 +2,8 @@
 
 // Package gcgraph implements the GC reference graph on OPFS.
 // Each edge, node inventory entry, and root-set entry is an individual
-// file under a structured directory layout. Per-file locking provides
-// concurrency safety.
+// file under a structured directory layout. Per-file locking protects
+// individual files, while ownership transitions use a graph-wide lock.
 package gcgraph
 
 import (
@@ -71,10 +71,22 @@ func NewGCGraph(root js.Value, lockPrefix string) (*GCGraph, error) {
 	}
 	return g, nil
 }
+func (g *GCGraph) acquireOwnershipLock(ctx context.Context) (func(), error) {
+	return filelock.AcquireWebLockContext(ctx, g.lockPrefix+"/ownership", true)
+}
 
 // AddRef adds a gc/ref edge from subject to object. Idempotent.
 // Ensures node inventory entries exist for both endpoints.
 func (g *GCGraph) AddRef(ctx context.Context, subject, object string) error {
+	release, err := g.acquireOwnershipLock(ctx)
+	if err != nil {
+		return err
+	}
+	defer release()
+	return g.addRef(subject, object)
+}
+
+func (g *GCGraph) addRef(subject, object string) error {
 	if err := g.ensureNode(subject); err != nil {
 		return errors.Wrap(err, "ensure subject node")
 	}
@@ -86,7 +98,6 @@ func (g *GCGraph) AddRef(ctx context.Context, subject, object string) error {
 	oh := hashName(object)
 	content := []byte(subject + "\n" + object)
 
-	// Forward edge: edges/<subject-hash>/<object-hash>
 	edgeSubDir, err := opfs.GetDirectory(g.edgesDir, sh, true)
 	if err != nil {
 		return errors.Wrap(err, "edges subdir")
@@ -95,7 +106,6 @@ func (g *GCGraph) AddRef(ctx context.Context, subject, object string) error {
 		return errors.Wrap(err, "write forward edge")
 	}
 
-	// Reverse edge: incoming/<object-hash>/<subject-hash>
 	inSubDir, err := opfs.GetDirectory(g.incomingDir, oh, true)
 	if err != nil {
 		return errors.Wrap(err, "incoming subdir")
@@ -106,16 +116,23 @@ func (g *GCGraph) AddRef(ctx context.Context, subject, object string) error {
 // RemoveRef removes a single gc/ref edge from subject to object.
 // Removing a non-existent edge is a no-op.
 func (g *GCGraph) RemoveRef(ctx context.Context, subject, object string) error {
+	release, err := g.acquireOwnershipLock(ctx)
+	if err != nil {
+		return err
+	}
+	defer release()
+	return g.removeRef(subject, object)
+}
+
+func (g *GCGraph) removeRef(subject, object string) error {
 	sh := hashName(subject)
 	oh := hashName(object)
 
-	// Forward edge.
 	edgeSubDir, err := opfs.GetDirectory(g.edgesDir, sh, false)
 	if err == nil {
 		_ = g.deleteFile(edgeSubDir, oh)
 	}
 
-	// Reverse edge.
 	inSubDir, err := opfs.GetDirectory(g.incomingDir, oh, false)
 	if err == nil {
 		_ = g.deleteFile(inSubDir, sh)

--- a/db/block/gc/ownership_test.go
+++ b/db/block/gc/ownership_test.go
@@ -1,0 +1,124 @@
+package block_gc_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/s4wave/spacewave/db/block"
+	block_gc "github.com/s4wave/spacewave/db/block/gc"
+	block_mock "github.com/s4wave/spacewave/db/block/mock"
+	store_kvkey "github.com/s4wave/spacewave/db/store/kvkey"
+	store_kvtx "github.com/s4wave/spacewave/db/store/kvtx"
+	store_kvtx_inmem "github.com/s4wave/spacewave/db/store/kvtx/inmem"
+	common_kvtx "github.com/s4wave/spacewave/db/volume/common/kvtx"
+)
+
+func TestGCStoreOpsDeduplicatedBlockRetainsBucketOwner(t *testing.T) {
+	for _, batch := range []bool{false, true} {
+		name := "put"
+		if batch {
+			name = "batch"
+		}
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			kvKey, err := store_kvkey.NewKVKey(store_kvkey.DefaultConfig())
+			if err != nil {
+				t.Fatalf("new kv key: %v", err)
+			}
+			vol, err := common_kvtx.NewVolume(
+				ctx,
+				"gc-deduplicated-owner-test",
+				kvKey,
+				store_kvtx_inmem.NewStore(),
+				&store_kvtx.Config{},
+				false,
+				false,
+				nil,
+				nil,
+			)
+			if err != nil {
+				t.Fatalf("new volume: %v", err)
+			}
+			t.Cleanup(func() {
+				if err := vol.Close(); err != nil {
+					t.Fatalf("close volume: %v", err)
+				}
+			})
+
+			rg := vol.GetRefGraph()
+			providerIRI := "provider:test"
+			bucketAIRI := block_gc.BucketIRI("bucket-a")
+			bucketBIRI := block_gc.BucketIRI("bucket-b")
+			for _, bucketIRI := range []string{bucketAIRI, bucketBIRI} {
+				if err := rg.AddRef(ctx, block_gc.NodeGCRoot, bucketIRI); err != nil {
+					t.Fatalf("root bucket: %v", err)
+				}
+				if err := rg.AddRef(ctx, providerIRI, bucketIRI); err != nil {
+					t.Fatalf("own bucket: %v", err)
+				}
+			}
+
+			bucketA := block_gc.NewGCStoreOpsWithParent(vol, rg, bucketAIRI)
+			bucketB := block_gc.NewGCStoreOpsWithParent(vol, rg, bucketBIRI)
+			example := block_mock.NewExample("shared bucket block")
+			data, err := example.MarshalBlock()
+			if err != nil {
+				t.Fatalf("marshal block: %v", err)
+			}
+			put := func(store *block_gc.GCStoreOps) *block.BlockRef {
+				t.Helper()
+				if batch {
+					ref, err := block.BuildBlockRef(data, nil)
+					if err != nil {
+						t.Fatalf("build block ref: %v", err)
+					}
+					entry := &block.PutBatchEntry{Ref: ref, Data: data}
+					if err := store.PutBlockBatch(ctx, []*block.PutBatchEntry{entry}); err != nil {
+						t.Fatalf("put block batch: %v", err)
+					}
+					return ref
+				}
+				ref, _, err := store.PutBlock(ctx, data, nil)
+				if err != nil {
+					t.Fatalf("put block: %v", err)
+				}
+				return ref
+			}
+
+			refA := put(bucketA)
+			if err := bucketA.FlushPending(ctx); err != nil {
+				t.Fatalf("flush bucket A: %v", err)
+			}
+			refB := put(bucketB)
+			if err := bucketB.FlushPending(ctx); err != nil {
+				t.Fatalf("flush bucket B: %v", err)
+			}
+			if !refA.EqualVT(refB) {
+				t.Fatalf("expected identical block refs, got %v and %v", refA, refB)
+			}
+
+			gcOps := block_gc.NewGCStoreOps(vol, rg)
+			if err := gcOps.RemoveGCRef(ctx, block_gc.NodeGCRoot, bucketAIRI); err != nil {
+				t.Fatalf("remove bucket root: %v", err)
+			}
+			if err := gcOps.RemoveGCRef(ctx, providerIRI, bucketAIRI); err != nil {
+				t.Fatalf("remove provider owner: %v", err)
+			}
+			if _, err := block_gc.NewCollector(rg, vol, nil).Collect(ctx); err != nil {
+				t.Fatalf("collect account blocks: %v", err)
+			}
+
+			got, exists, err := bucketB.GetBlock(ctx, refB)
+			if err != nil {
+				t.Fatalf("read surviving bucket block: %v", err)
+			}
+			if !exists {
+				t.Fatal("surviving bucket block was physically deleted")
+			}
+			if !bytes.Equal(got, data) {
+				t.Fatal("surviving bucket block data changed")
+			}
+		})
+	}
+}

--- a/db/block/gc/refgraph.go
+++ b/db/block/gc/refgraph.go
@@ -100,6 +100,14 @@ func (rg *RefGraph) RemoveRef(ctx context.Context, subject, object string) error
 func (rg *RefGraph) ApplyRefBatch(ctx context.Context, adds, removes []RefEdge) error {
 	rg.writeMu.Lock()
 	defer rg.writeMu.Unlock()
+	return rg.applyRefBatchLocked(ctx, adds, removes, true)
+}
+
+func (rg *RefGraph) applyRefBatchLocked(
+	ctx context.Context,
+	adds, removes []RefEdge,
+	markOrphaned bool,
+) error {
 	ctx = disableStoreTracking(ctx)
 	ctx, task := trace.NewTask(ctx, "hydra/block-gc/refgraph/apply-ref-batch")
 	defer task.End()
@@ -116,7 +124,7 @@ func (rg *RefGraph) ApplyRefBatch(ctx context.Context, adds, removes []RefEdge) 
 		return nil
 	}
 	var err error
-	removes, err = rg.filterExistingRemoves(ctx, adds, removes)
+	adds, removes, err = rg.prepareRefBatch(ctx, adds, removes, markOrphaned)
 	if err != nil {
 		return err
 	}
@@ -132,7 +140,7 @@ func (rg *RefGraph) ApplyRefBatch(ctx context.Context, adds, removes []RefEdge) 
 			removeCount = min(len(removes), refGraphApplyBatchLimit)
 		}
 		chunks++
-		if err := rg.applyRefBatch(ctx, adds[:addCount], removes[:removeCount]); err != nil {
+		if err := rg.applyRefBatchChunk(ctx, adds[:addCount], removes[:removeCount]); err != nil {
 			return err
 		}
 		adds = adds[addCount:]
@@ -142,7 +150,7 @@ func (rg *RefGraph) ApplyRefBatch(ctx context.Context, adds, removes []RefEdge) 
 	return nil
 }
 
-func (rg *RefGraph) applyRefBatch(ctx context.Context, adds, removes []RefEdge) error {
+func (rg *RefGraph) applyRefBatchChunk(ctx context.Context, adds, removes []RefEdge) error {
 	ctx, task := trace.NewTask(ctx, "hydra/block-gc/refgraph/apply-ref-batch/apply-transaction")
 	defer task.End()
 	trace.Logf(ctx, "hydra/block-gc/refgraph/apply-ref-batch/apply-transaction/shape", "adds=%d removes=%d", len(adds), len(removes))
@@ -156,6 +164,66 @@ func (rg *RefGraph) applyRefBatch(ctx context.Context, adds, removes []RefEdge) 
 		tx.RemoveQuad(quad.Make(quad.IRI(e.Subject), quad.IRI(PredGCRef), quad.IRI(e.Object), nil))
 	}
 	return rg.handle.ApplyTransaction(ctx, tx)
+}
+
+func (rg *RefGraph) prepareRefBatch(
+	ctx context.Context,
+	adds, removes []RefEdge,
+	markOrphaned bool,
+) ([]RefEdge, []RefEdge, error) {
+	removes, err := rg.filterExistingRemoves(ctx, adds, removes)
+	if err != nil {
+		return nil, nil, err
+	}
+	if !markOrphaned || len(removes) == 0 {
+		return adds, removes, nil
+	}
+
+	owners := make(map[string]map[string]struct{})
+	stagingRemoves := make(map[string]struct{})
+	for _, edge := range removes {
+		if edge.Subject == NodeUnreferenced {
+			stagingRemoves[edge.Object] = struct{}{}
+			continue
+		}
+		if IsPermanentRoot(edge.Object) {
+			continue
+		}
+		if _, ok := owners[edge.Object]; ok {
+			continue
+		}
+		sources, err := rg.GetIncomingRefs(ctx, edge.Object)
+		if err != nil {
+			return nil, nil, err
+		}
+		set := make(map[string]struct{}, len(sources))
+		for _, source := range sources {
+			if source != NodeUnreferenced {
+				set[source] = struct{}{}
+			}
+		}
+		owners[edge.Object] = set
+	}
+	for _, edge := range removes {
+		if set, ok := owners[edge.Object]; ok {
+			delete(set, edge.Subject)
+		}
+	}
+	for _, edge := range adds {
+		if set, ok := owners[edge.Object]; ok && edge.Subject != NodeUnreferenced {
+			set[edge.Subject] = struct{}{}
+		}
+	}
+	for object, set := range owners {
+		if len(set) != 0 {
+			continue
+		}
+		if _, removingStaging := stagingRemoves[object]; removingStaging {
+			continue
+		}
+		adds = append(adds, RefEdge{Subject: NodeUnreferenced, Object: object})
+	}
+	return adds, removes, nil
 }
 
 func (rg *RefGraph) filterExistingRemoves(
@@ -201,30 +269,19 @@ func (rg *RefGraph) hasRef(ctx context.Context, subject, object string) (bool, e
 // If markOrphaned is true, targets that have no remaining incoming
 // refs (excluding from "unreferenced") get an unreferenced edge.
 func (rg *RefGraph) RemoveNodeRefs(ctx context.Context, node string, markOrphaned bool) ([]string, error) {
+	rg.writeMu.Lock()
+	defer rg.writeMu.Unlock()
+
 	targets, err := rg.GetOutgoingRefs(ctx, node)
 	if err != nil {
 		return nil, err
 	}
-	for _, t := range targets {
-		if err := rg.RemoveRef(ctx, node, t); err != nil {
-			return nil, err
-		}
+	removes := make([]RefEdge, 0, len(targets))
+	for _, target := range targets {
+		removes = append(removes, RefEdge{Subject: node, Object: target})
 	}
-	if markOrphaned {
-		for _, t := range targets {
-			if IsPermanentRoot(t) {
-				continue
-			}
-			has, err := rg.HasIncomingRefs(ctx, t)
-			if err != nil {
-				return nil, err
-			}
-			if !has {
-				if err := rg.AddRef(ctx, NodeUnreferenced, t); err != nil {
-					return nil, err
-				}
-			}
-		}
+	if err := rg.applyRefBatchLocked(ctx, nil, removes, markOrphaned); err != nil {
+		return nil, err
 	}
 	return targets, nil
 }

--- a/db/block/gc/refgraph.go
+++ b/db/block/gc/refgraph.go
@@ -24,6 +24,7 @@ import (
 type RefGraph struct {
 	handle *cayley.Handle
 
+	writeMu    sync.Mutex
 	mu         sync.Mutex
 	iriRefKeys map[string]any
 }
@@ -66,6 +67,8 @@ func RegisterEntityChain(ctx context.Context, rg RefGraphOps, nodes ...string) e
 
 // AddRef adds a gc/ref edge from subject to object. Idempotent.
 func (rg *RefGraph) AddRef(ctx context.Context, subject, object string) error {
+	rg.writeMu.Lock()
+	defer rg.writeMu.Unlock()
 	ctx = disableStoreTracking(ctx)
 	ctx, task := trace.NewTask(ctx, "hydra/block-gc/refgraph/add-ref")
 	defer task.End()
@@ -84,6 +87,8 @@ func (rg *RefGraph) AddRef(ctx context.Context, subject, object string) error {
 // RemoveRef removes a single gc/ref edge from subject to object.
 // Removing a non-existent edge is a no-op.
 func (rg *RefGraph) RemoveRef(ctx context.Context, subject, object string) error {
+	rg.writeMu.Lock()
+	defer rg.writeMu.Unlock()
 	ctx = disableStoreTracking(ctx)
 	q := quad.Make(quad.IRI(subject), quad.IRI(PredGCRef), quad.IRI(object), nil)
 	return rg.handle.RemoveQuad(ctx, q)
@@ -93,6 +98,8 @@ func (rg *RefGraph) RemoveRef(ctx context.Context, subject, object string) error
 // Small batches run in one Cayley transaction; larger batches chunk at a
 // bounded size while preserving add-before-remove order.
 func (rg *RefGraph) ApplyRefBatch(ctx context.Context, adds, removes []RefEdge) error {
+	rg.writeMu.Lock()
+	defer rg.writeMu.Unlock()
 	ctx = disableStoreTracking(ctx)
 	ctx, task := trace.NewTask(ctx, "hydra/block-gc/refgraph/apply-ref-batch")
 	defer task.End()
@@ -107,6 +114,11 @@ func (rg *RefGraph) ApplyRefBatch(ctx context.Context, adds, removes []RefEdge) 
 
 	if len(adds) == 0 && len(removes) == 0 {
 		return nil
+	}
+	var err error
+	removes, err = rg.filterExistingRemoves(ctx, adds, removes)
+	if err != nil {
+		return err
 	}
 
 	chunks := 0
@@ -144,6 +156,44 @@ func (rg *RefGraph) applyRefBatch(ctx context.Context, adds, removes []RefEdge) 
 		tx.RemoveQuad(quad.Make(quad.IRI(e.Subject), quad.IRI(PredGCRef), quad.IRI(e.Object), nil))
 	}
 	return rg.handle.ApplyTransaction(ctx, tx)
+}
+
+func (rg *RefGraph) filterExistingRemoves(
+	ctx context.Context,
+	adds, removes []RefEdge,
+) ([]RefEdge, error) {
+	added := make(map[RefEdge]struct{}, len(adds))
+	for _, edge := range adds {
+		added[edge] = struct{}{}
+	}
+	existing := make([]RefEdge, 0, len(removes))
+	for _, edge := range removes {
+		if _, ok := added[edge]; ok {
+			existing = append(existing, edge)
+			continue
+		}
+		found, err := rg.hasRef(ctx, edge.Subject, edge.Object)
+		if err != nil {
+			return nil, err
+		}
+		if found {
+			existing = append(existing, edge)
+		}
+	}
+	return existing, nil
+}
+
+func (rg *RefGraph) hasRef(ctx context.Context, subject, object string) (bool, error) {
+	var found bool
+	err := iterateFilteredNodeRefs(ctx, rg.handle, quad.Quad{
+		Subject:   quad.IRI(subject),
+		Predicate: quad.IRI(PredGCRef),
+		Object:    quad.IRI(object),
+	}, quad.Subject, func(graph.Ref) error {
+		found = true
+		return io.EOF
+	})
+	return found, err
 }
 
 // RemoveNodeRefs removes ALL outgoing gc/ref edges for a node.

--- a/db/block/gc/rpc/client/refgraph.go
+++ b/db/block/gc/rpc/client/refgraph.go
@@ -2,6 +2,7 @@ package block_gc_rpc_client
 
 import (
 	"context"
+	"sync"
 
 	"github.com/pkg/errors"
 	"github.com/s4wave/spacewave/db/block"
@@ -12,6 +13,7 @@ import (
 // RefGraph implements RefGraphOps backed by a RefGraph RPC service.
 type RefGraph struct {
 	client block_gc_rpc.SRPCRefGraphClient
+	mu     sync.Mutex
 }
 
 // NewRefGraph constructs a new RefGraph RPC client.
@@ -21,6 +23,12 @@ func NewRefGraph(client block_gc_rpc.SRPCRefGraphClient) *RefGraph {
 
 // AddRef adds a gc/ref edge from subject to object.
 func (r *RefGraph) AddRef(ctx context.Context, subject, object string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.addRef(ctx, subject, object)
+}
+
+func (r *RefGraph) addRef(ctx context.Context, subject, object string) error {
 	resp, err := r.client.AddRef(ctx, &block_gc_rpc.AddRefRequest{
 		Subject: subject,
 		Object:  object,
@@ -36,6 +44,12 @@ func (r *RefGraph) AddRef(ctx context.Context, subject, object string) error {
 
 // RemoveRef removes a single gc/ref edge from subject to object.
 func (r *RefGraph) RemoveRef(ctx context.Context, subject, object string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.removeRef(ctx, subject, object)
+}
+
+func (r *RefGraph) removeRef(ctx context.Context, subject, object string) error {
 	resp, err := r.client.RemoveRef(ctx, &block_gc_rpc.RemoveRefRequest{
 		Subject: subject,
 		Object:  object,
@@ -51,6 +65,8 @@ func (r *RefGraph) RemoveRef(ctx context.Context, subject, object string) error 
 
 // RemoveNodeRefs removes all outgoing gc/ref edges for a node.
 func (r *RefGraph) RemoveNodeRefs(ctx context.Context, node string, markOrphaned bool) ([]string, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	resp, err := r.client.RemoveNodeRefs(ctx, &block_gc_rpc.RemoveNodeRefsRequest{
 		Node:         node,
 		MarkOrphaned: markOrphaned,
@@ -171,15 +187,64 @@ func (r *RefGraph) RemoveObjectRoot(ctx context.Context, objectKey string, ref *
 }
 
 // ApplyRefBatch applies a batch of ref graph edge additions and removals.
-// Falls back to sequential RPC calls since no batch RPC is defined.
+// The RPC protocol has no batch endpoint, so the client serializes the full
+// ownership transition and performs orphan marking before issuing the calls.
 func (r *RefGraph) ApplyRefBatch(ctx context.Context, adds, removes []block_gc.RefEdge) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	owners := make(map[string]map[string]struct{})
+	stagingRemoves := make(map[string]struct{})
+	for _, edge := range removes {
+		if edge.Subject == block_gc.NodeUnreferenced {
+			stagingRemoves[edge.Object] = struct{}{}
+			continue
+		}
+		if block_gc.IsPermanentRoot(edge.Object) {
+			continue
+		}
+		if _, ok := owners[edge.Object]; ok {
+			continue
+		}
+		sources, err := r.GetIncomingRefs(ctx, edge.Object)
+		if err != nil {
+			return err
+		}
+		set := make(map[string]struct{}, len(sources))
+		for _, source := range sources {
+			if source != block_gc.NodeUnreferenced {
+				set[source] = struct{}{}
+			}
+		}
+		owners[edge.Object] = set
+	}
+	for _, edge := range removes {
+		if set, ok := owners[edge.Object]; ok {
+			delete(set, edge.Subject)
+		}
+	}
+	for _, edge := range adds {
+		if set, ok := owners[edge.Object]; ok && edge.Subject != block_gc.NodeUnreferenced {
+			set[edge.Subject] = struct{}{}
+		}
+	}
+	for object, set := range owners {
+		if len(set) == 0 {
+			if _, removingStaging := stagingRemoves[object]; !removingStaging {
+				adds = append(adds, block_gc.RefEdge{
+					Subject: block_gc.NodeUnreferenced,
+					Object:  object,
+				})
+			}
+		}
+	}
 	for _, e := range adds {
-		if err := r.AddRef(ctx, e.Subject, e.Object); err != nil {
+		if err := r.addRef(ctx, e.Subject, e.Object); err != nil {
 			return err
 		}
 	}
 	for _, e := range removes {
-		if err := r.RemoveRef(ctx, e.Subject, e.Object); err != nil {
+		if err := r.removeRef(ctx, e.Subject, e.Object); err != nil {
 			return err
 		}
 	}

--- a/db/block/gc/store.go
+++ b/db/block/gc/store.go
@@ -537,24 +537,14 @@ func (g *GCStoreOps) AddGCRef(ctx context.Context, subject, object string) error
 // RemoveGCRef removes a gc/ref edge from subject to object and marks
 // the object as orphaned if it has no remaining incoming references.
 func (g *GCStoreOps) RemoveGCRef(ctx context.Context, subject, object string) error {
-	if err := g.refGraph.RemoveRef(ctx, subject, object); err != nil {
+	if err := g.refGraph.ApplyRefBatch(ctx, nil, []RefEdge{{
+		Subject: subject,
+		Object:  object,
+	}}); err != nil {
 		if ctx.Err() != nil {
 			return context.Canceled
 		}
 		return errors.Wrap(err, "remove gc ref")
-	}
-	if IsPermanentRoot(object) {
-		return nil
-	}
-	has, err := g.refGraph.HasIncomingRefs(ctx, object)
-	if err != nil {
-		if ctx.Err() != nil {
-			return context.Canceled
-		}
-		return errors.Wrap(err, "check incoming refs")
-	}
-	if !has {
-		return g.refGraph.AddRef(ctx, NodeUnreferenced, object)
 	}
 	return nil
 }

--- a/db/block/gc/store.go
+++ b/db/block/gc/store.go
@@ -164,9 +164,9 @@ func (g *GCStoreOps) BeginReadOperation(ctx context.Context) (block.StoreOps, fu
 	return scoped, release, nil
 }
 
-// PutBlock puts a block into the store and buffers a gc/ref edge for
-// later flush if the block is new. When parentIRI is set, the edge
-// is parentIRI -> block; otherwise unreferenced -> block.
+// PutBlock puts a block into the store and buffers a gc/ref edge for later
+// flush. A parent owns every non-empty block it writes. Without a parent, only
+// new blocks are staged under unreferenced.
 func (g *GCStoreOps) PutBlock(ctx context.Context, data []byte, opts *block.PutOpts) (*block.BlockRef, bool, error) {
 	ctx, task := trace.NewTask(ctx, "hydra/block-gc/store/put-block")
 	defer task.End()
@@ -190,7 +190,7 @@ func (g *GCStoreOps) PutBlock(ctx context.Context, data []byte, opts *block.PutO
 	if storeTrackingDisabled(ctx) {
 		return finish(ref, existed)
 	}
-	if !existed && ref != nil && !ref.GetEmpty() {
+	if ref != nil && !ref.GetEmpty() && (g.parentIRI != "" || !existed) {
 		_, subtask = trace.NewTask(ctx, "hydra/block-gc/store/put-block/buffer-pending-unref")
 		iri := BlockIRI(ref)
 		g.mu.Lock()
@@ -209,13 +209,12 @@ func (g *GCStoreOps) PutBlock(ctx context.Context, data []byte, opts *block.PutO
 }
 
 // PutBlockBatch writes a batch of blocks through the inner store and buffers
-// GC ref edges for all new non-tombstone blocks. The inner store decides
-// whether the batch flows through a native path or an internal fallback.
+// GC ref edges for all non-tombstone blocks. The inner store decides whether
+// the batch flows through a native path or an internal fallback.
 //
-// Tombstone entries are handled via GCStoreOps.RmBlock so refgraph
-// cleanup (outgoing edge removal, orphan cascade) is preserved.
-// Non-tombstone entries that already exist in the store are skipped
-// for GC edge buffering to avoid reviving unreferenced edges.
+// Tombstone entries are handled via GCStoreOps.RmBlock so refgraph cleanup
+// (outgoing edge removal, orphan cascade) is preserved. Existing entries skip
+// unreferenced staging, but a configured parent owns every block it writes.
 func (g *GCStoreOps) PutBlockBatch(ctx context.Context, entries []*block.PutBatchEntry) error {
 	ctx, task := trace.NewTask(ctx, "hydra/block-gc/store/put-block-batch")
 	defer task.End()
@@ -240,26 +239,26 @@ func (g *GCStoreOps) PutBlockBatch(ctx context.Context, entries []*block.PutBatc
 		return g.store.PutBlockBatch(ctx, puts)
 	}
 
-	// Check which blocks already exist so we only buffer GC edges
-	// for genuinely new blocks (matching the single-put !existed guard).
-	newBlock := make([]bool, len(puts))
-	checkCtx, checkTask := trace.NewTask(ctx, "hydra/block-gc/store/put-block-batch/check-existing")
-	refs := make([]*block.BlockRef, len(puts))
-	for i, entry := range puts {
-		if entry.Ref == nil || entry.Ref.GetEmpty() {
-			continue
+	var existing []bool
+	if g.parentIRI == "" {
+		// Staging an existing block under unreferenced could revive a block
+		// that already has real parents.
+		checkCtx, checkTask := trace.NewTask(ctx, "hydra/block-gc/store/put-block-batch/check-existing")
+		refs := make([]*block.BlockRef, len(puts))
+		for i, entry := range puts {
+			if entry.Ref == nil || entry.Ref.GetEmpty() {
+				continue
+			}
+			refs[i] = entry.Ref
 		}
-		refs[i] = entry.Ref
-	}
-	exists, err := g.store.GetBlockExistsBatch(checkCtx, refs)
-	if err != nil {
+		exists, err := g.store.GetBlockExistsBatch(checkCtx, refs)
+		if err != nil {
+			checkTask.End()
+			return err
+		}
+		existing = exists
 		checkTask.End()
-		return err
 	}
-	for i, found := range exists {
-		newBlock[i] = !found
-	}
-	checkTask.End()
 
 	writeCtx, writeTask := trace.NewTask(ctx, "hydra/block-gc/store/put-block-batch/inner-put-block-batch")
 	if err := g.store.PutBlockBatch(writeCtx, puts); err != nil {
@@ -268,17 +267,15 @@ func (g *GCStoreOps) PutBlockBatch(ctx context.Context, entries []*block.PutBatc
 	}
 	writeTask.End()
 
-	// Buffer GC ref edges only for genuinely new blocks.
 	_, subtask := trace.NewTask(ctx, "hydra/block-gc/store/put-block-batch/buffer-pending-unref")
 	g.mu.Lock()
 	for i, entry := range puts {
-		if !newBlock[i] || entry.Ref == nil || entry.Ref.GetEmpty() {
-			if entry.Ref != nil && !entry.Ref.GetEmpty() && len(entry.Refs) != 0 {
-				g.bufferBlockRefsLocked(entry.Ref, entry.Refs)
-			}
+		if entry.Ref == nil || entry.Ref.GetEmpty() {
 			continue
 		}
-		g.pendingUnref = append(g.pendingUnref, BlockIRI(entry.Ref))
+		if g.parentIRI != "" || !existing[i] {
+			g.pendingUnref = append(g.pendingUnref, BlockIRI(entry.Ref))
+		}
 		if len(entry.Refs) != 0 {
 			g.bufferBlockRefsLocked(entry.Ref, entry.Refs)
 		}

--- a/db/block/gc/store.go
+++ b/db/block/gc/store.go
@@ -430,16 +430,33 @@ func (g *GCStoreOps) FlushPending(ctx context.Context) error {
 	if parent == "" {
 		parent = NodeUnreferenced
 	}
+	// Only queue stale staging edges. A no-op removal in the same batch as a
+	// parent add can hide the remaining owner from graph index queries.
+	var unrefSet map[string]struct{}
+	if g.parentIRI != "" && len(unrefs) != 0 {
+		existing, err := g.refGraph.GetOutgoingRefs(ctx, NodeUnreferenced)
+		if err != nil {
+			return errors.Wrap(err, "get unreferenced refs")
+		}
+		unrefSet = make(map[string]struct{}, len(existing))
+		for _, iri := range existing {
+			unrefSet[iri] = struct{}{}
+		}
+	}
 
 	adds := make([]RefEdge, 0, len(unrefs)+len(refs))
+	removes := make([]RefEdge, 0, len(ununrefs)+len(unrefs))
 	for _, iri := range unrefs {
 		adds = append(adds, RefEdge{Subject: parent, Object: iri})
+		if g.parentIRI != "" {
+			if _, ok := unrefSet[iri]; ok {
+				removes = append(removes, RefEdge{Subject: NodeUnreferenced, Object: iri})
+			}
+		}
 	}
 	for _, r := range refs {
 		adds = append(adds, RefEdge{Subject: r.source, Object: r.target})
 	}
-
-	removes := make([]RefEdge, 0, len(ununrefs))
 	for _, iri := range ununrefs {
 		removes = append(removes, RefEdge{Subject: parent, Object: iri})
 	}

--- a/db/block/gc/store.go
+++ b/db/block/gc/store.go
@@ -430,28 +430,14 @@ func (g *GCStoreOps) FlushPending(ctx context.Context) error {
 	if parent == "" {
 		parent = NodeUnreferenced
 	}
-	// Only queue stale staging edges. A no-op removal in the same batch as a
-	// parent add can hide the remaining owner from graph index queries.
-	var unrefSet map[string]struct{}
-	if g.parentIRI != "" && len(unrefs) != 0 {
-		existing, err := g.refGraph.GetOutgoingRefs(ctx, NodeUnreferenced)
-		if err != nil {
-			return errors.Wrap(err, "get unreferenced refs")
-		}
-		unrefSet = make(map[string]struct{}, len(existing))
-		for _, iri := range existing {
-			unrefSet[iri] = struct{}{}
-		}
-	}
-
+	// Parent-backed writes remove their staging edge in the same batch as the
+	// parent edge. RefGraph treats removal of a missing edge as a no-op.
 	adds := make([]RefEdge, 0, len(unrefs)+len(refs))
 	removes := make([]RefEdge, 0, len(ununrefs)+len(unrefs))
 	for _, iri := range unrefs {
 		adds = append(adds, RefEdge{Subject: parent, Object: iri})
 		if g.parentIRI != "" {
-			if _, ok := unrefSet[iri]; ok {
-				removes = append(removes, RefEdge{Subject: NodeUnreferenced, Object: iri})
-			}
+			removes = append(removes, RefEdge{Subject: NodeUnreferenced, Object: iri})
 		}
 	}
 	for _, r := range refs {

--- a/db/block/gc/store_test.go
+++ b/db/block/gc/store_test.go
@@ -2,14 +2,14 @@ package block_gc
 
 import (
 	"context"
-	"slices"
-	"testing"
-
 	"github.com/s4wave/spacewave/db/block"
 	block_mock "github.com/s4wave/spacewave/db/block/mock"
 	block_store_kvtx "github.com/s4wave/spacewave/db/block/store/kvtx"
 	store_kvkey "github.com/s4wave/spacewave/db/store/kvkey"
 	store_kvtx_inmem "github.com/s4wave/spacewave/db/store/kvtx/inmem"
+	"slices"
+	"sync"
+	"testing"
 )
 
 // gcTestEnv holds the test environment for GCStoreOps tests.
@@ -706,6 +706,52 @@ func TestGCStoreOps_ParentIRI_FlushPendingRemovesConcurrentUnref(t *testing.T) {
 	}
 }
 
+// TestGCStoreOps_RemoveGCRefDoesNotReviveStagingAfterParentBatch verifies
+// that orphan marking waits inside the ownership transition.
+func TestGCStoreOps_RemoveGCRefDoesNotReviveStagingAfterParentBatch(t *testing.T) {
+	env := newGCTestEnv(t)
+	ref := env.putBlock(t, "orphan-transition")
+	object := BlockIRI(ref)
+	if err := env.gcStore.AddGCRef(env.ctx, "owner:old", object); err != nil {
+		t.Fatal(err.Error())
+	}
+
+	raceGraph := &orphanRaceRefGraph{
+		RefGraphOps:    env.refGraph,
+		removerStarted: make(chan struct{}),
+		parentDone:     make(chan struct{}),
+	}
+	remover := NewGCStoreOps(env.rawStore, raceGraph)
+	removerErr := make(chan error, 1)
+	go func() {
+		removerErr <- remover.RemoveGCRef(env.ctx, "owner:old", object)
+	}()
+	<-raceGraph.removerStarted
+
+	parent := NewGCStoreOps(env.rawStore, raceGraph)
+	parent.bufferBlockRefs(ref, []*block.BlockRef{ref})
+	if err := parent.FlushPending(env.ctx); err != nil {
+		t.Fatal(err.Error())
+	}
+	if err := <-removerErr; err != nil {
+		t.Fatal(err.Error())
+	}
+
+	if _, err := NewCollector(env.refGraph, env.rawStore, nil).Collect(env.ctx); err != nil {
+		t.Fatal(err.Error())
+	}
+	if !env.blockExists(t, ref) {
+		t.Fatal("parent-owned block should survive collection")
+	}
+	nodes, err := env.refGraph.GetUnreferencedNodes(env.ctx)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if slices.Contains(nodes, object) {
+		t.Fatal("parent-owned block should not be staged as unreferenced")
+	}
+}
+
 // buildBatchEntry creates a PutBatchEntry from a mock block message.
 func buildBatchEntry(t *testing.T, msg string) *block.PutBatchEntry {
 	t.Helper()
@@ -867,6 +913,44 @@ func (r *injectUnrefRefGraph) ApplyRefBatch(
 		}
 	}
 	return r.RefGraphOps.ApplyRefBatch(ctx, adds, removes)
+}
+
+type orphanRaceRefGraph struct {
+	RefGraphOps
+	removerStarted chan struct{}
+	parentDone     chan struct{}
+	startOnce      sync.Once
+	parentOnce     sync.Once
+}
+
+func (r *orphanRaceRefGraph) signalRemoverStarted() {
+	r.startOnce.Do(func() { close(r.removerStarted) })
+}
+
+func (r *orphanRaceRefGraph) signalParentDone() {
+	r.parentOnce.Do(func() { close(r.parentDone) })
+}
+
+func (r *orphanRaceRefGraph) ApplyRefBatch(
+	ctx context.Context,
+	adds, removes []RefEdge,
+) error {
+	removalOnly := len(adds) == 0 && len(removes) == 1 && removes[0].Subject != NodeUnreferenced
+	if removalOnly {
+		r.signalRemoverStarted()
+		<-r.parentDone
+	}
+	err := r.RefGraphOps.ApplyRefBatch(ctx, adds, removes)
+	if len(adds) != 0 {
+		r.signalParentDone()
+	}
+	return err
+}
+
+func (r *orphanRaceRefGraph) HasIncomingRefs(ctx context.Context, node string) (bool, error) {
+	r.signalRemoverStarted()
+	<-r.parentDone
+	return false, nil
 }
 
 func (r *recordingRefGraph) RemoveNodeRefs(context.Context, string, bool) ([]string, error) {

--- a/db/block/gc/store_test.go
+++ b/db/block/gc/store_test.go
@@ -584,6 +584,80 @@ func TestGCStoreOps_ParentIRI_FlushPending(t *testing.T) {
 	}
 }
 
+// TestGCStoreOps_ParentIRI_DedupClearsStaleUnref tests that taking ownership
+// of a block staged under unreferenced removes the stale staging edge.
+func TestGCStoreOps_ParentIRI_DedupClearsStaleUnref(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		batch bool
+	}{
+		{name: "PutBlock"},
+		{name: "PutBlockBatch", batch: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			env := newGCTestEnv(t)
+			var ref *block.BlockRef
+			if tc.batch {
+				entry := buildBatchEntry(t, "parent-dedup-batch")
+				if err := env.gcStore.PutBlockBatch(env.ctx, []*block.PutBatchEntry{entry}); err != nil {
+					t.Fatal(err.Error())
+				}
+				ref = entry.Ref
+			} else {
+				ex := block_mock.NewExample("parent-dedup-single")
+				var err error
+				ref, _, err = block.PutBlock(env.ctx, env.gcStore, ex)
+				if err != nil {
+					t.Fatal(err.Error())
+				}
+			}
+			env.flush(t)
+			nodes, err := env.refGraph.GetUnreferencedNodes(env.ctx)
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			if !slices.Contains(nodes, BlockIRI(ref)) {
+				t.Fatal("block should be staged under unreferenced")
+			}
+
+			parent := BucketIRI("parent-dedup")
+			parentStore := NewGCStoreOpsWithParent(env.rawStore, env.refGraph, parent)
+			if tc.batch {
+				entry := buildBatchEntry(t, "parent-dedup-batch")
+				if err := parentStore.PutBlockBatch(env.ctx, []*block.PutBatchEntry{entry}); err != nil {
+					t.Fatal(err.Error())
+				}
+			} else {
+				ex := block_mock.NewExample("parent-dedup-single")
+				if _, _, err := block.PutBlock(env.ctx, parentStore, ex); err != nil {
+					t.Fatal(err.Error())
+				}
+			}
+			if err := parentStore.FlushPending(env.ctx); err != nil {
+				t.Fatal(err.Error())
+			}
+			nodes, err = env.refGraph.GetUnreferencedNodes(env.ctx)
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			if slices.Contains(nodes, BlockIRI(ref)) {
+				t.Fatal("parent-owned block should not remain unreferenced")
+			}
+
+			if _, err := NewCollector(env.refGraph, env.rawStore, nil).Collect(env.ctx); err != nil {
+				t.Fatal(err.Error())
+			}
+			_, exists, err := parentStore.GetBlock(env.ctx, ref)
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+			if !exists {
+				t.Fatal("parent-owned block should survive collection")
+			}
+		})
+	}
+}
+
 // buildBatchEntry creates a PutBatchEntry from a mock block message.
 func buildBatchEntry(t *testing.T, msg string) *block.PutBatchEntry {
 	t.Helper()

--- a/db/block/gc/store_test.go
+++ b/db/block/gc/store_test.go
@@ -658,6 +658,54 @@ func TestGCStoreOps_ParentIRI_DedupClearsStaleUnref(t *testing.T) {
 	}
 }
 
+// TestGCStoreOps_ParentIRI_FlushPendingRemovesConcurrentUnref tests that a
+// staging edge created after reconciliation begins is removed by the same
+// ref-graph batch as the parent edge.
+func TestGCStoreOps_ParentIRI_FlushPendingRemovesConcurrentUnref(t *testing.T) {
+	env := newGCTestEnv(t)
+	ex := block_mock.NewExample("concurrent-unref")
+	ref, _, err := block.PutBlock(env.ctx, env.gcStore, ex)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	env.flush(t)
+
+	blockIRI := BlockIRI(ref)
+	if err := env.refGraph.RemoveRef(env.ctx, NodeUnreferenced, blockIRI); err != nil {
+		t.Fatal(err.Error())
+	}
+
+	raceGraph := &injectUnrefRefGraph{
+		RefGraphOps: env.refGraph,
+		object:      blockIRI,
+	}
+	parentStore := NewGCStoreOpsWithParent(
+		env.rawStore,
+		raceGraph,
+		BucketIRI("concurrent-unref"),
+	)
+	_, existed, err := block.PutBlock(env.ctx, parentStore, ex)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if !existed {
+		t.Fatal("expected parent write to deduplicate the block")
+	}
+	if err := parentStore.FlushPending(env.ctx); err != nil {
+		t.Fatal(err.Error())
+	}
+	if !raceGraph.injected {
+		t.Fatal("expected concurrent staging edge injection")
+	}
+
+	if _, err := NewCollector(env.refGraph, env.rawStore, nil).Collect(env.ctx); err != nil {
+		t.Fatal(err.Error())
+	}
+	if !env.blockExists(t, ref) {
+		t.Fatal("parent-owned block should survive collection")
+	}
+}
+
 // buildBatchEntry creates a PutBatchEntry from a mock block message.
 func buildBatchEntry(t *testing.T, msg string) *block.PutBatchEntry {
 	t.Helper()
@@ -800,6 +848,25 @@ func (r *recordingRefGraph) ApplyRefBatch(_ context.Context, adds, removes []Ref
 	r.adds = append([]RefEdge(nil), adds...)
 	r.removes = append([]RefEdge(nil), removes...)
 	return nil
+}
+
+type injectUnrefRefGraph struct {
+	RefGraphOps
+	object   string
+	injected bool
+}
+
+func (r *injectUnrefRefGraph) ApplyRefBatch(
+	ctx context.Context,
+	adds, removes []RefEdge,
+) error {
+	if !r.injected {
+		r.injected = true
+		if err := r.RefGraphOps.AddRef(ctx, NodeUnreferenced, r.object); err != nil {
+			return err
+		}
+	}
+	return r.RefGraphOps.ApplyRefBatch(ctx, adds, removes)
 }
 
 func (r *recordingRefGraph) RemoveNodeRefs(context.Context, string, bool) ([]string, error) {


### PR DESCRIPTION
Deleting one bucket could physically remove a deduplicated block still referenced by another bucket. The shared volume reported the second write as existing, and GCStoreOps skipped its parent edge, leaving graph ownership incomplete.

GCStoreOps now records configured parent ownership on every nonempty put in both the single and batch paths. Parentless staging still checks novelty, so rewriting an existing block cannot revive an unreferenced marker. Block formats and APIs remain unchanged.

An in-memory two-bucket regression fails on both write paths before the change because the surviving block is deleted, and passes after the change. Focused GC and world tests pass, and the database packages build.

@codex review