### PR TITLE
fix(provider): guard P2P sync state with broadcast

### DIFF
--- a/core/provider/local/bstore_test.go
+++ b/core/provider/local/bstore_test.go
@@ -67,6 +67,49 @@ func (s *localDEXTestStore) GetBlock(ctx context.Context, ref *block.BlockRef) (
 
 var _ block.StoreOps = ((*localDEXTestStore)(nil))
 
+func TestBlockStoreReadRetainsPriorP2PSyncSourceDuringReplacement(t *testing.T) {
+	ctx := t.Context()
+	data := []byte("from-prior-p2p-state")
+	ref, err := block.BuildBlockRef(data, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	priorStore := newBatchForwardTestStore()
+	if _, _, err := priorStore.PutBlock(ctx, data, nil); err != nil {
+		t.Fatal(err)
+	}
+	prior := &p2pSyncState{
+		ctx:     ctx,
+		started: true,
+		stores:  map[string]block.StoreOps{"bucket": priorStore},
+	}
+	replacement := &p2pSyncState{
+		ctx:         ctx,
+		lowerSource: prior,
+	}
+	account := &ProviderAccount{}
+	account.p2pSyncBcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		account.p2pSync = replacement
+	})
+
+	localStore := newBatchForwardTestStore()
+	readOps := block_store.NewStoreReadThrough(
+		func() block.StoreOps { return localStore },
+		func() block.StoreOps { return account.getP2PStore("bucket") },
+		true,
+	)
+	store := &BlockStore{
+		store:     block_store.NewStore("local-store", localStore),
+		readStore: block_store.NewStore("local-store", readOps),
+	}
+
+	got, found, err := store.GetBlock(ctx, ref)
+	if err != nil || !found || string(got) != string(data) {
+		t.Fatalf("replacement lower source = %q/%v/%v", got, found, err)
+	}
+}
+
 func TestLocalBlockStoreMissRoutesToSessionChildDEX(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()

--- a/core/provider/local/bstore_test.go
+++ b/core/provider/local/bstore_test.go
@@ -6,12 +6,15 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/aperturerobotics/controllerbus/controller/resolver"
+	"github.com/aperturerobotics/controllerbus/directive"
 	"github.com/s4wave/spacewave/core/provider"
 	"github.com/s4wave/spacewave/db/block"
 	block_mock "github.com/s4wave/spacewave/db/block/mock"
 	block_store "github.com/s4wave/spacewave/db/block/store"
 	block_store_inmem "github.com/s4wave/spacewave/db/block/store/inmem"
 	lookup_concurrent "github.com/s4wave/spacewave/db/bucket/lookup/concurrent"
+	dex_solicit "github.com/s4wave/spacewave/db/dex/solicit"
 	store_kvkey "github.com/s4wave/spacewave/db/store/kvkey"
 	store_kvtx_inmem "github.com/s4wave/spacewave/db/store/kvtx/inmem"
 )
