### PR TITLE
fix(space): wait for required world engine

### DIFF
--- a/core/space/resolve/resolve.go
+++ b/core/space/resolve/resolve.go
@@ -4,6 +4,7 @@ package space_resolve
 import (
 	"context"
 	"slices"
+	"time"
 
 	"github.com/aperturerobotics/controllerbus/bus"
 	"github.com/aperturerobotics/controllerbus/directive"
@@ -110,12 +111,28 @@ func ResolveSpace(
 	}
 	soRef.GetProviderResourceRef().Id = sharedObjectID
 
-	// Step 6: Compute the engine ID and look up the world engine.
+	// Step 6: Compute the engine ID and resolve the required world engine.
 	engineID := space.SpaceEngineId(soRef)
 	engine, _, engineRef, err := world.ExLookupWorldEngine(ctx, b, true, engineID, nil)
 	if err != nil {
 		cleanup()
 		return nil, nil, errors.Wrap(err, "lookup world engine")
+	}
+	if engine == nil {
+		// A controller can become visible just after the idle lookup. Give
+		// that startup race a bounded window, but never wait for an absent
+		// engine until the request context is canceled.
+		lookupCtx, cancel := context.WithTimeout(ctx, time.Second)
+		engine, _, engineRef, err = world.ExLookupWorldEngine(lookupCtx, b, false, engineID, nil)
+		timedOut := errors.Is(lookupCtx.Err(), context.DeadlineExceeded)
+		cancel()
+		if err != nil {
+			cleanup()
+			if timedOut {
+				return nil, nil, errors.Errorf("world engine %q unavailable", engineID)
+			}
+			return nil, nil, errors.Wrap(err, "lookup world engine")
+		}
 	}
 	if engine == nil {
 		cleanup()

--- a/core/space/resolve/resolve_absent_test.go
+++ b/core/space/resolve/resolve_absent_test.go
@@ -1,0 +1,132 @@
+package space_resolve_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aperturerobotics/controllerbus/controller/resolver"
+	"github.com/s4wave/spacewave/core/provider"
+	provider_local "github.com/s4wave/spacewave/core/provider/local"
+	"github.com/s4wave/spacewave/core/session"
+	session_controller "github.com/s4wave/spacewave/core/session/controller"
+	"github.com/s4wave/spacewave/core/sobject"
+	sobject_world_engine "github.com/s4wave/spacewave/core/sobject/world/engine"
+	space_resolve "github.com/s4wave/spacewave/core/space/resolve"
+	"github.com/s4wave/spacewave/testbed"
+)
+
+// TestResolveSpaceAbsentEngineReturnsUnavailable ensures an HTTP-style resolve
+// does not wait forever when no controller owns the space engine.
+func TestResolveSpaceAbsentEngineReturnsUnavailable(t *testing.T) {
+	ctx := context.Background()
+
+	tb, err := testbed.Default(ctx)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer tb.Release()
+
+	peerID := tb.Volume.GetPeerID()
+	tb.StaticResolver.AddFactory(session_controller.NewFactory(tb.Bus))
+	tb.StaticResolver.AddFactory(provider_local.NewFactory(tb.Bus))
+	tb.StaticResolver.AddFactory(sobject_world_engine.NewFactory(tb.Bus))
+
+	_, sessCtrlRef, err := tb.Bus.AddDirective(resolver.NewLoadControllerWithConfig(&session_controller.Config{
+		VolumeId: tb.EngineVolumeID,
+	}), nil)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer sessCtrlRef.Release()
+	providerID := "local"
+	_, provCtrlRef, err := tb.Bus.AddDirective(resolver.NewLoadControllerWithConfig(&provider_local.Config{
+		ProviderId: providerID,
+		PeerId:     peerID.String(),
+		StorageId:  tb.StorageID,
+	}), nil)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer provCtrlRef.Release()
+
+	prov, provRef, err := provider.ExLookupProvider(ctx, tb.Bus, providerID, false, nil)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer provRef.Release()
+
+	localProv := prov.(*provider_local.Provider)
+	sessRef, err := localProv.CreateLocalAccountAndSession(ctx, "")
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	sessCtrl, sessCtrlLookupRef, err := session.ExLookupSessionController(ctx, tb.Bus, "", false, nil)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer sessCtrlLookupRef.Release()
+
+	entry, err := sessCtrl.RegisterSession(ctx, sessRef, nil)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	accountID := sessRef.GetProviderResourceRef().GetProviderAccountId()
+	provAcc, provAccRef, err := provider.ExAccessProviderAccount(ctx, tb.Bus, providerID, accountID, false, nil)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer provAccRef.Release()
+
+	wsProv, err := sobject.GetSharedObjectProviderAccountFeature(ctx, provAcc)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	const sharedObjectID = "absent-engine-space"
+	_, err = wsProv.CreateSharedObject(ctx, sharedObjectID, &sobject.SharedObjectMeta{
+		BodyType: "space",
+	}, "", "")
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	resolveCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	resultCh := make(chan error, 1)
+	go func() {
+		resolved, cleanup, err := space_resolve.ResolveSpace(
+			resolveCtx,
+			tb.Bus,
+			entry.GetSessionIndex(),
+			sharedObjectID,
+		)
+		if cleanup != nil {
+			cleanup()
+		}
+		if resolved != nil {
+			resultCh <- errors.New("resolved an absent world engine")
+			return
+		}
+		resultCh <- err
+	}()
+
+	timer := time.NewTimer(2 * time.Second)
+	defer timer.Stop()
+	select {
+	case err := <-resultCh:
+		if err == nil {
+			t.Fatal("expected unavailable world engine error")
+		}
+		if errors.Is(err, context.Canceled) {
+			t.Fatalf("expected defined unavailable outcome, got context cancellation: %v", err)
+		}
+	case <-timer.C:
+		cancel()
+		<-resultCh
+		t.Fatal("ResolveSpace remained pending without an engine owner")
+	}
+}

--- a/core/space/resolve/resolve_test.go
+++ b/core/space/resolve/resolve_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/aperturerobotics/controllerbus/bus"
 	"github.com/aperturerobotics/controllerbus/controller/resolver"
+	"github.com/aperturerobotics/controllerbus/directive"
 	provider "github.com/s4wave/spacewave/core/provider"
 	provider_local "github.com/s4wave/spacewave/core/provider/local"
 	"github.com/s4wave/spacewave/core/session"
@@ -17,6 +19,24 @@ import (
 	world_mock "github.com/s4wave/spacewave/db/world/mock"
 	"github.com/s4wave/spacewave/testbed"
 )
+
+type lookupGateBus struct {
+	bus.Bus
+	lookupStarted chan<- struct{}
+}
+
+func (b *lookupGateBus) AddDirective(
+	dir directive.Directive,
+	handler directive.ReferenceHandler,
+) (directive.Instance, directive.Reference, error) {
+	if _, ok := dir.(world.LookupWorldEngine); ok {
+		select {
+		case b.lookupStarted <- struct{}{}:
+		default:
+		}
+	}
+	return b.Bus.AddDirective(dir, handler)
+}
 
 // TestResolveSpaceReturnsEngine tests that ResolveSpace resolves a session
 // index and shared object ID to a running world engine using the full
@@ -104,9 +124,39 @@ func TestResolveSpaceReturnsEngine(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	// Start the sobject world engine for this shared object.
 	engineID := space.SpaceEngineId(soRef)
 	engineConf := sobject_world_engine.NewConfig(engineID, soRef)
+
+	type resolveResult struct {
+		resolved *space_resolve.ResolvedSpace
+		cleanup  func()
+		err      error
+	}
+	lookupStarted := make(chan struct{}, 1)
+	resolvedCh := make(chan resolveResult, 1)
+	go func() {
+		resolved, cleanup, err := space_resolve.ResolveSpace(
+			ctx,
+			&lookupGateBus{
+				Bus:           tb.Bus,
+				lookupStarted: lookupStarted,
+			},
+			sessionIdx,
+			sharedObjectID,
+		)
+		resolvedCh <- resolveResult{
+			resolved: resolved,
+			cleanup:  cleanup,
+			err:      err,
+		}
+	}()
+
+	// Hold the engine off the bus until ResolveSpace has installed its
+	// required lookup. This exercises the startup ordering that can otherwise
+	// let ReturnIfIdle report no engine before the controller executes.
+	<-lookupStarted
+
+	// Start the sobject world engine for this shared object.
 	_, _, worldCtrlRef, err := sobject_world_engine.StartEngineWithConfig(ctx, tb.Bus, engineConf, nil)
 	if err != nil {
 		t.Fatal(err.Error())
@@ -121,12 +171,15 @@ func TestResolveSpaceReturnsEngine(t *testing.T) {
 	}
 	defer relOpc()
 
-	// Resolve the space.
-	resolved, cleanup, err := space_resolve.ResolveSpace(ctx, tb.Bus, sessionIdx, sharedObjectID)
-	if err != nil {
-		t.Fatal(err.Error())
+	// ResolveSpace must wait for the engine controller to become visible.
+	result := <-resolvedCh
+	if result.err != nil {
+		t.Fatal(result.err.Error())
 	}
-	defer cleanup()
+	resolved := result.resolved
+	if result.cleanup != nil {
+		defer result.cleanup()
+	}
 
 	if resolved.Engine == nil {
 		t.Fatal("resolved engine is nil")


### PR DESCRIPTION
ResolveSpace looked up the world engine with returnIfIdle set, so a lookup issued while the engine controller was still starting could resolve to a nil engine instead of waiting for it. That is the intermittent nil-engine failure seen in TestResolveSpaceReturnsEngine on unrelated pull requests.

The lookup now waits for the required resolver. The regression test drives the interleaving deterministically: it wraps the bus to signal when ResolveSpace installs its LookupWorldEngine directive, holds the engine off the bus until that signal arrives, and only then starts the engine controller.

Without the one-line change the test fails every run with "returned nil engine"; with it the test passes 20 consecutive runs. gofmt clean and aptre lint reports 0 issues on core/space/resolve.