### PR TITLE
fix(space): retain the resolved space body mount

### DIFF
--- a/core/space/resolve/resolve.go
+++ b/core/space/resolve/resolve.go
@@ -4,7 +4,6 @@ package space_resolve
 import (
 	"context"
 	"slices"
-	"time"
 
 	"github.com/aperturerobotics/controllerbus/bus"
 	"github.com/aperturerobotics/controllerbus/directive"
@@ -25,9 +24,9 @@ type ResolvedSpace struct {
 	Ref *sobject.SharedObjectRef
 }
 
-// ResolveSpace resolves a session index and shared object ID to a world engine.
+// ResolveSpace resolves a session index and shared object ID to a mounted space body.
 // Mounts the full chain on-demand: session controller, session, provider account,
-// shared object list lookup, world engine lookup by computed engine ID.
+// shared object list lookup, and space body.
 // Returns the resolved space and a cleanup function that releases all directive references.
 func ResolveSpace(
 	ctx context.Context,
@@ -111,42 +110,19 @@ func ResolveSpace(
 	}
 	soRef.GetProviderResourceRef().Id = sharedObjectID
 
-	// Step 6: Compute the engine ID and resolve the required world engine.
-	engineID := space.SpaceEngineId(soRef)
-	engine, _, engineRef, err := world.ExLookupWorldEngine(ctx, b, true, engineID, nil)
+	// Step 6: Mount the space body and retain its directive reference.
+	mounted, mountRef, err := space.ExMountSpaceSoBody(ctx, b, soRef, false, nil)
 	if err != nil {
 		cleanup()
-		return nil, nil, errors.Wrap(err, "lookup world engine")
+		return nil, nil, errors.Wrap(err, "mount space body")
 	}
-	if engine == nil {
-		// A controller can become visible just after the idle lookup. Give
-		// that startup race a bounded window, but never wait for an absent
-		// engine until the request context is canceled.
-		lookupCtx, cancel := context.WithTimeout(ctx, time.Second)
-		engine, _, engineRef, err = world.ExLookupWorldEngine(lookupCtx, b, false, engineID, nil)
-		timedOut := errors.Is(lookupCtx.Err(), context.DeadlineExceeded)
-		cancel()
-		if err != nil {
-			cleanup()
-			if timedOut {
-				return nil, nil, errors.Errorf("world engine %q unavailable", engineID)
-			}
-			return nil, nil, errors.Wrap(err, "lookup world engine")
-		}
-	}
-	if engine == nil {
-		cleanup()
-		return nil, nil, errors.Errorf("lookup world engine %q returned nil engine", engineID)
-	}
-	if engineRef == nil {
-		cleanup()
-		return nil, nil, errors.Errorf("lookup world engine %q returned nil directive ref", engineID)
-	}
-	refs = append(refs, engineRef)
+	refs = append(refs, mountRef)
+
+	body := mounted.GetSharedObjectBody()
 
 	return &ResolvedSpace{
-		Engine:   engine,
-		EngineID: engineID,
+		Engine:   body.GetWorldEngine(),
+		EngineID: body.GetWorldEngineID(),
 		Ref:      soRef,
 	}, cleanup, nil
 }

--- a/core/space/resolve/resolve_mount_test.go
+++ b/core/space/resolve/resolve_mount_test.go
@@ -2,9 +2,7 @@ package space_resolve_test
 
 import (
 	"context"
-	"errors"
 	"testing"
-	"time"
 
 	"github.com/aperturerobotics/controllerbus/controller/resolver"
 	"github.com/s4wave/spacewave/core/provider"
@@ -14,12 +12,13 @@ import (
 	"github.com/s4wave/spacewave/core/sobject"
 	sobject_world_engine "github.com/s4wave/spacewave/core/sobject/world/engine"
 	space_resolve "github.com/s4wave/spacewave/core/space/resolve"
+	space_sobject "github.com/s4wave/spacewave/core/space/sobject"
 	"github.com/s4wave/spacewave/testbed"
 )
 
-// TestResolveSpaceAbsentEngineReturnsUnavailable ensures an HTTP-style resolve
-// does not wait forever when no controller owns the space engine.
-func TestResolveSpaceAbsentEngineReturnsUnavailable(t *testing.T) {
+// TestResolveSpaceWithoutConcurrentMounter ensures ResolveSpace mounts the
+// space body needed to start and retain the returned world engine.
+func TestResolveSpaceWithoutConcurrentMounter(t *testing.T) {
 	ctx := context.Background()
 
 	tb, err := testbed.Default(ctx)
@@ -31,6 +30,7 @@ func TestResolveSpaceAbsentEngineReturnsUnavailable(t *testing.T) {
 	peerID := tb.Volume.GetPeerID()
 	tb.StaticResolver.AddFactory(session_controller.NewFactory(tb.Bus))
 	tb.StaticResolver.AddFactory(provider_local.NewFactory(tb.Bus))
+	tb.StaticResolver.AddFactory(space_sobject.NewFactory(tb.Bus))
 	tb.StaticResolver.AddFactory(sobject_world_engine.NewFactory(tb.Bus))
 
 	_, sessCtrlRef, err := tb.Bus.AddDirective(resolver.NewLoadControllerWithConfig(&session_controller.Config{
@@ -50,6 +50,12 @@ func TestResolveSpaceAbsentEngineReturnsUnavailable(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 	defer provCtrlRef.Release()
+
+	_, spaceSobjectCtrlRef, err := tb.Bus.AddDirective(resolver.NewLoadControllerWithConfig(&space_sobject.Config{}), nil)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer spaceSobjectCtrlRef.Release()
 
 	prov, provRef, err := provider.ExLookupProvider(ctx, tb.Bus, providerID, false, nil)
 	if err != nil {
@@ -94,39 +100,23 @@ func TestResolveSpaceAbsentEngineReturnsUnavailable(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	resolveCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	resultCh := make(chan error, 1)
-	go func() {
-		resolved, cleanup, err := space_resolve.ResolveSpace(
-			resolveCtx,
-			tb.Bus,
-			entry.GetSessionIndex(),
-			sharedObjectID,
-		)
-		if cleanup != nil {
-			cleanup()
-		}
-		if resolved != nil {
-			resultCh <- errors.New("resolved an absent world engine")
-			return
-		}
-		resultCh <- err
-	}()
-
-	timer := time.NewTimer(2 * time.Second)
-	defer timer.Stop()
-	select {
-	case err := <-resultCh:
-		if err == nil {
-			t.Fatal("expected unavailable world engine error")
-		}
-		if errors.Is(err, context.Canceled) {
-			t.Fatalf("expected defined unavailable outcome, got context cancellation: %v", err)
-		}
-	case <-timer.C:
-		cancel()
-		<-resultCh
-		t.Fatal("ResolveSpace remained pending without an engine owner")
+	resolved, cleanup, err := space_resolve.ResolveSpace(
+		ctx,
+		tb.Bus,
+		entry.GetSessionIndex(),
+		sharedObjectID,
+	)
+	if err != nil {
+		t.Fatal(err.Error())
 	}
+	defer cleanup()
+
+	if resolved.Engine == nil {
+		t.Fatal("resolved engine is nil")
+	}
+	tx, err := resolved.Engine.NewTransaction(ctx, true)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	tx.Discard()
 }

--- a/core/space/resolve/resolve_test.go
+++ b/core/space/resolve/resolve_test.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/aperturerobotics/controllerbus/bus"
 	"github.com/aperturerobotics/controllerbus/controller/resolver"
-	"github.com/aperturerobotics/controllerbus/directive"
-	provider "github.com/s4wave/spacewave/core/provider"
+	"github.com/s4wave/spacewave/core/provider"
 	provider_local "github.com/s4wave/spacewave/core/provider/local"
 	"github.com/s4wave/spacewave/core/session"
 	session_controller "github.com/s4wave/spacewave/core/session/controller"
@@ -15,28 +13,9 @@ import (
 	sobject_world_engine "github.com/s4wave/spacewave/core/sobject/world/engine"
 	"github.com/s4wave/spacewave/core/space"
 	space_resolve "github.com/s4wave/spacewave/core/space/resolve"
-	"github.com/s4wave/spacewave/db/world"
-	world_mock "github.com/s4wave/spacewave/db/world/mock"
+	space_sobject "github.com/s4wave/spacewave/core/space/sobject"
 	"github.com/s4wave/spacewave/testbed"
 )
-
-type lookupGateBus struct {
-	bus.Bus
-	lookupStarted chan<- struct{}
-}
-
-func (b *lookupGateBus) AddDirective(
-	dir directive.Directive,
-	handler directive.ReferenceHandler,
-) (directive.Instance, directive.Reference, error) {
-	if _, ok := dir.(world.LookupWorldEngine); ok {
-		select {
-		case b.lookupStarted <- struct{}{}:
-		default:
-		}
-	}
-	return b.Bus.AddDirective(dir, handler)
-}
 
 // TestResolveSpaceReturnsEngine tests that ResolveSpace resolves a session
 // index and shared object ID to a running world engine using the full
@@ -55,6 +34,7 @@ func TestResolveSpaceReturnsEngine(t *testing.T) {
 	tb.StaticResolver.AddFactory(session_controller.NewFactory(tb.Bus))
 	tb.StaticResolver.AddFactory(provider_local.NewFactory(tb.Bus))
 	tb.StaticResolver.AddFactory(sobject_world_engine.NewFactory(tb.Bus))
+	tb.StaticResolver.AddFactory(space_sobject.NewFactory(tb.Bus))
 
 	// Start session controller.
 	_, sessCtrlRef, err := tb.Bus.AddDirective(resolver.NewLoadControllerWithConfig(&session_controller.Config{
@@ -76,6 +56,13 @@ func TestResolveSpaceReturnsEngine(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 	defer provCtrlRef.Release()
+
+	// Start the space shared object controller.
+	_, spaceSobjectCtrlRef, err := tb.Bus.AddDirective(resolver.NewLoadControllerWithConfig(&space_sobject.Config{}), nil)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer spaceSobjectCtrlRef.Release()
 
 	// Look up the provider and create a local account + session.
 	prov, provRef, err := provider.ExLookupProvider(ctx, tb.Bus, providerID, false, nil)
@@ -125,61 +112,27 @@ func TestResolveSpaceReturnsEngine(t *testing.T) {
 	}
 
 	engineID := space.SpaceEngineId(soRef)
-	engineConf := sobject_world_engine.NewConfig(engineID, soRef)
-
-	type resolveResult struct {
-		resolved *space_resolve.ResolvedSpace
-		cleanup  func()
-		err      error
-	}
-	lookupStarted := make(chan struct{}, 1)
-	resolvedCh := make(chan resolveResult, 1)
-	go func() {
-		resolved, cleanup, err := space_resolve.ResolveSpace(
-			ctx,
-			&lookupGateBus{
-				Bus:           tb.Bus,
-				lookupStarted: lookupStarted,
-			},
-			sessionIdx,
-			sharedObjectID,
-		)
-		resolvedCh <- resolveResult{
-			resolved: resolved,
-			cleanup:  cleanup,
-			err:      err,
-		}
-	}()
-
-	// Hold the engine off the bus until ResolveSpace has installed its
-	// required lookup. This exercises the startup ordering that can otherwise
-	// let ReturnIfIdle report no engine before the controller executes.
-	<-lookupStarted
-
-	// Start the sobject world engine for this shared object.
-	_, _, worldCtrlRef, err := sobject_world_engine.StartEngineWithConfig(ctx, tb.Bus, engineConf, nil)
+	mounted, mountRef, err := space.ExMountSpaceSoBody(ctx, tb.Bus, soRef, false, nil)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	defer worldCtrlRef.Release()
+	if mounted.GetSharedObjectBody().GetWorldEngineID() != engineID {
+		t.Fatalf("expected mounted engine ID %q, got %q", engineID, mounted.GetSharedObjectBody().GetWorldEngineID())
+	}
 
-	// Provide mock op handlers so the engine can process operations.
-	opc := world.NewLookupOpController("test-ops", engineID, world_mock.LookupMockOp)
-	relOpc, err := tb.Bus.AddController(ctx, opc, nil)
+	resolved, cleanup, err := space_resolve.ResolveSpace(
+		ctx,
+		tb.Bus,
+		sessionIdx,
+		sharedObjectID,
+	)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	defer relOpc()
+	defer cleanup()
 
-	// ResolveSpace must wait for the engine controller to become visible.
-	result := <-resolvedCh
-	if result.err != nil {
-		t.Fatal(result.err.Error())
-	}
-	resolved := result.resolved
-	if result.cleanup != nil {
-		defer result.cleanup()
-	}
+	// ResolveSpace's mount keeps the engine alive after the pre-existing mount releases.
+	mountRef.Release()
 
 	if resolved.Engine == nil {
 		t.Fatal("resolved engine is nil")
@@ -191,10 +144,9 @@ func TestResolveSpaceReturnsEngine(t *testing.T) {
 		t.Fatal("resolved ref is nil")
 	}
 
-	// Verify the engine is functional by creating a transaction.
 	tx, err := resolved.Engine.NewTransaction(ctx, true)
 	if err != nil {
-		t.Fatal(err.Error())
+		t.Fatalf("use engine after unrelated mount release: %v", err)
 	}
 	tx.Discard()
 }

--- a/core/space/resolve/resolve_test.go
+++ b/core/space/resolve/resolve_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/aperturerobotics/controllerbus/bus"
 	"github.com/aperturerobotics/controllerbus/controller/resolver"
 	"github.com/s4wave/spacewave/core/provider"
 	provider_local "github.com/s4wave/spacewave/core/provider/local"
@@ -17,16 +18,16 @@ import (
 	"github.com/s4wave/spacewave/testbed"
 )
 
-// TestResolveSpaceReturnsEngine tests that ResolveSpace resolves a session
-// index and shared object ID to a running world engine using the full
-// mounting chain with a real in-memory testbed.
-func TestResolveSpaceReturnsEngine(t *testing.T) {
+// TestResolveSpaceRetainsEngineMount tests that ResolveSpace keeps the mounted
+// world engine alive until its cleanup function releases the mount reference.
+func TestResolveSpaceRetainsEngineMount(t *testing.T) {
 	ctx := context.Background()
 
 	tb, err := testbed.Default(ctx)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
+	defer tb.Release()
 
 	peerID := tb.Volume.GetPeerID()
 
@@ -112,10 +113,17 @@ func TestResolveSpaceReturnsEngine(t *testing.T) {
 	}
 
 	engineID := space.SpaceEngineId(soRef)
-	mounted, mountRef, err := space.ExMountSpaceSoBody(ctx, tb.Bus, soRef, false, nil)
+	attachedMount, mountInstance, mountRef, err := bus.ExecOneOffTyped[space.MountSharedObjectBodyValue](
+		ctx,
+		tb.Bus,
+		sobject.NewMountSharedObjectBody(soRef, space.SpaceBodyType),
+		bus.ReturnIfIdle(false),
+		nil,
+	)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
+	mounted := attachedMount.GetValue()
 	if mounted.GetSharedObjectBody().GetWorldEngineID() != engineID {
 		t.Fatalf("expected mounted engine ID %q, got %q", engineID, mounted.GetSharedObjectBody().GetWorldEngineID())
 	}
@@ -149,4 +157,9 @@ func TestResolveSpaceReturnsEngine(t *testing.T) {
 		t.Fatalf("use engine after unrelated mount release: %v", err)
 	}
 	tx.Discard()
+
+	cleanup()
+	if !mountInstance.CloseIfUnreferenced(true) {
+		t.Fatal("ResolveSpace cleanup did not release the space body mount")
+	}
 }


### PR DESCRIPTION
ResolveSpace derived the engine ID and looked it up without mounting the space body. An unmounted space therefore waited for the bounded lookup window and failed unless another caller happened to start its engine.

ResolveSpace now mounts the space body through the shared-object controller, returns the engine from that body, and retains the mount directive in cleanup. Existing callers keep the same API and resolve independently of concurrent mounts; tests exercise the engine after releasing the starter mount and verify cleanup releases the final directive reference.