@@ -67,46 +70,116 @@ func (s *localDEXTestStore) GetBlock(ctx context.Context, ref *block.BlockRef) (
 
 var _ block.StoreOps = ((*localDEXTestStore)(nil))
 
-func TestBlockStoreReadRetainsPriorP2PSyncSourceDuringReplacement(t *testing.T) {
-	ctx := t.Context()
-	data := []byte("from-prior-p2p-state")
-	ref, err := block.BuildBlockRef(data, nil)
+func TestMountedBlockStoreReadUsesPriorSourceDuringReplacement(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	_, _, acc, sess, release := setupProviderAndSessionInternal(ctx, t)
+	defer release()
+
+	if err := acc.CreateSessionTransport(ctx, sess.GetPrivKey(), ""); err != nil {
+		t.Fatal(err)
+	}
+	defer acc.StopSessionTransport()
+	first := acc.GetSessionTransport()
+	if first == nil {
+		t.Fatal("expected initial session transport")
+	}
+
+	data := []byte("from-prior-production-source")
+	blockRef, err := block.BuildBlockRef(data, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	priorStore := newBatchForwardTestStore()
 	if _, _, err := priorStore.PutBlock(ctx, data, nil); err != nil {
 		t.Fatal(err)
 	}
+
+	bstoreRef, err := acc.CreateBlockStore(ctx, "replacement-window")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bucketID := BlockStoreBucketID(
+		acc.GetProviderID(),
+		acc.GetAccountID(),
+		bstoreRef.GetProviderResourceRef().GetId(),
+	)
+	priorCtx, priorCancel := context.WithCancel(ctx)
+	defer priorCancel()
 	prior := &p2pSyncState{
-		ctx:     ctx,
-		started: true,
-		stores:  map[string]block.StoreOps{"bucket": priorStore},
+		ctx:              priorCtx,
+		cancel:           priorCancel,
+		sessionTransport: first,
+		startComplete:    true,
+		started:          true,
+		startupExited:    true,
+		stores:           map[string]block.StoreOps{bucketID: priorStore},
 	}
-	replacement := &p2pSyncState{
-		ctx:         ctx,
-		lowerSource: prior,
-	}
-	account := &ProviderAccount{}
-	account.p2pSyncBcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
-		account.p2pSync = replacement
+	acc.p2pSyncBcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
+		acc.p2pSync = prior
+		bcast()
 	})
 
-	localStore := newBatchForwardTestStore()
-	readOps := block_store.NewStoreReadThrough(
-		func() block.StoreOps { return localStore },
-		func() block.StoreOps { return account.getP2PStore("bucket") },
-		true,
-	)
-	store := &BlockStore{
-		store:     block_store.NewStore("local-store", localStore),
-		readStore: block_store.NewStore("local-store", readOps),
+	if err := acc.CreateSessionTransport(ctx, sess.GetPrivKey(), ""); err != nil {
+		t.Fatal(err)
+	}
+	second := acc.GetSessionTransport()
+	if second == nil || second == first {
+		t.Fatal("expected replacement session transport")
 	}
 
-	got, found, err := store.GetBlock(ctx, ref)
+	loadStarted := make(chan struct{})
+	releaseLoad := make(chan struct{})
+	var gate atomic.Bool
+	removeHandler, err := second.GetChildBus().AddHandler(directive.NewFuncHandler(
+		func(handlerCtx context.Context, di directive.Instance) ([]directive.Resolver, error) {
+			load, ok := di.GetDirective().(resolver.LoadControllerWithConfig)
+			if !ok {
+				return nil, nil
+			}
+			if _, ok := load.GetLoadControllerConfig().(*dex_solicit.Config); !ok {
+				return nil, nil
+			}
+			if gate.CompareAndSwap(false, true) {
+				close(loadStarted)
+				select {
+				case <-releaseLoad:
+				case <-handlerCtx.Done():
+				}
+			}
+			return nil, nil
+		},
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer removeHandler()
+
+	mounted, releaseMounted, err := acc.MountBlockStore(ctx, bstoreRef, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer releaseMounted()
+
+	startDone := make(chan error, 1)
+	go func() {
+		startDone <- acc.StartP2PSync(ctx, second)
+	}()
+	select {
+	case <-loadStarted:
+	case <-ctx.Done():
+		t.Fatal("replacement controller load did not start")
+	}
+
+	got, found, err := mounted.GetBlock(ctx, blockRef)
 	if err != nil || !found || string(got) != string(data) {
-		t.Fatalf("replacement lower source = %q/%v/%v", got, found, err)
+		t.Fatalf("production replacement lower source = %q/%v/%v", got, found, err)
+	}
+
+	close(releaseLoad)
+	if err := <-startDone; err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/core/provider/local/bstore_test.go
+++ b/core/provider/local/bstore_test.go
@@ -188,6 +188,15 @@ func TestMountedBlockStoreReadUsesPriorSourceDuringReplacement(t *testing.T) {
 	if err := <-startDone; err != nil {
 		t.Fatal(err)
 	}
+	var current *p2pSyncState
+	acc.p2pSyncBcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		current = acc.p2pSync
+	})
+	current.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		if current.lowerSource != nil || current.lowerSourceHeld {
+			t.Fatal("replacement retained its lower P2P source after startup")
+		}
+	})
 }
 
 func TestLocalBlockStoreMissRoutesToSessionChildDEX(t *testing.T) {

--- a/core/provider/local/bstore_test.go
+++ b/core/provider/local/bstore_test.go
@@ -114,6 +114,7 @@ func TestMountedBlockStoreReadUsesPriorSourceDuringReplacement(t *testing.T) {
 		startComplete:    true,
 		started:          true,
 		startupExited:    true,
+		owners:           1,
 		stores:           map[string]block.StoreOps{bucketID: priorStore},
 	}
 	acc.p2pSyncBcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
@@ -171,6 +172,12 @@ func TestMountedBlockStoreReadUsesPriorSourceDuringReplacement(t *testing.T) {
 	case <-ctx.Done():
 		t.Fatal("replacement controller load did not start")
 	}
+	acc.releaseP2PSyncState(prior)
+	prior.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		if prior.stopping {
+			t.Fatal("prior P2P source stopped while replacement was starting")
+		}
+	})
 
 	got, found, err := mounted.GetBlock(ctx, blockRef)
 	if err != nil || !found || string(got) != string(data) {

--- a/core/provider/local/p2p-sync-lifecycle_test.go
+++ b/core/provider/local/p2p-sync-lifecycle_test.go
@@ -1,16 +1,97 @@
 package provider_local
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
-func TestP2PSyncStateStartCompletionIsIdempotent(t *testing.T) {
-	state := &p2pSyncState{startDone: make(chan struct{})}
+func TestP2PSyncStateFinishStartPublishesStableState(t *testing.T) {
+	ctx := t.Context()
+	state := &p2pSyncState{ctx: ctx}
 
-	state.completeStart()
-	state.completeStart()
+	restart, published, err := state.finishStart(nil)
+	if restart || !published || err != nil {
+		t.Fatalf("finish start = restart %v, published %v, err %v", restart, published, err)
+	}
+
+	state.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		if !state.startComplete || !state.started || state.startErr != nil {
+			t.Fatalf("unexpected completed state: %+v", state)
+		}
+	})
+
+	restart, published, err = state.finishStart(context.Canceled)
+	if restart || published || err != nil {
+		t.Fatalf("second finish start = restart %v, published %v, err %v", restart, published, err)
+	}
+}
+
+func TestP2PSyncStateRestartStaysIncompleteUntilStable(t *testing.T) {
+	ctx := t.Context()
+	state := &p2pSyncState{ctx: ctx, restartPending: true}
+
+	restart, published, err := state.finishStart(nil)
+	if !restart || published || err != nil {
+		t.Fatalf("pending finish start = restart %v, published %v, err %v", restart, published, err)
+	}
+	state.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		if state.startComplete {
+			t.Fatal("restart decision published startup completion")
+		}
+		if state.restartPending {
+			t.Fatal("restart decision remained pending")
+		}
+	})
+
+	restart, published, err = state.finishStart(nil)
+	if restart || !published || err != nil {
+		t.Fatalf("stable finish start = restart %v, published %v, err %v", restart, published, err)
+	}
+}
+
+func TestRetireP2PSyncStateWaitsForOwnedWork(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	state := &p2pSyncState{
+		ctx:           ctx,
+		cancel:        cancel,
+		startupExited: false,
+		workers:       1,
+		relFns:        []func(){func() {}},
+	}
+	account := &ProviderAccount{}
+	account.p2pSyncBcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		account.p2pSync = state
+	})
+
+	retired := make(chan struct{})
+	go func() {
+		account.retireP2PSyncState(nil)
+		close(retired)
+	}()
+
+	var stoppingCh <-chan struct{}
+	state.bcast.HoldLock(func(_ func(), getWaitCh func() <-chan struct{}) {
+		stoppingCh = getWaitCh()
+	})
+	<-stoppingCh
 
 	select {
-	case <-state.startDone:
+	case <-retired:
+		t.Fatal("retirement completed while owned work remained")
 	default:
-		t.Fatal("expected startup completion signal to be closed")
 	}
+
+	state.bcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
+		state.startupExited = true
+		state.workers = 0
+		bcast()
+	})
+	<-retired
+
+	state.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		if !state.cleanupDone {
+			t.Fatal("retirement did not complete cleanup")
+		}
+	})
 }

