### PR TITLE
fix(provider): bound session transport startup waits

### DIFF
--- a/core/provider/local/account-transport-pairing_test.go
+++ b/core/provider/local/account-transport-pairing_test.go
@@ -1,0 +1,231 @@
+package provider_local
+
+import (
+	"context"
+	"crypto/rand"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/aperturerobotics/util/routine"
+	"github.com/s4wave/spacewave/core/transport"
+	"github.com/s4wave/spacewave/net/crypto"
+	"github.com/s4wave/spacewave/testbed"
+	"github.com/sirupsen/logrus"
+)
+
+func newPairingTransportAccount(ctx context.Context, t *testing.T) (*ProviderAccount, crypto.PrivKey, func()) {
+	t.Helper()
+	tb, err := testbed.Default(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privKey, _, err := crypto.GenerateEd25519Key(rand.Reader)
+	if err != nil {
+		tb.Release()
+		t.Fatal(err)
+	}
+	acc := &ProviderAccount{
+		t:  &providerAccountTracker{p: &Provider{b: tb.Bus}},
+		le: logrus.New().WithField("test", t.Name()),
+	}
+	acc.setPairingContext(ctx)
+	release := func() {
+		acc.StopSessionTransport()
+		acc.ClearPairingState()
+		tb.Release()
+	}
+	return acc, privKey, release
+}
+
+func startTestSessionTransport(
+	ctx context.Context,
+	t *testing.T,
+	acc *ProviderAccount,
+	sessionKey crypto.PrivKey,
+	signalingURL string,
+	startupTimeout time.Duration,
+) *sessionTransportState {
+	t.Helper()
+	st, err := transport.NewSessionTransport(
+		acc.le,
+		acc.t.p.b,
+		sessionKey,
+		signalingURL,
+		"",
+		transport.WithStartupTimeout(startupTimeout),
+		transport.WithStartupRetry(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rc := routine.NewRoutineContainer(routine.WithRetry(providerBackoff))
+	sts := &sessionTransportState{transport: st, rc: rc}
+	rc.SetRoutine(st.Execute)
+	rc.SetContext(ctx, false)
+	acc.transportBcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
+		acc.sessionTransport = sts
+		bcast()
+	})
+	return sts
+}
+
+func waitForPairingStatus(
+	ctx context.Context,
+	t *testing.T,
+	acc *ProviderAccount,
+	status PairingStatus,
+) PairingSnapshot {
+	t.Helper()
+	for {
+		var (
+			waitCh <-chan struct{}
+			snap   PairingSnapshot
+		)
+		acc.GetPairingBroadcast().HoldLock(func(_ func(), getWaitCh func() <-chan struct{}) {
+			waitCh = getWaitCh()
+			snap = acc.GetPairingSnapshot()
+		})
+		if snap.Status == status {
+			return snap
+		}
+		select {
+		case <-ctx.Done():
+			t.Fatalf("pairing status did not become %d: %v", status, ctx.Err())
+		case <-waitCh:
+		}
+	}
+}
+
+func TestTerminalTransportStartupFailurePublishesPairingStatus(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	acc, sessionKey, release := newPairingTransportAccount(ctx, t)
+	defer release()
+
+	var ticketRequests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/api/signal/ticket" {
+			ticketRequests.Add(1)
+		}
+		http.Error(w, "terminal test signaling failure", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	acc.SetPairingCode("TESTCODE", sessionKey)
+	sts := startTestSessionTransport(ctx, t, acc, sessionKey, server.URL, 1500*time.Millisecond)
+	err := acc.waitSessionTransportReady(ctx, sts)
+	if err == nil {
+		t.Fatal("expected terminal startup failure")
+	}
+	if ticketRequests.Load() < 2 {
+		t.Fatalf("startup retry did not retain attempt ownership: %d requests", ticketRequests.Load())
+	}
+
+	snap := waitForPairingStatus(ctx, t, acc, PairingStatusSignalingFailed)
+	if snap.ErrMsg != err.Error() {
+		t.Fatalf("pairing error %q != startup error %q", snap.ErrMsg, err)
+	}
+}
+
+func TestTransportStartupCancellationDoesNotPublishPairingFailure(t *testing.T) {
+	ctx := t.Context()
+	acc, sessionKey, release := newPairingTransportAccount(ctx, t)
+	defer release()
+
+	acc.SetPairingCode("TESTCODE", sessionKey)
+	transportCtx, transportCancel := context.WithCancel(ctx)
+	defer transportCancel()
+	sts := startTestSessionTransport(transportCtx, t, acc, sessionKey, "", time.Second)
+
+	waitCtx, waitCancel := context.WithCancel(ctx)
+	waitCancel()
+	if err := acc.waitSessionTransportReady(waitCtx, sts); !errors.Is(err, context.Canceled) {
+		t.Fatalf("startup cancellation returned %v", err)
+	}
+	snap := acc.GetPairingSnapshot()
+	if snap.Status == PairingStatusSignalingFailed {
+		t.Fatalf("caller cancellation published signaling failure: %q", snap.ErrMsg)
+	}
+}
+
+func TestSupersededTransportStartupDoesNotPublishPairingFailure(t *testing.T) {
+	ctx := t.Context()
+	acc, sessionKey, release := newPairingTransportAccount(ctx, t)
+	defer release()
+
+	acc.SetPairingCode("TESTCODE", sessionKey)
+	transportCtx, transportCancel := context.WithCancel(ctx)
+	defer transportCancel()
+	sts := startTestSessionTransport(transportCtx, t, acc, sessionKey, "", time.Second)
+	sts.setReplaced()
+
+	err := acc.waitSessionTransportReady(ctx, sts)
+	if !errors.Is(err, errSessionTransportSuperseded) {
+		t.Fatalf("superseded startup returned %v", err)
+	}
+	acc.stopSessionTransportState(sts)
+	snap := acc.GetPairingSnapshot()
+	if snap.Status == PairingStatusSignalingFailed {
+		t.Fatalf("supersession published signaling failure: %q", snap.ErrMsg)
+	}
+}
+
+func TestCreateSessionTransportCancellationAfterReadyRecreatesCurrent(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	acc, sessionKey, release := newPairingTransportAccount(ctx, t)
+	defer release()
+
+	sts, err := acc.createSessionTransport(ctx, sessionKey, "")
+	if err != nil {
+		t.Fatalf("createSessionTransport: %v", err)
+	}
+	var stateWaitCh, providerWaitCh <-chan struct{}
+	sts.bcast.HoldLock(func(_ func(), getWaitCh func() <-chan struct{}) {
+		stateWaitCh = getWaitCh()
+	})
+	acc.transportBcast.HoldLock(func(_ func(), getWaitCh func() <-chan struct{}) {
+		providerWaitCh = getWaitCh()
+	})
+
+	cancel()
+	select {
+	case <-stateWaitCh:
+	case <-time.After(time.Second):
+		t.Fatal("ready transport did not publish exit after owner cancellation")
+	}
+	select {
+	case <-providerWaitCh:
+	case <-time.After(time.Second):
+		t.Fatal("ready transport was not removed after owner cancellation")
+	}
+
+	newCtx, newCancel := context.WithTimeout(context.Background(), time.Second)
+	defer newCancel()
+	if err := acc.EnsureSessionTransport(newCtx, sessionKey, ""); err != nil {
+		t.Fatalf("EnsureSessionTransport after cancellation: %v", err)
+	}
+	current := acc.GetSessionTransport()
+	if current == nil || current == sts.transport {
+		t.Fatal("expected cancellation to recreate the current transport")
+	}
+}
+
+func TestSessionTransportReadyCommitRejectsReplacement(t *testing.T) {
+	sts := &sessionTransportState{}
+	sts.setReplaced()
+
+	if sts.setReady() {
+		t.Fatal("replaced transport committed readiness")
+	}
+	sts.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		if sts.ready {
+			t.Fatal("replaced transport recorded readiness")
+		}
+	})
+}

--- a/core/provider/local/account-transport.go
+++ b/core/provider/local/account-transport.go
@@ -2,6 +2,7 @@ package provider_local
 
 import (
 	"context"
+	"time"
 
 	"github.com/aperturerobotics/util/broadcast"
 	"github.com/aperturerobotics/util/routine"
@@ -26,11 +27,56 @@ func (c sessionTransportConfig) matches(peerID peer.ID, signalingURL, signingEnv
 		c.signingEnvPrefix == signingEnvPrefix
 }
 
-// sessionTransportState holds a running SessionTransport.
+// sessionTransportState holds a running SessionTransport and its readiness
+// lifecycle.
 type sessionTransportState struct {
 	transport *transport.SessionTransport
 	rc        *routine.RoutineContainer
 	config    sessionTransportConfig
+
+	bcast    broadcast.Broadcast
+	ready    bool
+	exited   bool
+	replaced bool
+	err      error
+}
+
+func (s *sessionTransportState) setReady() bool {
+	committed := false
+	s.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
+		if s.ready || s.exited || s.replaced {
+			return
+		}
+		s.ready = true
+		committed = true
+		broadcast()
+	})
+	return committed
+}
+
+func (s *sessionTransportState) setReplaced() {
+	s.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
+		if s.replaced {
+			return
+		}
+		s.replaced = true
+		broadcast()
+	})
+}
+
+func (s *sessionTransportState) setExited(err error) {
+	s.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
+		if s.exited {
+			if s.err == nil || errors.Is(s.err, context.Canceled) && !errors.Is(err, context.Canceled) {
+				s.err = err
+				broadcast()
+			}
+			return
+		}
+		s.exited = true
+		s.err = err
+		broadcast()
+	})
 }
 
 type cloudRelayEndpoint struct {
@@ -39,62 +85,147 @@ type cloudRelayEndpoint struct {
 }
 
 var errSessionTransportReplaced = errors.New("session transport replaced before ready")
+var errSessionTransportSuperseded = errors.New("session transport request superseded by newer configuration")
+
+func sessionTransportReplacementContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return sessionTransportCleanupContext(ctx)
+}
+
+func sessionTransportCleanupContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cleanupCtx := context.WithoutCancel(ctx)
+	if deadline, ok := ctx.Deadline(); ok && time.Until(deadline) > 0 {
+		return context.WithDeadline(cleanupCtx, deadline)
+	}
+	timeout := time.Duration(providerBackoff.GetExponential().GetMaxInterval()) * time.Millisecond
+	return context.WithTimeout(cleanupCtx, timeout)
+}
 
 // CreateSessionTransport creates and starts a session transport using the
 // given session private key and signaling URL. If a transport is already
 // running, it is stopped first.
 //
-// The transport runs via a RoutineContainer. On post-Ready failures, the
-// exit callback clears sessionTransport and broadcasts.
+// The transport runs via a retrying RoutineContainer. Startup attempts remain
+// owned by the same transport until readiness or a terminal stop.
 func (a *ProviderAccount) CreateSessionTransport(ctx context.Context, sessionKey crypto.PrivKey, signalingURL string) error {
 	_, err := a.createSessionTransport(ctx, sessionKey, signalingURL)
 	return err
 }
 
 func (a *ProviderAccount) createSessionTransport(ctx context.Context, sessionKey crypto.PrivKey, signalingURL string) (*sessionTransportState, error) {
-	rel, err := a.mtx.Lock(ctx)
+	cleanupCtx, cleanupCancel := sessionTransportReplacementContext(ctx)
+	defer cleanupCancel()
+	rel, err := a.mtx.Lock(cleanupCtx)
 	if err != nil {
 		return nil, err
 	}
-	sts, exitedCh, err := a.startSessionTransportLocked(ctx, sessionKey, signalingURL, "")
+	sts, err := a.startSessionTransportLocked(ctx, cleanupCtx, sessionKey, signalingURL, "")
 	rel()
 	if err != nil {
 		return nil, err
 	}
-	if err := a.waitSessionTransportReady(ctx, sts, exitedCh); err != nil {
+	if err := a.waitSessionTransportReady(ctx, sts); err != nil {
 		return nil, err
 	}
 	return sts, nil
 }
 
-func (a *ProviderAccount) startSessionTransportLocked(ctx context.Context, sessionKey crypto.PrivKey, signalingURL string, signingEnvPrefix string) (*sessionTransportState, <-chan error, error) {
+func (a *ProviderAccount) waitExistingSessionTransportReady(ctx context.Context, sts *sessionTransportState) error {
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		var (
+			providerWaitCh <-chan struct{}
+			stateWaitCh    <-chan struct{}
+			current        bool
+			ready          bool
+			replaced       bool
+			exited         bool
+			exitErr        error
+		)
+		a.transportBcast.HoldLock(func(_ func(), getWaitCh func() <-chan struct{}) {
+			providerWaitCh = getWaitCh()
+			current = a.sessionTransport == sts
+		})
+		sts.bcast.HoldLock(func(_ func(), getWaitCh func() <-chan struct{}) {
+			stateWaitCh = getWaitCh()
+			ready = sts.ready
+			replaced = sts.replaced
+			exited = sts.exited
+			exitErr = sts.err
+		})
+		if replaced {
+			return errSessionTransportSuperseded
+		}
+		if !current {
+			return errSessionTransportReplaced
+		}
+		if ready {
+			return nil
+		}
+		if exited {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			if exitErr == nil {
+				exitErr = errors.New("session transport exited before ready")
+			}
+			return errors.Wrap(exitErr, "session transport failed to start")
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-providerWaitCh:
+		case <-stateWaitCh:
+		}
+	}
+}
+
+func (a *ProviderAccount) startSessionTransportLocked(
+	ctx context.Context,
+	cleanupCtx context.Context,
+	sessionKey crypto.PrivKey,
+	signalingURL string,
+	signingEnvPrefix string,
+) (*sessionTransportState, error) {
 	sessionPeerID, err := peer.IDFromPrivateKey(sessionKey)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "derive session peer ID")
+		return nil, errors.Wrap(err, "derive session peer ID")
 	}
 
-	a.stopSessionTransportLocked()
+	if err := a.stopSessionTransportForReplacementLocked(cleanupCtx); err != nil {
+		return nil, err
+	}
 
-	st, err := transport.NewSessionTransport(a.le, a.t.p.b, sessionKey, signalingURL, signingEnvPrefix)
+	st, err := transport.NewSessionTransport(
+		a.le,
+		a.t.p.b,
+		sessionKey,
+		signalingURL,
+		signingEnvPrefix,
+		transport.WithStartupRetry(),
+	)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "create session transport")
+		return nil, errors.Wrap(err, "create session transport")
 	}
 
