### PR TITLE
fix(provider): retire displaced P2P states

### DIFF
--- a/core/provider/local/bstore_test.go
+++ b/core/provider/local/bstore_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/aperturerobotics/controllerbus/controller/resolver"
 	"github.com/aperturerobotics/controllerbus/directive"
@@ -71,7 +72,7 @@ func (s *localDEXTestStore) GetBlock(ctx context.Context, ref *block.BlockRef) (
 var _ block.StoreOps = ((*localDEXTestStore)(nil))
 
 func TestMountedBlockStoreReadUsesPriorSourceDuringReplacement(t *testing.T) {
-	ctx, cancel := context.WithCancel(t.Context())
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	_, _, acc, sess, release := setupProviderAndSessionInternal(ctx, t)
@@ -114,7 +115,7 @@ func TestMountedBlockStoreReadUsesPriorSourceDuringReplacement(t *testing.T) {
 		startComplete:    true,
 		started:          true,
 		startupExited:    true,
-		owners:           1,
+		owners:           2,
 		stores:           map[string]block.StoreOps{bucketID: priorStore},
 	}
 	acc.p2pSyncBcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
@@ -195,6 +196,31 @@ func TestMountedBlockStoreReadUsesPriorSourceDuringReplacement(t *testing.T) {
 	current.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
 		if current.lowerSource != nil || current.lowerSourceHeld {
 			t.Fatal("replacement retained its lower P2P source after startup")
+		}
+	})
+	for {
+		var (
+			clean  bool
+			waitCh <-chan struct{}
+		)
+		prior.bcast.HoldLock(func(_ func(), getWaitCh func() <-chan struct{}) {
+			clean = prior.cleanupDone
+			if !clean {
+				waitCh = getWaitCh()
+			}
+		})
+		if clean {
+			break
+		}
+		select {
+		case <-waitCh:
+		case <-ctx.Done():
+			t.Fatalf("displaced prior P2P source cleanup: %v", ctx.Err())
+		}
+	}
+	prior.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		if !prior.stopping {
+			t.Fatal("displaced prior P2P source remained active")
 		}
 	})
 }

--- a/core/provider/local/p2p-sync-lifecycle_test.go
+++ b/core/provider/local/p2p-sync-lifecycle_test.go
@@ -2,7 +2,9 @@ package provider_local
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
 )
 
 func TestP2PSyncStateFinishStartPublishesStableState(t *testing.T) {
@@ -149,4 +151,161 @@ func TestRetireP2PSyncStateReleasesLowerChain(t *testing.T) {
 			t.Fatalf("%s state context was not canceled", name)
 		}
 	}
+}
+
+func TestFailedP2PSyncStartDoesNotRestoreStoppedPrevious(t *testing.T) {
+	makeState := func(stopping bool) *p2pSyncState {
+		ctx, cancel := context.WithCancel(context.Background())
+		return &p2pSyncState{
+			ctx:           ctx,
+			cancel:        cancel,
+			startComplete: true,
+			started:       !stopping,
+			startupExited: true,
+			stopping:      stopping,
+		}
+	}
+
+	previous := makeState(true)
+	failed := makeState(true)
+	account := &ProviderAccount{}
+	account.p2pSyncBcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		account.p2pSync = failed
+	})
+
+	account.restoreP2PSyncAfterFailedStart(failed, previous, false)
+
+	account.p2pSyncBcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		if account.p2pSync != nil {
+			t.Fatal("failed replacement restored a stopped previous state")
+		}
+	})
+	previous.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		if !previous.cleanupDone {
+			t.Fatal("stopped previous state was not retired")
+		}
+	})
+}
+
+func TestFailedP2PSyncStartDoesNotRestoreErroredPrevious(t *testing.T) {
+	previousCtx, previousCancel := context.WithCancel(context.Background())
+	previousCancel()
+	previous := &p2pSyncState{
+		ctx:           previousCtx,
+		cancel:        previousCancel,
+		startComplete: true,
+		started:       true,
+		startupExited: true,
+	}
+	failedCtx, failedCancel := context.WithCancel(context.Background())
+	defer failedCancel()
+	failed := &p2pSyncState{
+		ctx:           failedCtx,
+		cancel:        failedCancel,
+		startComplete: true,
+		startupExited: true,
+		stopping:      true,
+	}
+	account := &ProviderAccount{}
+	account.p2pSyncBcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		account.p2pSync = failed
+	})
+
+	account.restoreP2PSyncAfterFailedStart(failed, previous, true)
+
+	account.p2pSyncBcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		if account.p2pSync != nil {
+			t.Fatal("failed replacement restored a previous state with an errored context")
+		}
+	})
+	previous.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		if !previous.cleanupDone {
+			t.Fatal("previous state with an errored context was not retired")
+		}
+	})
+}
+
+func TestFailedP2PSyncStartDoesNotRestoreRetiredRetainedPredecessor(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	makeState := func(owners int, complete bool) *p2pSyncState {
+		stateCtx, stateCancel := context.WithCancel(ctx)
+		return &p2pSyncState{
+			ctx:           stateCtx,
+			cancel:        stateCancel,
+			owners:        owners,
+			startComplete: complete,
+			started:       complete,
+			startupExited: true,
+		}
+	}
+
+	oldest := makeState(1, true)
+	middle := makeState(1, false)
+	newest := makeState(1, false)
+	account := &ProviderAccount{}
+	account.p2pSyncBcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
+		account.p2pSync = oldest
+		if !account.retainP2PSyncLowerSourceLocked(oldest) {
+			t.Fatal("middle start did not retain oldest state")
+		}
+		middle.lowerSource = oldest
+		middle.lowerSourceHeld = true
+		account.p2pSync = middle
+		if !account.retainP2PSyncLowerSourceLocked(middle) {
+			t.Fatal("newest start did not retain middle state")
+		}
+		newest.lowerSource = middle
+		newest.lowerSourceHeld = true
+		account.p2pSync = newest
+		bcast()
+	})
+
+	// The oldest caller gives up while the middle and newest starts still
+	// retain the replacement chain.
+	account.releaseP2PSyncState(oldest)
+
+	middleRetired := make(chan struct{})
+	go func() {
+		account.retireP2PSyncState(middle)
+		close(middleRetired)
+	}()
+	select {
+	case <-middleRetired:
+	case <-ctx.Done():
+		t.Fatal("middle state retirement did not complete")
+	}
+	select {
+	case <-oldest.ctx.Done():
+	case <-ctx.Done():
+		t.Fatal("middle retirement did not stop oldest state")
+	}
+	oldest.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		if !oldest.stopping {
+			t.Fatal("retired middle state left oldest state active")
+		}
+	})
+
+	if restart := newest.finishStart(errors.New("controlled startup failure")); restart {
+		t.Fatal("failed newest start requested a restart")
+	}
+	newest.markStartupExited()
+	newestRetired := make(chan struct{})
+	go func() {
+		account.restoreP2PSyncAfterFailedStart(newest, middle, true)
+		account.retireP2PSyncState(newest)
+		close(newestRetired)
+	}()
+	select {
+	case <-newestRetired:
+	case <-ctx.Done():
+		t.Fatal("newest state retirement did not complete")
+	}
+
+	account.p2pSyncBcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+		if account.p2pSync != nil {
+			t.Fatal("failed newest start restored a retired predecessor")
+		}
+	})
 }