--- a/core/provider/local/p2p-sync-lifecycle_test.go
+++ b/core/provider/local/p2p-sync-lifecycle_test.go
@@ -9,9 +9,9 @@ func TestP2PSyncStateFinishStartPublishesStableState(t *testing.T) {
 	ctx := t.Context()
 	state := &p2pSyncState{ctx: ctx}
 
-	restart, published, err := state.finishStart(nil)
-	if restart || !published || err != nil {
-		t.Fatalf("finish start = restart %v, published %v, err %v", restart, published, err)
+	restart := state.finishStart(nil)
+	if restart {
+		t.Fatal("stable startup requested a restart")
 	}
 
 	state.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
@@ -20,9 +20,9 @@ func TestP2PSyncStateFinishStartPublishesStableState(t *testing.T) {
 		}
 	})
 
-	restart, published, err = state.finishStart(context.Canceled)
-	if restart || published || err != nil {
-		t.Fatalf("second finish start = restart %v, published %v, err %v", restart, published, err)
+	restart = state.finishStart(context.Canceled)
+	if restart {
+		t.Fatal("completed startup requested a restart")
 	}
 }
 
@@ -30,9 +30,9 @@ func TestP2PSyncStateRestartStaysIncompleteUntilStable(t *testing.T) {
 	ctx := t.Context()
 	state := &p2pSyncState{ctx: ctx, restartPending: true}
 
-	restart, published, err := state.finishStart(nil)
-	if !restart || published || err != nil {
-		t.Fatalf("pending finish start = restart %v, published %v, err %v", restart, published, err)
+	restart := state.finishStart(nil)
+	if !restart {
+		t.Fatal("pending startup did not request a restart")
 	}
 	state.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
 		if state.startComplete {
@@ -43,9 +43,9 @@ func TestP2PSyncStateRestartStaysIncompleteUntilStable(t *testing.T) {
 		}
 	})
 
-	restart, published, err = state.finishStart(nil)
-	if restart || !published || err != nil {
-		t.Fatalf("stable finish start = restart %v, published %v, err %v", restart, published, err)
+	restart = state.finishStart(nil)
+	if restart {
+		t.Fatal("stable startup requested an extra restart")
 	}
 }
 

--- a/core/provider/local/p2p-sync-lifecycle_test.go
+++ b/core/provider/local/p2p-sync-lifecycle_test.go
@@ -70,11 +70,22 @@ func TestRetireP2PSyncStateWaitsForOwnedWork(t *testing.T) {
 		close(retired)
 	}()
 
-	var stoppingCh <-chan struct{}
-	state.bcast.HoldLock(func(_ func(), getWaitCh func() <-chan struct{}) {
-		stoppingCh = getWaitCh()
-	})
-	<-stoppingCh
+	for {
+		var (
+			stopping bool
+			waitCh   <-chan struct{}
+		)
+		state.bcast.HoldLock(func(_ func(), getWaitCh func() <-chan struct{}) {
+			stopping = state.stopping
+			if !stopping {
+				waitCh = getWaitCh()
+			}
+		})
+		if stopping {
+			break
+		}
+		<-waitCh
+	}
 
 	select {
 	case <-retired:
@@ -94,4 +105,48 @@ func TestRetireP2PSyncStateWaitsForOwnedWork(t *testing.T) {
 			t.Fatal("retirement did not complete cleanup")
 		}
 	})
+}
+
+func TestRetireP2PSyncStateReleasesLowerChain(t *testing.T) {
+	makeState := func(lower *p2pSyncState) *p2pSyncState {
+		ctx, cancel := context.WithCancel(context.Background())
+		return &p2pSyncState{
+			ctx:             ctx,
+			cancel:          cancel,
+			owners:          1,
+			startComplete:   true,
+			started:         true,
+			startupExited:   true,
+			lowerSource:     lower,
+			lowerSourceHeld: lower != nil,
+		}
+	}
+
+	first := makeState(nil)
+	second := makeState(first)
+	third := makeState(second)
+	account := &ProviderAccount{}
+	account.p2pSyncBcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		account.p2pSync = third
+	})
+
+	account.retireP2PSyncState(nil)
+
+	for name, state := range map[string]*p2pSyncState{
+		"first":  first,
+		"second": second,
+		"third":  third,
+	} {
+		state.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+			if !state.stopping || !state.cleanupDone {
+				t.Fatalf("%s state was not fully retired", name)
+			}
+			if state.lowerSource != nil || state.lowerSourceHeld {
+				t.Fatalf("%s state retained its lower source", name)
+			}
+		})
+		if state.ctx.Err() == nil {
+			t.Fatalf("%s state context was not canceled", name)
+		}
+	}
 }