-	// exitedCh signals startup failure (Execute returned before Ready).
-	exitedCh := make(chan error, 1)
 	var sts *sessionTransportState
 
 	rc := routine.NewRoutineContainerWithLogger(
 		a.le.WithField("routine", "session-transport"),
+		routine.WithRetry(providerBackoff),
 		routine.WithExitCb(func(err error) {
-			select {
-			case exitedCh <- err:
-			default:
-			}
-			if err != nil && !errors.Is(err, context.Canceled) {
-				a.le.WithError(err).Warn("session transport exited with error")
-				// If a pairing is active, surface the error as SIGNALING_FAILED.
-				a.SetPairingSignalingFailed(err.Error())
+			var ready bool
+			sts.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+				ready = sts.ready
+			})
+			if !ready {
+				// Pre-ready cancellation is cleaned up by the startup waiter.
+				return
 			}
 			a.transportBcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
 				if a.sessionTransport == sts {
@@ -102,6 +233,7 @@ func (a *ProviderAccount) startSessionTransportLocked(ctx context.Context, sessi
 					bcast()
 				}
 			})
+			sts.setExited(err)
 		}),
 	)
 	sts = &sessionTransportState{
@@ -121,41 +253,122 @@ func (a *ProviderAccount) startSessionTransportLocked(ctx context.Context, sessi
 		a.sessionTransport = sts
 		bcast()
 	})
-
-	return sts, exitedCh, nil
+	return sts, nil
 }
 
-func (a *ProviderAccount) waitSessionTransportReady(ctx context.Context, sts *sessionTransportState, exitedCh <-chan error) error {
-	select {
-	case <-ctx.Done():
-		a.stopSessionTransportState(sts)
-		return ctx.Err()
-	case err := <-exitedCh:
-		return errors.Wrap(err, "session transport failed to start")
-	case <-sts.transport.Ready():
-		return nil
+func (a *ProviderAccount) waitSessionTransportReady(ctx context.Context, sts *sessionTransportState) error {
+	cleanup := func(err error) error {
+		return a.cleanupSessionTransportReadyError(ctx, sts, err)
 	}
-}
+	if err := ctx.Err(); err != nil {
+		return cleanup(err)
+	}
+	waitCtx, waitCancel := context.WithCancel(ctx)
+	defer waitCancel()
+	readyErr := make(chan error, 1)
+	go func() {
+		readyErr <- sts.transport.AwaitReady(waitCtx)
+	}()
 
-func (a *ProviderAccount) waitExistingSessionTransportReady(ctx context.Context, sts *sessionTransportState) error {
 	for {
-		var waitCh <-chan struct{}
-		var current bool
+		var (
+			providerWaitCh <-chan struct{}
+			stateWaitCh    <-chan struct{}
+			current        bool
+			ready          bool
+			replaced       bool
+			exited         bool
+			exitErr        error
+		)
 		a.transportBcast.HoldLock(func(_ func(), getWaitCh func() <-chan struct{}) {
-			waitCh = getWaitCh()
+			providerWaitCh = getWaitCh()
 			current = a.sessionTransport == sts
 		})
+		sts.bcast.HoldLock(func(_ func(), getWaitCh func() <-chan struct{}) {
+			stateWaitCh = getWaitCh()
+			ready = sts.ready
+			replaced = sts.replaced
+			exited = sts.exited
+			exitErr = sts.err
+		})
+		if replaced {
+			return errSessionTransportSuperseded
+		}
 		if !current {
 			return errSessionTransportReplaced
 		}
+		if ready {
+			return nil
+		}
+		if exited {
+			if exitErr == nil {
+				exitErr = errors.New("session transport exited before ready")
+			}
+			return errors.Wrap(exitErr, "session transport failed to start")
+		}
+
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
-		case <-sts.transport.Ready():
-			return nil
-		case <-waitCh:
+			return cleanup(ctx.Err())
+		case err := <-readyErr:
+			if err == nil {
+				if sts.setReady() {
+					return nil
+				}
+				continue
+			}
+			return classifySessionTransportReadyError(ctx, sts, err, cleanup)
+		case <-providerWaitCh:
+		case <-stateWaitCh:
 		}
 	}
+}
+
+func (a *ProviderAccount) cleanupSessionTransportReadyError(ctx context.Context, sts *sessionTransportState, err error) error {
+	cleanupCtx, cleanupCancel := sessionTransportCleanupContext(ctx)
+	defer cleanupCancel()
+	rel, lockErr := a.mtx.Lock(cleanupCtx)
+	if lockErr != nil {
+		return lockErr
+	}
+	defer rel()
+
+	var current, replaced bool
+	a.transportBcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		current = a.sessionTransport == sts
+	})
+	sts.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		replaced = sts.replaced
+	})
+	if replaced {
+		return errSessionTransportSuperseded
+	}
+	if !current {
+		return errSessionTransportReplaced
+	}
+
+	if stopErr := a.stopSessionTransportStateLocked(cleanupCtx, sts); stopErr != nil {
+		return stopErr
+	}
+	sts.setExited(err)
+	if !errors.Is(err, context.Canceled) {
+		a.SetPairingSignalingFailed(err.Error())
+	}
+	return err
+}
+
+func classifySessionTransportReadyError(ctx context.Context, sts *sessionTransportState, err error, cleanup func(error) error) error {
+	var replaced bool
+	sts.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		replaced = sts.replaced
+	})
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return cleanup(ctxErr)
+	}
+	if replaced {
+		return errSessionTransportSuperseded
+	}
+	return cleanup(err)
 }
 
 // GetSessionTransport returns the running session transport, or nil.
@@ -187,49 +400,78 @@ func (a *ProviderAccount) GetTransportSnapshotWithWait() (bool, <-chan struct{})
 
 // StopSessionTransport stops the running session transport if any.
 func (a *ProviderAccount) StopSessionTransport() {
-	rel, err := a.mtx.Lock(context.Background())
+	cleanupCtx, cleanupCancel := sessionTransportReplacementContext(nil)
+	defer cleanupCancel()
+	rel, err := a.mtx.Lock(cleanupCtx)
 	if err != nil {
+		a.le.WithError(err).Warn("failed to lock session transport for stop")
 		return
 	}
 	defer rel()
 
-	a.stopSessionTransportLocked()
+	if err := a.stopSessionTransportLocked(cleanupCtx); err != nil {
+		a.le.WithError(err).Warn("failed to stop session transport")
+	}
 }
 
 func (a *ProviderAccount) stopSessionTransportState(sts *sessionTransportState) {
-	rel, err := a.mtx.Lock(context.Background())
+	cleanupCtx, cleanupCancel := sessionTransportReplacementContext(nil)
+	defer cleanupCancel()
+	rel, err := a.mtx.Lock(cleanupCtx)
 	if err != nil {
+		a.le.WithError(err).Warn("failed to lock session transport state for stop")
 		return
 	}
 	defer rel()
 
-	a.stopSessionTransportStateLocked(sts)
+	if err := a.stopSessionTransportStateLocked(cleanupCtx, sts); err != nil {
+		a.le.WithError(err).Warn("failed to stop session transport state")
+	}
 }
 
-func (a *ProviderAccount) stopSessionTransportLocked() {
+func (a *ProviderAccount) stopSessionTransportLocked(ctx context.Context) error {
+	var sts *sessionTransportState
+	a.transportBcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		sts = a.sessionTransport
+	})
+	return a.stopSessionTransportStateLocked(ctx, sts)
+}
+
+func (a *ProviderAccount) stopSessionTransportForReplacementLocked(ctx context.Context) error {
 	var sts *sessionTransportState
 	a.transportBcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
 		sts = a.sessionTransport
 	})
 	if sts == nil {
-		return
+		return nil
 	}
-	a.stopSessionTransportStateLocked(sts)
+	sts.setReplaced()
+	if err := a.stopSessionTransportStateLocked(ctx, sts); err != nil {
+		return errors.Wrap(err, "stop replaced session transport")
+	}
+	return nil
 }
 
-func (a *ProviderAccount) stopSessionTransportStateLocked(sts *sessionTransportState) {
+func (a *ProviderAccount) stopSessionTransportStateLocked(ctx context.Context, sts *sessionTransportState) error {
 	if sts == nil {
-		return
+		return nil
 	}
+	waitCh, _ := sts.rc.SetRoutine(nil)
 	sts.rc.ClearContext()
-	_ = sts.rc.WaitExited(context.Background(), true, nil)
-	// Clear explicitly: WaitExited may return before the exit callback runs.
+	if waitCh != nil {
+		select {
+		case <-waitCh:
+		case <-ctx.Done():
+			return errors.Wrap(ctx.Err(), "wait for session transport routine exit")
+		}
+	}
 	a.transportBcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
 		if a.sessionTransport == sts {
 			a.sessionTransport = nil
 			bcast()
 		}
 	})
+	return nil
 }
 
 // lookupCloudRelayEndpoint resolves the cloud relay endpoint and signing
