### PR TITLE
fix(opfs): preserve metashard generation floor on reset

### DIFF
--- a/db/volume/js/opfs/metashard/errors.go
+++ b/db/volume/js/opfs/metashard/errors.go
@@ -28,6 +28,14 @@ var ErrGenerationChanged = fmt.Errorf(
 	kvtx.ErrInvalidSnapshot,
 )
 
+type generationFloorError struct {
+	generation uint64
+}
+
+func (e *generationFloorError) Error() string {
+	return fmt.Sprintf("generation floor exhausted at %d", e.generation)
+}
+
 // CorruptError is returned when committed metashard state cannot be decoded.
 type CorruptError struct {
 	Err error

--- a/db/volume/js/opfs/metashard/metashard.go
+++ b/db/volume/js/opfs/metashard/metashard.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/binary"
+	"math"
 	"sync"
 	"syscall/js"
 
@@ -138,6 +139,9 @@ func (ms *MetaShard) WriteTx(fn func(tree *pagestore.Tree) error) error {
 			return errors.Wrap(err, "reset corrupt meta shard")
 		}
 	}
+	if ms.generation == math.MaxUint64 {
+		return &generationFloorError{generation: ms.generation}
+	}
 	tree, gen := ms.openCommittedTreeLocked()
 
 	// Execute mutations.
@@ -198,6 +202,9 @@ func (ms *MetaShard) WriteTx(fn func(tree *pagestore.Tree) error) error {
 		// database's epoch, which is harmless: every generation it produces is
 		// above every generation that database published.
 		if gen <= ms.resetGenerationFloor {
+			if ms.resetGenerationFloor == math.MaxUint64 {
+				return &generationFloorError{generation: ms.resetGenerationFloor}
+			}
 			gen = ms.resetGenerationFloor + 1
 		}
 	}