--- a/core/provider/local/p2p-sync.go
+++ b/core/provider/local/p2p-sync.go
@@ -3,12 +3,12 @@ package provider_local
 import (
 	"bytes"
 	"context"
-	"sync"
 
 	"github.com/aperturerobotics/controllerbus/bus"
 	"github.com/aperturerobotics/controllerbus/controller/loader"
 	"github.com/aperturerobotics/controllerbus/controller/resolver"
 	"github.com/aperturerobotics/controllerbus/directive"
+	"github.com/aperturerobotics/util/broadcast"
 	"github.com/pkg/errors"
 	"github.com/s4wave/spacewave/core/sobject"
 	sobject_invite "github.com/s4wave/spacewave/core/sobject/invite"
@@ -22,78 +22,93 @@ import (
 
 // p2pSyncState holds P2P sync startup or running state and DEX stores.
 type p2pSyncState struct {
-	ctx context.Context
-	// sessionTransport is the transport this state's controllers run on. A
-	// start for a different transport cannot join this one: the startup pass
-	// loads controllers onto the child bus of the transport it began with, so
-	// coalescing across transports would leave the newer transport without
-	// them while its caller was told sync had started.
+	// bcast guards every lifecycle and resource field below.
+	bcast broadcast.Broadcast
+
+	ctx              context.Context
 	sessionTransport *transport.SessionTransport
 	cancel           context.CancelFunc
-	startDone        chan struct{}
-	startOnce        sync.Once
-	runDone          chan struct{}
-	stopDone         chan struct{}
-	stopOnce         sync.Once
-	wg               sync.WaitGroup
-	mtx              sync.Mutex
 	owners           int
+	startComplete    bool
+	started          bool
+	startupExited    bool
+	stopping         bool
+	cleanupRunning   bool
+	cleanupDone      bool
 	restartPending   bool
-	// startErr is the failure that ended startup, published to every waiter
-	// under the account's sync lock before startDone closes.
-	startErr error
-	refs     []directive.Reference
-	relFns   []func()
-	stores   map[string]block.StoreOps
-	soIDs    map[string]struct{}
+	startErr         error
+	lowerSource      *p2pSyncState
+	workers          int
+	refs             []directive.Reference
+	relFns           []func()
+	stores           map[string]block.StoreOps
+	soIDs            map[string]struct{}
 }
 
-func (s *p2pSyncState) completeStart() {
-	s.startOnce.Do(func() {
-		close(s.startDone)
-	})
-}
-
-// retainP2PSyncState is called with the account sync lock held before it takes
-// state.mtx. The release path drops state.mtx before reacquiring the account
-// lock to retire the state, so the locks are never held in reverse order.
-func (a *ProviderAccount) retainP2PSyncState(ctx context.Context, state *p2pSyncState) bool {
+func (a *ProviderAccount) retainP2PSyncStateLocked(ctx context.Context, state *p2pSyncState) bool {
 	if ctx.Err() != nil {
 		return false
 	}
 
-	state.mtx.Lock()
-	if state.ctx.Err() != nil {
-		state.mtx.Unlock()
-		return false
-	}
-	state.owners++
-	state.mtx.Unlock()
+	retained := false
+	state.bcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
+		if state.stopping || state.ctx.Err() != nil || ctx.Err() != nil {
+			return
+		}
+		state.owners++
+		retained = true
+		bcast()
+	})
+	return retained
+}
 
+func (a *ProviderAccount) watchP2PSyncOwner(ctx context.Context, state *p2pSyncState) {
 	if ctx.Done() == nil {
-		return true
+		return
 	}
 	go func() {
-		select {
-		case <-ctx.Done():
-			a.releaseP2PSyncState(state)
-		case <-state.stopDone:
+		for {
+			var waitCh <-chan struct{}
+			var stopped bool
+			state.bcast.HoldLock(func(_ func(), getWaitCh func() <-chan struct{}) {
+				stopped = state.stopping
+				if !stopped {
+					waitCh = getWaitCh()
+				}
+			})
+			if stopped {
+				return
+			}
+			select {
+			case <-ctx.Done():
+				a.releaseP2PSyncState(state)
+				return
+			case <-waitCh:
+			}
 		}
 	}()
-	return true
 }
 
 func (a *ProviderAccount) releaseP2PSyncState(state *p2pSyncState) {
 	retire := false
-	state.mtx.Lock()
-	if state.owners > 0 {
-		state.owners--
+	state.bcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
 		if state.owners == 0 {
-			state.cancel()
-			retire = true
+			return
 		}
-	}
-	state.mtx.Unlock()
+		state.owners--
+		if state.owners != 0 {
+			bcast()
+			return
+		}
+		state.cancel()
+		state.stopping = true
+		if !state.startComplete {
+			state.startErr = context.Canceled
+			state.startComplete = true
+		}
+		bcast()
+		retire = true
+	})
 
 	if retire {
 		a.retireP2PSyncState(state)
@@ -101,42 +116,85 @@ func (a *ProviderAccount) releaseP2PSyncState(state *p2pSyncState) {
 }
 
 func (s *p2pSyncState) addStore(bucketID string, store block.StoreOps) {
-	s.mtx.Lock()
-	if s.stores == nil {
-		s.stores = make(map[string]block.StoreOps)
-	}
-	s.stores[bucketID] = store
-	s.mtx.Unlock()
+	s.bcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
+		if s.stores == nil {
+			s.stores = make(map[string]block.StoreOps)
+		}
+		s.stores[bucketID] = store
+		bcast()
+	})
 }
 
 func (s *p2pSyncState) hasStore(bucketID string) bool {
-	s.mtx.Lock()
-	_, ok := s.stores[bucketID]
-	s.mtx.Unlock()
+	var ok bool
+	s.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		_, ok = s.stores[bucketID]
+	})
 	return ok
 }
 
 func (s *p2pSyncState) hasSO(soID string) bool {
-	s.mtx.Lock()
-	_, ok := s.soIDs[soID]
-	s.mtx.Unlock()
+	var ok bool
+	s.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		_, ok = s.soIDs[soID]
+	})
 	return ok
 }
 
 func (s *p2pSyncState) addSO(soID string) {
-	s.mtx.Lock()
-	if s.soIDs == nil {
-		s.soIDs = make(map[string]struct{})
-	}
-	s.soIDs[soID] = struct{}{}
-	s.mtx.Unlock()
+	s.bcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
+		if s.soIDs == nil {
+			s.soIDs = make(map[string]struct{})
+		}
+		s.soIDs[soID] = struct{}{}
+		bcast()
+	})
+}
+
+func (s *p2pSyncState) addRef(ref directive.Reference) {
+	s.bcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
+		s.refs = append(s.refs, ref)
+		bcast()
+	})
+}
+
+func (s *p2pSyncState) addRelease(rel func()) {
+	s.bcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
+		s.relFns = append(s.relFns, rel)
+		bcast()
+	})
+}
+
+func (s *p2pSyncState) addWorker() {
+	s.bcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
+		s.workers++
+		bcast()
+	})
+}
+
+func (s *p2pSyncState) workerDone() {
+	s.bcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
+		if s.workers == 0 {
+			return
+		}
+		s.workers--
+		bcast()
+	})
 }
 
 func (s *p2pSyncState) getStore(bucketID string) block.StoreOps {
-	s.mtx.Lock()
-	store := s.stores[bucketID]
-	s.mtx.Unlock()
-	return store
+	var store block.StoreOps
+	var lowerSource *p2pSyncState
+	s.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		store = s.stores[bucketID]
+		if store == nil && !s.started {
+			lowerSource = s.lowerSource
+		}
+	})
+	if store != nil || lowerSource == nil {
+		return store
+	}
+	return lowerSource.getStore(bucketID)
 }
 
 // StartP2PSync starts SO sync and DEX block exchange for all mounted
