### PR TITLE
fix(resource): release lazy owners when the root server closes

### DIFF
--- a/core/resource/cdn/registry.go
+++ b/core/resource/cdn/registry.go
@@ -14,6 +14,9 @@ import (
 // cdn_id. Today only the default slot is populated.
 var ErrUnknownCdn = errors.New("unknown cdn id")
 
+// ErrRegistryClosed is returned when a lookup occurs after registry shutdown.
+var ErrRegistryClosed = errors.New("cdn registry is closed")
+
 // Registry owns the process-scoped map of CdnInstances keyed by cdn_id.
 // The default instance (empty id) is lazily constructed on first lookup
 // against the production or SPACEWAVE_CDN_SPACE_ID-overridden Space id.
@@ -56,6 +59,9 @@ func (r *Registry) Lookup(cdnID string) (*CdnInstance, error) {
 
 	r.mtx.Lock()
 	defer r.mtx.Unlock()
+	if r.instances == nil {
+		return nil, ErrRegistryClosed
+	}
 	if inst, ok := r.instances[cdnID]; ok {
 		return inst, nil
 	}

--- a/core/resource/root/server.go
+++ b/core/resource/root/server.go
@@ -35,6 +35,8 @@ type CoreRootServer struct {
 	stateAtomStoreIndex *session.StateAtomStoreIndex
 	// releaseStateAtomStoreIndex releases the root object store handle.
 	releaseStateAtomStoreIndex func()
+	// stateAtomStoreClosed rejects lazy store acquisition after shutdown.
+	stateAtomStoreClosed bool
 	// cdnRegistry owns the process-scoped map of CdnInstances.
 	cdnRegistry *resource_cdn.Registry
 	// webListeners owns daemon-background localhost web listeners.
@@ -70,6 +72,7 @@ func (s *CoreRootServer) Close() {
 	if s.cdnRegistry != nil {
 		s.cdnRegistry.Close()
 	}
+	s.closeStateAtomStoreIndex()
 }
 
 // Register registers the server with the mux.

--- a/core/resource/root/server.go
+++ b/core/resource/root/server.go
@@ -67,6 +67,9 @@ func (s *CoreRootServer) Close() {
 	if s.webListeners != nil {
 		s.webListeners.close()
 	}
+	if s.cdnRegistry != nil {
+		s.cdnRegistry.Close()
+	}
 }
 
 // Register registers the server with the mux.

--- a/core/resource/root/server.go
+++ b/core/resource/root/server.go
@@ -37,6 +37,8 @@ type CoreRootServer struct {
 	releaseStateAtomStoreIndex func()
 	// stateAtomStoreClosed rejects lazy store acquisition after shutdown.
 	stateAtomStoreClosed bool
+	// stateAtomStoreIndexBuilder overrides the external acquisition in owner tests.
+	stateAtomStoreIndexBuilder func(context.Context) (*session.StateAtomStoreIndex, func(), error)
 	// cdnRegistry owns the process-scoped map of CdnInstances.
 	cdnRegistry *resource_cdn.Registry
 	// webListeners owns daemon-background localhost web listeners.

--- a/core/resource/root/server_close_test.go
+++ b/core/resource/root/server_close_test.go
@@ -1,0 +1,113 @@
+package resource_root
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	resource_cdn "github.com/s4wave/spacewave/core/resource/cdn"
+	"github.com/s4wave/spacewave/core/session"
+	"github.com/sirupsen/logrus"
+)
+
+func TestRootServerCloseBeforeStateAtomUse(t *testing.T) {
+	var builds atomic.Int32
+	server := newCloseTestServer(t)
+	server.stateAtomStoreIndexBuilder = func(context.Context) (*session.StateAtomStoreIndex, func(), error) {
+		builds.Add(1)
+		return session.NewStateAtomStoreIndex(nil), func() {}, nil
+	}
+
+	server.Close()
+	if builds.Load() != 0 {
+		t.Fatalf("state atom store built after close: %d builds", builds.Load())
+	}
+	if _, err := server.getStateAtomStoreIndex(context.Background()); err == nil {
+		t.Fatal("state atom store use succeeded after close")
+	}
+}
+
+func TestRootServerCloseReleasesStateAtomAndCDN(t *testing.T) {
+	var releases atomic.Int32
+	server := newCloseTestServer(t)
+	server.stateAtomStoreIndexBuilder = func(context.Context) (*session.StateAtomStoreIndex, func(), error) {
+		return session.NewStateAtomStoreIndex(nil), func() {
+			releases.Add(1)
+		}, nil
+	}
+	if _, err := server.getStateAtomStoreIndex(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := server.cdnRegistry.Lookup(""); err != nil {
+		t.Fatalf("create CDN instance: %v", err)
+	}
+
+	server.Close()
+	server.Close()
+
+	if releases.Load() != 1 {
+		t.Fatalf("state atom reference releases = %d, want 1", releases.Load())
+	}
+	if server.stateAtomStoreIndex != nil || server.releaseStateAtomStoreIndex != nil {
+		t.Fatal("state atom handle remained cached after close")
+	}
+	if _, err := server.cdnRegistry.Lookup(""); !errors.Is(err, resource_cdn.ErrRegistryClosed) {
+		t.Fatalf("CDN lookup after close error = %v, want %v", err, resource_cdn.ErrRegistryClosed)
+	}
+}
+
+func TestRootServerCloseWaitsForConcurrentStateAtomUse(t *testing.T) {
+	started := make(chan struct{})
+	allow := make(chan struct{})
+	var releases atomic.Int32
+	server := newCloseTestServer(t)
+	server.stateAtomStoreIndexBuilder = func(context.Context) (*session.StateAtomStoreIndex, func(), error) {
+		close(started)
+		<-allow
+		return session.NewStateAtomStoreIndex(nil), func() {
+			releases.Add(1)
+		}, nil
+	}
+
+	useDone := make(chan error, 1)
+	go func() {
+		_, err := server.getStateAtomStoreIndex(context.Background())
+		useDone <- err
+	}()
+	<-started
+
+	closeDone := make(chan struct{})
+	go func() {
+		server.Close()
+		close(closeDone)
+	}()
+	select {
+	case <-closeDone:
+		t.Fatal("root close returned while state atom acquisition was blocked")
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	close(allow)
+	if err := <-useDone; err != nil {
+		t.Fatalf("state atom use: %v", err)
+	}
+	select {
+	case <-closeDone:
+	case <-time.After(time.Second):
+		t.Fatal("root close did not complete after state atom acquisition")
+	}
+	if releases.Load() != 1 {
+		t.Fatalf("state atom reference releases = %d, want 1", releases.Load())
+	}
+}
+
+func newCloseTestServer(t *testing.T) *CoreRootServer {
+	t.Helper()
+	le := logrus.New().WithField("test", t.Name())
+	return &CoreRootServer{
+		le:          le,
+		cdnRegistry: resource_cdn.NewRegistry(le, nil),
+	}
+}

--- a/core/resource/root/state-watch.go
+++ b/core/resource/root/state-watch.go
@@ -15,6 +15,9 @@ func (s *CoreRootServer) getStateAtomStoreIndex(
 ) (*session.StateAtomStoreIndex, error) {
 	s.stateAtomStoreIndexMtx.Lock()
 	defer s.stateAtomStoreIndexMtx.Unlock()
+	if s.stateAtomStoreClosed {
+		return nil, errors.New("root resource server is closed")
+	}
 
 	if s.stateAtomStoreIndex != nil {
 		return s.stateAtomStoreIndex, nil
@@ -35,6 +38,19 @@ func (s *CoreRootServer) getStateAtomStoreIndex(
 	s.stateAtomStoreIndex = session.NewStateAtomStoreIndex(objStoreHandle.GetObjectStore())
 	s.releaseStateAtomStoreIndex = diRef.Release
 	return s.stateAtomStoreIndex, nil
+}
+
+func (s *CoreRootServer) closeStateAtomStoreIndex() {
+	s.stateAtomStoreIndexMtx.Lock()
+	s.stateAtomStoreClosed = true
+	release := s.releaseStateAtomStoreIndex
+	s.stateAtomStoreIndex = nil
+	s.releaseStateAtomStoreIndex = nil
+	s.stateAtomStoreIndexMtx.Unlock()
+
+	if release != nil {
+		release()
+	}
 }
 
 // WatchStateAtoms streams the known root state atom store ids on change.

--- a/core/resource/root/state-watch.go
+++ b/core/resource/root/state-watch.go
@@ -23,20 +23,34 @@ func (s *CoreRootServer) getStateAtomStoreIndex(
 		return s.stateAtomStoreIndex, nil
 	}
 
-	objStoreHandle, _, diRef, err := volume.ExBuildObjectStoreAPI(
-		ctx,
-		s.b,
-		false,
-		StateAtomObjectStoreID,
-		bldr_plugin.PluginVolumeID,
-		nil,
+	var (
+		stateAtomStoreIndex *session.StateAtomStoreIndex
+		release             func()
+		err                 error
 	)
+	if builder := s.stateAtomStoreIndexBuilder; builder != nil {
+		stateAtomStoreIndex, release, err = builder(ctx)
+	} else {
+		objStoreHandle, _, diRef, buildErr := volume.ExBuildObjectStoreAPI(
+			ctx,
+			s.b,
+			false,
+			StateAtomObjectStoreID,
+			bldr_plugin.PluginVolumeID,
+			nil,
+		)
+		if buildErr != nil {
+			return nil, buildErr
+		}
+		stateAtomStoreIndex = session.NewStateAtomStoreIndex(objStoreHandle.GetObjectStore())
+		release = diRef.Release
+	}
 	if err != nil {
 		return nil, err
 	}
 
-	s.stateAtomStoreIndex = session.NewStateAtomStoreIndex(objStoreHandle.GetObjectStore())
-	s.releaseStateAtomStoreIndex = diRef.Release
+	s.stateAtomStoreIndex = stateAtomStoreIndex
+	s.releaseStateAtomStoreIndex = release
 	return s.stateAtomStoreIndex, nil
 }
 


### PR DESCRIPTION
Root server shutdown closed web listeners but left the CDN registry, CDN instances, and cached state-atom index and directive reference alive. A late first state-atom use could publish a handle after shutdown, leaving lazy owners beyond root lifecycle.

Close now tears down the CDN registry through idempotent owner teardown, synchronizes state-atom acquisition with shutdown, clears cached fields together, rejects acquisition after close, and waits for initialization before releasing them. Tests cover before-use, initialized, repeated, blocked, and concurrent acquisition states and verify each lazy owner releases once.