### PR TITLE
fix(wasm): normalize TinyGo browser runtime pointers

### DIFF
--- a/bldr/web/entrypoint/browser/build/build.go
+++ b/bldr/web/entrypoint/browser/build/build.go
@@ -60,6 +60,7 @@ func BuildWasmRuntimeEntrypoint(
 		}
 		opts.Inject = append(opts.Inject, nodeStubsLoc)
 		entrypoint_browser_bundle.ApplyTinyGoNodeFallbacks(&opts)
+		entrypoint_browser_bundle.ApplyTinyGoWasmExecPatches(&opts, wasmExecFile)
 	}
 	opts.Inject = append(opts.Inject, wasmExecFile)
 

--- a/bldr/web/entrypoint/browser/bundle/tinygo-wasm-exec.go
+++ b/bldr/web/entrypoint/browser/bundle/tinygo-wasm-exec.go
@@ -1,0 +1,104 @@
+//go:build !js
+
+package entrypoint_browser_bundle
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	esbuild "github.com/aperturerobotics/esbuild/pkg/api"
+	"github.com/pkg/errors"
+)
+
+const tinyGoWasmDataView = `class TinyGoWasmDataView extends DataView {
+	getBigUint64(offset, littleEndian) {
+		return super.getBigUint64(offset >>> 0, littleEndian);
+	}
+
+	getUint32(offset, littleEndian) {
+		return super.getUint32(offset >>> 0, littleEndian);
+	}
+
+	getUint8(offset) {
+		return super.getUint8(offset >>> 0);
+	}
+
+	setBigUint64(offset, value, littleEndian) {
+		super.setBigUint64(offset >>> 0, value, littleEndian);
+	}
+
+	setInt32(offset, value, littleEndian) {
+		super.setInt32(offset >>> 0, value, littleEndian);
+	}
+
+	setUint32(offset, value, littleEndian) {
+		super.setUint32(offset >>> 0, value, littleEndian);
+	}
+
+	setUint8(offset, value) {
+		super.setUint8(offset >>> 0, value);
+	}
+}
+
+`
+
+// ApplyTinyGoWasmExecPatches normalizes wasm32 pointers in TinyGo's injected
+// browser runtime before esbuild bundles it with the host runtime.
+func ApplyTinyGoWasmExecPatches(opts *esbuild.BuildOptions, wasmExecFile string) {
+	pattern := regexp.QuoteMeta(filepath.Base(wasmExecFile)) + "$"
+	opts.Plugins = append(opts.Plugins, esbuild.Plugin{
+		Name: "bldr-patch-tinygo-wasm-exec",
+		Setup: func(build esbuild.PluginBuild) {
+			build.OnLoad(
+				esbuild.OnLoadOptions{Filter: pattern},
+				func(args esbuild.OnLoadArgs) (esbuild.OnLoadResult, error) {
+					source, err := os.ReadFile(wasmExecFile)
+					if err != nil {
+						return esbuild.OnLoadResult{}, errors.Wrap(err, "read TinyGo wasm_exec.js")
+					}
+					patched, err := patchTinyGoWasmExecSource(string(source))
+					if err != nil {
+						return esbuild.OnLoadResult{}, err
+					}
+					return esbuild.OnLoadResult{
+						Contents:   &patched,
+						Loader:     esbuild.LoaderJS,
+						WatchFiles: []string{filepath.Clean(wasmExecFile)},
+					}, nil
+				},
+			)
+		},
+	})
+}
+
+func patchTinyGoWasmExecSource(source string) (string, error) {
+	const dataViewSource = "return new DataView(this._inst.exports.memory.buffer);"
+	const dataViewPatched = "return new TinyGoWasmDataView(this._inst.exports.memory.buffer);"
+	const sliceSource = "new Uint8Array(this._inst.exports.memory.buffer, array, len)"
+	const slicePatched = "new Uint8Array(this._inst.exports.memory.buffer, array >>> 0, len)"
+	const stringSource = "new DataView(this._inst.exports.memory.buffer, ptr, len)"
+	const stringPatched = "new DataView(this._inst.exports.memory.buffer, ptr >>> 0, len)"
+
+	if strings.Contains(source, dataViewPatched) &&
+		strings.Contains(source, slicePatched) &&
+		strings.Contains(source, stringPatched) {
+		return source, nil
+	}
+	if !strings.Contains(source, dataViewSource) {
+		return "", errors.New("TinyGo wasm_exec.js memory view source is unsupported")
+	}
+	if !strings.Contains(source, sliceSource) {
+		return "", errors.New("TinyGo wasm_exec.js slice source is unsupported")
+	}
+	if !strings.Contains(source, stringSource) {
+		return "", errors.New("TinyGo wasm_exec.js string source is unsupported")
+	}
+
+	source = strings.Replace(source, "const mem = () => {", tinyGoWasmDataView+"const mem = () => {", 1)
+	source = strings.Replace(source, dataViewSource, dataViewPatched, 1)
+	source = strings.Replace(source, sliceSource, slicePatched, 1)
+	source = strings.Replace(source, stringSource, stringPatched, 1)
+	return source, nil
+}