@@ -158,18 +216,26 @@ func (a *ProviderAccount) StartP2PSync(ctx context.Context, sessionTransport *tr
 		previous  *p2pSyncState
 		waitState *p2pSyncState
 		state     *p2pSyncState
+		watch     bool
 	)
 	a.p2pSyncBcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
 		previous = a.p2pSync
 		if previous != nil && previous.sessionTransport == sessionTransport {
-			select {
-			case <-previous.startDone:
-			default:
-				if previous.ctx.Err() == nil && a.retainP2PSyncState(ctx, previous) {
-					previous.restartPending = true
-					waitState = previous
+			previous.bcast.HoldLock(func(stateBcast func(), _ func() <-chan struct{}) {
+				if previous.startComplete || previous.stopping || previous.ctx.Err() != nil {
 					return
 				}
+				if ctx.Err() != nil {
+					return
+				}
+				previous.owners++
+				previous.restartPending = true
+				stateBcast()
+				waitState = previous
+				watch = true
+			})
+			if waitState != nil {
+				return
 			}
 		}
 
@@ -178,18 +244,24 @@ func (a *ProviderAccount) StartP2PSync(ctx context.Context, sessionTransport *tr
 			ctx:              syncCtx,
 			sessionTransport: sessionTransport,
 			cancel:           syncCancel,
-			startDone:        make(chan struct{}),
-			runDone:          make(chan struct{}),
-			stopDone:         make(chan struct{}),
+			lowerSource:      previous,
 		}
-		if !a.retainP2PSyncState(ctx, state) {
+		if !a.retainP2PSyncStateLocked(ctx, state) {
 			syncCancel()
 			state = nil
 			return
 		}
 		a.p2pSync = state
 		bcast()
+		watch = true
 	})
+	if watch {
+		if waitState != nil {
+			a.watchP2PSyncOwner(ctx, waitState)
+		} else {
+			a.watchP2PSyncOwner(ctx, state)
+		}
+	}
 	if state == nil {
 		if waitState == nil {
 			return ctx.Err()
@@ -209,17 +281,32 @@ func (a *ProviderAccount) StartP2PSync(ctx context.Context, sessionTransport *tr
 // own context to end, whichever comes first. Giving up releases this caller's
 // ownership without stopping the run; it ends only when the last owner leaves.
 func (a *ProviderAccount) awaitP2PSyncStart(ctx context.Context, state *p2pSyncState) error {
-	select {
-	case <-state.startDone:
-	case <-ctx.Done():
-		return ctx.Err()
+	for {
+		var waitCh <-chan struct{}
+		var complete bool
+		state.bcast.HoldLock(func(_ func(), getWaitCh func() <-chan struct{}) {
+			complete = state.startComplete
+			if !complete {
+				waitCh = getWaitCh()
+			}
+		})
+		if complete {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-waitCh:
+		}
 	}
 
 	var running bool
 	var startErr error
 	a.p2pSyncBcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
 		running = a.p2pSync == state
-		startErr = state.startErr
+		state.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+			startErr = state.startErr
+		})
 	})
 	if startErr != nil {
 		return startErr
@@ -233,114 +320,159 @@ func (a *ProviderAccount) awaitP2PSyncStart(ctx context.Context, state *p2pSyncS
 	return errors.New("P2P sync stopped during startup")
 }
 
-// runP2PSyncStart performs the startup pass and publishes its outcome to every
-// caller waiting on the state.
+func (s *p2pSyncState) finishStart(err error) (bool, bool, error) {
+	restart := false
+	published := false
+	terminalErr := err
+	s.bcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
+		if terminalErr == nil && s.stopping {
+			terminalErr = context.Canceled
+		}
+		if terminalErr == nil {
+			terminalErr = s.ctx.Err()
+		}
+		if terminalErr == nil && s.restartPending && !s.stopping && !s.startComplete {
+			s.restartPending = false
+			restart = true
+			bcast()
+			return
+		}
+		if s.startComplete {
+			terminalErr = s.startErr
+			return
+		}
+		s.startErr = terminalErr
+		s.started = terminalErr == nil
+		s.startComplete = true
+		published = true
+		bcast()
+	})
+	return restart, published, terminalErr
+}
+
+func (s *p2pSyncState) markStartupExited() {
+	s.bcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
+		s.startupExited = true
+		bcast()
+	})
+}
+
+// runP2PSyncStart performs startup and publishes each stable lifecycle outcome
+// through the state broadcast.
 func (a *ProviderAccount) runP2PSyncStart(
 	state *p2pSyncState,
 	previous *p2pSyncState,
 	sessionTransport *transport.SessionTransport,
 	childBus bus.Bus,
 ) {
-	err := a.startP2PSyncControllers(state, previous, sessionTransport, childBus)
-
-	a.p2pSyncBcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
-		state.startErr = err
-		state.completeStart()
-		bcast()
-	})
-	close(state.runDone)
-
-	if err != nil {
-		a.retireP2PSyncState(state)
+	var (
+		err           error
+		inviteStarted bool
+	)
+	for {
+		err = a.startP2PSyncControllers(
+			state,
+			sessionTransport,
+			childBus,
+			&inviteStarted,
+		)
+		restart, published, terminalErr := state.finishStart(err)
+		err = terminalErr
+		if published {
+			a.p2pSyncBcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
+				bcast()
+			})
+		}
+		if restart {
+			continue
+		}
+		break
 	}
