### PR TITLE
fix(releasewasm): ignore artifact transport file modes

### DIFF
--- a/e2e/releasewasm/artifact/identity.go
+++ b/e2e/releasewasm/artifact/identity.go
@@ -70,7 +70,7 @@ func ComputeIdentity(repoRoot string, inputs *BuildInputs) (*Identity, error) {
 		case path == "app/prerender" || strings.HasPrefix(path, "app/prerender/"):
 			h = prerenderHash
 		}
-		if err := hashFile(h, repoRoot, path); err != nil {
+		if err := hashFile(h, repoRoot, path, true); err != nil {
 			return nil, err
 		}
 	}
@@ -164,7 +164,9 @@ func isLockfile(path string) bool {
 	}
 }
 
-func hashFile(h hash.Hash, repoRoot, path string) error {
+// includeMode controls whether filesystem permission bits participate in the
+// digest. Source inputs retain modes, while transported output trees do not.
+func hashFile(h hash.Hash, repoRoot, path string, includeMode bool) error {
 	fullPath := filepath.Join(repoRoot, filepath.FromSlash(path))
 	info, err := os.Lstat(fullPath)
 	if os.IsNotExist(err) {
@@ -176,7 +178,9 @@ func hashFile(h hash.Hash, repoRoot, path string) error {
 	}
 
 	writeDigestField(h, "path", path)
-	writeDigestField(h, "mode", strconv.FormatUint(uint64(info.Mode()), 8))
+	if includeMode {
+		writeDigestField(h, "mode", strconv.FormatUint(uint64(info.Mode()), 8))
+	}
 	if info.Mode()&os.ModeSymlink != 0 {
 		target, err := os.Readlink(fullPath)
 		if err != nil {

--- a/e2e/releasewasm/artifact/store.go
+++ b/e2e/releasewasm/artifact/store.go
@@ -389,7 +389,7 @@ func treeDigest(root string) (string, error) {
 		if rel == identityFilename {
 			return nil
 		}
-		return hashFile(h, root, rel)
+		return hashFile(h, root, rel, false)
 	})
 	if err != nil {
 		return "", err

--- a/e2e/releasewasm/artifact/store_test.go
+++ b/e2e/releasewasm/artifact/store_test.go
@@ -331,6 +331,34 @@ func TestValidGenerationsTreatsOutputDigestMismatchAsCacheMiss(t *testing.T) {
 	}
 }
 
+func TestValidGenerationsIgnoresTransportModeChanges(t *testing.T) {
+	repoRoot := newIdentityTestRepo(t)
+	identity := computeTestIdentity(t, repoRoot, testBuildInputs())
+	storeDir := filepath.Join(t.TempDir(), "store")
+	releaseDir, prerenderDir := newArtifactFixture(t, "transported")
+	recordPath := filepath.Join(releaseDir, ".bundle-cache", "renderer.json")
+	writeTestFile(t, recordPath, "{}")
+	if err := os.Chmod(recordPath, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	generation, err := PublishGeneration(storeDir, releaseDir, prerenderDir, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(filepath.Join(generation.ReleaseDir, ".bundle-cache", "renderer.json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	generations, err := ValidGenerations(storeDir, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(generations) != 1 || generations[0] != generation {
+		t.Fatalf("generations = %#v, want transported generation %#v", generations, generation)
+	}
+}
+
 func TestValidGenerationsRejectsExternalValidFixtureSymlink(t *testing.T) {
 	repoRoot := newIdentityTestRepo(t)
 	identity := computeTestIdentity(t, repoRoot, testBuildInputs())


### PR DESCRIPTION
The Nightly release-wasm browser smoke failed twice on master with the same shape: the smoke job downloaded the build-envelope artifact, rejected it as a stale generation, entered the TinyGo rebuild fallback, and the harness's 20-minute boot context killed the rebuild (signal: killed at 1380s, no --- FAIL line).

The rejection was a false cache miss. Bldr writes the four .bundle-cache/{service-worker,shared-worker,renderer,opfs-worker}.json records via os.CreateTemp, so they are mode 0600, and GitHub artifact transport restores regular files as 0644. The output tree digest hashed file modes, so a byte-identical artifact recomputed to a different digest. Replaying the digest over both runs' downloaded artifacts after restoring exactly those four modes reproduces the published digests.

Keep hashing modes for source identity inputs, but exclude filesystem modes from release and prerender output tree digests, which cross the artifact transport. Byte, path, size, and symlink-target changes still miss, and identity and structural validation remain fatal. Old generations with the mode-sensitive digest miss once and republish. A regression test publishes a 0600 record, flips it to the transported 0644, and requires ValidGenerations to keep the generation.