@@ -281,8 +523,10 @@ func (a *ProviderAccount) ensureSessionTransport(
 	}
 
 	for {
-		rel, err := a.mtx.Lock(ctx)
+		cleanupCtx, cleanupCancel := sessionTransportReplacementContext(ctx)
+		rel, err := a.mtx.Lock(cleanupCtx)
 		if err != nil {
+			cleanupCancel()
 			return nil, false, err
 		}
 
@@ -292,6 +536,7 @@ func (a *ProviderAccount) ensureSessionTransport(
 		})
 		if sts != nil && sts.config.matches(sessionPeerID, relayURL, signingEnvPrefix) {
 			rel()
+			cleanupCancel()
 			a.le.Debug("session transport already exists, skipping creation")
 			err := a.waitExistingSessionTransportReady(ctx, sts)
 			if errors.Is(err, errSessionTransportReplaced) {
@@ -303,12 +548,14 @@ func (a *ProviderAccount) ensureSessionTransport(
 		if sts != nil {
 			a.le.Debug("replacing session transport with requested configuration")
 		}
-		sts, exitedCh, err := a.startSessionTransportLocked(ctx, sessionPriv, relayURL, signingEnvPrefix)
+		sts, err = a.startSessionTransportLocked(ctx, cleanupCtx, sessionPriv, relayURL, signingEnvPrefix)
 		rel()
+		cleanupCancel()
 		if err != nil {
 			return nil, false, err
 		}
-		return sts, true, a.waitSessionTransportReady(ctx, sts, exitedCh)
+		err = a.waitSessionTransportReady(ctx, sts)
+		return sts, true, err
 	}
 }
 

--- a/core/provider/local/pairing_test.go
+++ b/core/provider/local/pairing_test.go
@@ -252,12 +252,17 @@ func TestPairingCreatesTransport(t *testing.T) {
 	defer release()
 
 	// Pre-create transport without signaling (test relay is HTTP only).
+	if err := acc.EnsureSessionTransport(ctx, sess.GetPrivKey(), ""); err != nil {
+		t.Fatalf("settle session transport startup: %v", err)
+	}
+
 	if err := acc.CreateSessionTransport(ctx, sess.GetPrivKey(), ""); err != nil {
 		t.Fatal(err)
 	}
 
 	srv := newPairingRelayServer("")
 	defer srv.Close()
+	defer acc.StopSessionTransport()
 
 	code, err := acc.GeneratePairingCode(ctx, srv.URL, "", sess.GetPrivKey(), sess.GetPeerId())
 	if err != nil {
@@ -290,7 +295,6 @@ func TestPairingCreatesTransport(t *testing.T) {
 		t.Fatal("expected same transport on second call")
 	}
 
-	acc.StopSessionTransport()
 }
 
 // TestCompletePairingWaitsForLink verifies that CompletePairing ensures
@@ -396,8 +400,8 @@ func TestCompletePairingReplacesEmptyTransportWithSignaling(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	if err := acc.CreateSessionTransport(ctx, sess.GetPrivKey(), ""); err != nil {
-		t.Fatal(err)
+	if err := acc.EnsureSessionTransport(ctx, sess.GetPrivKey(), ""); err != nil {
+		t.Fatalf("settle session transport startup: %v", err)
 	}
 
 	got, err := acc.CompletePairing(ctx, srv.URL, "spacewave-staging", "TESTCODE", sess.GetPrivKey(), sess.GetPeerId())

--- a/core/provider/local/session-lock-low-cost_test.go
+++ b/core/provider/local/session-lock-low-cost_test.go
@@ -3,21 +3,45 @@ package provider_local
 import (
 	"context"
 	"crypto/rand"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/aperturerobotics/controllerbus/controller/resolver"
+	websocket "github.com/aperturerobotics/go-websocket"
+	"github.com/aperturerobotics/util/routine"
 	"github.com/aperturerobotics/util/scrub"
 	"github.com/s4wave/spacewave/core/provider"
+	api "github.com/s4wave/spacewave/core/provider/spacewave/api"
 	core_session "github.com/s4wave/spacewave/core/session"
 	session_lock "github.com/s4wave/spacewave/core/session/lock"
 	"github.com/s4wave/spacewave/core/transport"
 	"github.com/s4wave/spacewave/db/util/blockenc"
+	bifrost_crypto "github.com/s4wave/spacewave/net/crypto"
 	"github.com/s4wave/spacewave/net/keypem"
+	"github.com/s4wave/spacewave/net/peer"
 	"github.com/s4wave/spacewave/testbed"
 	"github.com/zeebo/blake3"
 	"golang.org/x/crypto/scrypt"
 )
+
+type observedDoneContext struct {
+	context.Context
+	observed chan struct{}
+	once     sync.Once
+}
+
+func (c *observedDoneContext) Done() <-chan struct{} {
+	c.once.Do(func() {
+		close(c.observed)
+	})
+	return c.Context.Done()
+}
 
 func TestMountedPINUnlockRestoresLocalSessionStateLowCost(t *testing.T) {
 	ctx := t.Context()
@@ -58,7 +82,8 @@ func TestMountedPINUnlockRestoresLocalSessionStateLowCost(t *testing.T) {
 }
 
 func TestEnsureSessionTransportReleasesAccountLockWhileWaitingReady(t *testing.T) {
-	ctx := t.Context()
+	ctx, ctxCancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer ctxCancel()
 	_, _, acc, sess, release := setupProviderAndSessionInternal(ctx, t)
 	defer release()
 	acc.StopSessionTransport()
@@ -97,11 +122,263 @@ func TestEnsureSessionTransportReleasesAccountLockWhileWaitingReady(t *testing.T
 	rel()
 
 	cancel()
-	<-done
+	select {
+	case <-done:
+	case <-ctx.Done():
+		t.Fatalf("transport wait did not return after cancellation: %v", ctx.Err())
+	}
 }
 
+func TestSessionTransportReadyErrorCleanupHonorsCallerDeadline(t *testing.T) {
+	ctx, ctxCancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer ctxCancel()
+	acc, _, release := newPairingTransportAccount(ctx, t)
+	defer release()
+
+	rel, err := acc.mtx.Lock(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleanupCtx, cleanupCancel := context.WithTimeout(ctx, 50*time.Millisecond)
+	defer cleanupCancel()
+	done := make(chan error, 1)
+	go func() {
+		done <- acc.cleanupSessionTransportReadyError(
+			cleanupCtx,
+			&sessionTransportState{},
+			errors.New("startup timeout"),
+		)
+	}()
+
+	select {
+	case err := <-done:
+		rel()
+		if err == nil || !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("cleanup returned %v, want bounded context cancellation", err)
+		}
+	case <-time.After(time.Second):
+		rel()
+		t.Fatal("cleanup remained blocked on the account owner")
+	}
+}
+
+func TestSessionTransportReadyErrorCleanupUsesFreshBudgetAfterCallerExpiry(t *testing.T) {
+	ctx, ctxCancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer ctxCancel()
+	acc, sessionKey, release := newPairingTransportAccount(ctx, t)
+	defer release()
+
+	requestStarted := make(chan struct{})
+	var requestOnce sync.Once
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestOnce.Do(func() {
+			close(requestStarted)
+		})
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	st, err := transport.NewSessionTransport(
+		acc.le,
+		acc.t.p.b,
+		sessionKey,
+		server.URL,
+		"",
+		transport.WithStartupTimeout(time.Second),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rc := routine.NewRoutineContainer()
+	rc.SetRoutine(st.Execute)
+	runCtx, runCancel := context.WithCancel(ctx)
+	defer runCancel()
+	rc.SetContext(runCtx, false)
+	peerID, err := peer.IDFromPrivateKey(sessionKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sts := &sessionTransportState{
+		transport: st,
+		rc:        rc,
+		config:    sessionTransportConfig{peerID: peerID},
+	}
+	acc.transportBcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
+		acc.sessionTransport = sts
+		bcast()
+	})
+
+	ownerRelease, err := acc.mtx.Lock(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	callerCtx, callerCancel := context.WithTimeout(ctx, 100*time.Millisecond)
+	defer callerCancel()
+	done := make(chan error, 1)
+	go func() {
+		done <- acc.waitSessionTransportReady(callerCtx, sts)
+	}()
+
+	select {
+	case <-requestStarted:
+	case <-callerCtx.Done():
+		ownerRelease()
+		t.Fatal("transport startup did not reach its causal request")
+	}
+	select {
+	case <-callerCtx.Done():
+	case <-ctx.Done():
+		ownerRelease()
+		t.Fatalf("caller context did not expire: %v", ctx.Err())
+	}
+	ownerRelease()
+
+	var cleanupErr error
+	select {
+	case cleanupErr = <-done:
+	case <-ctx.Done():
+		t.Fatalf("cleanup did not return after releasing the account owner: %v", ctx.Err())
+	}
+	if cleanupErr == nil || !errors.Is(cleanupErr, context.Canceled) && !errors.Is(cleanupErr, context.DeadlineExceeded) {
+		t.Fatalf("expired caller returned %v, want caller cancellation", cleanupErr)
+	}
+
+	var current *sessionTransportState
+	acc.transportBcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		current = acc.sessionTransport
+	})
+	if current != nil {
+		t.Fatal("expired caller left dead transport current")
+	}
+	var exited bool
+	sts.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		exited = sts.exited
+	})
+	if !exited {
+		t.Fatal("expired caller did not publish dead transport exit")
+	}
+
+	replacementCtx, replacementCancel := context.WithTimeout(ctx, time.Second)
+	defer replacementCancel()
+	if err := acc.EnsureSessionTransport(replacementCtx, sessionKey, ""); err != nil {
+		t.Fatalf("same-configuration replacement: %v", err)
+	}
+	replacement := acc.GetSessionTransport()
+	if replacement == nil || replacement == sts.transport {
+		t.Fatal("same-configuration ensure did not create a replacement")
+	}
+}
+
+func TestCanceledSessionTransportCreatorStopsPendingState(t *testing.T) {
+	if runtime.GOOS == "js" {
+		t.Skip("causal startup cancellation test requires native HTTP server context and WebSocket support")
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	acc, sessionKey, release := newPairingTransportAccount(ctx, t)
+	defer release()
+
+	var ticketRequests atomic.Int32
+	requestStarted := make(chan struct{}, 1)
+	requestCanceled := make(chan struct{}, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/signal/ticket":
+			if ticketRequests.Add(1) == 1 {
+				requestStarted <- struct{}{}
+				<-r.Context().Done()
+				requestCanceled <- struct{}{}
+				return
+			}
+			data, err := (&api.SignalTicketResponse{Token: "test-token"}).MarshalVT()
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(data)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/signal/ws":
+			conn, err := websocket.Accept(w, r, nil)
+			if err != nil {
+				return
+			}
+			defer conn.Close(websocket.StatusNormalClosure, "")
+			<-r.Context().Done()
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	creatorCtx, creatorCancel := context.WithCancel(ctx)
+	type ensureResult struct {
+		sts *sessionTransportState
+		err error
+	}
+	creatorDone := make(chan ensureResult, 1)
+	go func() {
+		sts, _, err := acc.ensureSessionTransport(creatorCtx, sessionKey, server.URL, "")
+		creatorDone <- ensureResult{sts: sts, err: err}
+	}()
+
+	select {
+	case <-requestStarted:
+	case <-ctx.Done():
+		t.Fatalf("creator did not reach signaling startup: %v", ctx.Err())
+	}
+	creatorCancel()
+	select {
+	case <-requestCanceled:
+	case <-ctx.Done():
+		t.Fatalf("signaling request did not observe creator cancellation: %v", ctx.Err())
+	}
+
+	var result ensureResult
+	select {
+	case result = <-creatorDone:
+	case <-ctx.Done():
+		t.Fatalf("creator did not return after cancellation: %v", ctx.Err())
+	}
+	if !errors.Is(result.err, context.Canceled) {
+		t.Fatalf("creator returned %v, want context cancellation", result.err)
+	}
+	if result.sts == nil {
+		t.Fatal("creator did not return its pending transport state")
+	}
+	var exited bool
+	var exitErr error
+	result.sts.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		exited = result.sts.exited
+		exitErr = result.sts.err
+	})
+	if !exited {
+		t.Fatal("canceled creator did not publish transport exit")
+	}
+	if !errors.Is(exitErr, context.Canceled) {
+		t.Fatalf("canceled creator exit error = %v, want context cancellation", exitErr)
+	}
+	if acc.GetSessionTransport() != nil {
+		t.Fatal("canceled creator left its transport current")
+	}
+
+	replacement, created, err := acc.ensureSessionTransport(ctx, sessionKey, server.URL, "")
+	if err != nil {
+		t.Fatalf("same-configuration ensure after cancellation failed: %v", err)
+	}
+	if !created {
+		t.Fatal("same-configuration ensure reused the abandoned transport")
+	}
+	if replacement == result.sts {
+		t.Fatal("same-configuration ensure returned the abandoned transport")
+	}
+	if replacement.transport.GetChildBus() == nil {
+		t.Fatal("replacement transport was not usable after readiness")
+	}
+}
 func TestEnsureSessionTransportRetriesWhenExistingTransportClearsBeforeReady(t *testing.T) {
-	ctx := t.Context()
+	ctx, ctxCancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer ctxCancel()
 	_, _, acc, sess, release := setupProviderAndSessionInternal(ctx, t)
 	defer release()
 	acc.StopSessionTransport()
@@ -148,17 +425,446 @@ func TestEnsureSessionTransportRetriesWhenExistingTransportClearsBeforeReady(t *
 
 	clearFakeState()
 
-	completeCtx, completeCancel := context.WithTimeout(ctx, time.Second)
-	defer completeCancel()
 	select {
 	case err := <-done:
 		if err != nil {
 			t.Fatalf("ensure session transport after cleared state: %v", err)
 		}
-	case <-completeCtx.Done():
+	case <-ctx.Done():
 		cancel()
-		err := <-done
-		t.Fatalf("ensure session transport remained blocked after cleared state: %v", err)
+		t.Fatalf("ensure session transport remained blocked after cleared state: %v", ctx.Err())
+	}
+}
+
+func TestEnsureSessionTransportCoalescesSameConfiguration(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	_, _, acc, sess, release := setupProviderAndSessionInternal(ctx, t)
+	defer release()
+	acc.StopSessionTransport()
+
+	first, created, err := acc.ensureSessionTransport(ctx, sess.GetPrivKey(), "", "")
+	if err != nil {
+		t.Fatalf("first ensure failed: %v", err)
+	}
+	if !created {
+		t.Fatal("first ensure did not create the transport")
+	}
+	second, created, err := acc.ensureSessionTransport(ctx, sess.GetPrivKey(), "", "")
+	if err != nil {
+		t.Fatalf("same-configuration ensure failed: %v", err)
+	}
+	if created {
+		t.Fatal("same-configuration ensure created a second transport")
+	}
+	if second != first {
+		t.Fatal("same-configuration ensure did not coalesce onto the existing transport")
+	}
+}
+
+func TestExistingSessionTransportWaitReturnsStateExit(t *testing.T) {
+	baseCtx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	_, _, acc, sess, release := setupProviderAndSessionInternal(baseCtx, t)
+	defer release()
+	acc.StopSessionTransport()
+
+	fakeTransport, err := transport.NewSessionTransport(acc.le, acc.t.p.b, sess.GetPrivKey(), "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fakeState := &sessionTransportState{
+		transport: fakeTransport,
+		rc:        routine.NewRoutineContainer(),
+	}
+	acc.transportBcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
+		acc.sessionTransport = fakeState
+		bcast()
+	})
+	defer func() {
+		acc.transportBcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
+			if acc.sessionTransport == fakeState {
+				acc.sessionTransport = nil
+				bcast()
+			}
+		})
+	}()
+
+	observed := make(chan struct{})
+	waitCtx := &observedDoneContext{
+		Context:  baseCtx,
+		observed: observed,
+	}
+	done := make(chan error, 1)
+	go func() {
+		done <- acc.waitExistingSessionTransportReady(waitCtx, fakeState)
+	}()
+	select {
+	case <-observed:
+	case <-baseCtx.Done():
+		t.Fatalf("waiter did not enter its wait path: %v", baseCtx.Err())
+	}
+	fakeState.setExited(context.Canceled)
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("wait returned %v, want state cancellation", err)
+		}
+	case <-baseCtx.Done():
+		t.Fatalf("state exit did not wake existing wait: %v", baseCtx.Err())
+	}
+}
+
+func TestExistingSessionTransportWaitReturnsSuperseded(t *testing.T) {
+	baseCtx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	_, _, acc, sess, release := setupProviderAndSessionInternal(baseCtx, t)
+	defer release()
+	acc.StopSessionTransport()
+
+	fakeTransport, err := transport.NewSessionTransport(acc.le, acc.t.p.b, sess.GetPrivKey(), "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fakeState := &sessionTransportState{
+		transport: fakeTransport,
+		rc:        routine.NewRoutineContainer(),
+	}
+	acc.transportBcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
+		acc.sessionTransport = fakeState
+		bcast()
+	})
+	defer func() {
+		acc.transportBcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
+			if acc.sessionTransport == fakeState {
+				acc.sessionTransport = nil
+				bcast()
+			}
+		})
+	}()
+
+	observed := make(chan struct{})
+	waitCtx := &observedDoneContext{
+		Context:  baseCtx,
+		observed: observed,
+	}
+	done := make(chan error, 1)
+	go func() {
+		done <- acc.waitExistingSessionTransportReady(waitCtx, fakeState)
+	}()
+	select {
+	case <-observed:
+	case <-baseCtx.Done():
+		t.Fatalf("waiter did not enter its wait path: %v", baseCtx.Err())
+	}
+	fakeState.setReplaced()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, errSessionTransportSuperseded) {
+			t.Fatalf("wait returned %v, want superseded signal", err)
+		}
+	case <-baseCtx.Done():
+		t.Fatalf("replacement did not wake existing wait: %v", baseCtx.Err())
+	}
+}
+
+func TestSessionTransportReadyErrorClassifiesReplacementFromFreshState(t *testing.T) {
+	ctx := t.Context()
+	sts := &sessionTransportState{}
+	readyResult := make(chan error, 1)
+	readyResult <- context.Canceled
+
+	var stateWaitCh <-chan struct{}
+	sts.bcast.HoldLock(func(_ func(), getWaitCh func() <-chan struct{}) {
+		stateWaitCh = getWaitCh()
+	})
+	sts.setReplaced()
+
+	select {
+	case <-readyResult:
+	default:
+		t.Fatal("readiness result was not eligible")
+	}
+	select {
+	case <-stateWaitCh:
+	default:
+		t.Fatal("replacement notification was not eligible")
+	}
+
+	err := classifySessionTransportReadyError(ctx, sts, context.Canceled, func(err error) error {
+		t.Fatalf("cleanup called for superseded transport: %v", err)
+		return err
+	})
+	if !errors.Is(err, errSessionTransportSuperseded) {
+		t.Fatalf("ready error classification = %v, want superseded signal", err)
+	}
+}
+
+func TestSessionTransportReadyErrorCleanupRechecksSupersession(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	acc, oldPriv, release := newPairingTransportAccount(ctx, t)
+	defer release()
+	acc.SetPairingCode("TESTCODE", oldPriv)
+
+	oldTransport, err := transport.NewSessionTransport(acc.le, acc.t.p.b, oldPriv, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldRC := routine.NewRoutineContainer()
+	oldRC.SetRoutine(func(ctx context.Context) error {
+		<-ctx.Done()
+		return ctx.Err()
+	})
+	oldRC.SetContext(ctx, false)
+	oldPeerID, err := peer.IDFromPrivateKey(oldPriv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldState := &sessionTransportState{
+		transport: oldTransport,
+		rc:        oldRC,
+		config:    sessionTransportConfig{peerID: oldPeerID},
+	}
+	acc.transportBcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
+		acc.sessionTransport = oldState
+		bcast()
+	})
+
+	cleanupStarted := make(chan struct{})
+	releaseCleanup := make(chan struct{})
+	oldDone := make(chan error, 1)
+	go func() {
+		oldDone <- classifySessionTransportReadyError(
+			ctx,
+			oldState,
+			context.DeadlineExceeded,
+			func(err error) error {
+				close(cleanupStarted)
+				<-releaseCleanup
+				return acc.cleanupSessionTransportReadyError(ctx, oldState, err)
+			},
+		)
+	}()
+	select {
+	case <-cleanupStarted:
+	case <-ctx.Done():
+		t.Fatalf("old startup did not reach cleanup overlap: %v", ctx.Err())
+	}
+
+	newPriv, _, err := bifrost_crypto.GenerateEd25519Key(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newDone := make(chan error, 1)
+	go func() {
+		_, _, err := acc.ensureSessionTransport(ctx, newPriv, "", "")
+		newDone <- err
+	}()
+	select {
+	case err := <-newDone:
+		if err != nil {
+			t.Fatalf("new configuration failed to start: %v", err)
+		}
+	case <-ctx.Done():
+		t.Fatalf("new configuration did not become ready: %v", ctx.Err())
+	}
+	close(releaseCleanup)
+
+	select {
+	case err := <-oldDone:
+		if !errors.Is(err, errSessionTransportSuperseded) {
+			t.Fatalf("superseded startup returned %v, want superseded error", err)
+		}
+	case <-ctx.Done():
+		t.Fatalf("superseded startup did not return: %v", ctx.Err())
+	}
+	snapshot := acc.GetPairingSnapshot()
+	if snapshot.Status == PairingStatusSignalingFailed {
+		t.Fatalf("superseded startup published stale pairing failure: %q", snapshot.ErrMsg)
+	}
+}
+
+func TestSessionTransportReplacementReturnsSupersededSignal(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	_, _, acc, sess, release := setupProviderAndSessionInternal(ctx, t)
+	defer release()
+	acc.StopSessionTransport()
+
+	st, err := transport.NewSessionTransport(acc.le, acc.t.p.b, sess.GetPrivKey(), "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rc := routine.NewRoutineContainer()
+	sts := &sessionTransportState{
+		transport: st,
+		rc:        rc,
+	}
+	runCtx := t.Context()
+	rc.SetRoutine(st.Execute)
+	rc.SetContext(runCtx, false)
+
+	rel, err := acc.mtx.Lock(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	acc.transportBcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
+		acc.sessionTransport = sts
+		bcast()
+	})
+	if err := acc.stopSessionTransportForReplacementLocked(ctx); err != nil {
+		rel()
+		t.Fatalf("stop session transport for replacement: %v", err)
+	}
+	rel()
+
+	err = acc.waitSessionTransportReady(ctx, sts)
+	if !errors.Is(err, errSessionTransportSuperseded) {
+		t.Fatalf("replacement wait returned %v, want superseded signal", err)
+	}
+}
+
+func TestSessionTransportReplacementReportsUncooperativeRoutine(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	_, _, acc, sess, release := setupProviderAndSessionInternal(ctx, t)
+	defer release()
+	acc.StopSessionTransport()
+
+	st, err := transport.NewSessionTransport(acc.le, acc.t.p.b, sess.GetPrivKey(), "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rc := routine.NewRoutineContainer()
+	started := make(chan struct{})
+	releaseRoutine := make(chan struct{})
+	routineExited := make(chan struct{})
+	rc.SetRoutine(func(context.Context) error {
+		close(started)
+		<-releaseRoutine
+		close(routineExited)
+		return nil
+	})
+	rc.SetContext(ctx, false)
+	sts := &sessionTransportState{transport: st, rc: rc}
+	acc.transportBcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
+		acc.sessionTransport = sts
+		bcast()
+	})
+
+	rel, err := acc.mtx.Lock(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-started:
+	case <-ctx.Done():
+		rel()
+		t.Fatalf("old routine did not start: %v", ctx.Err())
+	}
+	stopCtx, stopCancel := context.WithTimeout(ctx, 50*time.Millisecond)
+	err = acc.stopSessionTransportForReplacementLocked(stopCtx)
+	stopCancel()
+	rel()
+	if err == nil {
+		t.Fatal("replacement returned nil while old routine ignored cancellation")
+	}
+	var current *sessionTransportState
+	acc.transportBcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		current = acc.sessionTransport
+	})
+	if current != sts {
+		t.Fatal("replacement removed the current state after an unconfirmed stop")
+	}
+
+	close(releaseRoutine)
+	select {
+	case <-routineExited:
+	case <-ctx.Done():
+		t.Fatalf("old routine did not exit after release: %v", ctx.Err())
+	}
+}
+func TestSupersededSessionTransportCreatorKeepsNewConfiguration(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	_, _, acc, sess, release := setupProviderAndSessionInternal(ctx, t)
+	defer release()
+	if _, _, err := acc.ensureSessionTransport(ctx, sess.GetPrivKey(), "", ""); err != nil {
+		t.Fatalf("settle session transport startup: %v", err)
+	}
+
+	var requestCount atomic.Int32
+	requestStarted := make(chan struct{}, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if requestCount.Add(1) == 1 {
+			requestStarted <- struct{}{}
+			<-r.Context().Done()
+			return
+		}
+		http.Error(w, "stale transport recreation", http.StatusServiceUnavailable)
+	}))
+	defer func() {
+		cancel()
+		server.Close()
+	}()
+
+	oldPriv := sess.GetPrivKey()
+	newPriv, _, err := bifrost_crypto.GenerateEd25519Key(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	oldDone := make(chan error, 1)
+	go func() {
+		_, _, err := acc.ensureSessionTransport(ctx, oldPriv, server.URL, "old")
+		oldDone <- err
+	}()
+
+	select {
+	case <-requestStarted:
+	case <-ctx.Done():
+		t.Fatalf("old transport did not reach signaling startup: %v", ctx.Err())
+	}
+
+	newDone := make(chan error, 1)
+	go func() {
+		_, _, err := acc.ensureSessionTransport(ctx, newPriv, "", "")
+		newDone <- err
+	}()
+	select {
+	case err := <-newDone:
+		if err != nil {
+			t.Fatalf("new transport failed to start: %v", err)
+		}
+	case <-ctx.Done():
+		t.Fatalf("new transport did not become ready: %v", ctx.Err())
+	}
+
+	select {
+	case err := <-oldDone:
+		if !errors.Is(err, errSessionTransportSuperseded) {
+			t.Fatalf("superseded creator returned %v, want superseded error", err)
+		}
+	case <-ctx.Done():
+		t.Fatalf("superseded creator did not return: %v", ctx.Err())
+	}
+
+	var current *sessionTransportState
+	acc.transportBcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		current = acc.sessionTransport
+	})
+	if current == nil {
+		t.Fatal("superseded creator removed the newer transport")
+	}
+	newPeerID, err := peer.IDFromPrivateKey(newPriv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !current.config.matches(newPeerID, "", "") {
+		t.Fatalf("current transport configuration = %+v, want peer %s with empty relay", current.config, newPeerID)
 	}
 }
 

