### PR TITLE
fix(e2e): rebuild stale release wasm artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -470,3 +470,49 @@ jobs:
 
       - name: Run Playwright E2E suite
         run: bun run ${{ matrix.suite.script }}
+  nightly-workflow-contract:
+    name: Nightly workflow contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Validate release-WASM smoke toolchain contract
+        shell: bash
+        run: |
+          ruby -ryaml <<'RUBY'
+          options = Psych::VERSION.to_i >= 4 ? { aliases: true } : {}
+          workflow = YAML.load_file(".github/workflows/e2e-nightly.yml", **options)
+          jobs = workflow.fetch("jobs")
+          build = jobs.fetch("release-wasm-build")
+          smoke = jobs.fetch("release-wasm-smoke")
+
+          step = lambda do |job, name|
+            job.fetch("steps").find { |candidate| candidate["name"] == name } ||
+              abort("missing step #{name.inspect}")
+          end
+
+          unless smoke.fetch("env")["E2E_RELEASE_WASM_TINYGO"] == true
+            abort("smoke job must enable TinyGo release-WASM builds")
+          end
+
+          ["Install Binaryen", "Install TinyGo"].each do |name|
+            producer = step.call(build, name)
+            consumer = step.call(smoke, name)
+            unless producer["run"] == consumer["run"]
+              abort("#{name} differs between build and smoke jobs")
+            end
+          end
+
+          verify = step.call(smoke, "Verify release-WASM fallback toolchain")
+          unless verify.fetch("run").include?("command -v tinygo") &&
+              verify.fetch("run").include?("command -v wasm-opt")
+            abort("smoke job must probe TinyGo and Binaryen before the test")
+          end
+
+          smoke_steps = smoke.fetch("steps")
+          verify_index = smoke_steps.index(verify)
+          test_index = smoke_steps.index { |candidate| candidate["name"] == "Run release-WASM browser smoke" }
+          abort("toolchain probe must precede the smoke test") unless verify_index < test_index
+          puts "nightly release-WASM smoke contract: PASS"
+          RUBY

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -91,7 +91,8 @@ jobs:
       - name: Install Bun dependencies
         run: bun install --frozen-lockfile --ignore-scripts
 
-      - name: Install Binaryen
+      - &release-wasm-install-binaryen
+        name: Install Binaryen
         shell: bash
         run: |
           set -euo pipefail
@@ -105,7 +106,8 @@ jobs:
           echo "${RUNNER_TEMP}/binaryen/bin" >> "${GITHUB_PATH}"
           "${RUNNER_TEMP}/binaryen/bin/wasm-opt" --version
 
-      - name: Install TinyGo
+      - &release-wasm-install-tinygo
+        name: Install TinyGo
         shell: bash
         run: |
           set -euo pipefail
@@ -234,6 +236,18 @@ jobs:
 
       - name: Install Bun dependencies
         run: bun install --frozen-lockfile --ignore-scripts
+      - *release-wasm-install-binaryen
+
+      - *release-wasm-install-tinygo
+
+      - name: Verify release-WASM fallback toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          command -v tinygo
+          command -v wasm-opt
+          tinygo version
+          wasm-opt --version
 
       - name: Install Playwright browsers
         run: go run github.com/mxschmitt/playwright-go/cmd/playwright install --with-deps chromium

--- a/e2e/releasewasm/artifact/store.go
+++ b/e2e/releasewasm/artifact/store.go
@@ -19,6 +19,11 @@ const (
 	generationsDir   = "generations"
 )
 
+var (
+	errReleaseArtifactOutputDigestMismatch   = errors.New("release artifact output digest mismatch")
+	errPrerenderArtifactOutputDigestMismatch = errors.New("prerender artifact output digest mismatch")
+)
+
 type publishHooks struct {
 	beforeRename             func()
 	afterRenameBeforeCurrent func()
@@ -183,7 +188,15 @@ func ValidGenerations(storeDir string, expected *Identity) ([]Generation, error)
 		releaseDir := filepath.Join(generationDir, "release")
 		prerenderDir := filepath.Join(generationDir, "prerender")
 		if err := Validate(releaseDir, prerenderDir, expected); err != nil {
-			return nil, err
+			// Artifact transport can preserve the identity manifest while
+			// changing output bytes or modes. Let the resolver rebuild that
+			// stale generation, but keep identity and structural failures fatal.
+			switch errors.Cause(err) {
+			case errReleaseArtifactOutputDigestMismatch, errPrerenderArtifactOutputDigestMismatch:
+				continue
+			default:
+				return nil, err
+			}
 		}
 		generation := Generation{
 			ID:           name,
@@ -241,14 +254,14 @@ func Validate(releaseDir, prerenderDir string, expected *Identity) error {
 		return errors.Wrap(err, "digest release output")
 	}
 	if actualReleaseDigest != releaseDigest {
-		return errors.New("release artifact output digest mismatch")
+		return errReleaseArtifactOutputDigestMismatch
 	}
 	actualPrerenderDigest, err := treeDigest(prerenderDir)
 	if err != nil {
 		return errors.Wrap(err, "digest prerender output")
 	}
 	if actualPrerenderDigest != prerenderDigest {
-		return errors.New("prerender artifact output digest mismatch")
+		return errPrerenderArtifactOutputDigestMismatch
 	}
 	return nil
 }

--- a/e2e/releasewasm/artifact/store_test.go
+++ b/e2e/releasewasm/artifact/store_test.go
@@ -298,6 +298,39 @@ func TestValidGenerationsCandidatePredicate(t *testing.T) {
 	})
 }
 
+func TestValidGenerationsTreatsOutputDigestMismatchAsCacheMiss(t *testing.T) {
+	repoRoot := newIdentityTestRepo(t)
+	identity := computeTestIdentity(t, repoRoot, testBuildInputs())
+	storeDir := filepath.Join(t.TempDir(), "store")
+	releaseDir, prerenderDir := newArtifactFixture(t, "downloaded")
+	generation, err := PublishGeneration(storeDir, releaseDir, prerenderDir, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	writeTestFile(t, filepath.Join(generation.ReleaseDir, "marker.txt"), "changed after download")
+	generations, err := ValidGenerations(storeDir, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(generations) != 0 {
+		t.Fatalf("generations = %#v, want stale output to be treated as a miss", generations)
+	}
+
+	rebuiltRelease, rebuiltPrerender := newArtifactFixture(t, "rebuilt")
+	rebuilt, err := PublishGeneration(storeDir, rebuiltRelease, rebuiltPrerender, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	generations, err = ValidGenerations(storeDir, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(generations) != 1 || generations[0] != rebuilt {
+		t.Fatalf("generations = %#v, want rebuilt generation %#v", generations, rebuilt)
+	}
+}
+
 func TestValidGenerationsRejectsExternalValidFixtureSymlink(t *testing.T) {
 	repoRoot := newIdentityTestRepo(t)
 	identity := computeTestIdentity(t, repoRoot, testBuildInputs())


### PR DESCRIPTION
The release-WASM browser smoke downloaded the producer artifact successfully, then stopped before browser launch when transported output bytes no longer matched the embedded output digest. That validation error bypassed the existing TinyGo fallback even though the artifact identity and structure remained valid.

Treat only release and prerender output digest mismatches as stale generation cache misses. Identity mismatches, malformed generations, missing files, and structural failures remain fatal, while the resolver can rebuild stale output through its existing owner.

The causal artifact-store regression and full artifact package pass. The focused release-WASM descriptor path also passes, and the protected Nightly run remains the final browser verification.