@@ -542,9 +549,14 @@ func (ms *MetaShard) resetCorruptStateLocked(cause error) error {
 }
 
 func (ms *MetaShard) resetCommittedStateLocked() error {
-	if ms.generation > ms.resetGenerationFloor {
-		ms.resetGenerationFloor = ms.generation
+	floor := ms.resetGenerationFloor
+	if ms.generation > floor {
+		floor = ms.generation
 	}
+	if floor == math.MaxUint64 {
+		return &generationFloorError{generation: floor}
+	}
+	ms.resetGenerationFloor = floor
 	if err := ms.pager.Close(); err != nil {
 		return errors.Wrap(err, "close page file")
 	}

--- a/db/volume/js/opfs/metashard/metashard.go
+++ b/db/volume/js/opfs/metashard/metashard.go
@@ -50,10 +50,8 @@ type MetaShard struct {
 	// assert that a run of reads over an unchanged shard performs one.
 	revalidations uint64
 	testHook      func(string) error
-	// resetGenerationFloor is the last generation this process saw before deleting
-	// and recreating on-disk metadata. A reset keeps this value in memory so the
-	// next creation generation stays above it, and stale cached state does not
-	// look current.
+	// resetGenerationFloor is the greatest generation this process has seen
+	// in validated state or decoded from on-disk superblocks before reset.
 	resetGenerationFloor uint64
 }
 
@@ -399,6 +397,15 @@ func (ms *MetaShard) reloadCommittedStateLocked(revalidate bool) error {
 		return err
 	}
 
+	// A decodable generation is evidence about the database on disk even when
+	// validation later rejects the page tree behind it.
+	for _, buf := range [][pagestore.SuperblockSize]byte{aBuf, bBuf} {
+		if sb, err := pagestore.DecodeSuperblock(buf[:]); err == nil &&
+			sb.Generation > ms.resetGenerationFloor {
+			ms.resetGenerationFloor = sb.Generation
+		}
+	}
+
 	// Every read operation reloads, because another agent may have committed
 	// since the last one. Reloading in full costs a whole-tree validation walk
 	// and a pager rebuild that drops the page cache, so a point read would cost
@@ -406,6 +413,7 @@ func (ms *MetaShard) reloadCommittedStateLocked(revalidate bool) error {
 	// whether any of that is necessary: when both are byte for byte the ones
 	// this state was loaded from, nothing has been committed since, the state in
 	// hand is that state, and it was validated when it was loaded.
+
 	if !revalidate && ms.stateLoaded &&
 		aBuf == ms.loadedSupers[0] && bBuf == ms.loadedSupers[1] {
 		return nil
@@ -534,7 +542,9 @@ func (ms *MetaShard) resetCorruptStateLocked(cause error) error {
 }
 
 func (ms *MetaShard) resetCommittedStateLocked() error {
-	ms.resetGenerationFloor = ms.generation
+	if ms.generation > ms.resetGenerationFloor {
+		ms.resetGenerationFloor = ms.generation
+	}
 	if err := ms.pager.Close(); err != nil {
 		return errors.Wrap(err, "close page file")
 	}

--- a/db/volume/js/opfs/metashard/metashard_test.go
+++ b/db/volume/js/opfs/metashard/metashard_test.go
@@ -5,6 +5,7 @@ package metashard
 import (
 	"bytes"
 	"context"
+	"math"
 	"strings"
 	"testing"
 
@@ -585,6 +586,58 @@ func TestMetaShardConstructionRecoveryPreservesGenerationFloor(t *testing.T) {
 	putMetaValue(t, ms, "k", "v2")
 
 	const corruptGeneration = uint64(0xFFFFFFFF)<<generationEpochShift | 1
+	prepareCorruptMetaShard(t, ms, corruptGeneration)
+
+	reopened := reopenTestMetaShard(t, name)
+	putMetaValue(t, reopened, "after-reset", "ok")
+	if after := reopened.Generation(); after <= corruptGeneration {
+		t.Fatalf("generation %d after construction reset did not exceed corrupt generation %d",
+			after, corruptGeneration)
+	}
+}
+
+func TestMetaShardConstructionRecoveryRejectsSaturatedGenerationFloor(t *testing.T) {
+	name := "test-metashard-construction-saturated-generation-floor"
+	ms := newTestMetaShard(t, name)
+	putMetaValue(t, ms, "k", "v1")
+	putMetaValue(t, ms, "k", "v2")
+	prepareCorruptMetaShard(t, ms, math.MaxUint64)
+
+	root, err := opfs.GetRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir, err := opfs.GetDirectory(root, name, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = NewMetaShard(dir, name, 0, logrus.New().WithField("test", name))
+	if err == nil {
+		t.Fatal("expected construction to reject saturated generation floor")
+	}
+	var floorErr *generationFloorError
+	if !errors.As(err, &floorErr) {
+		t.Fatalf("error = %v, want generationFloorError", err)
+	}
+	if floorErr.generation != math.MaxUint64 {
+		t.Fatalf("generation = %d, want %d", floorErr.generation, uint64(math.MaxUint64))
+	}
+
+	var buf [pagestore.SuperblockSize]byte
+	if err := readSuper(dir, "super-a", buf[:]); err != nil {
+		t.Fatal(err)
+	}
+	sb, err := pagestore.DecodeSuperblock(buf[:])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sb.Generation != math.MaxUint64 {
+		t.Fatalf("on-disk generation = %d, want %d", sb.Generation, uint64(math.MaxUint64))
+	}
+}
+
+func prepareCorruptMetaShard(t *testing.T, ms *MetaShard, generation uint64) {
+	t.Helper()
 	for _, slot := range []string{"super-a", "super-b"} {
 		var buf [pagestore.SuperblockSize]byte
 		if err := readSuper(ms.dir, slot, buf[:]); err != nil {
@@ -594,7 +647,7 @@ func TestMetaShardConstructionRecoveryPreservesGenerationFloor(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		sb.Generation = corruptGeneration
+		sb.Generation = generation
 		pagestore.EncodeSuperblock(buf[:], sb)
 		if err := writeSuper(ms.dir, slot, buf[:]); err != nil {
 			t.Fatal(err)
@@ -604,13 +657,6 @@ func TestMetaShardConstructionRecoveryPreservesGenerationFloor(t *testing.T) {
 		t.Fatal(err)
 	}
 	zeroSuperblockRoots(t, ms)
-
-	reopened := reopenTestMetaShard(t, name)
-	putMetaValue(t, reopened, "after-reset", "ok")
-	if after := reopened.Generation(); after <= corruptGeneration {
-		t.Fatalf("generation %d after construction reset did not exceed corrupt generation %d",
-			after, corruptGeneration)
-	}
 }
 
 func TestMetaStoreReadTxRecoversCorruptSnapshot(t *testing.T) {

--- a/db/volume/js/opfs/metashard/metashard_test.go
+++ b/db/volume/js/opfs/metashard/metashard_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/s4wave/spacewave/db/opfs"
 	"github.com/s4wave/spacewave/db/volume/js/opfs/pagestore"
+	"github.com/sirupsen/logrus"
 )
 
 func newTestMetaShard(t *testing.T, name string) *MetaShard {
@@ -46,7 +47,7 @@ func reopenTestMetaShard(t *testing.T, name string) *MetaShard {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ms, err := NewMetaShard(dir, name, 0, nil)
+	ms, err := NewMetaShard(dir, name, 0, logrus.New().WithField("test", name))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -574,6 +575,41 @@ func TestMetaShardResetGenerationUsesProcessFloor(t *testing.T) {
 				t.Fatalf("generation %d after reset did not exceed prior %d", after, before)
 			}
 		})
+	}
+}
+
+func TestMetaShardConstructionRecoveryPreservesGenerationFloor(t *testing.T) {
+	name := "test-metashard-construction-generation-floor"
+	ms := newTestMetaShard(t, name)
+	putMetaValue(t, ms, "k", "v1")
+	putMetaValue(t, ms, "k", "v2")
+
+	const corruptGeneration = uint64(0xFFFFFFFF)<<generationEpochShift | 1
+	for _, slot := range []string{"super-a", "super-b"} {
+		var buf [pagestore.SuperblockSize]byte
+		if err := readSuper(ms.dir, slot, buf[:]); err != nil {
+			t.Fatal(err)
+		}
+		sb, err := pagestore.DecodeSuperblock(buf[:])
+		if err != nil {
+			t.Fatal(err)
+		}
+		sb.Generation = corruptGeneration
+		pagestore.EncodeSuperblock(buf[:], sb)
+		if err := writeSuper(ms.dir, slot, buf[:]); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := ms.Close(); err != nil {
+		t.Fatal(err)
+	}
+	zeroSuperblockRoots(t, ms)
+
+	reopened := reopenTestMetaShard(t, name)
+	putMetaValue(t, reopened, "after-reset", "ok")
+	if after := reopened.Generation(); after <= corruptGeneration {
+		t.Fatalf("generation %d after construction reset did not exceed corrupt generation %d",
+			after, corruptGeneration)
 	}
 }
 


### PR DESCRIPTION
A newly constructed MetaShard could reset a corrupt database while its in-memory generation was still zero. The replacement then drew an epoch below the database it replaced, so consumers holding the old generation could suppress valid replacement commits.

The metashard owner now records the greatest decodable superblock generation before page validation and preserves that value through reset. Recovery generation selection changes only in this case. The on-disk format and normal validated reload behavior are unchanged.

The volume build and focused package checks pass. A browser DedicatedWorker regression constructs a corrupt high-generation database, observes construction reset it, and verifies the first replacement commit is above the recovered generation.