--- a/core/provider/local/session.go
+++ b/core/provider/local/session.go
@@ -143,13 +143,13 @@ func (s *Session) UnlockSession(ctx context.Context, pin []byte) error {
 	if s.tkr.cloudAccountID != "" {
 		relay = s.tkr.a.lookupCloudRelayEndpoint(transportCtx)
 	}
-	if _, _, err := s.tkr.a.ensureSessionTransport(transportCtx, privKey, relay.url, relay.signingEnvPrefix); err != nil {
-		if errors.Is(err, context.Canceled) {
+	_, _, transportErr := s.tkr.a.ensureSessionTransport(transportCtx, privKey, relay.url, relay.signingEnvPrefix)
+	if transportErr != nil {
+		if errors.Is(transportErr, context.Canceled) {
 			return context.Canceled
 		}
-		s.tkr.a.le.WithError(err).Warn("failed to start session transport after unlock")
-	}
-	if st := s.tkr.a.GetSessionTransport(); st != nil {
+		s.tkr.a.le.WithError(transportErr).Warn("failed to start session transport after unlock")
+	} else if st := s.tkr.a.GetSessionTransport(); st != nil {
 		if err := s.tkr.a.AutoStartP2PSyncIfPaired(transportCtx, st); err != nil {
 			s.tkr.a.le.WithError(err).Warn("failed to auto-start P2P sync after unlock")
 		}
@@ -491,8 +491,7 @@ func (t *sessionTracker) executeSessionTracker(rctx context.Context) (rerr error
 			return context.Canceled
 		}
 		le.WithError(err).Warn("failed to start session transport")
-	}
-	if st := t.a.GetSessionTransport(); st != nil {
+	} else if st := t.a.GetSessionTransport(); st != nil {
 		// Restore P2P sync controllers for accounts that already have paired
 		// devices, so a session that was paired in a prior mount resumes
 		// DEX/SOSync without requiring an explicit re-pair.

--- a/core/provider/local/transport_test.go
+++ b/core/provider/local/transport_test.go
@@ -1,8 +1,6 @@
 package provider_local_test
 
-import (
-	"testing"
-)
+import "testing"
 
 // TestSessionTransportCreate verifies that CreateSessionTransport creates a
 // transport with the session's private key and the child bus resolves the peer.

--- a/core/provider/spacewave/account-transport-native_test.go
+++ b/core/provider/spacewave/account-transport-native_test.go
@@ -5,12 +5,26 @@ package provider_spacewave
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/aperturerobotics/controllerbus/controller/resolver"
+	websocket "github.com/aperturerobotics/go-websocket"
+	"github.com/aperturerobotics/util/ccontainer"
+	"github.com/aperturerobotics/util/keyed"
+	"github.com/aperturerobotics/util/routine"
+	"github.com/s4wave/spacewave/core/provider"
+	api "github.com/s4wave/spacewave/core/provider/spacewave/api"
+	"github.com/s4wave/spacewave/core/session"
+	session_controller "github.com/s4wave/spacewave/core/session/controller"
+	"github.com/s4wave/spacewave/core/sobject"
+	"github.com/s4wave/spacewave/testbed"
+	"github.com/sirupsen/logrus"
 )
 
 // These tests exercise the native WebRTC session transport startup lifecycle,
@@ -18,6 +32,323 @@ import (
 // The goscript browser build replaces that selector with a no-op (browser
 // sessions obtain transport from the web runtime), so the signal-ticket
 // lifecycle does not exist there and these tests only apply to the native build.
+
+func TestCreateSessionTransportCancellationAfterReadyClearsCurrentTransport(t *testing.T) {
+	acc := NewTestProviderAccount(t, "http://example.invalid")
+	priv, _ := generateTestKeypair(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := acc.CreateSessionTransport(ctx, priv, ""); err != nil {
+		t.Fatalf("CreateSessionTransport: %v", err)
+	}
+
+	var sts *sessionTransportState
+	acc.transportBcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		sts = acc.sessionTransports[""]
+	})
+	if sts == nil {
+		t.Fatal("expected ready session transport state")
+	}
+	var stateWaitCh <-chan struct{}
+	sts.bcast.HoldLock(func(_ func(), getWaitCh func() <-chan struct{}) {
+		stateWaitCh = getWaitCh()
+	})
+	running, transportWaitCh := acc.GetTransportSnapshotWithWait()
+	if !running {
+		t.Fatal("expected transport snapshot to report running")
+	}
+
+	cancel()
+
+	select {
+	case <-stateWaitCh:
+	case <-time.After(time.Second):
+		t.Fatal("transport exit was not published")
+	}
+	select {
+	case <-transportWaitCh:
+	case <-time.After(time.Second):
+		t.Fatal("transport removal was not published")
+	}
+
+	sts.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		if !sts.exited {
+			t.Fatal("expected canceled ready transport to publish exit")
+		}
+	})
+	if st := acc.GetSessionTransport(); st != nil {
+		t.Fatal("expected canceled ready session transport to be cleared")
+	}
+	running, _ = acc.GetTransportSnapshotWithWait()
+	if running {
+		t.Fatal("expected canceled transport snapshot to report not running")
+	}
+
+}
+
+type testSessionTransportStatusError struct {
+	statusCode int
+}
+
+func (e *testSessionTransportStatusError) Error() string {
+	return "transport message changed"
+}
+
+func (e *testSessionTransportStatusError) StatusCode() int {
+	return e.statusCode
+}
+
+func TestMountedSessionReRegistersAfterUnauthorizedTransport(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 8*time.Second)
+	defer cancel()
+
+	firstTicketStarted := make(chan struct{})
+	releaseFirstTicket := make(chan struct{})
+	firstRegistration := make(chan struct{})
+	reregistration := make(chan struct{})
+	secondTicketStarted := make(chan struct{})
+	permitSecondTicket := make(chan struct{})
+	var registrations atomic.Int32
+	var tickets atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/account/session/register":
+			switch registrations.Add(1) {
+			case 1:
+				close(firstRegistration)
+			case 2:
+				close(reregistration)
+			}
+			response, err := (&api.RegisterSessionResponse{
+				AccountId:        "test-account",
+				ObservedMetadata: &api.ObservedSessionMetadata{Label: "test"},
+			}).MarshalVT()
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(response)
+		case "/api/signal/ticket":
+			switch tickets.Add(1) {
+			case 1:
+				close(firstTicketStarted)
+				<-releaseFirstTicket
+				http.Error(w, "wrapped unauthorized response", http.StatusUnauthorized)
+			case 2:
+				close(secondTicketStarted)
+				<-permitSecondTicket
+				response, err := (&api.SignalTicketResponse{Token: "test-token"}).MarshalVT()
+				if err != nil {
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+					return
+				}
+				w.Header().Set("Content-Type", "application/octet-stream")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(response)
+			default:
+				http.Error(w, "unexpected extra ticket", http.StatusInternalServerError)
+			}
+		case "/api/signal/ws":
+			conn, err := websocket.Accept(w, r, nil)
+			if err != nil {
+				return
+			}
+			defer conn.Close(websocket.StatusNormalClosure, "")
+			<-r.Context().Done()
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	tb, err := testbed.Default(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tb.Release()
+	tb.StaticResolver.AddFactory(session_controller.NewFactory(tb.Bus))
+	_, controllerRef, err := tb.Bus.AddDirective(
+		resolver.NewLoadControllerWithConfig(&session_controller.Config{
+			VolumeId: tb.Volume.GetID(),
+		}),
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer controllerRef.Release()
+	sessionController, sessionControllerRef, err := session.ExLookupSessionController(ctx, tb.Bus, "", false, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sessionControllerRef.Release()
+
+	priv, pid := generateTestKeypair(t)
+	sessionID := "session-401"
+	sessionRef := &session.SessionRef{
+		ProviderResourceRef: &provider.ProviderResourceRef{
+			Id:                sessionID,
+			ProviderId:        "spacewave",
+			ProviderAccountId: "test-account",
+		},
+	}
+	if _, err := sessionController.RegisterSession(ctx, sessionRef, &session.SessionMetadata{}); err != nil {
+		t.Fatal(err)
+	}
+
+	le := logrus.New().WithField("test", t.Name())
+	prov := NewProvider(le, tb.Bus, &Config{Endpoint: srv.URL}, NewProviderInfo("spacewave"), nil, nil)
+	acc := &ProviderAccount{
+		le:        le,
+		p:         prov,
+		accountID: "test-account",
+		vol:       tb.Volume,
+		conf:      prov.conf,
+		sfs:       prov.sfs,
+		soListCtr: ccontainer.NewCContainer[*sobject.SharedObjectList](nil),
+		entityCli: NewEntityClientDirect(prov.httpCli, srv.URL, DefaultSigningEnvPrefix, priv, pid),
+	}
+	acc.sessions = keyed.NewKeyedRefCount(acc.buildSessionTracker)
+	acc.sessions.SetContext(ctx, false)
+	defer acc.sessions.ClearContext()
+	_, tkr, existed := acc.sessions.AddKeyRef(sessionID)
+	if existed {
+		t.Fatal("expected mounted Session tracker to be created")
+	}
+	defer acc.sessions.RemoveKey(sessionID)
+	tkr.ref.SetResult(sessionRef, nil)
+
+	executing := make(chan error, 1)
+	go func() {
+		executing <- tkr.executeSessionTracker(ctx)
+	}()
+
+	mounted, mountedRelease, err := acc.MountSession(ctx, sessionRef, nil)
+	if err != nil {
+		t.Fatalf("mount Session: %v", err)
+	}
+	defer mountedRelease()
+	if mounted == nil {
+		t.Fatal("mounted Session is nil")
+	}
+
+	select {
+	case <-firstTicketStarted:
+	case <-ctx.Done():
+		t.Fatalf("first transport ticket did not start: %v", ctx.Err())
+	}
+	select {
+	case <-firstRegistration:
+	case <-ctx.Done():
+		t.Fatalf("initial Session registration was not observed: %v", ctx.Err())
+	}
+	close(releaseFirstTicket)
+
+	select {
+	case <-reregistration:
+	case <-ctx.Done():
+		t.Fatalf("Session did not re-register after HTTP 401: %v", ctx.Err())
+	}
+	close(permitSecondTicket)
+	select {
+	case <-secondTicketStarted:
+	case <-ctx.Done():
+		t.Fatalf("second transport ticket did not start: %v", ctx.Err())
+	}
+
+	for {
+		snapshot, waitCh := acc.GetTransportCompositionSnapshotWithWait(sessionID)
+		if snapshot.P2PState == TransportCompositionP2PStateError {
+			t.Fatalf("mounted Session transport remained in error state: %s", snapshot.LastError)
+		}
+		if snapshot.P2PState == TransportCompositionP2PStateNoPeers ||
+			snapshot.P2PState == TransportCompositionP2PStateIdle ||
+			snapshot.P2PState == TransportCompositionP2PStateActive {
+			break
+		}
+		select {
+		case <-waitCh:
+		case <-ctx.Done():
+			t.Fatalf("mounted Session transport did not become live: %v", ctx.Err())
+		}
+	}
+	if got := registrations.Load(); got < 2 {
+		t.Fatalf("session registrations = %d, want initial registration and re-registration", got)
+	}
+	if got := tickets.Load(); got != 2 {
+		t.Fatalf("signal tickets = %d, want two", got)
+	}
+
+	cancel()
+	select {
+	case err := <-executing:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("session tracker exit = %v, want cancellation", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("session tracker did not exit after test cancellation")
+	}
+}
+
+func TestSessionTransportReplacementReportsUncooperativeRoutine(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	acc := NewTestProviderAccount(t, "")
+	acc.sessionTransports = make(map[string]*sessionTransportState)
+
+	started := make(chan struct{})
+	releaseRoutine := make(chan struct{})
+	routineExited := make(chan struct{})
+	rc := routine.NewRoutineContainer()
+	rc.SetRoutine(func(context.Context) error {
+		close(started)
+		<-releaseRoutine
+		close(routineExited)
+		return nil
+	})
+	rc.SetContext(ctx, false)
+	sts := &sessionTransportState{
+		sessionID: "",
+		rc:        rc,
+		readyRc:   routine.NewRoutineContainer(),
+	}
+	acc.sessionTransports[""] = sts
+
+	select {
+	case <-started:
+	case <-ctx.Done():
+		t.Fatalf("old routine did not start: %v", ctx.Err())
+	}
+	stopCtx, stopCancel := context.WithTimeout(ctx, 50*time.Millisecond)
+	err := acc.stopSessionTransportForSession(stopCtx, "", sts)
+	stopCancel()
+	if err == nil {
+		t.Fatal("replacement returned nil while old routine ignored cancellation")
+	}
+	if got := acc.sessionTransports[""]; got != sts {
+		t.Fatal("replacement removed current state after an unconfirmed stop")
+	}
+
+	close(releaseRoutine)
+	select {
+	case <-routineExited:
+	case <-ctx.Done():
+		t.Fatalf("old routine did not exit after release: %v", ctx.Err())
+	}
+}
+
+func TestClassifySessionTransportErrorUsesStatusThroughWrappedMessage(t *testing.T) {
+	err := fmt.Errorf("message changed: %w", &testSessionTransportStatusError{
+		statusCode: http.StatusUnauthorized,
+	})
+	if !errors.Is(classifySessionTransportError(err), errSessionTransportUnauthorized) {
+		t.Fatalf("classification lost unauthorized status through wrapped message: %v", err)
+	}
+}
 
 func TestCreateSessionTransportConcurrentReplacementKeepsNewTransport(t *testing.T) {
 	requested := make(chan struct{})
@@ -67,36 +398,6 @@ func TestCreateSessionTransportConcurrentReplacementKeepsNewTransport(t *testing
 	}
 	if acc.GetSessionTransport() != current {
 		t.Fatal("old CreateSessionTransport cleared the newer transport")
-	}
-	assertNoUnexpectedSessionTransportPath(t, unexpectedPath)
-}
-
-func TestCreateSessionTransportEarlyExitClearsCurrentTransport(t *testing.T) {
-	unexpectedPath := make(chan string, 1)
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/signal/ticket" {
-			select {
-			case unexpectedPath <- r.URL.Path:
-			default:
-			}
-			http.NotFound(w, r)
-			return
-		}
-		http.Error(w, "no ticket", http.StatusInternalServerError)
-	}))
-	defer srv.Close()
-
-	acc := NewTestProviderAccount(t, srv.URL)
-	priv, _ := generateTestKeypair(t)
-	err := acc.CreateSessionTransport(context.Background(), priv, srv.URL)
-	if err == nil {
-		t.Fatal("expected session transport startup failure")
-	}
-	if !strings.Contains(err.Error(), "session transport failed to start") {
-		t.Fatalf("startup error = %v, want wrapped startup failure", err)
-	}
-	if st := acc.GetSessionTransport(); st != nil {
-		t.Fatal("expected failed session transport to be cleared")
 	}
 	assertNoUnexpectedSessionTransportPath(t, unexpectedPath)
 }

