### PR TITLE
fix(gc): index refgraph batch removal probes

### DIFF
--- a/db/block/gc/refgraph-large-bench_test.go
+++ b/db/block/gc/refgraph-large-bench_test.go
@@ -1,0 +1,62 @@
+package block_gc
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/aperturerobotics/cayley/graph"
+	"github.com/aperturerobotics/cayley/quad"
+	store_kvtx_inmem "github.com/s4wave/spacewave/db/store/kvtx/inmem"
+)
+
+func BenchmarkRefGraphRemoveBatchLargeStore(b *testing.B) {
+	const (
+		seedEdgeCount = 100_000
+		removeCount   = 600
+	)
+
+	ctx := context.Background()
+	rg := newLargeBenchRefGraph(b, ctx)
+	seed := make([]RefEdge, seedEdgeCount)
+	for i := range seed {
+		seed[i] = RefEdge{
+			Subject: "bench/large/subject/" + strconv.Itoa(i),
+			Object:  "bench/large/object/" + strconv.Itoa(i),
+		}
+	}
+	tx := graph.NewTransactionN(seedEdgeCount)
+	for _, edge := range seed {
+		tx.AddQuad(quad.Make(quad.IRI(edge.Subject), quad.IRI(PredGCRef), quad.IRI(edge.Object), nil))
+	}
+	if err := rg.handle.ApplyTransaction(ctx, tx); err != nil {
+		b.Fatal(err)
+	}
+	removes := seed[:removeCount]
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		if err := rg.ApplyRefBatch(ctx, nil, removes); err != nil {
+			b.Fatal(err)
+		}
+		b.StopTimer()
+		if err := rg.ApplyRefBatch(ctx, removes, nil); err != nil {
+			b.Fatal(err)
+		}
+		b.StartTimer()
+	}
+	b.ReportMetric(float64(seedEdgeCount), "seed_edges/op")
+	b.ReportMetric(float64(removeCount), "remove_edges/op")
+}
+
+func newLargeBenchRefGraph(b *testing.B, ctx context.Context) *RefGraph {
+	b.Helper()
+
+	rg, err := NewRefGraph(ctx, store_kvtx_inmem.NewStore(), []byte("gc/"))
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(func() { rg.Close() })
+	return rg
+}

