### PR TITLE
fix(ci): provision release-wasm smoke toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -470,3 +470,49 @@ jobs:
 
       - name: Run Playwright E2E suite
         run: bun run ${{ matrix.suite.script }}
+  nightly-workflow-contract:
+    name: Nightly workflow contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Validate release-WASM smoke toolchain contract
+        shell: bash
+        run: |
+          ruby -ryaml <<'RUBY'
+          options = Psych::VERSION.to_i >= 4 ? { aliases: true } : {}
+          workflow = YAML.load_file(".github/workflows/e2e-nightly.yml", **options)
+          jobs = workflow.fetch("jobs")
+          build = jobs.fetch("release-wasm-build")
+          smoke = jobs.fetch("release-wasm-smoke")
+
+          step = lambda do |job, name|
+            job.fetch("steps").find { |candidate| candidate["name"] == name } ||
+              abort("missing step #{name.inspect}")
+          end
+
+          unless smoke.fetch("env")["E2E_RELEASE_WASM_TINYGO"] == true
+            abort("smoke job must enable TinyGo release-WASM builds")
+          end
+
+          ["Install Binaryen", "Install TinyGo"].each do |name|
+            producer = step.call(build, name)
+            consumer = step.call(smoke, name)
+            unless producer["run"] == consumer["run"]
+              abort("#{name} differs between build and smoke jobs")
+            end
+          end
+
+          verify = step.call(smoke, "Verify release-WASM fallback toolchain")
+          unless verify.fetch("run").include?("command -v tinygo") &&
+              verify.fetch("run").include?("command -v wasm-opt")
+            abort("smoke job must probe TinyGo and Binaryen before the test")
+          end
+
+          smoke_steps = smoke.fetch("steps")
+          verify_index = smoke_steps.index(verify)
+          test_index = smoke_steps.index { |candidate| candidate["name"] == "Run release-WASM browser smoke" }
+          abort("toolchain probe must precede the smoke test") unless verify_index < test_index
+          puts "nightly release-WASM smoke contract: PASS"
+          RUBY

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -91,7 +91,8 @@ jobs:
       - name: Install Bun dependencies
         run: bun install --frozen-lockfile --ignore-scripts
 
-      - name: Install Binaryen
+      - &release-wasm-install-binaryen
+        name: Install Binaryen
         shell: bash
         run: |
           set -euo pipefail
@@ -105,7 +106,8 @@ jobs:
           echo "${RUNNER_TEMP}/binaryen/bin" >> "${GITHUB_PATH}"
           "${RUNNER_TEMP}/binaryen/bin/wasm-opt" --version
 
-      - name: Install TinyGo
+      - &release-wasm-install-tinygo
+        name: Install TinyGo
         shell: bash
         run: |
           set -euo pipefail
@@ -234,6 +236,18 @@ jobs:
 
       - name: Install Bun dependencies
         run: bun install --frozen-lockfile --ignore-scripts
+      - *release-wasm-install-binaryen
+
+      - *release-wasm-install-tinygo
+
+      - name: Verify release-WASM fallback toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          command -v tinygo
+          command -v wasm-opt
+          tinygo version
+          wasm-opt --version
 
       - name: Install Playwright browsers
         run: go run github.com/mxschmitt/playwright-go/cmd/playwright install --with-deps chromium


### PR DESCRIPTION
The release-WASM browser smoke job can enter its fallback build when the downloaded artifact identity does not match. That path invokes TinyGo and Binaryen, but the smoke runner previously depended on toolchain setup performed only in the producer job, so the nightly stopped before exercising the browser scenarios.

The producer now owns anchored Binaryen and TinyGo setup steps that the smoke job reuses. The smoke job verifies both tools before running the existing browser test, and regular CI parses the nightly workflow to prevent producer and consumer setup from drifting.

The contract check fails on the prior head with all three smoke prerequisites missing and passes on this head. The nightly run remains the protected-branch verification for the full fallback and browser path.