### PR TITLE
fix(shell): isolate document hash from shared tab updates

### DIFF
--- a/app/ShellAppPanel.test.tsx
+++ b/app/ShellAppPanel.test.tsx
@@ -8,7 +8,7 @@ import {
   waitFor,
 } from '@testing-library/react'
 
-import { getAppPath } from '@s4wave/web/router/app-path.js'
+import { getAppPath, setAppPath } from '@s4wave/web/router/app-path.js'
 
 import { ShellAppPanel } from './ShellAppPanel.js'
 import { ShellTabsProvider, useShellTabs } from './ShellTabContext.js'
@@ -16,6 +16,7 @@ import {
   installShellTabTestBrowser,
   readShellTabsSnapshot,
   seedShellTabs,
+  type ShellTabTestBrowser,
 } from './ShellTabTestHarness.js'
 import type { ShellDocumentEntry } from './ShellDocumentEntry.js'
 
@@ -85,6 +86,12 @@ vi.mock('./routes/AppRoutes.js', async () => {
         >
           Add Docs Tab
         </button>
+        <button
+          onClick={() => void tabContext?.navigateTab('/docs')}
+          type="button"
+        >
+          Navigate Tab
+        </button>
       </div>
     )
   }
@@ -102,9 +109,17 @@ function ActiveTabProbe() {
   const { activeTabId } = useShellTabs()
   return <span data-testid="active-tab-id">{activeTabId}</span>
 }
