### PR TITLE
fix(docs): keep responsive reader controls clear

### DIFF
--- a/app/docs/DocsLayout.tsx
+++ b/app/docs/DocsLayout.tsx
@@ -34,7 +34,7 @@ function DocsMobileNav({ portalContainer, sidebar }: DocsMobileNavProps) {
 
   return (
     <Sheet open={mobileOpen} onOpenChange={setMobileOpen}>
-      <div className="border-b border-white/10 px-4 py-2.5 @lg:hidden">
+      <div className="border-b border-white/10 px-4 py-2.5 @2xl:hidden">
         <SheetTrigger asChild>
           <button
             type="button"
@@ -76,7 +76,7 @@ function DocsMobileNav({ portalContainer, sidebar }: DocsMobileNavProps) {
 }
 
 // DocsLayout renders the responsive documentation shell: a persistent left rail
-// on wide displays that collapses into a top-bar drawer below the @lg container
+// on wide displays that collapses into a top-bar drawer below the @2xl container
 // breakpoint. The content column carries its own min-w-0 so wide code blocks and
 // tables scroll within it instead of forcing the page to scroll sideways.
 export function DocsLayout({
@@ -104,7 +104,7 @@ export function DocsLayout({
 
       <div className="flex min-h-0 flex-1 overflow-hidden">
         {/* Sidebar - wide widths only */}
-        <aside className="hidden w-[216px] shrink-0 overflow-y-auto border-r border-white/10 @lg:block">
+        <aside className="hidden w-[216px] shrink-0 overflow-y-auto border-r border-white/10 @2xl:block">
           {sidebar}
         </aside>
 
@@ -114,7 +114,7 @@ export function DocsLayout({
         <main className="flex min-w-0 flex-1 flex-col overflow-x-hidden overflow-y-auto">
           <div
             className={cn(
-              'mx-auto w-full flex-1 px-5 pt-6 pb-20 @lg:px-8 @lg:pt-10',
+              'mx-auto w-full flex-1 px-5 pt-6 pb-20 @2xl:px-8 @2xl:pt-10',
               maxWidth,
             )}
           >

--- a/app/docs/DocsPage.tsx
+++ b/app/docs/DocsPage.tsx
@@ -36,9 +36,9 @@ const siteLabels = new Map(siteDefs.map((s) => [s.id, s.label]))
 
 // toolbarActionBase sizes a header action to a 44px touch target while it is
 // icon-only on narrow displays, then relaxes to a compact inline control once
-// the @lg label appears.
+// the @2xl label appears.
 const toolbarActionBase =
-  'flex h-11 min-w-11 items-center justify-center gap-1.5 rounded-md px-2 text-xs transition-colors @lg:h-8 @lg:min-w-0 @lg:justify-start'
+  'flex h-11 min-w-11 items-center justify-center gap-1.5 rounded-md px-2 text-xs transition-colors @2xl:h-8 @2xl:min-w-0 @2xl:justify-start'
 
 // toolbarActionIdle is the resting color treatment shared by the header actions.
 const toolbarActionIdle =
@@ -90,16 +90,16 @@ export function DocsPage({ doc, prevDoc, nextDoc }: DocsPageProps) {
   return (
     <article>
       {/* Header bar: breadcrumb + utility actions */}
-      <div className="mb-6 flex items-center justify-between gap-3">
+      <div className="mb-6 flex flex-wrap items-start justify-between gap-x-3 gap-y-2">
         <div className="text-foreground-alt/50 flex min-w-0 flex-1 items-center gap-2 text-xs">
-          <span className="hidden @lg:inline">
+          <span className="hidden @2xl:inline">
             {siteLabels.get(doc.site) ?? doc.site}
           </span>
-          <span className="text-foreground-alt/30 hidden @lg:inline">/</span>
-          <span className="hidden @lg:inline">
+          <span className="text-foreground-alt/30 hidden @2xl:inline">/</span>
+          <span className="hidden @2xl:inline">
             {getSectionLabel(doc.site, doc.section)}
           </span>
-          <span className="text-foreground-alt/30 hidden @lg:inline">/</span>
+          <span className="text-foreground-alt/30 hidden @2xl:inline">/</span>
           <span className="text-foreground-alt truncate">{doc.title}</span>
         </div>
 
@@ -118,7 +118,7 @@ export function DocsPage({ doc, prevDoc, nextDoc }: DocsPageProps) {
             ) : (
               <LuCopy className="size-3" />
             )}
-            <span className="hidden @lg:inline">
+            <span className="hidden @2xl:inline">
               {copied ? 'Copied' : 'Copy MD'}
             </span>
           </button>
@@ -130,7 +130,7 @@ export function DocsPage({ doc, prevDoc, nextDoc }: DocsPageProps) {
             aria-label="Open raw Markdown on GitHub"
           >
             <LuFileText className="size-3" />
-            <span className="hidden @lg:inline">Open MD</span>
+            <span className="hidden @2xl:inline">Open MD</span>
           </ExternalLink>
 
           <DropdownMenu>
@@ -141,7 +141,7 @@ export function DocsPage({ doc, prevDoc, nextDoc }: DocsPageProps) {
                 aria-label="Open page in an AI assistant"
               >
                 <LuSparkles className="size-3" />
-                <span className="hidden @lg:inline">AI</span>
+                <span className="hidden @2xl:inline">AI</span>
                 <LuChevronDown className="size-2.5" />
               </button>
             </DropdownMenuTrigger>
@@ -162,7 +162,7 @@ export function DocsPage({ doc, prevDoc, nextDoc }: DocsPageProps) {
 
       {/* Page header */}
       <header className="mb-8">
-        <h1 className="text-foreground mb-3 text-2xl leading-snug font-semibold tracking-tight @lg:text-3xl @lg:leading-snug">
+        <h1 className="text-foreground mb-3 text-2xl leading-snug font-semibold tracking-tight @2xl:text-3xl @2xl:leading-snug">
           {doc.title}
         </h1>
         <p className="text-foreground-alt text-sm leading-relaxed">

--- a/app/docs/DocsResponsive.e2e.test.tsx
+++ b/app/docs/DocsResponsive.e2e.test.tsx
@@ -22,11 +22,11 @@ function DocsRouteHarness({ initialPath }: { initialPath: string }) {
   )
 }
 
-// WIDTHS are the responsive breakpoints under test: narrow phone, tablet, and
-// desktop. 360 is the production floor the docs viewer must stay readable at.
+// WIDTHS exercise phone, tablet, intermediate, and desktop container widths.
 const WIDTHS: [string, number][] = [
   ['360', 360],
   ['768', 768],
+  ['955', 955],
   ['1280', 1280],
 ]
 
@@ -174,6 +174,46 @@ describe('docs viewer responsive layout', () => {
         page.getByRole('button', { name: 'Open documentation navigation' }),
       )
       .toBeInTheDocument()
+    await page
+      .getByRole('button', { name: 'Open documentation navigation' })
+      .click()
+    await expect
+      .element(
+        page.getByRole('button', { name: 'Close documentation navigation' }),
+      )
+      .toBeInTheDocument()
+    await page
+      .getByRole('textbox', { name: 'Search documentation' })
+      .fill('backup')
+    await expect
+      .element(
+        page.getByRole('button', {
+          name: 'Backup and Lock Setup',
+          exact: true,
+        }),
+      )
+      .toBeInTheDocument()
+    await page
+      .getByRole('button', { name: 'Backup and Lock Setup', exact: true })
+      .click()
+    await expect
+      .element(page.getByRole('heading', { name: 'Backup and Lock Setup' }))
+      .toBeInTheDocument()
+
+    await cleanup()
+    await page.viewport(360, 900)
+    await render(<DocsRouteHarness initialPath="/docs" />)
+    await page
+      .getByRole('button', { name: 'Open documentation navigation' })
+      .click()
+    await page
+      .getByRole('button', { name: 'Close documentation navigation' })
+      .click()
+    await expect
+      .element(
+        page.getByRole('button', { name: 'Close documentation navigation' }),
+      )
+      .not.toBeInTheDocument()
 
     await cleanup()
 

--- a/app/docs/DocsResponsive.e2e.test.tsx
+++ b/app/docs/DocsResponsive.e2e.test.tsx
@@ -92,7 +92,8 @@ describe('docs viewer responsive layout', () => {
 
   it('hub, site home, and article stay within narrow, tablet, and desktop widths', async () => {
     for (const [label, width] of WIDTHS) {
-      await page.viewport(width, 900)
+      const height = width === 955 ? 1568 : 900
+      await page.viewport(width, height)
 
       await render(<DocsRouteHarness initialPath="/docs" />)
       await expect

--- a/app/docs/DocsResponsive.e2e.test.tsx
+++ b/app/docs/DocsResponsive.e2e.test.tsx
@@ -118,6 +118,16 @@ describe('docs viewer responsive layout', () => {
         .toBeInTheDocument()
       await shot(`article-${label}`)
       expect(horizontalOverflow()).toBeLessThanOrEqual(1)
+      await page
+        .getByRole('button', { name: 'Open page in an AI assistant' })
+        .click()
+      await expect
+        .element(page.getByRole('menuitem', { name: 'Copy .md URL' }))
+        .toBeInTheDocument()
+      const openMarkdown = document.querySelector(
+        'a[title="Open raw Markdown on GitHub"]',
+      )
+      expect(openMarkdown).not.toBeNull()
       await cleanup()
     }
   }, 120000)

--- a/app/docs/DocsSearch.test.tsx
+++ b/app/docs/DocsSearch.test.tsx
@@ -46,4 +46,16 @@ describe('DocsSearch', () => {
     expect(results[0].textContent).toContain('Backup and Recovery')
     expect(results[1].textContent).toContain('CLI Reference')
   })
+
+  it('selects a result from keyboard focus', async () => {
+    const user = userEvent.setup()
+    let selected: DocPage | undefined
+    render(<DocsSearch docs={docs} onSelect={(doc) => (selected = doc)} />)
+
+    await user.type(screen.getByPlaceholderText('Search docs…'), 'backup')
+    await user.tab()
+    await user.keyboard('{Enter}')
+
+    expect(selected?.title).toBe('Backup and Recovery')
+  })
 })

--- a/app/docs/DocsSearch.tsx
+++ b/app/docs/DocsSearch.tsx
@@ -75,6 +75,7 @@ export function DocsSearch({ docs, onSelect }: DocsSearchProps) {
           onChange={handleSearchChange}
           onFocus={handleSearchFocus}
           onBlur={handleSearchBlur}
+          aria-label="Search documentation"
           placeholder="Search docs…"
           className={cn(
             'border-foreground/10 bg-background-card/50 text-foreground placeholder:text-foreground-alt/40 w-full rounded-md border py-2 pr-3 pl-9 text-sm transition-colors outline-none',
@@ -93,7 +94,8 @@ export function DocsSearch({ docs, onSelect }: DocsSearchProps) {
           {results.map((doc) => (
             <button
               key={doc.url}
-              onMouseDown={() => handleSelect(doc)}
+              type="button"
+              onClick={() => handleSelect(doc)}
               className="hover:bg-foreground/5 w-full cursor-pointer px-4 py-2.5 text-left transition-colors"
             >
               <div className="text-foreground text-sm font-medium">

--- a/app/docs/DocsSidebar.tsx
+++ b/app/docs/DocsSidebar.tsx
@@ -56,9 +56,10 @@ export function DocsSidebar({ sections, currentDoc }: DocsSidebarProps) {
   }, [sections, siteLabels])
 
   return (
-    <nav className="flex flex-1 flex-col">
+    <nav aria-label="Documentation navigation" className="flex flex-1 flex-col">
       <div className="flex flex-col gap-1 p-4">
         <button
+          type="button"
           onClick={goToIndex}
           className={cn(
             'mb-4 cursor-pointer text-left text-sm font-semibold transition-colors',
@@ -84,6 +85,7 @@ export function DocsSidebar({ sections, currentDoc }: DocsSidebarProps) {
                   {section.pages.map((page) => (
                     <li key={page.url}>
                       <button
+                        type="button"
                         onClick={() => goToPage(page.url)}
                         className={cn(
                           'w-full cursor-pointer border-l-2 py-2 pl-3 text-left text-sm transition-colors',

--- a/app/docs/docs-prose.css
+++ b/app/docs/docs-prose.css
@@ -1,9 +1,16 @@
 /* docs-prose scopes prose typography for rendered documentation markdown. */
 
 .docs-prose {
+  max-width: 70ch;
   font-size: 0.875rem;
   /* Long URLs and identifiers must break rather than force horizontal scroll. */
   overflow-wrap: break-word;
+}
+
+@container (min-width: 42rem) {
+  .docs-prose {
+    font-size: 0.9375rem;
+  }
 }
 
 .docs-prose h1 {


### PR DESCRIPTION
The docs reader kept its navigation rail and labeled toolbar at an intermediate container width, leaving too little room for the article and allowing search results to depend on pointer activation. This made narrow docs panes cramped and left keyboard users without a reliable search selection path.

The reader now keeps the rail and labels behind the wide container threshold, wraps the breadcrumb and action row before controls can collide, and bounds prose to a readable measure with a responsive type step. Narrow panes use the existing dismissible Sheet navigation, while wide readers preserve the two-column layout. Search results are native buttons with an accessible input label, so pointer and keyboard activation share the same route transition.

Focused unit tests, the Chromium responsive docs test at 360, 768, 955, and 1280 pixels, the overflow fixture, the declared TypeScript check, and git diff --check pass.