--- a/core/provider/local/p2p-sync.go
+++ b/core/provider/local/p2p-sync.go
@@ -239,10 +239,11 @@ func (a *ProviderAccount) StartP2PSync(ctx context.Context, sessionTransport *tr
 	}
 
 	var (
-		previous  *p2pSyncState
-		waitState *p2pSyncState
-		state     *p2pSyncState
-		watch     bool
+		previous         *p2pSyncState
+		previousRetained bool
+		waitState        *p2pSyncState
+		state            *p2pSyncState
+		watch            bool
 	)
 	a.p2pSyncBcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
 		previous = a.p2pSync
@@ -279,6 +280,7 @@ func (a *ProviderAccount) StartP2PSync(ctx context.Context, sessionTransport *tr
 		if previous != nil && a.retainP2PSyncLowerSourceLocked(previous) {
 			state.lowerSource = previous
 			state.lowerSourceHeld = true
+			previousRetained = true
 		}
 		a.p2pSync = state
 		bcast()
@@ -302,7 +304,7 @@ func (a *ProviderAccount) StartP2PSync(ctx context.Context, sessionTransport *tr
 	// happened to create it. Running it here would tie it to that caller's
 	// goroutine, so a caller whose context is canceled while later owners keep
 	// the state alive could not return until startup finished on its own.
-	go a.runP2PSyncStart(state, previous, sessionTransport, childBus)
+	go a.runP2PSyncStart(state, previous, previousRetained, sessionTransport, childBus)
 	return a.awaitP2PSyncStart(ctx, state)
 }
 
@@ -388,6 +390,7 @@ func (s *p2pSyncState) markStartupExited() {
 func (a *ProviderAccount) runP2PSyncStart(
 	state *p2pSyncState,
 	previous *p2pSyncState,
+	previousRetained bool,
 	sessionTransport *transport.SessionTransport,
 	childBus bus.Bus,
 ) {
@@ -413,21 +416,47 @@ func (a *ProviderAccount) runP2PSyncStart(
 		})
 		break
 	}
-
 	if err == nil {
 		state.markStartupExited()
 		a.releaseP2PSyncLowerSource(state)
+		if previous != nil {
+			a.retireP2PSyncState(previous)
+		}
 		return
 	}
 
 	state.markStartupExited()
-	a.p2pSyncBcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
-		if a.p2pSync == state {
-			a.p2pSync = previous
-			bcast()
-		}
-	})
+	a.restoreP2PSyncAfterFailedStart(state, previous, previousRetained)
 	a.retireP2PSyncState(state)
+}
+
+func (a *ProviderAccount) restoreP2PSyncAfterFailedStart(
+	state *p2pSyncState,
+	previous *p2pSyncState,
+	previousRetained bool,
+) {
+	retirePrevious := false
+	a.p2pSyncBcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
+		if a.p2pSync != state {
+			return
+		}
+		restorePrevious := false
+		if previousRetained {
+			previous.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
+				restorePrevious = !previous.stopping && previous.ctx.Err() == nil
+			})
+		}
+		if restorePrevious {
+			a.p2pSync = previous
+		} else {
+			a.p2pSync = nil
+			retirePrevious = previous != nil
+		}
+		bcast()
+	})
+	if retirePrevious {
+		a.retireP2PSyncState(previous)
+	}
 }
 
 func (a *ProviderAccount) startP2PSyncControllers(


### PR DESCRIPTION
A successful P2P transport replacement could leave the displaced state unreachable while its original caller remained live. A failed replacement could also restore a prior state that had already begun stopping, leaving stale resources behind.

The provider now retains the lower source only when it is live, retires the displaced state after stable startup, and clears the account state when a failed replacement has no safe prior owner. The lifecycle tests cover lower-source reads, overlapping replacement cleanup, and failed restoration. The focused package checks and three-run race matrix pass.

This follow-up contains only the post-PR-392 lifecycle correction. It is rebased onto current master without changing production or test behavior.