--- a/bldr/web/entrypoint/browser/bundle/tinygo-wasm-exec_test.go
+++ b/bldr/web/entrypoint/browser/bundle/tinygo-wasm-exec_test.go
@@ -1,0 +1,86 @@
+//go:build !js
+
+package entrypoint_browser_bundle
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	esbuild "github.com/aperturerobotics/esbuild/pkg/api"
+)
+
+func TestPatchTinyGoWasmExecSourceNormalizesWasmPointers(t *testing.T) {
+	source := `
+	const mem = () => {
+		return new DataView(this._inst.exports.memory.buffer);
+	}
+	const loadSlice = (array, len, cap) => {
+		return new Uint8Array(this._inst.exports.memory.buffer, array, len);
+	}
+	const loadString = (ptr, len) => {
+		return decoder.decode(new DataView(this._inst.exports.memory.buffer, ptr, len));
+	}
+	`
+
+	patched, err := patchTinyGoWasmExecSource(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"new TinyGoWasmDataView(this._inst.exports.memory.buffer)",
+		"new Uint8Array(this._inst.exports.memory.buffer, array >>> 0, len)",
+		"new DataView(this._inst.exports.memory.buffer, ptr >>> 0, len)",
+	} {
+		if !strings.Contains(patched, want) {
+			t.Fatalf("patched TinyGo wasm_exec.js is missing %q:\n%s", want, patched)
+		}
+	}
+}
+
+func TestApplyTinyGoWasmExecPatchesInjectedSource(t *testing.T) {
+	dir := t.TempDir()
+	wasmExecPath := filepath.Join(dir, "wasm_exec.js")
+	entrypointPath := filepath.Join(dir, "entrypoint.js")
+	if err := os.WriteFile(wasmExecPath, []byte(`
+	const mem = () => {
+		return new DataView(this._inst.exports.memory.buffer);
+	}
+	const loadSlice = (array, len, cap) => {
+		return new Uint8Array(this._inst.exports.memory.buffer, array, len);
+	}
+	const loadString = (ptr, len) => {
+		return decoder.decode(new DataView(this._inst.exports.memory.buffer, ptr, len));
+	}
+	globalThis.tinyGoMemory = mem
+	globalThis.tinyGoLoadSlice = loadSlice
+	globalThis.tinyGoLoadString = loadString
+	globalThis.Go = class {}
+	`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(entrypointPath, []byte("console.log(Go)\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := esbuild.BuildOptions{
+		AbsWorkingDir: dir,
+		Bundle:        true,
+		EntryPoints:   []string{entrypointPath},
+		Inject:        []string{wasmExecPath},
+		Write:         false,
+	}
+	ApplyTinyGoWasmExecPatches(&opts, wasmExecPath)
+	result := esbuild.Build(opts)
+	if len(result.Errors) != 0 {
+		t.Fatalf("esbuild errors: %v", result.Errors)
+	}
+	if len(result.OutputFiles) != 1 {
+		t.Fatalf("output files = %d, want 1", len(result.OutputFiles))
+	}
+	output := string(result.OutputFiles[0].Contents)
+	if !strings.Contains(output, "array >>> 0") {
+		t.Fatalf("injected TinyGo runtime was not patched:\n%s", output)
+	}
+}

--- a/bldr/web/runtime/wasm/build/build.go
+++ b/bldr/web/runtime/wasm/build/build.go
@@ -81,6 +81,7 @@ func BuildWebWasmPluginScript(ctx context.Context, le *logrus.Entry, bldrDistRoo
 		}
 		opts.Inject = append(opts.Inject, nodeStubsLoc)
 		entrypoint_browser_bundle.ApplyTinyGoNodeFallbacks(&opts)
+		entrypoint_browser_bundle.ApplyTinyGoWasmExecPatches(&opts, wasmExecFile)
 	}
 
 	opts.Inject = append(opts.Inject, wasmExecFile)

--- a/e2e/releasewasm/releasewasm_test.go
+++ b/e2e/releasewasm/releasewasm_test.go
@@ -85,7 +85,7 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-func TestBrowserReleaseDescriptorIncludesPrerenderedWasmShell(t *testing.T) {
+func TestBrowserReleaseDescriptorIncludesPrerenderedShell(t *testing.T) {
 	desc, err := testHarness.browserRelease(context.Background())
 	if err != nil {
 		t.Fatal(err)
@@ -104,9 +104,6 @@ func TestBrowserReleaseDescriptorIncludesPrerenderedWasmShell(t *testing.T) {
 	}
 	if desc.ShellAssets.SharedWorker == "" {
 		t.Fatal("expected shellAssets.sharedWorker")
-	}
-	if desc.ShellAssets.Wasm == "" {
-		t.Fatal("expected shellAssets.wasm")
 	}
 	if !slices.Contains(desc.PrerenderedRoutes, "/") {
 		t.Fatalf("expected / in prerendered routes: %v", desc.PrerenderedRoutes)


### PR DESCRIPTION
TinyGo's injected wasm_exec.js passes wasm32 pointers to DataView and typed-array helpers as signed JavaScript numbers, so once the linear-memory heap grows past 2 GiB the high-bit pointers arrive negative and throw RangeError (Start offset -21xxxxxxxx is outside the bounds of the buffer), killing the spacewave-core worker in the nightly browser smoke. This patches the injected runtime source before esbuild bundles it: a DataView subclass normalizes every offset method the runtime uses, and the loadSlice and loadString call sites normalize their pointers with an unsigned shift. The patch hard-fails if a future TinyGo changes the expected source shapes so an unpatched runtime cannot ship silently. The descriptor test also asserted shellAssets.wasm, but since f3036c3d2 the browser release ships the GoScript shell which has no entrypoint runtime.wasm; the test now checks the entrypoint, workers, and prerendered routes without requiring the wasm asset. Regression tests cover the source transform and the esbuild injection.