--- a/core/provider/spacewave/account-transport.go
+++ b/core/provider/spacewave/account-transport.go
@@ -2,6 +2,8 @@ package provider_spacewave
 
 import (
 	"context"
+	"net/http"
+	"time"
 
 	"github.com/aperturerobotics/controllerbus/bus"
 	"github.com/aperturerobotics/controllerbus/directive"
@@ -26,6 +28,52 @@ type sessionTransportState struct {
 	err    error
 }
 
+var errSessionTransportUnauthorized = errors.New("session transport unauthorized")
+
+type sessionTransportStatusError interface {
+	StatusCode() int
+}
+
+type unauthorizedSessionTransportError struct {
+	err error
+}
+
+func (e *unauthorizedSessionTransportError) Error() string {
+	return e.err.Error()
+}
+
+func (e *unauthorizedSessionTransportError) Unwrap() error {
+	return e.err
+}
+
+func (e *unauthorizedSessionTransportError) Is(target error) bool {
+	return target == errSessionTransportUnauthorized
+}
+
+func classifySessionTransportError(err error) error {
+	var statusErr sessionTransportStatusError
+	if errors.As(err, &statusErr) && statusErr.StatusCode() == http.StatusUnauthorized {
+		return &unauthorizedSessionTransportError{err: err}
+	}
+	return err
+}
+
+func sessionTransportReplacementContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return sessionTransportCleanupContext(ctx)
+}
+
+func sessionTransportCleanupContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cleanupCtx := context.WithoutCancel(ctx)
+	if deadline, ok := ctx.Deadline(); ok && time.Until(deadline) > 0 {
+		return context.WithDeadline(cleanupCtx, deadline)
+	}
+	timeout := time.Duration(providerBackoff.GetExponential().GetMaxInterval()) * time.Millisecond
+	return context.WithTimeout(cleanupCtx, timeout)
+}
+
 func newSessionTransportState(
 	a *ProviderAccount,
 	sessionID string,
@@ -37,18 +85,9 @@ func newSessionTransportState(
 	}
 	sts.rc = routine.NewRoutineContainerWithLogger(
 		a.le.WithField("routine", "session-transport"),
+		routine.WithRetry(providerBackoff),
 		routine.WithExitCb(func(err error) {
-			sts.setExited(err)
-			sts.readyRc.ClearContext()
-			if err != nil && !errors.Is(err, context.Canceled) {
-				a.le.WithError(err).WithField("session-id", sessionID).Warn("session transport exited with error")
-			}
-			a.transportBcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
-				if a.sessionTransports[sessionID] == sts {
-					delete(a.sessionTransports, sessionID)
-					broadcast()
-				}
-			})
+			a.handleSessionTransportExit(sessionID, sts, err)
 		}),
 	)
 	sts.rc.SetRoutine(st.Execute)
@@ -59,20 +98,57 @@ func newSessionTransportState(
 	return sts
 }
 
+func (a *ProviderAccount) handleSessionTransportExit(
+	sessionID string,
+	sts *sessionTransportState,
+	err error,
+) {
+	var ready bool
+	sts.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		ready = sts.ready
+	})
+	if !ready {
+		if !errors.Is(err, context.Canceled) {
+			a.le.WithError(err).WithField("session-id", sessionID).Warn("session transport startup attempt failed")
+		}
+		return
+	}
+	sts.setExited(err)
+	sts.readyRc.ClearContext()
+	a.transportBcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
+		if a.sessionTransports[sessionID] == sts {
+			delete(a.sessionTransports, sessionID)
+			broadcast()
+		}
+	})
+}
+
 func (s *sessionTransportState) Start(ctx context.Context) {
 	s.readyRc.SetContext(ctx, false)
 	s.rc.SetContext(ctx, false)
 }
 