--- a/db/block/gc/refgraph.go
+++ b/db/block/gc/refgraph.go
@@ -234,13 +234,17 @@ func (rg *RefGraph) filterExistingRemoves(
 	for _, edge := range adds {
 		added[edge] = struct{}{}
 	}
+	if qs, ok := graph.Unwrap(rg.handle.QuadStore).(*cayley_kv.QuadStore); ok {
+		return rg.filterExistingRemovesIndexed(ctx, added, removes, qs)
+	}
+
 	existing := make([]RefEdge, 0, len(removes))
 	for _, edge := range removes {
 		if _, ok := added[edge]; ok {
 			existing = append(existing, edge)
 			continue
 		}
-		found, err := rg.hasRef(ctx, edge.Subject, edge.Object)
+		found, err := rg.hasRefGeneric(ctx, edge.Subject, edge.Object)
 		if err != nil {
 			return nil, err
 		}
@@ -251,7 +255,7 @@ func (rg *RefGraph) filterExistingRemoves(
 	return existing, nil
 }
 
-func (rg *RefGraph) hasRef(ctx context.Context, subject, object string) (bool, error) {
+func (rg *RefGraph) hasRefGeneric(ctx context.Context, subject, object string) (bool, error) {
 	var found bool
 	err := iterateFilteredNodeRefs(ctx, rg.handle, quad.Quad{
 		Subject:   quad.IRI(subject),
@@ -262,6 +266,108 @@ func (rg *RefGraph) hasRef(ctx context.Context, subject, object string) (bool, e
 		return io.EOF
 	})
 	return found, err
+}
+
+func (rg *RefGraph) filterExistingRemovesIndexed(
+	ctx context.Context,
+	added map[RefEdge]struct{},
+	removes []RefEdge,
+	qs *cayley_kv.QuadStore,
+) ([]RefEdge, error) {
+	existing := make([]RefEdge, 0, len(removes))
+	lookup := make([]string, 1, 1+2*len(removes))
+	lookup[0] = PredGCRef
+	lookupSet := map[string]struct{}{PredGCRef: {}}
+	unadded := 0
+	for _, edge := range removes {
+		if _, ok := added[edge]; ok {
+			continue
+		}
+		unadded++
+		if _, ok := lookupSet[edge.Subject]; !ok {
+			lookupSet[edge.Subject] = struct{}{}
+			lookup = append(lookup, edge.Subject)
+		}
+		if _, ok := lookupSet[edge.Object]; !ok {
+			lookupSet[edge.Object] = struct{}{}
+			lookup = append(lookup, edge.Object)
+		}
+	}
+	if unadded == 0 {
+		return removes, nil
+	}
+	ids, err := resolveIRIRefIDs(ctx, qs, lookup)
+	if err != nil {
+		return nil, errors.Wrap(err, "resolve remove refs")
+	}
+	predID := ids[PredGCRef]
+	if predID == 0 {
+		for _, edge := range removes {
+			if _, ok := added[edge]; ok {
+				existing = append(existing, edge)
+			}
+		}
+		return existing, nil
+	}
+
+	byObject := make(map[uint64]map[uint64][]int)
+	for i, edge := range removes {
+		if _, ok := added[edge]; ok {
+			continue
+		}
+		subjectID := ids[edge.Subject]
+		objectID := ids[edge.Object]
+		if subjectID == 0 || objectID == 0 {
+			continue
+		}
+		bySubject := byObject[objectID]
+		if bySubject == nil {
+			bySubject = make(map[uint64][]int)
+			byObject[objectID] = bySubject
+		}
+		bySubject[subjectID] = append(bySubject[subjectID], i)
+	}
+	found := make([]bool, len(removes))
+	for objectID, bySubject := range byObject {
+		remaining := 0
+		for _, indexes := range bySubject {
+			remaining += len(indexes)
+		}
+		err := iterateIncomingIndexRefs(ctx, qs, objectID, predID,
+			func(ref cayley_kv.Int64Value, hasLive func() (bool, error)) error {
+				indexes, ok := bySubject[uint64(ref)]
+				if !ok {
+					return nil
+				}
+				live, err := hasLive()
+				if err != nil {
+					return err
+				}
+				if !live {
+					return nil
+				}
+				for _, index := range indexes {
+					if !found[index] {
+						found[index] = true
+						remaining--
+					}
+				}
+				if remaining == 0 {
+					return io.EOF
+				}
+				return nil
+			},
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "iterate remove object index")
+		}
+	}
+	for i, edge := range removes {
+		if _, ok := added[edge]; ok || found[i] {
+			existing = append(existing, edge)
+		}
+	}
+	return existing, nil
 }
 
 // RemoveNodeRefs removes ALL outgoing gc/ref edges for a node.
@@ -471,6 +577,36 @@ func (rg *RefGraph) GetIncomingRefs(ctx context.Context, node string) ([]string,
 	ctx, task := trace.NewTask(ctx, "hydra/block-gc/refgraph/get-incoming-refs")
 	defer task.End()
 
+	if qs, ok := graph.Unwrap(rg.handle.QuadStore).(*cayley_kv.QuadStore); ok {
+		ids, err := resolveIRIRefIDs(ctx, qs, []string{PredGCRef, node})
+		if err != nil {
+			return nil, errors.Wrap(err, "resolve incoming refs")
+		}
+		predID := ids[PredGCRef]
+		objectID := ids[node]
+		if predID == 0 || objectID == 0 {
+			return nil, nil
+		}
+
+		var nodeRefs []graph.Ref
+		err = iterateIncomingIndexRefs(ctx, qs, objectID, predID,
+			func(ref cayley_kv.Int64Value, hasLive func() (bool, error)) error {
+				live, err := hasLive()
+				if err != nil {
+					return err
+				}
+				if live {
+					nodeRefs = append(nodeRefs, ref)
+				}
+				return nil
+			},
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "iterate incoming object index")
+		}
+		return resolveNodeIRIs(ctx, rg.handle, nodeRefs)
+	}
+
 	return collectFilteredNodeIRIs(ctx, rg.handle, quad.Quad{
 		Predicate: quad.IRI(PredGCRef),
 		Object:    quad.IRI(node),
@@ -542,25 +678,18 @@ func (rg *RefGraph) hasIncomingRefsExcludingFast(
 	if !ok {
 		return false, false, nil
 	}
-	predRef, err := rg.handle.ValueOf(ctx, quad.IRI(PredGCRef))
+	ids, err := resolveIRIRefIDs(ctx, qs, []string{PredGCRef, node})
 	if err != nil {
-		return false, true, errors.Wrap(err, "lookup gc/ref predicate")
+		return false, true, errors.Wrap(err, "lookup incoming refs")
 	}
-	objRef, err := rg.handle.ValueOf(ctx, quad.IRI(node))
-	if err != nil {
-		return false, true, errors.Wrap(err, "lookup incoming object")
-	}
-	predID, predOK := predRef.(cayley_kv.Int64Value)
-	objID, objOK := objRef.(cayley_kv.Int64Value)
-	if !predOK || !objOK || predID == 0 || objID == 0 {
+	predID := ids[PredGCRef]
+	objID := ids[node]
+	if predID == 0 || objID == 0 {
 		return false, true, nil
 	}
 
 	var found bool
-	err = qs.IterateIndexPrefixNextRefs(
-		ctx,
-		cayley_kv.DefaultQuadIndexes[1],
-		[]uint64{uint64(objID), uint64(predID)},
+	err = iterateIncomingIndexRefs(ctx, qs, objID, predID,
 		func(ref cayley_kv.Int64Value, hasLive func() (bool, error)) error {
 			if _, ok := excludedSet[refs.ToKey(ref)]; ok {
 				return nil
@@ -576,10 +705,44 @@ func (rg *RefGraph) hasIncomingRefsExcludingFast(
 			return io.EOF
 		},
 	)
-	if err != nil {
-		return false, true, errors.Wrap(err, "iterate incoming object index")
+	return found, true, errors.Wrap(err, "iterate incoming object index")
+}
+
+func resolveIRIRefIDs(
+	ctx context.Context,
+	qs *cayley_kv.QuadStore,
+	iris []string,
+) (map[string]uint64, error) {
+	values := make([]quad.Value, len(iris))
+	for i, iri := range iris {
+		values[i] = quad.IRI(iri)
 	}
-	return found, true, nil
+	refs, err := qs.RefsOf(ctx, values)
+	if err != nil {
+		return nil, err
+	}
+	ids := make(map[string]uint64, len(iris))
+	for i, ref := range refs {
+		id, ok := ref.(cayley_kv.Int64Value)
+		if ok && id != 0 {
+			ids[iris[i]] = uint64(id)
+		}
+	}
+	return ids, nil
+}
+
+func iterateIncomingIndexRefs(
+	ctx context.Context,
+	qs *cayley_kv.QuadStore,
+	objectID, predID uint64,
+	cb func(cayley_kv.Int64Value, func() (bool, error)) error,
+) error {
+	return qs.IterateIndexPrefixNextRefs(
+		ctx,
+		cayley_kv.DefaultQuadIndexes[1],
+		[]uint64{objectID, predID},
+		cb,
+	)
 }
 
 // iterateFilteredNodeRefs iterates node refs on dir from quads matching gq.

--- a/db/block/gc/refgraph_test.go
+++ b/db/block/gc/refgraph_test.go
@@ -114,6 +114,42 @@ func TestRemoveNonExistentRef(t *testing.T) {
 	}
 }
 
+func TestFilterExistingRemovesPreservesBatchAndGraphEdges(t *testing.T) {
+	ctx := context.Background()
+	rg := newTestRefGraph(t)
+
+	adds := []RefEdge{{Subject: "batch", Object: "in-adds"}}
+	if err := rg.AddRef(ctx, "graph", "in-graph"); err != nil {
+		t.Fatal(err)
+	}
+
+	removes := []RefEdge{
+		{Subject: "batch", Object: "in-adds"},
+		{Subject: "graph", Object: "in-graph"},
+		{Subject: "absent", Object: "absent"},
+	}
+	got, err := rg.filterExistingRemoves(ctx, adds, removes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := removes[:2]
+	if !slices.Equal(got, want) {
+		t.Fatalf("filtered removes = %#v, want %#v", got, want)
+	}
+
+	// An absent edge whose node names collide with the predicate IRI adds no
+	// lookup entries; it must still be probed, not assumed to exist.
+	got, err = rg.filterExistingRemoves(ctx, nil, []RefEdge{
+		{Subject: PredGCRef, Object: PredGCRef},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("filtered predicate-named removes = %#v, want none", got)
+	}
+}
+
 func TestRemoveNodeRefs(t *testing.T) {
 	ctx := context.Background()
 	rg := newTestRefGraph(t)

--- a/db/block/gc/store_test.go
+++ b/db/block/gc/store_test.go
@@ -2,14 +2,15 @@ package block_gc
 
 import (
 	"context"
+	"slices"
+	"sync"
+	"testing"
+
 	"github.com/s4wave/spacewave/db/block"
 	block_mock "github.com/s4wave/spacewave/db/block/mock"
 	block_store_kvtx "github.com/s4wave/spacewave/db/block/store/kvtx"
 	store_kvkey "github.com/s4wave/spacewave/db/store/kvkey"
 	store_kvtx_inmem "github.com/s4wave/spacewave/db/store/kvtx/inmem"
-	"slices"
-	"sync"
-	"testing"
 )
 
 // gcTestEnv holds the test environment for GCStoreOps tests.
@@ -908,7 +909,7 @@ func (r *injectUnrefRefGraph) ApplyRefBatch(
 ) error {
 	if !r.injected {
 		r.injected = true
-		if err := r.RefGraphOps.AddRef(ctx, NodeUnreferenced, r.object); err != nil {
+		if err := r.AddRef(ctx, NodeUnreferenced, r.object); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
World commits filtered each ref-graph removal through Cayley's generic shape iterator, probing existence once per removed edge, and orphan marking repeated the same broad incoming-reference walk. On a large store a several-hundred-edge removal batch held the RefGraph write lock inside the World commit flush long enough to starve every World read transaction into context cancellation, and daemon startup reconciliation retriggered the same grind.

Resolve the batch IRIs to ref IDs in one lookup and probe the existing object/predicate quad index for removal and incoming-reference existence, keeping the generic iterator only as the fallback for non-KV quad stores. Add-wins, existing-edge, and absent-edge filtering semantics are preserved and pinned by a regression test. Storage and index formats are unchanged.

The gc package tests pass, and the new benchmark removing 600 edges from a 100k-edge graph runs in 16.2 ms/op with the indexed probes versus 75.5 s/op before, reseeding the removed edges between iterations so every iteration removes existing edges. A follow-up commit fixes two pre-existing aptre lint findings in the package so the pre-commit lint gate passes.