+
+	if err == nil {
+		if previous != nil {
+			a.retireP2PSyncState(previous)
+		}
+		state.markStartupExited()
+		return
+	}
+
+	state.markStartupExited()
+	a.p2pSyncBcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
+		if a.p2pSync == state {
+			a.p2pSync = previous
+			bcast()
+		}
+	})
+	a.retireP2PSyncState(state)
 }
 
 func (a *ProviderAccount) startP2PSyncControllers(
 	state *p2pSyncState,
-	previous *p2pSyncState,
 	sessionTransport *transport.SessionTransport,
 	childBus bus.Bus,
+	inviteStarted *bool,
 ) error {
-	if previous != nil {
-		// The replacement has its own transport, so its startup can proceed
-		// while the prior state's lifecycle owner waits for detached startup.
-		go a.retireP2PSyncState(previous)
-	}
-
 	syncCtx := state.ctx
-	inviteStarted := false
-	for {
-		soList := a.soListCtr.GetValue()
-		for _, entry := range soList.GetSharedObjects() {
-			ref := entry.GetRef()
-			provRef := ref.GetProviderResourceRef()
-			soID := provRef.GetId()
-			blockStoreID := ref.GetBlockStoreId()
+	soList := a.soListCtr.GetValue()
+	for _, entry := range soList.GetSharedObjects() {
+		ref := entry.GetRef()
+		provRef := ref.GetProviderResourceRef()
+		soID := provRef.GetId()
+		blockStoreID := ref.GetBlockStoreId()
 
-			providerID := provRef.GetProviderId()
-			providerAccountID := provRef.GetProviderAccountId()
-			bucketID := BlockStoreBucketID(providerID, providerAccountID, blockStoreID)
-			if !state.hasStore(bucketID) {
-				if err := a.startDEXSolicit(syncCtx, childBus, bucketID, state); err != nil {
-					if syncCtx.Err() != nil {
-						return syncCtx.Err()
-					}
-					a.le.WithError(err).WithField("bucket-id", bucketID).Warn("failed to start dex solicit")
-				}
-			}
-
-			if !state.hasSO(soID) {
-				if err := a.startSOSync(syncCtx, childBus, ref, soID, state); err != nil {
-					if syncCtx.Err() != nil {
-						return syncCtx.Err()
-					}
-					a.le.WithError(err).WithField("so-id", soID).Warn("failed to start so sync")
-				} else {
-					state.addSO(soID)
-				}
-			}
-		}
-
-		// Start the SO invite server so invitees can join via alpha/so-invite.
-		if !inviteStarted {
-			if err := a.startInviteServer(syncCtx, childBus, sessionTransport, state); err != nil {
+		providerID := provRef.GetProviderId()
+		providerAccountID := provRef.GetProviderAccountId()
+		bucketID := BlockStoreBucketID(providerID, providerAccountID, blockStoreID)
+		if !state.hasStore(bucketID) {
+			if err := a.startDEXSolicit(syncCtx, childBus, bucketID, state); err != nil {
 				if syncCtx.Err() != nil {
 					return syncCtx.Err()
 				}
-				a.le.WithError(err).Warn("failed to start invite server")
-			} else {
-				inviteStarted = true
+				a.le.WithError(err).WithField("bucket-id", bucketID).Warn("failed to start dex solicit")
 			}
 		}
 
-		restart := false
-		a.p2pSyncBcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
-			if a.p2pSync == state && state.restartPending {
-				state.restartPending = false
-				restart = true
+		if !state.hasSO(soID) {
+			if err := a.startSOSync(syncCtx, childBus, ref, soID, state); err != nil {
+				if syncCtx.Err() != nil {
+					return syncCtx.Err()
+				}
+				a.le.WithError(err).WithField("so-id", soID).Warn("failed to start so sync")
+			} else {
+				state.addSO(soID)
 			}
-		})
-		if !restart {
-			return syncCtx.Err()
 		}
 	}
+
+	if !*inviteStarted {
+		if err := a.startInviteServer(syncCtx, childBus, sessionTransport, state); err != nil {
+			if syncCtx.Err() != nil {
+				return syncCtx.Err()
+			}
+			a.le.WithError(err).Warn("failed to start invite server")
+		} else {
+			*inviteStarted = true
+		}
+	}
+	return syncCtx.Err()
 }
 
 // GetP2PSyncSnapshotWithWait returns whether P2P sync is running and a channel
 // that closes when its lifecycle changes.
 func (a *ProviderAccount) GetP2PSyncSnapshotWithWait() (bool, <-chan struct{}) {
-	var running bool
-	var ch <-chan struct{}
+	var (
+		running bool
+		ch      <-chan struct{}
+	)
 	a.p2pSyncBcast.HoldLock(func(_ func(), getWaitCh func() <-chan struct{}) {
 		ch = getWaitCh()
 		if a.p2pSync == nil {
 			return
 		}
-		select {
-		case <-a.p2pSync.startDone:
-			running = true
-		default:
-		}
+		a.p2pSync.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+			running = a.p2pSync.started && !a.p2pSync.stopping
+		})
 	})
 	return running, ch
 }
@@ -371,39 +503,110 @@ func (a *ProviderAccount) getP2PStore(bucketID string) block.StoreOps {
 
 // retireP2PSyncState removes one state from the account lifecycle and releases
 // its resources. A nil state selects the current state atomically with removal.
-//
-// Callers never hold state.mtx here: the account lock may nest state.mtx while
-// retaining an owner, so retirement acquires only the account lock. Resource
-// cleanup waits outside both locks.
 func (a *ProviderAccount) retireP2PSyncState(state *p2pSyncState) {
+	var (
+		removed bool
+		lower   *p2pSyncState
+	)
 	a.p2pSyncBcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
 		if state == nil {
 			state = a.p2pSync
 		}
-		if state != nil && a.p2pSync == state {
-			a.p2pSync = nil
-			bcast()
+		if state == nil || a.p2pSync != state {
+			return
 		}
+		state.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+			lower = state.lowerSource
+		})
+		a.p2pSync = nil
+		removed = true
+		bcast()
 	})
 	a.stopP2PSyncState(state)
