### PR TITLE
fix(gc): flush ref graph batches incrementally

### DIFF
--- a/db/block/gc/refgraph-bench_test.go
+++ b/db/block/gc/refgraph-bench_test.go
@@ -14,7 +14,7 @@ import (
 
 func BenchmarkRefGraphApplyRefBatch(b *testing.B) {
 	ctx := context.Background()
-	for _, edgeCount := range []int{64, 1024} {
+	for _, edgeCount := range []int{64, 1024, 4096*2 + 17} {
 		b.Run("edges="+strconv.Itoa(edgeCount), func(b *testing.B) {
 			rg := newBenchRefGraph(b, ctx)
 

--- a/db/block/gc/refgraph.go
+++ b/db/block/gc/refgraph.go
@@ -29,7 +29,24 @@ type RefGraph struct {
 	iriRefKeys map[string]any
 }
 
-const refGraphApplyBatchLimit = 512
+const (
+	refGraphApplyBatchLimit = 512
+	refGraphApplySliceLimit = 4096
+)
+
+type refBatchError struct {
+	err     error
+	adds    []RefEdge
+	removes []RefEdge
+}
+
+func (e *refBatchError) Error() string {
+	return e.err.Error()
+}
+
+func (e *refBatchError) Unwrap() error {
+	return e.err
+}
 
 // NewRefGraph constructs a RefGraph backed by the given kvtx store.
 // prefix is prepended to all keys (e.g., "gc/" for space context).
@@ -95,18 +112,17 @@ func (rg *RefGraph) RemoveRef(ctx context.Context, subject, object string) error
 }
 
 // ApplyRefBatch applies a batch of ref graph edge additions and removals.
-// Small batches run in one Cayley transaction; larger batches chunk at a
-// bounded size while preserving add-before-remove order.
+// Preparation and application are bounded together so each slice commits
+// before preparation of the next slice begins.
 func (rg *RefGraph) ApplyRefBatch(ctx context.Context, adds, removes []RefEdge) error {
-	rg.writeMu.Lock()
-	defer rg.writeMu.Unlock()
-	return rg.applyRefBatchLocked(ctx, adds, removes, true)
+	return rg.applyRefBatch(ctx, adds, removes, true, true)
 }
 
-func (rg *RefGraph) applyRefBatchLocked(
+func (rg *RefGraph) applyRefBatch(
 	ctx context.Context,
 	adds, removes []RefEdge,
 	markOrphaned bool,
+	lockPerSlice bool,
 ) error {
 	ctx = disableStoreTracking(ctx)
 	ctx, task := trace.NewTask(ctx, "hydra/block-gc/refgraph/apply-ref-batch")
@@ -114,40 +130,145 @@ func (rg *RefGraph) applyRefBatchLocked(
 	trace.Logf(
 		ctx,
 		"hydra/block-gc/refgraph/apply-ref-batch/shape",
-		"adds=%d removes=%d limit=%d",
+		"adds=%d removes=%d slice_limit=%d transaction_limit=%d",
 		len(adds),
 		len(removes),
+		refGraphApplySliceLimit,
 		refGraphApplyBatchLimit,
 	)
 
 	if len(adds) == 0 && len(removes) == 0 {
 		return nil
 	}
-	var err error
-	adds, removes, err = rg.prepareRefBatch(ctx, adds, removes, markOrphaned)
-	if err != nil {
-		return err
-	}
-
-	chunks := 0
+	slice := 0
 	for len(adds) != 0 || len(removes) != 0 {
-		addCount := min(len(adds), refGraphApplyBatchLimit)
-		removeCount := 0
-		if addCount < refGraphApplyBatchLimit {
-			removeCount = min(len(removes), refGraphApplyBatchLimit-addCount)
+		if err := ctx.Err(); err != nil {
+			return &refBatchError{
+				err:     err,
+				adds:    cloneRefEdges(adds),
+				removes: cloneRefEdges(removes),
+			}
 		}
-		if addCount == 0 {
-			removeCount = min(len(removes), refGraphApplyBatchLimit)
+
+		addCount, removeCount := refBatchSliceCounts(adds, removes)
+		slice++
+		trace.Logf(
+			ctx,
+			"hydra/block-gc/refgraph/apply-ref-batch/slice-start",
+			"slice=%d adds=%d removes=%d remaining_adds=%d remaining_removes=%d",
+			slice,
+			addCount,
+			removeCount,
+			len(adds)-addCount,
+			len(removes)-removeCount,
+		)
+
+		sliceAdds := adds[:addCount]
+		sliceRemoves := removes[:removeCount]
+		if lockPerSlice {
+			rg.writeMu.Lock()
 		}
-		chunks++
-		if err := rg.applyRefBatchChunk(ctx, adds[:addCount], removes[:removeCount]); err != nil {
-			return err
+		preparedAdds, preparedRemoves, err := rg.prepareRefBatch(
+			ctx,
+			sliceAdds,
+			sliceRemoves,
+			markOrphaned,
+		)
+		if err == nil {
+			var remainingAdds, remainingRemoves []RefEdge
+			remainingAdds, remainingRemoves, err = rg.applyRefBatchSliceLocked(
+				ctx,
+				preparedAdds,
+				preparedRemoves,
+			)
+			if err != nil {
+				if lockPerSlice {
+					rg.writeMu.Unlock()
+				}
+				return &refBatchError{
+					err:     err,
+					adds:    appendRefEdges(remainingAdds, adds[addCount:]),
+					removes: appendRefEdges(remainingRemoves, removes[removeCount:]),
+				}
+			}
 		}
+		if lockPerSlice {
+			rg.writeMu.Unlock()
+		}
+		if err != nil {
+			return &refBatchError{
+				err:     err,
+				adds:    appendRefEdges(sliceAdds, adds[addCount:]),
+				removes: appendRefEdges(sliceRemoves, removes[removeCount:]),
+			}
+		}
+		trace.Logf(
+			ctx,
+			"hydra/block-gc/refgraph/apply-ref-batch/slice-complete",
+			"slice=%d adds=%d removes=%d",
+			slice,
+			addCount,
+			removeCount,
+		)
 		adds = adds[addCount:]
 		removes = removes[removeCount:]
 	}
-	trace.Logf(ctx, "hydra/block-gc/refgraph/apply-ref-batch/chunks", "chunks=%d", chunks)
+	trace.Logf(ctx, "hydra/block-gc/refgraph/apply-ref-batch/slices", "slices=%d", slice)
 	return nil
+}
+
+func refBatchSliceCounts(adds, removes []RefEdge) (int, int) {
+	addCount := min(len(adds), refGraphApplySliceLimit)
+	removeCount := 0
+	if addCount < refGraphApplySliceLimit {
+		removeCount = min(len(removes), refGraphApplySliceLimit-addCount)
+	}
+	if addCount == 0 {
+		removeCount = min(len(removes), refGraphApplySliceLimit)
+	}
+	return addCount, removeCount
+}
+
+func cloneRefEdges(edges []RefEdge) []RefEdge {
+	return append([]RefEdge(nil), edges...)
+}
+
+func appendRefEdges(first, second []RefEdge) []RefEdge {
+	if len(first) == 0 {
+		return cloneRefEdges(second)
+	}
+	if len(second) == 0 {
+		return cloneRefEdges(first)
+	}
+	out := make([]RefEdge, 0, len(first)+len(second))
+	out = append(out, first...)
+	out = append(out, second...)
+	return out
+}
+
+func (rg *RefGraph) applyRefBatchSliceLocked(
+	ctx context.Context,
+	adds, removes []RefEdge,
+) ([]RefEdge, []RefEdge, error) {
+	chunks := 0
+	for len(adds) != 0 {
+		count := min(len(adds), refGraphApplyBatchLimit)
+		chunks++
+		if err := rg.applyRefBatchChunk(ctx, adds[:count], nil); err != nil {
+			return adds, removes, err
+		}
+		adds = adds[count:]
+	}
+	for len(removes) != 0 {
+		count := min(len(removes), refGraphApplyBatchLimit)
+		chunks++
+		if err := rg.applyRefBatchChunk(ctx, nil, removes[:count]); err != nil {
+			return adds, removes, err
+		}
+		removes = removes[count:]
+	}
+	trace.Logf(ctx, "hydra/block-gc/refgraph/apply-ref-batch/chunks", "chunks=%d", chunks)
+	return nil, nil, nil
 }
 
 func (rg *RefGraph) applyRefBatchChunk(ctx context.Context, adds, removes []RefEdge) error {
@@ -386,7 +507,7 @@ func (rg *RefGraph) RemoveNodeRefs(ctx context.Context, node string, markOrphane
 	for _, target := range targets {
 		removes = append(removes, RefEdge{Subject: node, Object: target})
 	}
-	if err := rg.applyRefBatchLocked(ctx, nil, removes, markOrphaned); err != nil {
+	if err := rg.applyRefBatch(ctx, nil, removes, markOrphaned, false); err != nil {
 		return nil, err
 	}
 	return targets, nil

--- a/db/block/gc/refgraph_test.go
+++ b/db/block/gc/refgraph_test.go
@@ -2,11 +2,14 @@ package block_gc
 
 import (
 	"context"
+	"errors"
 	"slices"
 	"strconv"
+	"sync/atomic"
 	"testing"
 
 	"github.com/s4wave/spacewave/db/block"
+	"github.com/s4wave/spacewave/db/kvtx"
 	store_kvtx_inmem "github.com/s4wave/spacewave/db/store/kvtx/inmem"
 	"github.com/s4wave/spacewave/net/hash"
 )
@@ -650,6 +653,232 @@ func TestApplyRefBatchLargeBatchKeepsAddThenRemoveSemantics(t *testing.T) {
 			t.Fatalf("missing edge to %s", node)
 		}
 	}
+}
+
+func TestApplyRefBatchPreparesEachSliceAfterPriorCommit(t *testing.T) {
+	ctx := context.Background()
+	baseStore := store_kvtx_inmem.NewStore()
+	store := &refGraphTrackingStore{Store: baseStore}
+	rg, err := NewRefGraph(ctx, store, []byte("gc/"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { rg.Close() })
+
+	if err := rg.AddRef(ctx, "owner", "target"); err != nil {
+		t.Fatal(err)
+	}
+	store.commits.Store(0)
+	store.readsBeforeCommit.Store(0)
+
+	adds := make([]RefEdge, 4096)
+	for i := range adds {
+		adds[i] = RefEdge{
+			Subject: "batch-owner",
+			Object:  "batch-target-" + strconv.Itoa(i),
+		}
+	}
+
+	if err := rg.ApplyRefBatch(ctx, adds, []RefEdge{{Subject: "owner", Object: "target"}}); err != nil {
+		t.Fatal(err)
+	}
+	if store.commits.Load() == 0 {
+		t.Fatal("expected a committed add slice before the removal slice")
+	}
+	if got := store.readsBeforeCommit.Load(); got != 0 {
+		t.Fatalf("read transactions before first slice commit = %d, want 0", got)
+	}
+
+	refs, err := rg.GetOutgoingRefs(ctx, "batch-owner")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != len(adds) {
+		t.Fatalf("batch-owner refs = %d, want %d", len(refs), len(adds))
+	}
+	if has, err := rg.HasIncomingRefs(ctx, "target"); err != nil {
+		t.Fatal(err)
+	} else if has {
+		t.Fatal("target should have no real incoming refs after the removal slice")
+	}
+}
+
+func TestApplyRefBatchOrphanMarkingAcrossSliceBoundary(t *testing.T) {
+	ctx := context.Background()
+	removes := make([]RefEdge, 0, 4097)
+	for i := range 4095 {
+		removes = append(removes, RefEdge{
+			Subject: "absent-source-" + strconv.Itoa(i),
+			Object:  "absent-target-" + strconv.Itoa(i),
+		})
+	}
+	removes = append(removes,
+		RefEdge{Subject: "owner-a", Object: "shared"},
+		RefEdge{Subject: "owner-b", Object: "shared"},
+	)
+
+	for _, tc := range []struct {
+		name string
+		make func(*testing.T) *RefGraph
+	}{
+		{name: "incremental", make: func(t *testing.T) *RefGraph {
+			rg := newTestRefGraph(t)
+			if err := rg.AddRef(ctx, "owner-a", "shared"); err != nil {
+				t.Fatal(err)
+			}
+			if err := rg.AddRef(ctx, "owner-b", "shared"); err != nil {
+				t.Fatal(err)
+			}
+			return rg
+		}},
+		{name: "single-batch", make: func(t *testing.T) *RefGraph {
+			rg := newTestRefGraph(t)
+			if err := rg.AddRef(ctx, "owner-a", "shared"); err != nil {
+				t.Fatal(err)
+			}
+			if err := rg.AddRef(ctx, "owner-b", "shared"); err != nil {
+				t.Fatal(err)
+			}
+			return rg
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rg := tc.make(t)
+			inputRemoves := removes
+			if tc.name == "single-batch" {
+				inputRemoves = removes[4095:]
+			}
+			if err := rg.ApplyRefBatch(ctx, nil, inputRemoves); err != nil {
+				t.Fatal(err)
+			}
+			incoming, err := rg.GetIncomingRefs(ctx, "shared")
+			if err != nil {
+				t.Fatal(err)
+			}
+			unreferenced, err := rg.GetUnreferencedNodes(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !slices.Contains(unreferenced, "shared") {
+				t.Fatalf("shared should be marked unreferenced, got %v (incoming=%v)", unreferenced, incoming)
+			}
+			for _, owner := range []string{"owner-a", "owner-b"} {
+				refs, err := rg.GetOutgoingRefs(ctx, owner)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(refs) != 0 {
+					t.Fatalf("%s outgoing refs = %v, want none", owner, refs)
+				}
+			}
+		})
+	}
+}
+
+func TestApplyRefBatchInterruptionKeepsCommittedPrefix(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	store := &refGraphCancelOnCommitStore{
+		Store:    store_kvtx_inmem.NewStore(),
+		cancel:   cancel,
+		cancelAt: int64(refGraphApplySliceLimit / refGraphApplyBatchLimit),
+	}
+	rg, err := NewRefGraph(ctx, store, []byte("gc/"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { rg.Close() })
+	store.commits.Store(0)
+
+	adds := make([]RefEdge, refGraphApplySliceLimit+1)
+	for i := range adds {
+		adds[i] = RefEdge{
+			Subject: "interrupt-owner",
+			Object:  "interrupt-target-" + strconv.Itoa(i),
+		}
+	}
+
+	err = rg.ApplyRefBatch(ctx, adds, nil)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("interrupted ApplyRefBatch error = %v, want context.Canceled", err)
+	}
+	refs, err := rg.GetOutgoingRefs(context.Background(), "interrupt-owner")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != refGraphApplySliceLimit {
+		t.Fatalf("committed prefix refs = %d, want %d", len(refs), refGraphApplySliceLimit)
+	}
+
+	if err := rg.ApplyRefBatch(context.Background(), adds[refGraphApplySliceLimit:], nil); err != nil {
+		t.Fatal(err)
+	}
+	refs, err = rg.GetOutgoingRefs(context.Background(), "interrupt-owner")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != len(adds) {
+		t.Fatalf("rerun refs = %d, want %d", len(refs), len(adds))
+	}
+}
+
+type refGraphTrackingStore struct {
+	kvtx.Store
+	commits           atomic.Int64
+	readsBeforeCommit atomic.Int64
+}
+
+func (s *refGraphTrackingStore) NewTransaction(ctx context.Context, write bool) (kvtx.Tx, error) {
+	tx, err := s.Store.NewTransaction(ctx, write)
+	if err != nil {
+		return nil, err
+	}
+	if !write && s.commits.Load() == 0 {
+		s.readsBeforeCommit.Add(1)
+	}
+	return &refGraphTrackingTx{Tx: tx, store: s, write: write}, nil
+}
+
+type refGraphTrackingTx struct {
+	kvtx.Tx
+	store *refGraphTrackingStore
+	write bool
+}
+
+func (t *refGraphTrackingTx) Commit(ctx context.Context) error {
+	err := t.Tx.Commit(ctx)
+	if err == nil && t.write {
+		t.store.commits.Add(1)
+	}
+	return err
+}
+
+type refGraphCancelOnCommitStore struct {
+	kvtx.Store
+	commits  atomic.Int64
+	cancel   context.CancelFunc
+	cancelAt int64
+}
+
+func (s *refGraphCancelOnCommitStore) NewTransaction(ctx context.Context, write bool) (kvtx.Tx, error) {
+	tx, err := s.Store.NewTransaction(ctx, write)
+	if err != nil {
+		return nil, err
+	}
+	return &refGraphCancelOnCommitTx{Tx: tx, store: s, write: write}, nil
+}
+
+type refGraphCancelOnCommitTx struct {
+	kvtx.Tx
+	store *refGraphCancelOnCommitStore
+	write bool
+}
+
+func (t *refGraphCancelOnCommitTx) Commit(ctx context.Context) error {
+	err := t.Tx.Commit(ctx)
+	if err == nil && t.write && t.store.commits.Add(1) == t.store.cancelAt {
+		t.store.cancel()
+	}
+	return err
 }
 
 func TestBlockIRIRoundTrip(t *testing.T) {

--- a/db/block/gc/storage-write-bench_test.go
+++ b/db/block/gc/storage-write-bench_test.go
@@ -139,13 +139,17 @@ func (rg *driveRatioBenchmarkRefGraph) ApplyRefBatch(ctx context.Context, adds, 
 	start := time.Now()
 	err := rg.RefGraph.ApplyRefBatch(ctx, adds, removes)
 	rg.applyRefBatchDuration += time.Since(start)
-	rg.cayleyTransactions += refBatchTransactions(len(adds) + len(removes))
+	rg.cayleyTransactions += refBatchTransactions(len(adds), len(removes))
 	return err
 }
 
-func refBatchTransactions(edges int) int {
-	if edges == 0 {
-		return 0
+func refBatchTransactions(adds, removes int) int {
+	transactions := 0
+	if adds != 0 {
+		transactions += (adds + refGraphApplyBatchLimit - 1) / refGraphApplyBatchLimit
 	}
-	return (edges + refGraphApplyBatchLimit - 1) / refGraphApplyBatchLimit
+	if removes != 0 {
+		transactions += (removes + refGraphApplyBatchLimit - 1) / refGraphApplyBatchLimit
+	}
+	return transactions
 }

--- a/db/block/gc/store.go
+++ b/db/block/gc/store.go
@@ -46,6 +46,8 @@ type GCStoreOps struct {
 	pendingUnref   []string     // block IRIs needing parent/unreferenced -> block edges
 	pendingRefs    []pendingRef // source -> target block ref edges
 	pendingUnunref []string     // block IRIs to remove from unreferenced
+	pendingAdds    []RefEdge    // normalized add edges left by a failed direct flush
+	pendingRemoves []RefEdge    // normalized remove edges left by a failed direct flush
 }
 
 type storeTrackingDisabledContextKey struct{}
@@ -409,21 +411,33 @@ func (g *GCStoreOps) FlushPending(ctx context.Context) error {
 	unrefs := g.pendingUnref
 	refs := g.pendingRefs
 	ununrefs := g.pendingUnunref
+	pendingAdds := g.pendingAdds
+	pendingRemoves := g.pendingRemoves
 	g.pendingUnref = nil
 	g.pendingRefs = nil
 	g.pendingUnunref = nil
+	g.pendingAdds = nil
+	g.pendingRemoves = nil
 	g.mu.Unlock()
 
-	if len(unrefs) == 0 && len(refs) == 0 && len(ununrefs) == 0 {
+	if len(unrefs) == 0 && len(refs) == 0 && len(ununrefs) == 0 &&
+		len(pendingAdds) == 0 && len(pendingRemoves) == 0 {
 		return nil
+	}
+	path := "direct"
+	if g.wal != nil {
+		path = "wal"
 	}
 	trace.Logf(
 		ctx,
 		"hydra/block-gc/store/flush-pending/pending",
-		"unrefs=%d refs=%d ununrefs=%d",
+		"path=%s unrefs=%d refs=%d ununrefs=%d retry_adds=%d retry_removes=%d",
+		path,
 		len(unrefs),
 		len(refs),
 		len(ununrefs),
+		len(pendingAdds),
+		len(pendingRemoves),
 	)
 
 	parent := g.parentIRI
@@ -432,8 +446,10 @@ func (g *GCStoreOps) FlushPending(ctx context.Context) error {
 	}
 	// Parent-backed writes remove their staging edge in the same batch as the
 	// parent edge. RefGraph treats removal of a missing edge as a no-op.
-	adds := make([]RefEdge, 0, len(unrefs)+len(refs))
-	removes := make([]RefEdge, 0, len(ununrefs)+len(unrefs))
+	adds := make([]RefEdge, 0, len(pendingAdds)+len(unrefs)+len(refs))
+	removes := make([]RefEdge, 0, len(pendingRemoves)+len(ununrefs)+len(unrefs))
+	adds = append(adds, pendingAdds...)
+	removes = append(removes, pendingRemoves...)
 	for _, iri := range unrefs {
 		adds = append(adds, RefEdge{Subject: parent, Object: iri})
 		if g.parentIRI != "" {
@@ -454,7 +470,8 @@ func (g *GCStoreOps) FlushPending(ctx context.Context) error {
 	trace.Logf(
 		ctx,
 		"hydra/block-gc/store/flush-pending/normalized",
-		"adds_before=%d removes_before=%d adds_after=%d removes_after=%d",
+		"path=%s adds_before=%d removes_before=%d adds_after=%d removes_after=%d",
+		path,
 		preNormalizeAdds,
 		preNormalizeRemoves,
 		len(adds),
@@ -480,6 +497,11 @@ func (g *GCStoreOps) FlushPending(ctx context.Context) error {
 	batchCtx, batchTask := trace.NewTask(ctx, "hydra/block-gc/store/flush-pending/apply-ref-batch")
 	if err := g.refGraph.ApplyRefBatch(batchCtx, adds, removes); err != nil {
 		batchTask.End()
+		if remainderAdds, remainderRemoves, ok := refBatchRemainder(err); ok {
+			g.rebufferEdges(remainderAdds, remainderRemoves)
+		} else {
+			g.rebufferSourceBuffers(unrefs, refs, ununrefs)
+		}
 		if ctx.Err() != nil {
 			return context.Canceled
 		}
@@ -487,6 +509,36 @@ func (g *GCStoreOps) FlushPending(ctx context.Context) error {
 	}
 	batchTask.End()
 	return nil
+}
+
+func refBatchRemainder(err error) ([]RefEdge, []RefEdge, bool) {
+	var batchErr *refBatchError
+	if !errors.As(err, &batchErr) {
+		return nil, nil, false
+	}
+	return cloneRefEdges(batchErr.adds), cloneRefEdges(batchErr.removes), true
+}
+
+func (g *GCStoreOps) rebufferEdges(adds, removes []RefEdge) {
+	if len(adds) == 0 && len(removes) == 0 {
+		return
+	}
+	g.mu.Lock()
+	g.pendingAdds = append(append([]RefEdge(nil), adds...), g.pendingAdds...)
+	g.pendingRemoves = append(append([]RefEdge(nil), removes...), g.pendingRemoves...)
+	g.mu.Unlock()
+}
+
+func (g *GCStoreOps) rebufferSourceBuffers(
+	unrefs []string,
+	refs []pendingRef,
+	ununrefs []string,
+) {
+	g.mu.Lock()
+	g.pendingUnref = append(append([]string(nil), unrefs...), g.pendingUnref...)
+	g.pendingRefs = append(append([]pendingRef(nil), refs...), g.pendingRefs...)
+	g.pendingUnunref = append(append([]string(nil), ununrefs...), g.pendingUnunref...)
+	g.mu.Unlock()
 }
 
 type refEdgeKey struct {

--- a/db/block/gc/store_test.go
+++ b/db/block/gc/store_test.go
@@ -2,6 +2,7 @@ package block_gc
 
 import (
 	"context"
+	"errors"
 	"slices"
 	"sync"
 	"testing"
@@ -181,6 +182,77 @@ func TestGCStoreOps_FlushPendingNormalizesDuplicateEdges(t *testing.T) {
 	if !slices.Equal(refGraph.removes, wantRemoves) {
 		t.Fatalf("removes = %#v, want %#v", refGraph.removes, wantRemoves)
 	}
+}
+
+func TestGCStoreOps_FlushPendingRebuffersApplyRemainder(t *testing.T) {
+	ctx := context.Background()
+	rg, err := NewRefGraph(ctx, store_kvtx_inmem.NewStore(), []byte("gc/"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { rg.Close() })
+
+	refGraph := &failOnceRefGraph{RefGraphOps: rg}
+	gcStore := NewGCStoreOps(block.NopStoreOps{}, refGraph)
+	gcStore.mu.Lock()
+	gcStore.pendingUnref = []string{"block:a", "block:b", "block:c"}
+	gcStore.mu.Unlock()
+
+	err = gcStore.FlushPending(ctx)
+	if err == nil || !errors.Is(err, errInjectedRefBatch) {
+		t.Fatalf("first flush error = %v, want injected ref batch error", err)
+	}
+	if err := gcStore.FlushPending(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	unreferenced, err := rg.GetUnreferencedNodes(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	slices.Sort(unreferenced)
+	want := []string{"block:a", "block:b", "block:c"}
+	if !slices.Equal(unreferenced, want) {
+		t.Fatalf("unreferenced nodes = %v, want %v", unreferenced, want)
+	}
+	if !slices.Equal(refGraph.applied, wantRefEdges(
+		RefEdge{Subject: NodeUnreferenced, Object: "block:a"},
+		RefEdge{Subject: NodeUnreferenced, Object: "block:b"},
+		RefEdge{Subject: NodeUnreferenced, Object: "block:c"},
+	)) {
+		t.Fatalf("applied edges = %v, want each edge once", refGraph.applied)
+	}
+}
+
+var errInjectedRefBatch = errors.New("injected ref batch failure")
+
+type failOnceRefGraph struct {
+	RefGraphOps
+	failed  bool
+	applied []RefEdge
+}
+
+func (r *failOnceRefGraph) ApplyRefBatch(ctx context.Context, adds, removes []RefEdge) error {
+	if r.failed {
+		r.applied = append(r.applied, adds...)
+		r.applied = append(r.applied, removes...)
+		return r.RefGraphOps.ApplyRefBatch(ctx, adds, removes)
+	}
+	r.failed = true
+	prefix := 1
+	r.applied = append(r.applied, adds[:prefix]...)
+	if err := r.RefGraphOps.ApplyRefBatch(ctx, adds[:prefix], nil); err != nil {
+		return err
+	}
+	return &refBatchError{
+		err:     errInjectedRefBatch,
+		adds:    cloneRefEdges(adds[prefix:]),
+		removes: cloneRefEdges(removes),
+	}
+}
+
+func wantRefEdges(edges ...RefEdge) []RefEdge {
+	return edges
 }
 
 // TestGCStoreOps_RecordRefsRemovesUnrefEdge tests that recording refs


### PR DESCRIPTION
The native RefGraph.ApplyRefBatch path held the write mutex while preparing the entire batch before the first durable commit, so large direct bucket flushes spent minutes to hours without durable progress and blocked readers for the whole interval. This prepares and commits ref graph updates in bounded 4096-edge slices, releasing the write mutex between slices while preserving add-before-remove ordering and orphan marking across slice boundaries. Flush shape and per-slice progress are emitted through the GC trace stream. A failed direct flush previously dropped its drained in-memory buffers; it now retains the unapplied normalized remainder and retries it on the next flush. The WAL path is unchanged. Regression tests cover per-slice preparation, orphan marking across a slice boundary, interruption keeping the committed prefix, and remainder re-buffering after a mid-batch failure.