-func (s *sessionTransportState) Stop() {
-	waitCh, _ := s.rc.SetRoutine(nil)
+func (s *sessionTransportState) Stop(ctx context.Context) error {
+	readyWaitCh, _ := s.readyRc.SetRoutine(nil)
+	runWaitCh, _ := s.rc.SetRoutine(nil)
 	s.readyRc.ClearContext()
 	s.rc.ClearContext()
 	s.setExited(context.Canceled)
-	_ = s.readyRc.WaitExited(context.Background(), true, nil)
-	if waitCh != nil {
-		<-waitCh
+	if readyWaitCh != nil {
+		select {
+		case <-readyWaitCh:
+		case <-ctx.Done():
+			return errors.Wrap(ctx.Err(), "wait for session transport readiness routine exit")
+		}
 	}
+	if runWaitCh != nil {
+		select {
+		case <-runWaitCh:
+		case <-ctx.Done():
+			return errors.Wrap(ctx.Err(), "wait for session transport routine exit")
+		}
+	}
+	return nil
 }
 
 func (s *sessionTransportState) WaitStarted(ctx context.Context) error {
@@ -84,12 +160,12 @@ func (s *sessionTransportState) WaitStarted(ctx context.Context) error {
 		var ready bool
 		var exited bool
 		var exitErr error
-		var ch <-chan struct{}
+		var waitCh <-chan struct{}
 		s.bcast.HoldLock(func(_ func(), getWaitCh func() <-chan struct{}) {
 			ready = s.ready
 			exited = s.exited
 			exitErr = s.err
-			ch = getWaitCh()
+			waitCh = getWaitCh()
 		})
 		if ready {
 			return nil
@@ -104,19 +180,18 @@ func (s *sessionTransportState) WaitStarted(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-ch:
+		case <-waitCh:
 		}
 	}
 }
 
 func (s *sessionTransportState) watchReady(ctx context.Context) error {
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-s.transport.Ready():
-		s.setReady()
-		return nil
+	if err := s.transport.AwaitReady(ctx); err != nil {
+		s.setExited(err)
+		return err
 	}
+	s.setReady()
+	return nil
 }
 
 func (s *sessionTransportState) setReady() {
@@ -132,6 +207,10 @@ func (s *sessionTransportState) setReady() {
 func (s *sessionTransportState) setExited(err error) {
 	s.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
 		if s.exited {
+			if s.err == nil || errors.Is(s.err, context.Canceled) && !errors.Is(err, context.Canceled) {
+				s.err = err
+				broadcast()
+			}
 			return
 		}
 		s.exited = true
@@ -155,8 +234,17 @@ func (a *ProviderAccount) createSessionTransportForSession(
 	sessionKey crypto.PrivKey,
 	signalingURL string,
 ) error {
-	a.transportReplaceMtx.Lock()
-	a.stopSessionTransportLocked(sessionID, nil)
+	cleanupCtx, cleanupCancel := sessionTransportReplacementContext(ctx)
+	rel, err := a.transportReplaceMtx.Lock(cleanupCtx)
+	if err != nil {
+		cleanupCancel()
+		return err
+	}
+	if err := a.stopSessionTransportLocked(cleanupCtx, sessionID, nil); err != nil {
+		rel()
+		cleanupCancel()
+		return err
+	}
 
 	st, err := transport.NewSessionTransport(
 		a.le,
@@ -164,13 +252,15 @@ func (a *ProviderAccount) createSessionTransportForSession(
 		sessionKey,
 		signalingURL,
 		a.p.signingEnvPfx,
+		transport.WithStartupRetry(),
 		transport.WithBridgeDirectiveFilter(func(di directive.Instance) (bool, error) {
 			_, isMount := di.GetDirective().(sobject.MountSharedObject)
 			return !isMount, nil
 		}),
 	)
 	if err != nil {
-		a.transportReplaceMtx.Unlock()
+		rel()
+		cleanupCancel()
 		return errors.Wrap(err, "create session transport")
 	}
 
@@ -183,10 +273,14 @@ func (a *ProviderAccount) createSessionTransportForSession(
 		broadcast()
 	})
 	sts.Start(ctx)
-	a.transportReplaceMtx.Unlock()
+	rel()
+	cleanupCancel()
 
 	if err := sts.WaitStarted(ctx); err != nil {
-		a.stopSessionTransportForSession(sessionID, sts)
+		err = classifySessionTransportError(err)
+		if stopErr := a.stopSessionTransportForSession(ctx, sessionID, sts); stopErr != nil {
+			return errors.Wrap(stopErr, "cleanup failed session transport startup")
+		}
 		return err
 	}
 	return nil
@@ -261,28 +355,46 @@ func (a *ProviderAccount) getTransportSnapshotWithWaitForSession(sessionID strin
 
 // StopSessionTransport stops the legacy default session transport.
 func (a *ProviderAccount) StopSessionTransport() {
-	a.stopSessionTransportForSession("", nil)
+	if err := a.stopSessionTransportForSession(nil, "", nil); err != nil {
+		a.le.WithError(err).Warn("failed to stop session transport")
+	}
 }
 
-func (a *ProviderAccount) stopSessionTransportForSession(sessionID string, target *sessionTransportState) {
-	a.transportReplaceMtx.Lock()
-	defer a.transportReplaceMtx.Unlock()
-	a.stopSessionTransportLocked(sessionID, target)
+func (a *ProviderAccount) stopSessionTransportForSession(
+	ctx context.Context,
+	sessionID string,
+	target *sessionTransportState,
+) error {
+	cleanupCtx, cleanupCancel := sessionTransportCleanupContext(ctx)
+	defer cleanupCancel()
+	rel, err := a.transportReplaceMtx.Lock(cleanupCtx)
+	if err != nil {
+		return err
+	}
+	defer rel()
+	return a.stopSessionTransportLocked(cleanupCtx, sessionID, target)
 }
 
-func (a *ProviderAccount) stopSessionTransportLocked(sessionID string, target *sessionTransportState) {
+func (a *ProviderAccount) stopSessionTransportLocked(
+	ctx context.Context,
+	sessionID string,
+	target *sessionTransportState,
+) error {
 	var sts *sessionTransportState
 	a.transportBcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
 		sts = a.sessionTransports[sessionID]
 	})
-	if sts == nil || (target != nil && sts != target) {
-		return
+	if sts == nil || target != nil && sts != target {
+		return nil
 	}
-	sts.Stop()
+	if err := sts.Stop(ctx); err != nil {
+		return err
+	}
 	a.transportBcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
 		if a.sessionTransports[sessionID] == sts {
 			delete(a.sessionTransports, sessionID)
 			broadcast()
 		}
 	})
+	return nil
 }

--- a/core/provider/spacewave/account-transport_test.go
+++ b/core/provider/spacewave/account-transport_test.go
@@ -2,9 +2,27 @@ package provider_spacewave
 
 import (
 	"context"
+	"errors"
 	"strings"
+	"sync"
 	"testing"
+	"time"
+
+	"github.com/s4wave/spacewave/core/transport"
 )
+
+type observedDoneContext struct {
+	context.Context
+	observed chan struct{}
+	once     sync.Once
+}
+
+func (c *observedDoneContext) Done() <-chan struct{} {
+	c.once.Do(func() {
+		close(c.observed)
+	})
+	return c.Context.Done()
+}
 
 func TestCreateSessionTransportPublishesReadyAndStops(t *testing.T) {
 	acc := NewTestProviderAccount(t, "http://example.invalid")
@@ -71,5 +89,82 @@ func TestSessionTransportStateExitBeforeReadyFailsStartup(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "session transport exited before ready") {
 		t.Fatalf("startup error = %v, want exited-before-ready failure", err)
+	}
+}
+
+func TestSessionTransportStateExitWakesPendingStartup(t *testing.T) {
+	acc := NewTestProviderAccount(t, "http://example.invalid")
+	priv, _ := generateTestKeypair(t)
+	st, err := transport.NewSessionTransport(acc.le, acc.p.b, priv, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sts := &sessionTransportState{transport: st}
+	baseCtx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	observed := make(chan struct{})
+	waitCtx := &observedDoneContext{
+		Context:  baseCtx,
+		observed: observed,
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- sts.WaitStarted(waitCtx)
+	}()
+	select {
+	case <-observed:
+	case <-baseCtx.Done():
+		t.Fatalf("waiter did not enter its wait path: %v", baseCtx.Err())
+	}
+	sts.setExited(context.Canceled)
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("wait returned %v, want state cancellation", err)
+		}
+	case <-baseCtx.Done():
+		t.Fatalf("state exit did not wake pending startup: %v", baseCtx.Err())
+	}
+}
+
+func TestSessionTransportStateExitPreservesStartupError(t *testing.T) {
+	sts := &sessionTransportState{}
+	sts.setExited(context.Canceled)
+	startupErr := errors.New("session transport did not become ready")
+	sts.setExited(startupErr)
+
+	err := sts.WaitStarted(context.Background())
+	if !errors.Is(err, startupErr) {
+		t.Fatalf("startup error = %v, want preserved readiness error", err)
+	}
+}
+
+func TestSessionTransportCanceledStartupAttemptRemainsCurrent(t *testing.T) {
+	acc := NewTestProviderAccount(t, "http://example.invalid")
+	sts := &sessionTransportState{}
+	acc.transportBcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
+		acc.sessionTransports = map[string]*sessionTransportState{"": sts}
+		broadcast()
+	})
+
+	acc.handleSessionTransportExit("", sts, context.Canceled)
+
+	sts.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		if sts.exited {
+			t.Fatal("pre-ready cancellation must not publish terminal exit")
+		}
+	})
+	var current *sessionTransportState
+	acc.transportBcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		current = acc.sessionTransports[""]
+	})
+	if current != sts {
+		t.Fatal("pre-ready cancellation must leave transport state current")
+	}
+	running, _ := acc.GetTransportSnapshotWithWait()
+	if !running {
+		t.Fatal("pre-ready cancellation must leave transport eligible for retry")
 	}
 }

--- a/core/provider/spacewave/account.go
+++ b/core/provider/spacewave/account.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aperturerobotics/controllerbus/controller/resolver"
 	"github.com/aperturerobotics/util/broadcast"
 	"github.com/aperturerobotics/util/ccontainer"
+	"github.com/aperturerobotics/util/csync"
 	"github.com/aperturerobotics/util/keyed"
 	"github.com/aperturerobotics/util/refcount"
 	"github.com/aperturerobotics/util/routine"