+	if removed && lower != nil {
+		a.retireP2PSyncState(lower)
+	}
 }
 
 func (a *ProviderAccount) stopP2PSyncState(state *p2pSyncState) {
 	if state == nil {
 		return
 	}
-	state.stopOnce.Do(func() {
-		close(state.stopDone)
-		state.cancel()
-		state.completeStart()
-		<-state.runDone
-		state.wg.Wait()
-		for _, ref := range state.refs {
-			ref.Release()
+
+	for {
+		var (
+			waitCh <-chan struct{}
+			done   bool
+			owner  bool
+		)
+		state.bcast.HoldLock(func(bcast func(), getWaitCh func() <-chan struct{}) {
+			if !state.stopping {
+				state.stopping = true
+				state.cancel()
+				if !state.startComplete {
+					state.startErr = context.Canceled
+					state.startComplete = true
+				}
+				bcast()
+			}
+			if state.cleanupDone {
+				done = true
+				return
+			}
+			if !state.cleanupRunning {
+				state.cleanupRunning = true
+				owner = true
+				bcast()
+				return
+			}
+			waitCh = getWaitCh()
+		})
+		if done {
+			return
 		}
-		for _, rel := range state.relFns {
-			rel()
+		if owner {
+			break
 		}
+		<-waitCh
+	}
+
+	for {
+		var (
+			waitCh <-chan struct{}
+			ready  bool
+		)
+		state.bcast.HoldLock(func(_ func(), getWaitCh func() <-chan struct{}) {
+			ready = state.startupExited && state.workers == 0
+			if !ready {
+				waitCh = getWaitCh()
+			}
+		})
+		if ready {
+			break
+		}
+		<-waitCh
+	}
+
+	var (
+		refs   []directive.Reference
+		relFns []func()
+	)
+	state.bcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
+		refs = state.refs
+		relFns = state.relFns
+		state.refs = nil
+		state.relFns = nil
+	})
+	for _, ref := range refs {
+		ref.Release()
+	}
+	for _, rel := range relFns {
+		rel()
+	}
+	state.bcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
+		state.cleanupDone = true
+		state.cleanupRunning = false
+		bcast()
 	})
 }
 
@@ -419,12 +622,14 @@ func (a *ProviderAccount) startSOSync(ctx context.Context, childBus bus.Bus, ref
 
 	localSO := so.(*SharedObject)
 	soSync := sobject_sync.NewSOSync(a.le, childBus, soID, localSO.soHost)
-	state.wg.Go(func() {
+	state.addWorker()
+	go func() {
+		defer state.workerDone()
 		defer relSO()
 		if err := soSync.Execute(ctx); err != nil && ctx.Err() == nil {
 			a.le.WithError(err).WithField("so-id", soID).Warn("so sync exited with error")
 		}
-	})
+	}()
 
 	return nil
 }
@@ -520,7 +725,7 @@ func (a *ProviderAccount) startInviteServer(ctx context.Context, childBus bus.Bu
 	if err != nil {
 		return err
 	}
-	state.relFns = append(state.relFns, relCtrl)
+	state.addRelease(relCtrl)
 	return nil
 }
 
@@ -538,7 +743,7 @@ func (a *ProviderAccount) startDEXSolicit(ctx context.Context, childBus bus.Bus,
 	if err != nil {
 		return err
 	}
-	state.refs = append(state.refs, dexRef)
+	state.addRef(dexRef)
 	state.addStore(bucketID, dex_solicit.NewStore(ctrl))
 	return nil
 }

--- a/core/provider/local/p2p-sync.go
+++ b/core/provider/local/p2p-sync.go
@@ -38,6 +38,7 @@ type p2pSyncState struct {
 	restartPending   bool
 	startErr         error
 	lowerSource      *p2pSyncState
+	lowerSourceHeld  bool
 	workers          int
 	refs             []directive.Reference
 	relFns           []func()
@@ -53,6 +54,19 @@ func (a *ProviderAccount) retainP2PSyncStateLocked(ctx context.Context, state *p
 	retained := false
 	state.bcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
 		if state.stopping || state.ctx.Err() != nil || ctx.Err() != nil {
+			return
+		}
+		state.owners++
+		retained = true
+		bcast()
+	})
+	return retained
+}
+
+func (a *ProviderAccount) retainP2PSyncLowerSourceLocked(state *p2pSyncState) bool {
+	retained := false
+	state.bcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
+		if state.stopping || state.ctx.Err() != nil {
 			return
 		}
 		state.owners++
@@ -112,6 +126,22 @@ func (a *ProviderAccount) releaseP2PSyncState(state *p2pSyncState) {
 
 	if retire {
 		a.retireP2PSyncState(state)
+	}
+}
+
+func (a *ProviderAccount) releaseP2PSyncLowerSource(state *p2pSyncState) {
+	var lower *p2pSyncState
+	state.bcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
+		if !state.lowerSourceHeld {
+			return
+		}
+		lower = state.lowerSource
+		state.lowerSource = nil
+		state.lowerSourceHeld = false
+		bcast()
+	})
+	if lower != nil {
+		a.releaseP2PSyncState(lower)
 	}
 }
 
@@ -184,17 +214,13 @@ func (s *p2pSyncState) workerDone() {
 
 func (s *p2pSyncState) getStore(bucketID string) block.StoreOps {
 	var store block.StoreOps
-	var lowerSource *p2pSyncState
 	s.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
 		store = s.stores[bucketID]
-		if store == nil && !s.started {
-			lowerSource = s.lowerSource
+		if store == nil && !s.started && s.lowerSource != nil {
+			store = s.lowerSource.getStore(bucketID)
 		}
 	})
-	if store != nil || lowerSource == nil {
-		return store
-	}
-	return lowerSource.getStore(bucketID)
+	return store
 }
 
 // StartP2PSync starts SO sync and DEX block exchange for all mounted
@@ -244,12 +270,15 @@ func (a *ProviderAccount) StartP2PSync(ctx context.Context, sessionTransport *tr
 			ctx:              syncCtx,
 			sessionTransport: sessionTransport,
 			cancel:           syncCancel,
-			lowerSource:      previous,
 		}
 		if !a.retainP2PSyncStateLocked(ctx, state) {
 			syncCancel()
 			state = nil
 			return
+		}
+		if previous != nil && a.retainP2PSyncLowerSourceLocked(previous) {
+			state.lowerSource = previous
+			state.lowerSourceHeld = true
 		}
 		a.p2pSync = state
 		bcast()
