### PR TITLE
fix(bldr): wait for plugin host scheduler

### DIFF
--- a/bldr/plugin/host/scheduler/status.go
+++ b/bldr/plugin/host/scheduler/status.go
@@ -51,6 +51,22 @@ func FindControllerOnBus(b bus.Bus) *Controller {
 	return nil
 }
 
+// WaitControllerOnBus waits for a plugin host scheduler to be added to b.
+func WaitControllerOnBus(ctx context.Context, b bus.Bus) (*Controller, error) {
+	var scheduler *Controller
+	err := b.GetControllersBroadcast().Wait(ctx, func(
+		_ func(),
+		_ func() <-chan struct{},
+	) (bool, error) {
+		scheduler = FindControllerOnBus(b)
+		return scheduler != nil, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return scheduler, nil
+}
+
 // IsPluginRunningOnBus reports whether the scheduler on b has a running plugin.
 func IsPluginRunningOnBus(ctx context.Context, b bus.Bus, pluginID string) bool {
 	if err := ctx.Err(); err != nil {

--- a/bldr/plugin/host/scheduler/status_test.go
+++ b/bldr/plugin/host/scheduler/status_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aperturerobotics/controllerbus/bus/inmem"
+	directive_controller "github.com/aperturerobotics/controllerbus/directive/controller"
 	"github.com/aperturerobotics/util/ccontainer"
 	"github.com/pkg/errors"
 	bldr_manifest "github.com/s4wave/spacewave/bldr/manifest"
@@ -13,7 +15,90 @@ import (
 	bldr_plugin "github.com/s4wave/spacewave/bldr/plugin"
 	"github.com/s4wave/spacewave/db/block"
 	"github.com/s4wave/spacewave/db/bucket"
+	"github.com/s4wave/spacewave/net/peer"
+	"github.com/sirupsen/logrus"
 )
+
+func TestWaitControllerOnBusWaitsForDelayedScheduler(t *testing.T) {
+	busCtx := t.Context()
+
+	logger := logrus.NewEntry(logrus.New())
+	b := inmem.NewBus(directive_controller.NewController(busCtx, logger))
+	p, _, _, err := peer.NewPeerWithGenerateED25519()
+	if err != nil {
+		t.Fatal(err)
+	}
+	scheduler := NewController(logger, b, NewConfig(
+		"test-engine",
+		"test-plugin-host",
+		"test-volume",
+		p.GetPeerID().String(),
+		true,
+		false,
+		false,
+	))
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	type waitResult struct {
+		scheduler *Controller
+		err       error
+	}
+	resultCh := make(chan waitResult, 1)
+	go func() {
+		got, err := WaitControllerOnBus(ctx, b)
+		resultCh <- waitResult{scheduler: got, err: err}
+	}()
+
+	delay := time.NewTimer(50 * time.Millisecond)
+	defer delay.Stop()
+	select {
+	case result := <-resultCh:
+		t.Fatalf("wait returned before scheduler registration: scheduler=%p err=%v", result.scheduler, result.err)
+	case <-delay.C:
+	}
+
+	rel, err := b.AddController(busCtx, scheduler, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rel()
+
+	select {
+	case result := <-resultCh:
+		if result.err != nil {
+			t.Fatalf("wait: %v", result.err)
+		}
+		if result.scheduler != scheduler {
+			t.Fatalf("scheduler = %p, want %p", result.scheduler, scheduler)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("wait did not return after scheduler registration")
+	}
+}
+
+func TestWaitControllerOnBusReturnsContextCancellation(t *testing.T) {
+	busCtx := t.Context()
+
+	logger := logrus.NewEntry(logrus.New())
+	b := inmem.NewBus(directive_controller.NewController(busCtx, logger))
+	ctx, cancel := context.WithCancel(context.Background())
+	resultCh := make(chan error, 1)
+	go func() {
+		_, err := WaitControllerOnBus(ctx, b)
+		resultCh <- err
+	}()
+	cancel()
+
+	select {
+	case err := <-resultCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("wait error = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("wait did not return after context cancellation")
+	}
+}
 
 func TestPluginStatusRecordsAndClearsLastError(t *testing.T) {
 	ctrl := &Controller{

--- a/bldr/project/controller/startup.go
+++ b/bldr/project/controller/startup.go
@@ -5,7 +5,6 @@ package bldr_project_controller
 import (
 	"context"
 
-	"github.com/pkg/errors"
 	bldr_plugin "github.com/s4wave/spacewave/bldr/plugin"
 	plugin_host_scheduler "github.com/s4wave/spacewave/bldr/plugin/host/scheduler"
 	bldr_project "github.com/s4wave/spacewave/bldr/project"
@@ -27,9 +26,9 @@ func (c *Controller) executeStartup(ctx context.Context, conf *bldr_project.Star
 		defer plugRef.Release()
 	}
 
-	scheduler := plugin_host_scheduler.FindControllerOnBus(c.bus)
-	if scheduler == nil {
-		return errors.New("plugin host scheduler is not running")
+	scheduler, err := plugin_host_scheduler.WaitControllerOnBus(ctx, c.bus)
+	if err != nil {
+		return err
 	}
 	if err := scheduler.WaitPluginsRunning(ctx, loadPluginIDs); err != nil {
 		return err


### PR DESCRIPTION
When manifest builds complete the bldr/project keyed routines restart, and the plugin host scheduler exits and re-registers through the loader during the same cascade. The restarted startup routine did a point-in-time FindControllerOnBus scan that could run milliseconds before the scheduler's re-registration, so it exited with 'plugin host scheduler is not running' and was never retried: startup plugins never loaded and the nightly electron suite timed out waiting for the CDP endpoint. executeStartup now waits on the bus controllers broadcast, rechecking for the scheduler while the broadcast lock is held so an add cannot slip between the scan and the wait, bounded by the routine context. Regression tests cover delayed scheduler registration (red against the old one-shot lookup) and context cancellation while waiting.