@@ -147,7 +148,7 @@ type ProviderAccount struct {
 	// transportBcast guards sessionTransports.
 	transportBcast broadcast.Broadcast
 	// transportReplaceMtx serializes session transport create/replace/stop.
-	transportReplaceMtx sync.Mutex
+	transportReplaceMtx csync.Mutex
 	// p2pSyncMtx guards p2pSyncs.
 	p2pSyncMtx sync.Mutex
 	// syncTelemetry stores sync activity snapshots keyed by block store id.

--- a/core/provider/spacewave/session.go
+++ b/core/provider/spacewave/session.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"slices"
-	"strings"
 	"sync"
 
 	"github.com/aperturerobotics/controllerbus/bus"
@@ -655,7 +654,7 @@ func (t *sessionTracker) executeSessionTracker(rctx context.Context) (rerr error
 		if errors.Is(err, context.Canceled) {
 			return context.Canceled
 		}
-		if strings.Contains(err.Error(), "HTTP 401") {
+		if errors.Is(err, errSessionTransportUnauthorized) {
 			le.WithError(err).Warn("registered session rejected; re-registering")
 			observed, rerr := registerSession()
 			if rerr != nil {

--- a/core/provider/spacewave/transport-composition.go
+++ b/core/provider/spacewave/transport-composition.go
@@ -84,19 +84,25 @@ func (o *transportCompositionOwner) init(account *ProviderAccount) {
 			}
 			st := account.getSessionTransportForSession(sessionID)
 			if st == nil {
-				account.stopSessionTransportForSession(sessionID, nil)
+				if err := account.stopSessionTransportForSession(ctx, sessionID, nil); err != nil {
+					return nil, errors.Wrap(err, "stop missing session transport")
+				}
 				return nil, errors.New("session transport missing after startup")
 			}
 			if err := account.startP2PSyncForSession(ctx, sessionID, st); err != nil {
 				account.stopP2PSyncForSession(sessionID)
-				account.stopSessionTransportForSession(sessionID, nil)
+				if stopErr := account.stopSessionTransportForSession(ctx, sessionID, nil); stopErr != nil {
+					return nil, errors.Wrap(stopErr, "stop session transport after P2P startup failure")
+				}
 				return nil, err
 			}
 			return st, nil
 		}
 		o.stopDirect = func(sessionID string) {
 			account.stopP2PSyncForSession(sessionID)
-			account.stopSessionTransportForSession(sessionID, nil)
+			if err := account.stopSessionTransportForSession(nil, sessionID, nil); err != nil {
+				account.le.WithError(err).Warn("failed to stop session transport composition")
+			}
 		}
 		o.transportState = func(sessionID string) (bool, <-chan struct{}) {
 			return account.getTransportSnapshotWithWaitForSession(sessionID)

--- a/core/transport/ticket.go
+++ b/core/transport/ticket.go
@@ -6,12 +6,31 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"strconv"
 
 	"github.com/pkg/errors"
 	api "github.com/s4wave/spacewave/core/provider/spacewave/api"
 	bifrost_crypto "github.com/s4wave/spacewave/net/crypto"
 	"github.com/s4wave/spacewave/net/peer"
 )
+
+var errSignalTicketUnauthorized = errors.New("signal ticket unauthorized")
+
+type signalTicketHTTPError struct {
+	statusCode int
+}
+
+func (e *signalTicketHTTPError) Error() string {
+	return "signal ticket: HTTP " + strconv.Itoa(e.statusCode)
+}
+
+func (e *signalTicketHTTPError) StatusCode() int {
+	return e.statusCode
+}
+
+func (e *signalTicketHTTPError) Is(target error) bool {
+	return e.statusCode == http.StatusUnauthorized && target == errSignalTicketUnauthorized
+}
 
 // signalURL joins a signaling endpoint path to its relative or absolute base.
 func signalURL(baseURL, endpoint string) (*url.URL, error) {
@@ -72,7 +91,7 @@ func acquireSignalTicket(
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", errors.Errorf("signal ticket: HTTP %d", resp.StatusCode)
+		return "", &signalTicketHTTPError{statusCode: resp.StatusCode}
 	}
 
 	data, err := io.ReadAll(resp.Body)

--- a/core/transport/transport.go
+++ b/core/transport/transport.go
@@ -2,7 +2,7 @@ package transport
 
 import (
 	"context"
-	"sync"
+	"time"
 
 	"github.com/aperturerobotics/controllerbus/bus"
 	bus_bridge "github.com/aperturerobotics/controllerbus/bus/bridge"
@@ -10,6 +10,8 @@ import (
 	"github.com/aperturerobotics/controllerbus/controller/resolver"
 	cbc "github.com/aperturerobotics/controllerbus/core"
 	"github.com/aperturerobotics/controllerbus/directive"
+	"github.com/aperturerobotics/util/broadcast"
+	"github.com/pkg/errors"
 	dex_solicit "github.com/s4wave/spacewave/db/dex/solicit"
 	bifrost_crypto "github.com/s4wave/spacewave/net/crypto"
 	link_solicit_controller "github.com/s4wave/spacewave/net/link/solicit/controller"
@@ -25,7 +27,8 @@ type SessionTransport struct {
 	le *logrus.Entry
 	// parentBus is the parent controller bus to bridge directives to.
 	parentBus bus.Bus
-	mtx       sync.RWMutex
+	// bcast guards transport handles and startup lifecycle state.
+	bcast broadcast.Broadcast
 	// childBus is the session-scoped child bus.
 	childBus bus.Bus
 	// linkController is the active transport controller that owns link state.
@@ -40,18 +43,60 @@ type SessionTransport struct {
 	signingEnvPfx string
 	// bridgeFilter optionally excludes directives from the parent bridge.
 	bridgeFilter bus_bridge.FilterFn
-	// ready is closed when the child bus and base controllers started.
+	// startupTimeout bounds the readiness phase for every consumer.
+	startupTimeout time.Duration
+	// startupDeadlineCtx is the owner budget shared by every readiness waiter.
+	startupDeadlineCtx context.Context
+	// startupDeadlineCancel stops the owner budget after a terminal outcome.
+	startupDeadlineCancel context.CancelFunc
+	// startupDeadlineStarted prevents retries and waiters from resetting the budget.
+	startupDeadlineStarted bool
+	// cancel cancels the owner context after startup stop admission.
+	cancel context.CancelFunc
+	// startupStopped admits timeout cancellation before Execute publishes cancel.
+	startupStopped bool
+	// startupTimeoutAdmitted records that timeout owns the terminal error.
+	startupTimeoutAdmitted bool
+	// startupReady is true after all startup controllers are running.
+	startupReady bool
+	// ready closes when the child bus and base controllers become ready.
 	ready chan struct{}
+	// startupErr is the terminal startup error, including timeout.
+	startupErr error
+	// startupStage records the last startup stage entered.
+	startupStage string
+	// startupRetryable keeps per-attempt failures private to a retry owner.
+	startupRetryable bool
 }
 
-// SessionTransportOption configures child-bus directive routing.
+// SessionTransportOption configures child-bus directive routing and startup.
 type SessionTransportOption func(*SessionTransport)
+
+const defaultSessionTransportStartupTimeout = 2 * time.Minute
+
+// WithStartupTimeout bounds the transport startup readiness phase.
+func WithStartupTimeout(timeout time.Duration) SessionTransportOption {
+	return func(t *SessionTransport) {
+		if timeout > 0 {
+			t.startupTimeout = timeout
+		}
+	}
+}
 
 // WithBridgeDirectiveFilter excludes matching directives from the generic
 // child-to-parent bridge while preserving the transport package's ownership.
 func WithBridgeDirectiveFilter(filter bus_bridge.FilterFn) SessionTransportOption {
 	return func(t *SessionTransport) {
 		t.bridgeFilter = filter
+	}
+}
+
+// WithStartupRetry enables retry-owner startup semantics. Execute attempts
+// leave transient failures to the retry owner, while AwaitReady reports only
+// the transport's admitted terminal outcome.
+func WithStartupRetry() SessionTransportOption {
+	return func(t *SessionTransport) {
+		t.startupRetryable = true
 	}
 }
 
@@ -75,13 +120,14 @@ func NewSessionTransport(
 		return nil, err
 	}
 	t := &SessionTransport{
-		le:            le.WithField("transport-peer", pid.String()[:8]),
-		parentBus:     parentBus,
-		sessionKey:    sessionKey,
-		peerID:        pid,
-		signalingURL:  signalingURL,
-		signingEnvPfx: signingEnvPfx,
-		ready:         make(chan struct{}),
+		le:             le.WithField("transport-peer", pid.String()[:8]),
+		parentBus:      parentBus,
+		sessionKey:     sessionKey,
+		peerID:         pid,
+		signalingURL:   signalingURL,
+		signingEnvPfx:  signingEnvPfx,
+		startupTimeout: defaultSessionTransportStartupTimeout,
+		ready:          make(chan struct{}),
 	}
 	for _, opt := range opts {
 		if opt != nil {
@@ -96,19 +142,21 @@ func (t *SessionTransport) GetPeerID() peer.ID {
 	return t.peerID
 }
 
-// GetChildBus returns the child bus, or nil if not yet started.
 func (t *SessionTransport) GetChildBus() bus.Bus {
-	t.mtx.RLock()
-	defer t.mtx.RUnlock()
-	return t.childBus
+	var childBus bus.Bus
+	t.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		childBus = t.childBus
+	})
+	return childBus
 }
 
 // GetLinkedPeerIDsSnapshotWithWait returns linked peer IDs and a wait channel
 // that closes when the transport link set changes.
 func (t *SessionTransport) GetLinkedPeerIDsSnapshotWithWait(peerIDs []peer.ID) (map[peer.ID]struct{}, <-chan struct{}) {
-	t.mtx.RLock()
-	linkController := t.linkController
-	t.mtx.RUnlock()
+	var linkController *transport_controller.Controller
+	t.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		linkController = t.linkController
+	})
 	if linkController == nil {
 		return nil, nil
 	}
@@ -118,52 +166,290 @@ func (t *SessionTransport) GetLinkedPeerIDsSnapshotWithWait(peerIDs []peer.ID) (
 // GetLinkSnapshotsWithWait returns live link snapshots and a wait channel that
 // closes when the transport link set changes.
 func (t *SessionTransport) GetLinkSnapshotsWithWait() ([]transport_controller.LinkSnapshot, <-chan struct{}) {
-	t.mtx.RLock()
-	linkController := t.linkController
-	t.mtx.RUnlock()
+	var linkController *transport_controller.Controller
+	t.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		linkController = t.linkController
+	})
 	if linkController == nil {
 		return nil, nil
 	}
 	return linkController.GetLinkSnapshotsWithWait()
 }
 
-// Ready returns a channel that is closed when the child bus and base
-// controllers are started.
+// Ready returns a channel that closes when the child bus and base controllers
+// become ready.
 func (t *SessionTransport) Ready() <-chan struct{} {
 	return t.ready
 }
 
-// AwaitReady blocks until the transport's child bus is created and base
-// controllers are started, or until ctx is canceled.
+// GetStartupStage returns the last startup stage entered by Execute.
+func (t *SessionTransport) GetStartupStage() string {
+	var stage string
+	t.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		stage = t.startupStage
+	})
+	return stage
+}
+
+func (t *SessionTransport) setStartupStage(stage string) {
+	t.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
+		if t.startupStage == stage {
+			return
+		}
+		t.startupStage = stage
+		broadcast()
+	})
+}
+
+func (t *SessionTransport) ensureStartupDeadline(ctx context.Context) {
+	var deadlineCtx context.Context
+	t.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		if t.startupDeadlineStarted {
+			return
+		}
+		deadlineCtx, t.startupDeadlineCancel = context.WithTimeout(
+			context.WithoutCancel(ctx),
+			t.startupTimeout,
+		)
+		t.startupDeadlineCtx = deadlineCtx
+		t.startupDeadlineStarted = true
+	})
+	if deadlineCtx == nil {
+		return
+	}
+	go func() {
+		<-deadlineCtx.Done()
+		if deadlineCtx.Err() == context.DeadlineExceeded {
+			_ = t.admitStartupTimeout()
+		}
+	}()
+}
+
+func (t *SessionTransport) cancelStartupDeadline() {
+	var cancel context.CancelFunc
+	t.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		cancel = t.startupDeadlineCancel
+		t.startupDeadlineCancel = nil
+	})
+	if cancel != nil {
+		cancel()
+	}
+}
+
+// AwaitReady blocks until the transport's child bus and base controllers are
+// started, startup fails, the startup budget expires, or ctx is canceled.
 func (t *SessionTransport) AwaitReady(ctx context.Context) error {
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-t.ready:
-		return nil
+	return t.awaitReady(ctx, nil)
+}
+
+func (t *SessionTransport) awaitReady(ctx context.Context, beforeWait func()) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	t.ensureStartupDeadline(ctx)
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		var (
+			ready        bool
+			startupErr   error
+			startupStage string
+			timeout      bool
+			waitCh       <-chan struct{}
+			deadlineCtx  context.Context
+			deadlineCh   <-chan struct{}
+		)
+		t.bcast.HoldLock(func(_ func(), getWaitCh func() <-chan struct{}) {
+			ready = t.startupReady
+			startupErr = t.startupErr
+			startupStage = t.startupStage
+			timeout = t.startupTimeoutAdmitted
+			if !ready && startupErr == nil {
+				waitCh = getWaitCh()
+				deadlineCtx = t.startupDeadlineCtx
+				if deadlineCtx != nil {
+					deadlineCh = deadlineCtx.Done()
+				}
+			}
+		})
+		if ready {
+			return nil
+		}
+		if startupErr != nil {
+			if timeout {
+				return startupErr
+			}
+			return errors.Wrapf(startupErr, "session transport failed to start at %s", startupStage)
+		}
+		if beforeWait != nil {
+			beforeWait()
+		}
+
+		if deadlineCh != nil {
+			select {
+			case <-deadlineCh:
+				if deadlineCtx.Err() != context.DeadlineExceeded {
+					if err := ctx.Err(); err != nil {
+						return err
+					}
+					continue
+				}
+				if err := t.admitStartupTimeout(); err != nil {
+					return err
+				}
+				continue
+			default:
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-deadlineCh:
+			if deadlineCtx == nil || deadlineCtx.Err() != context.DeadlineExceeded {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+				continue
+			}
+			if err := t.admitStartupTimeout(); err != nil {
+				return err
+			}
+		case <-waitCh:
+		}
+	}
+}
+
+func (t *SessionTransport) admitStartupTimeout() error {
+	var (
+		err    error
+		cancel context.CancelFunc
+	)
+	t.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
+		if t.startupReady {
+			return
+		}
+		if t.startupErr != nil {
+			err = t.startupErr
+			if !t.startupTimeoutAdmitted {
+				err = errors.Wrapf(err, "session transport failed to start at %s", t.startupStage)
+			}
+			return
+		}
+		err = errors.Errorf(
+			"session transport did not become ready, stalled at %s",
+			t.startupStage,
+		)
+		t.startupStopped = true
+		t.startupTimeoutAdmitted = true
+		t.startupErr = err
+		cancel = t.cancel
+		broadcast()
+	})
+	if cancel != nil {
+		cancel()
+	}
+	return err
+}
+
+func (t *SessionTransport) publishStartupError(err error) bool {
+	var (
+		cancel    context.CancelFunc
+		published bool
+	)
+	t.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
+		if t.startupReady || t.startupErr != nil {
+			return
+		}
+		t.startupErr = err
+		published = true
+		cancel = t.startupDeadlineCancel
+		t.startupDeadlineCancel = nil
+		broadcast()
+	})
+	if cancel != nil {
+		cancel()
+	}
+	return published
+}
+
+func (t *SessionTransport) publishStartupReady() {
+	var cancel context.CancelFunc
+	t.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
+		if t.startupReady || t.startupStopped || t.startupErr != nil {
+			return
+		}
+		t.startupReady = true
+		close(t.ready)
+		cancel = t.startupDeadlineCancel
+		t.startupDeadlineCancel = nil
+		broadcast()
+	})
+	if cancel != nil {
+		cancel()
 	}
 }
 
 // Execute creates the child bus with bifrost transport controllers and
 // blocks until ctx is canceled.
-func (t *SessionTransport) Execute(ctx context.Context) error {
-	le := t.le
+func (t *SessionTransport) Execute(ctx context.Context) (err error) {
+	ctx, cancel := context.WithCancel(ctx)
+	t.ensureStartupDeadline(ctx)
+	var startupStopped bool
+	t.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
+		t.cancel = cancel
+		startupStopped = t.startupStopped
+		if !startupStopped && !t.startupReady {
+			t.startupErr = nil
+			t.startupStage = ""
+		}
+		broadcast()
+	})
+	if startupStopped {
+		cancel()
+		return context.Canceled
+	}
+	defer cancel()
+	defer func() {
+		if errors.Is(err, context.Canceled) {
+			t.cancelStartupDeadline()
+		}
+	}()
 
+	le := t.le
+	if !t.startupRetryable {
+		defer func() {
+			t.publishStartupError(err)
+		}()
+	} else {
+		defer func() {
+			if errors.Is(err, errSignalTicketUnauthorized) && t.publishStartupError(err) {
+				err = nil
+			}
+		}()
+	}
+
+	t.setStartupStage("child-bus")
 	// Create child bus with loader and resolver infrastructure.
 	b, sr, err := cbc.NewCoreBus(ctx, le)
 	if err != nil {
 		return err
 	}
-	t.mtx.Lock()
-	t.childBus = b
-	t.mtx.Unlock()
+	t.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
+		t.childBus = b
+		broadcast()
+	})
 	defer func() {
-		t.mtx.Lock()
-		t.childBus = nil
-		t.linkController = nil
-		t.mtx.Unlock()
+		t.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
+			t.childBus = nil
+			t.linkController = nil
+			broadcast()
+		})
 	}()
 