+function ActivateTabButton({ tabId }: { tabId: string }) {
+  const { setActiveTabId } = useShellTabs()
+  return (
+    <button onClick={() => setActiveTabId(tabId)} type="button">
+      Activate {tabId}
+    </button>
+  )
+}
 
 describe('ShellAppPanel', () => {
-  let restoreTestBrowser: (() => void) | undefined
+  let restoreTestBrowser: ShellTabTestBrowser | undefined
 
   beforeEach(() => {
     restoreTestBrowser = installShellTabTestBrowser()
@@ -156,6 +171,204 @@ describe('ShellAppPanel', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Docs' }))
 
     await waitFor(() => expect(getAppPath()).toBe('/docs'))
+  })
+
+  it('syncs active tab-context navigation to the global app path', async () => {
+    seedTabs('tab-2')
+
+    render(
+      <ShellTabsProvider entry={handoffEntry('tab-2')}>
+        <ShellAppPanel
+          tabId="tab-2"
+          initialPath="/quickstart/drive"
+          namespace={['test', 'tab-2']}
+          syncAppPath
+        />
+      </ShellTabsProvider>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Navigate Tab' }))
+
+    await waitFor(() => {
+      const record = readShellTabsSnapshot().records.find(
+        (tab) => tab.id === 'tab-2',
+      )
+      expect(record?.path).toBe('/docs')
+      expect(getAppPath()).toBe('/docs')
+    })
+  })
+
+  it('keeps the global app path when an inactive tab context navigates', async () => {
+    seedTabs('tab-2')
+
+    render(
+      <ShellTabsProvider entry={handoffEntry('tab-2')}>
+        <ShellAppPanel
+          tabId="tab-1"
+          initialPath="/"
+          namespace={['test', 'tab-1']}
+          syncAppPath
+        />
+      </ShellTabsProvider>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Navigate Tab' }))
+
+    await waitFor(() => {
+      const record = readShellTabsSnapshot().records.find(
+        (tab) => tab.id === 'tab-1',
+      )
+      expect(record?.path).toBe('/docs')
+    })
+    expect(getAppPath()).toBe('/')
+  })
+
+  it('keeps the global app path when the panel deactivates before the path commits', async () => {
+    if (!restoreTestBrowser) throw new Error('test browser not installed')
+    const browser = restoreTestBrowser
+    seedTabs('tab-2')
+
+    render(
+      <ShellTabsProvider entry={handoffEntry('tab-2')}>
+        <ActiveTabProbe />
+        <ActivateTabButton tabId="tab-1" />
+        <ShellAppPanel
+          tabId="tab-2"
+          initialPath="/quickstart/drive"
+          namespace={['test', 'tab-2']}
+          syncAppPath
+        />
+      </ShellTabsProvider>,
+    )
+
+    const blocked = browser.blockNextMutation()
+    fireEvent.click(screen.getByRole('button', { name: 'Navigate Tab' }))
+    await blocked
+
+    fireEvent.click(screen.getByRole('button', { name: 'Activate tab-1' }))
+    await waitFor(() =>
+      expect(screen.getByTestId('active-tab-id').textContent).toBe('tab-1'),
+    )
+
+    browser.releaseBlockedMutation()
+
+    await waitFor(() => {
+      const record = readShellTabsSnapshot().records.find(
+        (tab) => tab.id === 'tab-2',
+      )
+      expect(record?.path).toBe('/docs')
+    })
+    expect(getAppPath()).toBe('/')
+  })
+
+  it('syncs the global app path when the panel activates before the path commits', async () => {
+    if (!restoreTestBrowser) throw new Error('test browser not installed')
+    const browser = restoreTestBrowser
+    seedTabs('tab-2')
+
+    render(
+      <ShellTabsProvider entry={handoffEntry('tab-2')}>
+        <ActiveTabProbe />
+        <ActivateTabButton tabId="tab-1" />
+        <ShellAppPanel
+          tabId="tab-1"
+          initialPath="/"
+          namespace={['test', 'tab-1']}
+          syncAppPath
+        />
+      </ShellTabsProvider>,
+    )
+
+    const blocked = browser.blockNextMutation()
+    fireEvent.click(screen.getByRole('button', { name: 'Navigate Tab' }))
+    await blocked
+
+    fireEvent.click(screen.getByRole('button', { name: 'Activate tab-1' }))
+    await waitFor(() =>
+      expect(screen.getByTestId('active-tab-id').textContent).toBe('tab-1'),
+    )
+
+    browser.releaseBlockedMutation()
+
+    await waitFor(() => {
+      const record = readShellTabsSnapshot().records.find(
+        (tab) => tab.id === 'tab-1',
+      )
+      expect(record?.path).toBe('/docs')
+      expect(getAppPath()).toBe('/docs')
+    })
+  })
+
+  it('leaves a newer document navigation in place when an older path commits', async () => {
+    if (!restoreTestBrowser) throw new Error('test browser not installed')
+    const browser = restoreTestBrowser
+    seedTabs('tab-2')
+
+    render(
+      <ShellTabsProvider entry={handoffEntry('tab-2')}>
+        <ActiveTabProbe />
+        <ShellAppPanel
+          tabId="tab-2"
+          initialPath="/quickstart/drive"
+          namespace={['test', 'tab-2']}
+          syncAppPath
+        />
+      </ShellTabsProvider>,
+    )
+
+    const blocked = browser.blockNextMutation()
+    fireEvent.click(screen.getByRole('button', { name: 'Navigate Tab' }))
+    await blocked
+
+    // The user moves the document while the commit waits on the Web Lock.
+    setAppPath('/files')
+
+    browser.releaseBlockedMutation()
+
+    await waitFor(() => {
+      const record = readShellTabsSnapshot().records.find(
+        (tab) => tab.id === 'tab-2',
+      )
+      expect(record?.path).toBe('/docs')
+    })
+    expect(getAppPath()).toBe('/files')
+  })
+
+  it('leaves a document navigated away and back in place when an older path commits', async () => {
+    if (!restoreTestBrowser) throw new Error('test browser not installed')
+    const browser = restoreTestBrowser
+    seedTabs('tab-2')
+
+    render(
+      <ShellTabsProvider entry={handoffEntry('tab-2')}>
+        <ActiveTabProbe />
+        <ShellAppPanel
+          tabId="tab-2"
+          initialPath="/quickstart/drive"
+          namespace={['test', 'tab-2']}
+          syncAppPath
+        />
+      </ShellTabsProvider>,
+    )
+
+    const blocked = browser.blockNextMutation()
+    fireEvent.click(screen.getByRole('button', { name: 'Navigate Tab' }))
+    await blocked
+
+    // A round trip through history restores the path the commit started
+    // from, so only a navigation counter can tell that the user moved.
+    setAppPath('/files')
+    setAppPath('/')
+
+    browser.releaseBlockedMutation()
+
+    await waitFor(() => {
+      const record = readShellTabsSnapshot().records.find(
+        (tab) => tab.id === 'tab-2',
+      )
+      expect(record?.path).toBe('/docs')
+    })
+    expect(getAppPath()).toBe('/')
   })
 
   it('adds selected shell tabs from embedded tab-context requests', async () => {

--- a/app/ShellAppPanel.tsx
+++ b/app/ShellAppPanel.tsx
@@ -1,7 +1,10 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback, useMemo, useRef } from 'react'
 
 import { BottomBarRoot } from '@s4wave/web/frame/bottom-bar-root.js'
-import { setAppPath } from '@s4wave/web/router/app-path.js'
+import {
+  getAppNavigationGeneration,
+  setAppPath,
+} from '@s4wave/web/router/app-path.js'
 import { HistoryRouter } from '@s4wave/web/router/HistoryRouter.js'
 import { resolvePath, type To } from '@s4wave/web/router/router.js'
 import {
@@ -62,6 +65,29 @@ function ShellAppPanelInner({
   const tabId = useTabId()
   const { tabs, activeTabId, addShellTab, updateTabPath } = useShellTabs()
 
+  // The path commit can be delayed behind the store's Web Lock. Decide at
+  // commit time, not at initiation: a panel that lost active status, a
+  // navigation a later one superseded, and a document the user moved
+  // elsewhere in the meantime each forfeit the hash.
+  const activeTabIdRef = useRef(activeTabId)
+  activeTabIdRef.current = activeTabId
+  const syncAppPathRef = useRef(syncAppPath)
+  syncAppPathRef.current = syncAppPath
+  const navGenerationRef = useRef(0)
+  const beginAppPathCommit = useCallback(
+    (path: string) => {
+      const generation = ++navGenerationRef.current
+      const documentGeneration = getAppNavigationGeneration()
+      return () => {
+        if (generation !== navGenerationRef.current) return
+        if (!syncAppPathRef.current || tabId !== activeTabIdRef.current) return
+        if (getAppNavigationGeneration() !== documentGeneration) return
+        setAppPath(path)
+      }
+    },
+    [tabId],
+  )
+
   const addTab = useCallback(
     (request: AddTabRequest) => {
       const tab = request.tab
@@ -85,10 +111,16 @@ function ShellAppPanelInner({
 
   const navigateTab = useCallback(
     (path: string) => {
-      if (tabId) updateTabPath(tabId, path)
+      if (tabId) {
+        updateTabPath(
+          tabId,
+          path,
+          syncAppPath ? beginAppPathCommit(path) : undefined,
+        )
+      }
       return Promise.resolve({})
     },
-    [tabId, updateTabPath],
+    [tabId, updateTabPath, syncAppPath, beginAppPathCommit],
   )
 
   const tabContext = useMemo<TabContextValue>(
@@ -110,10 +142,10 @@ function ShellAppPanelInner({
       updateTabPath(
         tabId,
         newPath,
-        syncAppPath ? () => setAppPath(newPath) : undefined,
+        syncAppPath ? beginAppPathCommit(newPath) : undefined,
       )
     },
-    [tabId, activeTabId, path, updateTabPath, syncAppPath],
+    [tabId, activeTabId, path, updateTabPath, syncAppPath, beginAppPathCommit],
   )
 
   return (

--- a/app/ShellFlexLayout.tsx
+++ b/app/ShellFlexLayout.tsx
@@ -511,27 +511,6 @@ function ShellTabStripInner({
     }
   }, [activeTabId, isGridMode])
 
-  // A remote shared path update follows the active record into a normal Flex
-  // URL. The hash listener ignores this feedback and does not write it back.
-  useEffect(() => {
-    if (!initializedRef.current || isGridMode()) return
-    const activeTab = tabsRef.current.find((tab) => tab.id === activeTabId)
-    const currentPath = getAppPath()
-    const pendingLocalPath = pendingLocalHashIntentRef.current
-    if (pendingLocalPath?.tabId !== activeTabId) {
-      pendingLocalHashIntentRef.current = null
-    } else if (pendingLocalPath.path === currentPath) {
-      if (activeTab?.path === pendingLocalPath.path) {
-        pendingLocalHashIntentRef.current = null
-      } else {
-        return
-      }
-    }
-    if (!activeTab || activeTab.path === currentPath) return
-    suppressedHashPathRef.current = activeTab.path
-    setAppPath(activeTab.path)
-  }, [activeTabId, isGridMode, tabs])
-
   // Listen for hash changes (back/forward navigation)
   const handleHashChange = useEffectEvent(() => {
     if (!initializedRef.current) return

--- a/app/ShellTabStrip.test.tsx
+++ b/app/ShellTabStrip.test.tsx
@@ -13,6 +13,7 @@ import { getAppPath } from '@s4wave/web/router/app-path.js'
 import { APP_DRAG_MIME } from '@s4wave/web/dnd/app-drag.js'
 import type * as WebState from '@s4wave/web/state/index.js'
 import {
+  BROWSER_SHELL_TABS_STORAGE_KEY,
   getBrowserShellTabsStore,
   resetBrowserShellTabsStoreForTests,
 } from './BrowserShellTabsStore.js'
@@ -629,6 +630,41 @@ describe('ShellTabStrip', () => {
     })
     window.removeEventListener('hashchange', onHashChange)
     expect(navigations).not.toContain('/files')
+  })
+  it('keeps the document hash when a shared active record path changes', async () => {
+    seedShellTabs([{ id: 'active', name: 'Active', path: '/a-only' }])
+    window.location.hash = '#/a-only'
+
+    render(
+      <ShellTabStrip entry={continuationEntry}>
+        <ActiveTabProbe />
+      </ShellTabStrip>,
+    )
+
+    await waitFor(() => expect(getAppPath()).toBe('/a-only'))
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: BROWSER_SHELL_TABS_STORAGE_KEY,
+          newValue: JSON.stringify({
+            schemaVersion: 1,
+            epoch: 0,
+            revision: 1,
+            records: [
+              {
+                id: 'active',
+                name: 'Home',
+                path: '/',
+                creationSequence: 1,
+              },
+            ],
+          }),
+        }),
+      )
+    })
+
+    expect(getAppPath()).toBe('/a-only')
   })
 
   it('preserves every shared record while projecting an empty stored model', async () => {

--- a/web/router/app-path.test.ts
+++ b/web/router/app-path.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest'
 
 import {
+  getAppNavigationGeneration,
   getAppPath,
   isPathnameAppRoute,
   normalizeAppPath,
@@ -112,5 +113,54 @@ describe('app path helpers', () => {
     }
 
     expect(hashChanges).toBe(0)
+  })
+  it('advances the navigation generation across a history round trip', async () => {
+    setAppPath('/start')
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    const start = getAppNavigationGeneration()
+
+    setAppPath('/files')
+    setAppPath('/start')
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(getAppPath()).toBe('/start')
+    expect(getAppNavigationGeneration()).toBeGreaterThan(start)
+  })
+
+  it('holds the navigation generation when the path does not change', async () => {
+    setAppPath('/start')
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    const start = getAppNavigationGeneration()
+
+    setAppPath('/start')
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(getAppNavigationGeneration()).toBe(start)
+  })
+
+  it('advances the navigation generation on a raw hash write, before hashchange runs', async () => {
+    setAppPath('/start')
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    const start = getAppNavigationGeneration()
+
+    // A caller writing the hash directly, as app/debug/spacewave-global.ts
+    // does, moves the document now and queues hashchange for later. Read the
+    // generation in the same task, before that event can run.
+    window.location.hash = '#/files'
+
+    expect(getAppNavigationGeneration()).toBeGreaterThan(start)
+  })
+
+  it('counts a raw hash write once when hashchange later runs', async () => {
+    setAppPath('/start')
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    const start = getAppNavigationGeneration()
+
+    window.location.hash = '#/files'
+    const afterWrite = getAppNavigationGeneration()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(afterWrite).toBe(start + 1)
+    expect(getAppNavigationGeneration()).toBe(afterWrite)
   })
 })

--- a/web/router/app-path.ts
+++ b/web/router/app-path.ts
@@ -90,6 +90,45 @@ export function getAppPath(): string {
   return getAppNavigation().path
 }
 
+let navigationGeneration = 0
+let navigationGenerationTracked = false
+let observedLocation = ''
+
+function currentLocationKey(): string {
+  return `${window.location.pathname}${window.location.search}${window.location.hash}`
+}
+
+// observeNavigation advances the counter when the document location differs
+// from the one last observed. Reading the location is what makes a direct
+// `window.location.hash` write countable: that write moves the document
+// synchronously and only queues `hashchange`, so a counter driven by the
+// event alone still reads stale inside the same task.
+function observeNavigation(): void {
+  const key = currentLocationKey()
+  if (key === observedLocation) return
+  observedLocation = key
+  navigationGeneration++
+}
+
+function trackNavigationGeneration(): void {
+  if (navigationGenerationTracked) return
+  navigationGenerationTracked = true
+  observedLocation = currentLocationKey()
+  window.addEventListener('hashchange', observeNavigation)
+  window.addEventListener('popstate', observeNavigation)
+}
+
+// getAppNavigationGeneration returns a counter that advances on every
+// document navigation, whoever caused it: history traversal, an in-app
+// setAppPath, or an external hash edit. Comparing the counter across an
+// awaited boundary answers whether the document moved, which comparing
+// paths cannot, since a navigation away and back restores the old string.
+export function getAppNavigationGeneration(): number {
+  trackNavigationGeneration()
+  observeNavigation()
+  return navigationGeneration
+}
+
 // setAppPath sets the hash to the given path while retaining named parameters
 // unless an explicit parameter set is provided.
 export function setAppPath(
@@ -103,17 +142,23 @@ export function setAppPath(
     ? window.location.hash.slice(1)
     : window.location.hash
   if (currentHash === nextHash) return
+  // replaceState fires neither hashchange nor popstate, so the move is
+  // observed here rather than left to the listeners.
+  trackNavigationGeneration()
   if (window.location.search) {
     window.history.replaceState(
       {},
       '',
       `${window.location.pathname}${window.location.search}#${nextHash}`,
     )
+    observeNavigation()
     return
   }
   if (window.location.pathname !== '/') {
     window.history.replaceState({}, '', `/#${nextHash}`)
+    observeNavigation()
     return
   }
   window.location.hash = nextHash
+  observeNavigation()
 }


### PR DESCRIPTION
The composed shell-tabs browser proof failed on its first genuine nightly run (the release-wasm smoke class was masked until the TinyGo pointer fix landed): after concurrent tab creation in two documents, both documents ended at #/ even though the shared records converged to /a-only and /b-only.

ShellFlexLayout had an effect that treated every shared record projection change as a remote path navigation and called setAppPath with the active record path. A storage event carrying the other document's record update could therefore navigate a document that did not initiate any change, racing the document's own hash write back to the record's initial / path. Per the shell tab ownership decision, shared records carry content (path, name, membership); document URL projection is local, so the effect is removed. Cross-page record updates still propagate through the store listener without navigating the receiving document.

Regression test dispatches a newer storage event changing the shared active record path to / while the document sits at #/a-only and asserts the hash stays; it fails without the fix. Full app vitest suite passes (276 files, 1669 tests). The composed proof gets its production confirmation on the next nightly.