@@ -386,10 +415,8 @@ func (a *ProviderAccount) runP2PSyncStart(
 	}
 
 	if err == nil {
-		if previous != nil {
-			a.retireP2PSyncState(previous)
-		}
 		state.markStartupExited()
+		a.releaseP2PSyncLowerSource(state)
 		return
 	}
 
@@ -500,28 +527,19 @@ func (a *ProviderAccount) getP2PStore(bucketID string) block.StoreOps {
 // retireP2PSyncState removes one state from the account lifecycle and releases
 // its resources. A nil state selects the current state atomically with removal.
 func (a *ProviderAccount) retireP2PSyncState(state *p2pSyncState) {
-	var (
-		removed bool
-		lower   *p2pSyncState
-	)
 	a.p2pSyncBcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
 		if state == nil {
 			state = a.p2pSync
 		}
-		if state == nil || a.p2pSync != state {
+		if state == nil {
 			return
 		}
-		state.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
-			lower = state.lowerSource
-		})
-		a.p2pSync = nil
-		removed = true
-		bcast()
+		if a.p2pSync == state {
+			a.p2pSync = nil
+			bcast()
+		}
 	})
 	a.stopP2PSyncState(state)
-	if removed && lower != nil {
-		a.retireP2PSyncState(lower)
-	}
 }
 
 func (a *ProviderAccount) stopP2PSyncState(state *p2pSyncState) {
@@ -599,6 +617,8 @@ func (a *ProviderAccount) stopP2PSyncState(state *p2pSyncState) {
 	for _, rel := range relFns {
 		rel()
 	}
+	a.releaseP2PSyncLowerSource(state)
+
 	state.bcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
 		state.cleanupDone = true
 		state.cleanupRunning = false

--- a/core/provider/local/p2p-sync.go
+++ b/core/provider/local/p2p-sync.go
@@ -320,34 +320,31 @@ func (a *ProviderAccount) awaitP2PSyncStart(ctx context.Context, state *p2pSyncS
 	return errors.New("P2P sync stopped during startup")
 }
 
-func (s *p2pSyncState) finishStart(err error) (bool, bool, error) {
+// finishStart records a stable startup result or consumes a pending restart.
+func (s *p2pSyncState) finishStart(err error) bool {
 	restart := false
-	published := false
-	terminalErr := err
 	s.bcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
-		if terminalErr == nil && s.stopping {
-			terminalErr = context.Canceled
+		if err == nil && s.stopping {
+			err = context.Canceled
 		}
-		if terminalErr == nil {
-			terminalErr = s.ctx.Err()
+		if err == nil {
+			err = s.ctx.Err()
 		}
-		if terminalErr == nil && s.restartPending && !s.stopping && !s.startComplete {
+		if err == nil && s.restartPending && !s.stopping && !s.startComplete {
 			s.restartPending = false
 			restart = true
 			bcast()
 			return
 		}
 		if s.startComplete {
-			terminalErr = s.startErr
 			return
 		}
-		s.startErr = terminalErr
-		s.started = terminalErr == nil
+		s.startErr = err
+		s.started = err == nil
 		s.startComplete = true
-		published = true
 		bcast()
 	})
-	return restart, published, terminalErr
+	return restart
 }
 
 func (s *p2pSyncState) markStartupExited() {
@@ -376,16 +373,15 @@ func (a *ProviderAccount) runP2PSyncStart(
 			childBus,
 			&inviteStarted,
 		)
-		restart, published, terminalErr := state.finishStart(err)
-		err = terminalErr
-		if published {
-			a.p2pSyncBcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
-				bcast()
-			})
-		}
-		if restart {
+		if state.finishStart(err) {
 			continue
 		}
+		state.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+			err = state.startErr
+		})
+		a.p2pSyncBcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
+			bcast()
+		})
 		break
 	}
 

--- a/core/provider/local/p2p-sync_test.go
+++ b/core/provider/local/p2p-sync_test.go
@@ -624,7 +624,7 @@ func TestStartP2PSyncDoesNotCoalesceAcrossTransports(t *testing.T) {
 	releaseFirstLoad := make(chan struct{})
 	var gate sync.Once
 	removeFirst, err := first.GetChildBus().AddHandler(directive.NewFuncHandler(
-		func(_ context.Context, di directive.Instance) ([]directive.Resolver, error) {
+		func(handlerCtx context.Context, di directive.Instance) ([]directive.Resolver, error) {
 			load, ok := di.GetDirective().(resolver.LoadControllerWithConfig)
 			if !ok {
 				return nil, nil
@@ -637,7 +637,10 @@ func TestStartP2PSyncDoesNotCoalesceAcrossTransports(t *testing.T) {
 			// flight rather than one that already finished.
 			gate.Do(func() {
 				close(firstLoadStarted)
-				<-releaseFirstLoad
+				select {
+				case <-releaseFirstLoad:
+				case <-handlerCtx.Done():
+				}
 			})
 			return nil, nil
 		},

--- a/core/provider/local/p2p-sync_test.go
+++ b/core/provider/local/p2p-sync_test.go
@@ -359,7 +359,10 @@ func TestBlockSyncDEX(t *testing.T) {
 	waitForSyncedRootSeqno(ctx, t, accB, account_settings.BindingPurpose, 0)
 }
 
-func TestStartP2PSyncStartsDEXSolicit(t *testing.T) {
+// TestStartP2PSyncSameTransportRestartAddsDesiredWork proves that a
+// same-transport start arriving while the first startup pass is gated causes
+// the pass to restart and load a shared object added after its SO snapshot.
+func TestStartP2PSyncSameTransportRestartAddsDesiredWork(t *testing.T) {
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 


### PR DESCRIPTION
P2P sync startup used separate completion channels, a mutex, and a wait group for related lifecycle state. That split could lose a same-transport restart, detach prior-state retirement from account teardown, and expose an empty replacement source to block reads.

The lifecycle now uses one broadcast-owned state machine. Pending restarts are consumed before startup completion is published, replacement states retain the prior lower source until ready, and retirement waits for startup and workers before releasing controller and mount references. Start, stop, and cancellation behavior remains unchanged outside these race fixes.

Focused package and race checks pass, including causal regressions for restart ordering, prior-source reads, and retirement ownership.