+	t.setStartupStage("bridge")
 	// Bridge directives from child to parent.
 	bridge := bus_bridge.NewBusBridge(t.parentBus, func(di directive.Instance) (bool, error) {
 		if t.bridgeFilter != nil {
@@ -182,6 +468,7 @@ func (t *SessionTransport) Execute(ctx context.Context) error {
 		return err
 	}
 
+	t.setStartupStage("peer-controller")
 	// Register peer controller with the session's private key.
 	sessionPeer, err := peer.NewPeer(t.sessionKey)
 	if err != nil {
@@ -192,6 +479,7 @@ func (t *SessionTransport) Execute(ctx context.Context) error {
 		return err
 	}
 
+	t.setStartupStage("factories")
 	// Register bifrost transport factories on the child bus.
 	for _, factory := range sessionTransportFactories(b) {
 		sr.AddFactory(factory)
@@ -199,6 +487,7 @@ func (t *SessionTransport) Execute(ctx context.Context) error {
 	sr.AddFactory(link_solicit_controller.NewFactory())
 	sr.AddFactory(dex_solicit.NewFactory(b))
 
+	t.setStartupStage("solicit-controller")
 	// Start solicit controller for bilateral stream matching.
 	_, _, solicitRef, err := loader.WaitExecControllerRunning(
 		ctx, b,
@@ -210,6 +499,7 @@ func (t *SessionTransport) Execute(ctx context.Context) error {
 	}
 	defer solicitRef.Release()
 
+	t.setStartupStage("webrtc-controllers")
 	rtcCtrl, releaseRTC, err := t.startWebRTCControllers(ctx, le, b)
 	if err != nil {
 		return err
@@ -218,13 +508,14 @@ func (t *SessionTransport) Execute(ctx context.Context) error {
 		defer releaseRTC()
 	}
 	if rtcCtrl != nil {
-		t.mtx.Lock()
-		t.linkController = rtcCtrl
-		t.mtx.Unlock()
+		t.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
+			t.linkController = rtcCtrl
+			broadcast()
+		})
 	}
 
-	// Signal ready after all controllers (including signaling) are started.
-	close(t.ready)
+	t.setStartupStage("ready")
+	t.publishStartupReady()
 	le.Debug("session transport started")
 	<-ctx.Done()
 	return ctx.Err()

--- a/core/transport/transport_startup_test.go
+++ b/core/transport/transport_startup_test.go
@@ -1,0 +1,124 @@
+package transport
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestSessionTransportStartupTimeoutCannotBeOverwrittenByReady(t *testing.T) {
+	st := &SessionTransport{startupTimeout: time.Second}
+	st.setStartupStage("ready")
+
+	timeoutErr := st.admitStartupTimeout()
+	if timeoutErr == nil {
+		t.Fatal("expected startup timeout admission")
+	}
+
+	st.publishStartupReady()
+
+	if st.startupReady {
+		t.Fatal("startup timeout was overwritten by readiness")
+	}
+	err := st.AwaitReady(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "session transport did not become ready") {
+		t.Fatalf("AwaitReady returned %v after timeout admission", err)
+	}
+}
+
+func TestSessionTransportPublicationWinsInternalDeadlineCancellation(t *testing.T) {
+	terminalErr := errors.New("terminal startup")
+	tests := []struct {
+		name      string
+		publish   func(*SessionTransport)
+		check     func(error) bool
+		wantError string
+	}{
+		{
+			name: "ready",
+			publish: func(st *SessionTransport) {
+				st.publishStartupReady()
+			},
+			check: func(err error) bool {
+				return err == nil
+			},
+		},
+		{
+			name: "terminal error",
+			publish: func(st *SessionTransport) {
+				st.publishStartupError(terminalErr)
+			},
+			check: func(err error) bool {
+				return errors.Is(err, terminalErr)
+			},
+			wantError: terminalErr.Error(),
+		},
+		{
+			name: "unauthorized",
+			publish: func(st *SessionTransport) {
+				st.publishStartupError(&signalTicketHTTPError{statusCode: 401})
+			},
+			check: func(err error) bool {
+				return errors.Is(err, errSignalTicketUnauthorized)
+			},
+			wantError: errSignalTicketUnauthorized.Error(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+			defer cancel()
+			st := &SessionTransport{
+				startupTimeout: time.Second,
+				ready:          make(chan struct{}),
+			}
+			snapshot := make(chan struct{})
+			release := make(chan struct{})
+			var once sync.Once
+			done := make(chan error, 1)
+			go func() {
+				done <- st.awaitReady(ctx, func() {
+					once.Do(func() {
+						close(snapshot)
+						<-release
+					})
+				})
+			}()
+
+			select {
+			case <-snapshot:
+			case <-ctx.Done():
+				t.Fatalf("AwaitReady did not capture its wait epoch: %v", ctx.Err())
+			}
+			tt.publish(st)
+			close(release)
+
+			select {
+			case err := <-done:
+				if !tt.check(err) {
+					t.Fatalf("AwaitReady returned %v after %s publication, want %s", err, tt.name, tt.wantError)
+				}
+			case <-ctx.Done():
+				t.Fatalf("AwaitReady did not observe %s publication: %v", tt.name, ctx.Err())
+			}
+		})
+	}
+}
+
+func TestSessionTransportCancellationDoesNotAdmitStartupTimeout(t *testing.T) {
+	callerCtx, callerCancel := context.WithCancel(t.Context())
+	defer callerCancel()
+	st := &SessionTransport{startupTimeout: time.Second}
+	startupCtx, startupCancel := context.WithTimeout(t.Context(), time.Second)
+	defer startupCancel()
+	st.ensureStartupDeadline(startupCtx)
+	st.cancelStartupDeadline()
+
+	err := st.awaitReady(callerCtx, callerCancel)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("AwaitReady returned %v after owner cancellation, want context canceled", err)
+	}
+}

--- a/core/transport/transport_test.go
+++ b/core/transport/transport_test.go
@@ -1,0 +1,418 @@
+package transport_test
+
+import (
+	"context"
+	"crypto/rand"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	websocket "github.com/aperturerobotics/go-websocket"
+	cbackoff "github.com/aperturerobotics/util/backoff/cbackoff"
+	"github.com/aperturerobotics/util/routine"
+	api "github.com/s4wave/spacewave/core/provider/spacewave/api"
+	"github.com/s4wave/spacewave/core/transport"
+	"github.com/s4wave/spacewave/net/crypto"
+	"github.com/s4wave/spacewave/testbed"
+	"github.com/sirupsen/logrus"
+)
+
+func TestSessionTransportStartupTimeoutNamesStage(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	tb, err := testbed.Default(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tb.Release()
+
+	privKey, _, err := crypto.GenerateEd25519Key(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	requestStarted := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(requestStarted)
+		select {
+		case <-releaseRequest:
+		case <-r.Context().Done():
+		}
+	}))
+	defer func() {
+		close(releaseRequest)
+		server.Close()
+	}()
+
+	st, err := transport.NewSessionTransport(
+		logrus.New().WithField("test", t.Name()),
+		tb.Bus,
+		privKey,
+		server.URL,
+		"",
+		transport.WithStartupTimeout(time.Second),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- st.Execute(ctx)
+	}()
+
+	select {
+	case <-requestStarted:
+	case <-ctx.Done():
+		t.Fatalf("stalled signaling request did not start: %v", ctx.Err())
+	}
+
+	err = st.AwaitReady(ctx)
+	if err == nil {
+		t.Fatal("expected session transport startup error")
+	}
+	if !strings.Contains(err.Error(), "session transport did not become ready") {
+		t.Fatalf("startup error does not name readiness failure: %v", err)
+	}
+	if !strings.Contains(err.Error(), "webrtc-controllers") {
+		t.Fatalf("startup error does not name stalled stage: %v", err)
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("session transport did not stop after startup timeout")
+	}
+	if st.GetChildBus() != nil {
+		t.Fatal("expected transport to be nil after stop")
+	}
+}
+
+func TestSessionTransportStartupBudgetStartsAtExecute(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	tb, err := testbed.Default(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tb.Release()
+
+	privKey, _, err := crypto.GenerateEd25519Key(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	requestStarted := make(chan struct{})
+	requestCanceled := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(requestStarted)
+		<-r.Context().Done()
+		close(requestCanceled)
+	}))
+	defer server.Close()
+
+	st, err := transport.NewSessionTransport(
+		logrus.New().WithField("test", t.Name()),
+		tb.Bus,
+		privKey,
+		server.URL,
+		"",
+		transport.WithStartupTimeout(100*time.Millisecond),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	executeDone := make(chan error, 1)
+	go func() {
+		executeDone <- st.Execute(ctx)
+	}()
+	select {
+	case <-requestStarted:
+	case <-ctx.Done():
+		t.Fatalf("startup request did not begin: %v", ctx.Err())
+	}
+	select {
+	case <-requestCanceled:
+		if ctx.Err() != nil {
+			t.Fatalf("parent context canceled before owner startup budget: %v", ctx.Err())
+		}
+	case <-ctx.Done():
+		t.Fatalf("owner startup budget did not cancel Execute: %v", ctx.Err())
+	}
+
+	err = st.AwaitReady(ctx)
+	if err == nil {
+		t.Fatal("expected admitted startup timeout")
+	}
+	if !strings.Contains(err.Error(), "session transport did not become ready") {
+		t.Fatalf("startup error = %v, want admitted timeout", err)
+	}
+	select {
+	case executeErr := <-executeDone:
+		if !errors.Is(executeErr, context.Canceled) {
+			t.Fatalf("Execute returned %v after owner timeout, want %v", executeErr, context.Canceled)
+		}
+	case <-ctx.Done():
+		t.Fatalf("Execute did not stop after owner timeout: %v", ctx.Err())
+	}
+}
+
+func TestSessionTransportRetriesStartupAttemptWithoutRecreation(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	tb, err := testbed.Default(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tb.Release()
+
+	privKey, _, err := crypto.GenerateEd25519Key(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var ticketRequests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/signal/ticket":
+			if ticketRequests.Add(1) == 1 {
+				http.Error(w, "transient signaling failure", http.StatusServiceUnavailable)
+				return
+			}
+			data, err := (&api.SignalTicketResponse{Token: "test-token"}).MarshalVT()
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(data)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/signal/ws":
+			conn, err := websocket.Accept(w, r, nil)
+			if err != nil {
+				return
+			}
+			defer conn.Close(websocket.StatusNormalClosure, "")
+			<-r.Context().Done()
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	st, err := transport.NewSessionTransport(
+		logrus.New().WithField("test", t.Name()),
+		tb.Bus,
+		privKey,
+		server.URL,
+		"",
+		transport.WithStartupTimeout(time.Second),
+		transport.WithStartupRetry(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rc := routine.NewRoutineContainer(routine.WithBackoff(&cbackoff.ZeroBackOff{}))
+	rc.SetRoutine(st.Execute)
+	rc.SetContext(ctx, false)
+	defer rc.ClearContext()
+
+	if err := st.AwaitReady(ctx); err != nil {
+		t.Fatalf("transport did not become ready after retry: %v", err)
+	}
+	if ticketRequests.Load() < 2 {
+		t.Fatalf("startup retry did not make a second signaling request: %d", ticketRequests.Load())
+	}
+	if st.GetChildBus() == nil {
+		t.Fatal("startup retry lost the transport child bus")
+	}
+}
+
+func newTestSessionTransport(
+	t *testing.T,
+	signalingURL string,
+	timeout time.Duration,
+) (context.Context, context.CancelFunc, *testbed.Testbed, *transport.SessionTransport) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	tb, err := testbed.Default(ctx)
+	if err != nil {
+		cancel()
+		t.Fatal(err)
+	}
+	privKey, _, err := crypto.GenerateEd25519Key(rand.Reader)
+	if err != nil {
+		cancel()
+		tb.Release()
+		t.Fatal(err)
+	}
+	st, err := transport.NewSessionTransport(
+		logrus.New().WithField("test", t.Name()),
+		tb.Bus,
+		privKey,
+		signalingURL,
+		"",
+		transport.WithStartupTimeout(timeout),
+	)
+	if err != nil {
+		cancel()
+		tb.Release()
+		t.Fatal(err)
+	}
+	return ctx, cancel, tb, st
+}
+
+func TestSessionTransportStartupFailurePublishesError(t *testing.T) {
+	requestStarted := make(chan struct{}, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case requestStarted <- struct{}{}:
+		default:
+		}
+		http.Error(w, "test rejection", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	ctx, cancel, tb, st := newTestSessionTransport(t, server.URL, time.Second)
+	defer func() {
+		cancel()
+		tb.Release()
+	}()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- st.Execute(ctx)
+	}()
+	select {
+	case <-requestStarted:
+	case <-ctx.Done():
+		t.Fatalf("stalled signaling request did not start: %v", ctx.Err())
+	}
+
+	err := st.AwaitReady(ctx)
+	if err == nil {
+		t.Fatal("expected session transport startup error")
+	}
+	if !strings.Contains(err.Error(), "session transport failed to start at webrtc-controllers") {
+		t.Fatalf("startup error does not name failed stage: %v", err)
+	}
+	select {
+	case executeErr := <-done:
+		if executeErr == nil {
+			t.Fatal("expected Execute to return the startup error")
+		}
+	case <-ctx.Done():
+		t.Fatalf("session transport did not publish startup failure: %v", ctx.Err())
+	}
+}
+
+func TestSessionTransportStartupTimeoutBeforeExecute(t *testing.T) {
+	ctx, cancel, tb, st := newTestSessionTransport(t, "", 20*time.Millisecond)
+	defer func() {
+		cancel()
+		tb.Release()
+	}()
+
+	err := st.AwaitReady(ctx)
+	if err == nil {
+		t.Fatal("expected startup timeout before Execute")
+	}
+	if !strings.Contains(err.Error(), "session transport did not become ready") {
+		t.Fatalf("startup error does not name readiness failure: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- st.Execute(ctx)
+	}()
+	select {
+	case executeErr := <-done:
+		if executeErr != context.Canceled {
+			t.Fatalf("Execute returned %v after timeout admission, want %v", executeErr, context.Canceled)
+		}
+	case <-ctx.Done():
+		t.Fatalf("Execute did not observe timeout admission: %v", ctx.Err())
+	}
+}
+
+func TestSessionTransportReadyWinsStartupTimeout(t *testing.T) {
+	ctx, cancel, tb, st := newTestSessionTransport(t, "", time.Second)
+	defer func() {
+		cancel()
+		tb.Release()
+	}()
+
+	readyCh := st.Ready()
+	select {
+	case <-readyCh:
+		t.Fatal("Ready closed before startup completed")
+	default:
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- st.Execute(ctx)
+	}()
+	if err := st.AwaitReady(ctx); err != nil {
+		t.Fatalf("AwaitReady returned startup error: %v", err)
+	}
+	select {
+	case <-readyCh:
+	default:
+		t.Fatal("Ready remained open after AwaitReady succeeded")
+	}
+	cancel()
+	select {
+	case executeErr := <-done:
+		if executeErr != context.Canceled {
+			t.Fatalf("Execute returned %v after cancellation, want %v", executeErr, context.Canceled)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("session transport did not stop after cancellation")
+	}
+}
+
+func TestSessionTransportRepeatedWaitersObserveReady(t *testing.T) {
+	ctx, cancel, tb, st := newTestSessionTransport(t, "", time.Second)
+	defer func() {
+		cancel()
+		tb.Release()
+	}()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- st.Execute(ctx)
+	}()
+	const waiterCount = 8
+	results := make(chan error, waiterCount)
+	for range waiterCount {
+		go func() {
+			results <- st.AwaitReady(ctx)
+		}()
+	}
+	for range waiterCount {
+		if err := <-results; err != nil {
+			t.Fatalf("repeated waiter returned startup error: %v", err)
+		}
+	}
+	cancel()
+	select {
+	case executeErr := <-done:
+		if executeErr != context.Canceled {
+			t.Fatalf("Execute returned %v after cancellation, want %v", executeErr, context.Canceled)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("session transport did not stop after cancellation")
+	}
+}

--- a/core/transport/webrtc-runtime-goscript_test.go
+++ b/core/transport/webrtc-runtime-goscript_test.go
@@ -16,13 +16,17 @@ import (
 )
 
 func TestSessionTransportGoScriptStartsSignalingBeforeReady(t *testing.T) {
-	requested := make(chan struct{}, 1)
+	requested := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	observed := make(chan struct{}, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/signal/ticket" {
 			http.NotFound(w, r)
 			return
 		}
 		requested <- struct{}{}
+		<-releaseRequest
+		observed <- struct{}{}
 		http.Error(w, "test rejection", http.StatusServiceUnavailable)
 	}))
 	defer srv.Close()
@@ -51,9 +55,17 @@ func TestSessionTransportGoScriptStartsSignalingBeforeReady(t *testing.T) {
 	select {
 	case <-requested:
 	case <-st.Ready():
-		t.Fatal("GoScript session transport reported ready without starting signaling")
+		t.Fatal("session transport became ready before requesting a signal ticket")
 	case err := <-done:
 		t.Fatalf("session transport exited before requesting a signal ticket: %v", err)
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+	close(releaseRequest)
+	select {
+	case <-observed:
+	case err := <-done:
+		t.Fatalf("session transport exited before the signal ticket request was observed: %v", err)
 	case <-ctx.Done():
 		t.Fatal(ctx.Err())
 	}

--- a/core/transport/webrtc-runtime.go
+++ b/core/transport/webrtc-runtime.go
@@ -33,6 +33,9 @@ func (t *SessionTransport) startWebRTCControllers(
 
 	ticket, err := acquireSignalTicket(ctx, t.signalingURL, t.sessionKey, t.peerID, t.signingEnvPfx)
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, nil, ctxErr
+		}
 		return nil, nil, err
 	}
 


### PR DESCRIPTION
A stalled session transport used to wait on readiness until the caller context expired. In tests, that meant the ten minute package timeout killed the whole local provider package without identifying the startup stage that was stuck.

SessionTransport now records the startup stage under its existing mutex, covering the child bus, bridge, peer controller, factories, solicit controller, WebRTC controllers, and ready transition. ProviderAccount applies a two minute startup-only budget to both new and existing transport readiness waits, stops the stalled transport, and reports the stage in the error.

Verification covered the requested provider and transport build, the full local provider package, and five race repetitions of the pairing and transport tests. The new test uses a real ProviderAccount and a signaling request held by a test-controlled channel.
