### PR TITLE
fix(gcgraph): serialize exact opfs ref removals

### DIFF
--- a/db/block/gc/gcgraph/batch.go
+++ b/db/block/gc/gcgraph/batch.go
@@ -34,7 +34,7 @@ func (g *GCGraph) applyRefBatchLocked(
 		}
 	}
 	for _, e := range removes {
-		if err := g.removeRef(e.Subject, e.Object); err != nil {
+		if err := g.removeExistingRef(e.Subject, e.Object); err != nil {
 			return err
 		}
 	}
@@ -45,9 +45,32 @@ func (g *GCGraph) prepareRefBatch(
 	ctx context.Context,
 	adds, removes []block_gc.RefEdge,
 ) ([]block_gc.RefEdge, []block_gc.RefEdge, error) {
-	owners := make(map[string]map[string]struct{})
-	stagingRemoves := make(map[string]struct{})
+	added := make(map[block_gc.RefEdge]struct{}, len(adds))
+	for _, edge := range adds {
+		added[edge] = struct{}{}
+	}
+	existingRemoves := make([]block_gc.RefEdge, 0, len(removes))
 	for _, edge := range removes {
+		if _, addedInBatch := added[edge]; addedInBatch {
+			existingRemoves = append(existingRemoves, edge)
+			continue
+		}
+		exists, err := g.hasRef(edge.Subject, edge.Object)
+		if err != nil {
+			return nil, nil, err
+		}
+		if exists {
+			existingRemoves = append(existingRemoves, edge)
+		}
+	}
+
+	type ownerState struct {
+		owners  map[string]struct{}
+		hadEdge bool
+	}
+	owners := make(map[string]ownerState)
+	stagingRemoves := make(map[string]struct{})
+	for _, edge := range existingRemoves {
 		if edge.Subject == block_gc.NodeUnreferenced {
 			stagingRemoves[edge.Object] = struct{}{}
 			continue
@@ -68,29 +91,34 @@ func (g *GCGraph) prepareRefBatch(
 				set[source] = struct{}{}
 			}
 		}
-		owners[edge.Object] = set
-	}
-	for _, edge := range removes {
-		if set, ok := owners[edge.Object]; ok {
-			delete(set, edge.Subject)
-		}
+		owners[edge.Object] = ownerState{owners: set}
 	}
 	for _, edge := range adds {
-		if set, ok := owners[edge.Object]; ok && edge.Subject != block_gc.NodeUnreferenced {
-			set[edge.Subject] = struct{}{}
+		if state, ok := owners[edge.Object]; ok && edge.Subject != block_gc.NodeUnreferenced {
+			state.owners[edge.Subject] = struct{}{}
+			owners[edge.Object] = state
 		}
 	}
-	for object, set := range owners {
-		if len(set) == 0 {
-			if _, removingStaging := stagingRemoves[object]; !removingStaging {
-				adds = append(adds, block_gc.RefEdge{
-					Subject: block_gc.NodeUnreferenced,
-					Object:  object,
-				})
-			}
+	for _, edge := range existingRemoves {
+		if state, ok := owners[edge.Object]; ok {
+			state.hadEdge = true
+			delete(state.owners, edge.Subject)
+			owners[edge.Object] = state
 		}
 	}
-	return adds, removes, nil
+	for object, state := range owners {
+		if !state.hadEdge || len(state.owners) != 0 {
+			continue
+		}
+		if _, removingStaging := stagingRemoves[object]; removingStaging {
+			continue
+		}
+		adds = append(adds, block_gc.RefEdge{
+			Subject: block_gc.NodeUnreferenced,
+			Object:  object,
+		})
+	}
+	return adds, existingRemoves, nil
 }
 
 // RemoveNodeRefs removes all outgoing gc/ref edges for a node.

--- a/db/block/gc/gcgraph/batch.go
+++ b/db/block/gc/gcgraph/batch.go
@@ -28,6 +28,10 @@ func (g *GCGraph) applyRefBatchLocked(
 	if err != nil {
 		return err
 	}
+	return g.applyPreparedRefBatch(adds, removes)
+}
+
+func (g *GCGraph) applyPreparedRefBatch(adds, removes []block_gc.RefEdge) error {
 	for _, e := range adds {
 		if err := g.addRef(e.Subject, e.Object); err != nil {
 			return err

--- a/db/block/gc/gcgraph/batch.go
+++ b/db/block/gc/gcgraph/batch.go
@@ -69,14 +69,11 @@ func (g *GCGraph) prepareRefBatch(
 	}
 
 	type ownerState struct {
-		owners  map[string]struct{}
-		hadEdge bool
+		owners map[string]struct{}
 	}
 	owners := make(map[string]ownerState)
-	stagingRemoves := make(map[string]struct{})
 	for _, edge := range existingRemoves {
 		if edge.Subject == block_gc.NodeUnreferenced {
-			stagingRemoves[edge.Object] = struct{}{}
 			continue
 		}
 		if block_gc.IsPermanentRoot(edge.Object) {
@@ -105,16 +102,12 @@ func (g *GCGraph) prepareRefBatch(
 	}
 	for _, edge := range existingRemoves {
 		if state, ok := owners[edge.Object]; ok {
-			state.hadEdge = true
 			delete(state.owners, edge.Subject)
 			owners[edge.Object] = state
 		}
 	}
 	for object, state := range owners {
-		if !state.hadEdge || len(state.owners) != 0 {
-			continue
-		}
-		if _, removingStaging := stagingRemoves[object]; removingStaging {
+		if len(state.owners) != 0 {
 			continue
 		}
 		adds = append(adds, block_gc.RefEdge{

--- a/db/block/gc/gcgraph/gcgraph-cost_test.go
+++ b/db/block/gc/gcgraph/gcgraph-cost_test.go
@@ -1,0 +1,244 @@
+//go:build js
+
+package gcgraph
+
+import (
+	"context"
+	"os"
+	"slices"
+	"strconv"
+	"syscall/js"
+	"testing"
+	"time"
+
+	block_gc "github.com/s4wave/spacewave/db/block/gc"
+	"github.com/s4wave/spacewave/db/opfs"
+)
+
+func TestGCGraphRemovalCostByBatchSize(t *testing.T) {
+	if os.Getenv("SPACEWAVE_GCGRAPH_OPFS_COST") == "" {
+		t.Skip("set SPACEWAVE_GCGRAPH_OPFS_COST=1 to run the timed harness")
+	}
+
+	trialValues := make(map[int][]opfsRemovalCost, len(opfsRemovalCostCheckpoints))
+	for trial := 1; trial <= opfsRemovalCostTrialCount; trial++ {
+		for _, checkpoint := range opfsRemovalCostCheckpoints {
+			value := runOPFSRemovalCostTrial(t, trial, checkpoint)
+			trialValues[checkpoint] = append(trialValues[checkpoint], value)
+			t.Logf(
+				"trial=%d removals=%d existing=%d missing=%d file_ops=%d prepare_file_ops=%d mutation_file_ops=%d prepare=%s mutation=%s owner_held=%s",
+				trial,
+				checkpoint,
+				(checkpoint+1)/2,
+				checkpoint/2,
+				value.fileOperations,
+				value.preparationFileOperations,
+				value.mutationFileOperations,
+				value.preparation,
+				value.mutation,
+				value.ownerHeld,
+			)
+		}
+	}
+
+	for _, checkpoint := range opfsRemovalCostCheckpoints {
+		fileOperations := make([]int, 0, opfsRemovalCostTrialCount)
+		preparationFileOperations := make([]int, 0, opfsRemovalCostTrialCount)
+		mutationFileOperations := make([]int, 0, opfsRemovalCostTrialCount)
+		preparation := make([]time.Duration, 0, opfsRemovalCostTrialCount)
+		mutation := make([]time.Duration, 0, opfsRemovalCostTrialCount)
+		ownerHeld := make([]time.Duration, 0, opfsRemovalCostTrialCount)
+		for _, value := range trialValues[checkpoint] {
+			fileOperations = append(fileOperations, value.fileOperations)
+			preparationFileOperations = append(
+				preparationFileOperations,
+				value.preparationFileOperations,
+			)
+			mutationFileOperations = append(
+				mutationFileOperations,
+				value.mutationFileOperations,
+			)
+			preparation = append(preparation, value.preparation)
+			mutation = append(mutation, value.mutation)
+			ownerHeld = append(ownerHeld, value.ownerHeld)
+		}
+		slices.Sort(fileOperations)
+		slices.Sort(preparationFileOperations)
+		slices.Sort(mutationFileOperations)
+		slices.Sort(preparation)
+		slices.Sort(mutation)
+		slices.Sort(ownerHeld)
+		medianIndex := len(fileOperations) / 2
+		t.Logf(
+			"median removals=%d trials=%d file_ops=%d prepare_file_ops=%d mutation_file_ops=%d prepare=%s mutation=%s owner_held=%s",
+			checkpoint,
+			len(fileOperations),
+			fileOperations[medianIndex],
+			preparationFileOperations[medianIndex],
+			mutationFileOperations[medianIndex],
+			preparation[medianIndex],
+			mutation[medianIndex],
+			ownerHeld[medianIndex],
+		)
+	}
+}
+
+const opfsRemovalCostTrialCount = 7
+
+var opfsRemovalCostCheckpoints = []int{1, 8, 16, 32, 64, 96, 128}
+
+type opfsRemovalCost struct {
+	fileOperations            int
+	preparationFileOperations int
+	mutationFileOperations    int
+	preparation               time.Duration
+	mutation                  time.Duration
+	ownerHeld                 time.Duration
+}
+
+func runOPFSRemovalCostTrial(t *testing.T, trial, edgeCount int) opfsRemovalCost {
+	t.Helper()
+	ctx := context.Background()
+	name := "test-gcgraph-removal-cost-" + strconv.Itoa(trial) + "-" + strconv.Itoa(edgeCount)
+
+	baseDriver := opfs.DefaultDriver
+	countingDriver := &countingOPFSDriver{Driver: baseDriver}
+	opfs.DefaultDriver = countingDriver
+	defer func() { opfs.DefaultDriver = baseDriver }()
+	root, err := opfs.GetRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := opfs.DeleteEntry(root, name, true); err != nil && !opfs.IsNotFound(err) {
+		t.Fatal(err)
+	}
+
+	g, cleanup := newTestGraph(t, name)
+	defer cleanup()
+
+	removes := make([]block_gc.RefEdge, edgeCount)
+	for i := range removes {
+		removes[i] = block_gc.RefEdge{
+			Subject: name + "/subject/" + strconv.Itoa(i),
+			Object:  name + "/object/" + strconv.Itoa(i),
+		}
+		if i%2 == 0 {
+			if err := g.AddRef(ctx, removes[i].Subject, removes[i].Object); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	countingDriver.fileOperations = 0
+
+	release, err := g.acquireOwnershipLock(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	released := false
+	defer func() {
+		if !released {
+			release()
+		}
+	}()
+	lockStart := time.Now()
+
+	start := time.Now()
+	adds, existingRemoves, err := g.prepareRefBatch(ctx, nil, removes)
+	preparation := time.Since(start)
+	if err != nil {
+		t.Fatal(err)
+	}
+	preparationFileOperations := countingDriver.fileOperations
+	if len(existingRemoves) != (edgeCount+1)/2 {
+		t.Fatalf("prepared %d existing removals, want %d", len(existingRemoves), (edgeCount+1)/2)
+	}
+	if len(adds) != len(existingRemoves) {
+		t.Fatalf("prepared %d orphan additions, want %d", len(adds), len(existingRemoves))
+	}
+
+	start = time.Now()
+	err = g.applyPreparedRefBatch(adds, existingRemoves)
+	mutation := time.Since(start)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fileOperations := countingDriver.fileOperations
+	release()
+	released = true
+	ownerHeld := time.Since(lockStart)
+
+	return opfsRemovalCost{
+		fileOperations:            fileOperations,
+		preparationFileOperations: preparationFileOperations,
+		mutationFileOperations:    fileOperations - preparationFileOperations,
+		preparation:               preparation,
+		mutation:                  mutation,
+		ownerHeld:                 ownerHeld,
+	}
+}
+
+// countingOPFSDriver counts calls at the OPFS driver boundary while preserving
+// the selected driver's file and locking behavior.
+type countingOPFSDriver struct {
+	opfs.Driver
+	fileOperations int
+}
+
+func (d *countingOPFSDriver) GetDirectory(parent js.Value, name string, create bool) (js.Value, error) {
+	d.fileOperations++
+	return d.Driver.GetDirectory(parent, name, create)
+}
+
+func (d *countingOPFSDriver) OpenAsyncFile(dir js.Value, name string) (*opfs.AsyncFile, error) {
+	d.fileOperations++
+	return d.Driver.OpenAsyncFile(dir, name)
+}
+
+func (d *countingOPFSDriver) CreateAsyncFile(dir js.Value, name string) (*opfs.AsyncFile, error) {
+	d.fileOperations++
+	return d.Driver.CreateAsyncFile(dir, name)
+}
+
+func (d *countingOPFSDriver) WriteFile(dir js.Value, name string, data []byte) error {
+	d.fileOperations++
+	return d.Driver.WriteFile(dir, name, data)
+}
+
+func (d *countingOPFSDriver) ReadFile(dir js.Value, name string) ([]byte, error) {
+	d.fileOperations++
+	return d.Driver.ReadFile(dir, name)
+}
+
+func (d *countingOPFSDriver) DeleteEntry(dir js.Value, name string, recursive bool) error {
+	d.fileOperations++
+	return d.Driver.DeleteEntry(dir, name, recursive)
+}
+
+func (d *countingOPFSDriver) ListDirectory(dir js.Value) ([]string, error) {
+	d.fileOperations++
+	return d.Driver.ListDirectory(dir)
+}
+
+func (d *countingOPFSDriver) FileExists(dir js.Value, name string) (bool, error) {
+	d.fileOperations++
+	return d.Driver.FileExists(dir, name)
+}
+
+func (d *countingOPFSDriver) OpenSyncFile(dir js.Value, name string) (*opfs.SyncFile, error) {
+	d.fileOperations++
+	return d.Driver.OpenSyncFile(dir, name)
+}
+
+func (d *countingOPFSDriver) CreateSyncFile(dir js.Value, name string) (*opfs.SyncFile, error) {
+	d.fileOperations++
+	return d.Driver.CreateSyncFile(dir, name)
+}
+
+func (d *countingOPFSDriver) CreateSyncFileContext(
+	ctx context.Context,
+	dir js.Value,
+	name string,
+) (*opfs.SyncFile, error) {
+	d.fileOperations++
+	return d.Driver.CreateSyncFileContext(ctx, dir, name)
+}

--- a/db/block/gc/gcgraph/gcgraph-nonjs.go
+++ b/db/block/gc/gcgraph/gcgraph-nonjs.go
@@ -1,0 +1,4 @@
+//go:build !js
+
+// Package gcgraph is implemented for JS builds.
+package gcgraph

--- a/db/block/gc/gcgraph/gcgraph.go
+++ b/db/block/gc/gcgraph/gcgraph.go
@@ -124,20 +124,56 @@ func (g *GCGraph) RemoveRef(ctx context.Context, subject, object string) error {
 	return g.removeRef(subject, object)
 }
 
+func (g *GCGraph) hasRef(subject, object string) (bool, error) {
+	edgeSubDir, err := opfs.GetDirectory(g.edgesDir, hashName(subject), false)
+	if err != nil {
+		if opfs.IsNotFound(err) {
+			return false, nil
+		}
+		return false, errors.Wrap(err, "edges subdir")
+	}
+	data, err := g.readFileContent(edgeSubDir, hashName(object))
+	if err != nil {
+		if opfs.IsNotFound(err) {
+			return false, nil
+		}
+		return false, errors.Wrap(err, "read forward edge")
+	}
+	fileSubject, fileObject, ok := parseEdgeContent(data)
+	return ok && fileSubject == subject && fileObject == object, nil
+}
+
 func (g *GCGraph) removeRef(subject, object string) error {
+	exists, err := g.hasRef(subject, object)
+	if err != nil || !exists {
+		return err
+	}
+	return g.removeExistingRef(subject, object)
+}
+
+func (g *GCGraph) removeExistingRef(subject, object string) error {
 	sh := hashName(subject)
 	oh := hashName(object)
 
 	edgeSubDir, err := opfs.GetDirectory(g.edgesDir, sh, false)
-	if err == nil {
-		_ = g.deleteFile(edgeSubDir, oh)
+	if err != nil {
+		if opfs.IsNotFound(err) {
+			return nil
+		}
+		return errors.Wrap(err, "edges subdir")
+	}
+	if err := g.deleteFile(edgeSubDir, oh); err != nil {
+		return errors.Wrap(err, "delete forward edge")
 	}
 
 	inSubDir, err := opfs.GetDirectory(g.incomingDir, oh, false)
-	if err == nil {
-		_ = g.deleteFile(inSubDir, sh)
+	if err != nil {
+		if opfs.IsNotFound(err) {
+			return nil
+		}
+		return errors.Wrap(err, "incoming subdir")
 	}
-	return nil
+	return errors.Wrap(g.deleteFile(inSubDir, sh), "delete reverse edge")
 }
 
 // ensureNode creates a node inventory entry if it does not exist.

--- a/db/block/gc/gcgraph/gcgraph_test.go
+++ b/db/block/gc/gcgraph/gcgraph_test.go
@@ -3,8 +3,10 @@
 package gcgraph
 
 import (
+	"bytes"
 	"context"
 	"slices"
+	"syscall/js"
 	"testing"
 
 	block_gc "github.com/s4wave/spacewave/db/block/gc"
@@ -13,8 +15,14 @@ import (
 
 func newTestGraph(t *testing.T, name string) (*GCGraph, func()) {
 	t.Helper()
-	if !opfs.SyncAvailable() {
-		t.Skip("sync access handles not available")
+	navigator := js.Global().Get("navigator")
+	if navigator.IsUndefined() || navigator.IsNull() {
+		t.Skip("browser OPFS not available")
+	}
+	storage := navigator.Get("storage")
+	if storage.IsUndefined() || storage.IsNull() ||
+		storage.Get("getDirectory").Type() != js.TypeFunction {
+		t.Skip("browser OPFS not available")
 	}
 	root, err := opfs.GetRoot()
 	if err != nil {
@@ -30,6 +38,53 @@ func newTestGraph(t *testing.T, name string) (*GCGraph, func()) {
 		t.Fatal(err)
 	}
 	return g, func() { opfs.DeleteEntry(root, name, true) } //nolint
+}
+
+func snapshotEdgeDirectory(t *testing.T, g *GCGraph, root js.Value) map[string][]byte {
+	t.Helper()
+	subdirs, err := opfs.ListDirectory(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot := make(map[string][]byte)
+	for _, subdirName := range subdirs {
+		snapshot[subdirName+"/"] = nil
+		subdir, err := opfs.GetDirectory(root, subdirName, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		names, err := opfs.ListDirectory(subdir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, name := range names {
+			data, err := g.readFileContent(subdir, name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			snapshot[subdirName+"/"+name] = data
+		}
+	}
+	return snapshot
+}
+
+func equalEdgeDirectorySnapshots(left, right map[string][]byte) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for name, leftData := range left {
+		rightData, ok := right[name]
+		if !ok || !bytes.Equal(leftData, rightData) {
+			return false
+		}
+	}
+	return true
+}
+
+func sortedRefs(refs []string) []string {
+	refs = slices.Clone(refs)
+	slices.Sort(refs)
+	return refs
 }
 
 func TestGCGraphAddRemoveRef(t *testing.T) {
@@ -187,5 +242,186 @@ func TestGCGraphBatchAndOrphan(t *testing.T) {
 	// incoming refs either, so c1 should also be unreferenced.
 	if !slices.Contains(unref, "c1") {
 		t.Errorf("c1 not in unreferenced: %v", unref)
+	}
+}
+
+func TestApplyRefBatchMissingRemovalPreservesEdgeDirectories(t *testing.T) {
+	g, cleanup := newTestGraph(t, "test-gcgraph-batch-missing")
+	defer cleanup()
+	ctx := context.Background()
+
+	if err := g.AddRef(ctx, "owner", "target"); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.AddRef(ctx, "missing-owner", "other"); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.AddRef(ctx, block_gc.NodeUnreferenced, "staged"); err != nil {
+		t.Fatal(err)
+	}
+	incomingTargetDir, err := opfs.GetDirectory(g.incomingDir, hashName("target"), false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := g.writeFile(
+		incomingTargetDir,
+		hashName("missing-owner"),
+		[]byte("missing-owner\ntarget"),
+	); err != nil {
+		t.Fatal(err)
+	}
+	beforeForward := snapshotEdgeDirectory(t, g, g.edgesDir)
+	beforeIncoming := snapshotEdgeDirectory(t, g, g.incomingDir)
+	beforeUnreferenced, err := g.GetUnreferencedNodes(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := g.ApplyRefBatch(ctx, nil, []block_gc.RefEdge{
+		{Subject: "missing-owner", Object: "target"},
+		{Subject: "missing-owner", Object: "never-seen"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	afterForward := snapshotEdgeDirectory(t, g, g.edgesDir)
+	if !equalEdgeDirectorySnapshots(beforeForward, afterForward) {
+		t.Fatal("missing removal changed forward edge directory")
+	}
+	afterIncoming := snapshotEdgeDirectory(t, g, g.incomingDir)
+	if !equalEdgeDirectorySnapshots(beforeIncoming, afterIncoming) {
+		t.Fatal("missing removal changed incoming edge directory")
+	}
+	afterUnreferenced, err := g.GetUnreferencedNodes(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(sortedRefs(beforeUnreferenced), sortedRefs(afterUnreferenced)) {
+		t.Fatalf(
+			"missing removal changed orphan marks: before=%v after=%v",
+			beforeUnreferenced,
+			afterUnreferenced,
+		)
+	}
+}
+
+func TestApplyRefBatchExistingRemovalCleansPairedEdges(t *testing.T) {
+	g, cleanup := newTestGraph(t, "test-gcgraph-batch-existing")
+	defer cleanup()
+	ctx := context.Background()
+
+	if err := g.AddRef(ctx, "owner", "target"); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.ApplyRefBatch(ctx, nil, []block_gc.RefEdge{{
+		Subject: "owner",
+		Object:  "target",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	exists, err := g.hasRef("owner", "target")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Fatal("existing removal left forward edge file")
+	}
+	incoming, err := g.GetIncomingRefs(ctx, "target")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(incoming, []string{block_gc.NodeUnreferenced}) {
+		t.Fatalf("existing removal left paired reverse edge: incoming=%v", incoming)
+	}
+}
+
+func TestApplyRefBatchCollidingAddAndRemoveOrphans(t *testing.T) {
+	g, cleanup := newTestGraph(t, "test-gcgraph-batch-collision")
+	defer cleanup()
+	ctx := context.Background()
+
+	edge := block_gc.RefEdge{Subject: "owner", Object: "target"}
+	if err := g.ApplyRefBatch(ctx, []block_gc.RefEdge{edge}, []block_gc.RefEdge{edge}); err != nil {
+		t.Fatal(err)
+	}
+
+	exists, err := g.hasRef(edge.Subject, edge.Object)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Fatal("colliding add and remove left forward edge file")
+	}
+	unreferenced, err := g.GetUnreferencedNodes(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Contains(unreferenced, edge.Object) {
+		t.Fatalf("colliding add and remove did not mark target orphaned: %v", unreferenced)
+	}
+}
+
+func TestApplyRefBatchSharedOwnerRemovalKeepsObjectReachable(t *testing.T) {
+	g, cleanup := newTestGraph(t, "test-gcgraph-batch-shared-owner")
+	defer cleanup()
+	ctx := context.Background()
+
+	for _, owner := range []string{"owner-a", "owner-b"} {
+		if err := g.AddRef(ctx, owner, "shared"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := g.ApplyRefBatch(ctx, nil, []block_gc.RefEdge{{
+		Subject: "owner-a",
+		Object:  "shared",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	incoming, err := g.GetIncomingRefs(ctx, "shared")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(incoming, []string{"owner-b"}) {
+		t.Fatalf("shared owner removal incoming=%v, want [owner-b]", incoming)
+	}
+	unreferenced, err := g.GetUnreferencedNodes(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if slices.Contains(unreferenced, "shared") {
+		t.Fatalf("shared owner removal incorrectly marked object orphaned: %v", unreferenced)
+	}
+}
+
+func TestApplyRefBatchLastOwnerRemovalOrphansObject(t *testing.T) {
+	g, cleanup := newTestGraph(t, "test-gcgraph-batch-last-owner")
+	defer cleanup()
+	ctx := context.Background()
+
+	if err := g.AddRef(ctx, "owner", "target"); err != nil {
+		t.Fatal(err)
+	}
+	if err := g.ApplyRefBatch(ctx, nil, []block_gc.RefEdge{{
+		Subject: "owner",
+		Object:  "target",
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	incoming, err := g.GetIncomingRefs(ctx, "target")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(incoming, []string{block_gc.NodeUnreferenced}) {
+		t.Fatalf("last owner removal incoming=%v, want only unreferenced", incoming)
+	}
+	unreferenced, err := g.GetUnreferencedNodes(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Contains(unreferenced, "target") {
+		t.Fatalf("last owner removal did not mark target orphaned: %v", unreferenced)
 	}
 }

--- a/db/block/gc/gcgraph/gcgraph_test.go
+++ b/db/block/gc/gcgraph/gcgraph_test.go
@@ -137,6 +137,41 @@ func TestGCGraphAddRemoveRef(t *testing.T) {
 	}
 }
 
+func TestGCGraphHasRefRejectsMismatchedEdgeContent(t *testing.T) {
+	g, cleanup := newTestGraph(t, "test-gcgraph-hasref-content")
+	defer cleanup()
+
+	subject, object := "subject", "object"
+	edgeSubDir, err := opfs.GetDirectory(g.edgesDir, hashName(subject), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := g.writeFile(
+		edgeSubDir,
+		hashName(object),
+		[]byte("different-subject\ndifferent-object"),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	exists, err := g.hasRef(subject, object)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Fatal("hasRef accepted mismatched edge content")
+	}
+}
+
+func TestGCGraphRemoveExistingRefMissingSubjectDirectory(t *testing.T) {
+	g, cleanup := newTestGraph(t, "test-gcgraph-remove-missing-dir")
+	defer cleanup()
+
+	if err := g.removeExistingRef("missing-subject", "object"); err != nil {
+		t.Fatalf("removeExistingRef on missing subject directory: %v", err)
+	}
+}
+
 func TestGCGraphNodeInventory(t *testing.T) {
 	g, cleanup := newTestGraph(t, "test-gcgraph-nodes")
 	defer cleanup()


### PR DESCRIPTION
Reference-graph batch preparation and removal used broad candidate filtering and backend graph reads, so missing or colliding removals could affect orphan and incoming-owner state, while native preparation paid per-candidate deletion checks. The serialized ownership contract also left exact removals, add-before-remove ordering, orphan derivation, and committed-prefix remainders implicit.

RefGraph now owns exact edge membership under its write lock, with a native exact edge and incoming-owner index updated for direct and batch mutations; native batches simulate add-before-remove state and pass removals to indexed transactions, while generic graphs retain exact fallback filtering. OPFS checks the direct forward edge under its ownership WebLock and removes paired edges only when present. The RPC path carries adds and removals together through ApplyRefBatch, reports uncommitted suffixes for rebuffering, and the client no longer rebuilds ownership across calls.

Durable graph and edge-file formats remain unchanged, idempotent adds are unchanged, and missing removals are strict no-ops. Tests cover colliding and missing removals, shared and last owners, backend removal counts, RPC errors, and cost scaling.