### PR TITLE
fix(provider): prevent unlock transport supersession

### DIFF
--- a/core/provider/local/account-transport.go
+++ b/core/provider/local/account-transport.go
@@ -517,6 +517,16 @@ func (a *ProviderAccount) ensureSessionTransport(
 	relayURL string,
 	signingEnvPrefix string,
 ) (*sessionTransportState, bool, error) {
+	return a.ensureSessionTransportWithReplacement(ctx, sessionPriv, relayURL, signingEnvPrefix, true)
+}
+
+func (a *ProviderAccount) ensureSessionTransportWithReplacement(
+	ctx context.Context,
+	sessionPriv crypto.PrivKey,
+	relayURL string,
+	signingEnvPrefix string,
+	replaceMismatched bool,
+) (*sessionTransportState, bool, error) {
 	sessionPeerID, err := peer.IDFromPrivateKey(sessionPriv)
 	if err != nil {
 		return nil, false, errors.Wrap(err, "derive session peer ID")
@@ -534,12 +544,13 @@ func (a *ProviderAccount) ensureSessionTransport(
 		a.transportBcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
 			sts = a.sessionTransport
 		})
-		if sts != nil && sts.config.matches(sessionPeerID, relayURL, signingEnvPrefix) {
+		if sts != nil && (!replaceMismatched || sts.config.matches(sessionPeerID, relayURL, signingEnvPrefix)) {
 			rel()
 			cleanupCancel()
 			a.le.Debug("session transport already exists, skipping creation")
 			err := a.waitExistingSessionTransportReady(ctx, sts)
-			if errors.Is(err, errSessionTransportReplaced) {
+			if errors.Is(err, errSessionTransportReplaced) ||
+				!replaceMismatched && errors.Is(err, errSessionTransportSuperseded) {
 				continue
 			}
 			return sts, false, err
@@ -555,8 +566,22 @@ func (a *ProviderAccount) ensureSessionTransport(
 			return nil, false, err
 		}
 		err = a.waitSessionTransportReady(ctx, sts)
+		if !replaceMismatched && errors.Is(err, errSessionTransportSuperseded) {
+			continue
+		}
 		return sts, true, err
 	}
+}
+
+// ensureSessionTransportWithoutReplacement follows an installed transport
+// instead of replacing it, so lifecycle startup cannot displace explicit work.
+func (a *ProviderAccount) ensureSessionTransportWithoutReplacement(
+	ctx context.Context,
+	sessionPriv crypto.PrivKey,
+	relayURL string,
+	signingEnvPrefix string,
+) (*sessionTransportState, bool, error) {
+	return a.ensureSessionTransportWithReplacement(ctx, sessionPriv, relayURL, signingEnvPrefix, false)
 }
 
 // GetOnlinePeerIDsWithWait returns the base58 peer IDs of paired devices that

--- a/core/provider/local/session-lock-low-cost_test.go
+++ b/core/provider/local/session-lock-low-cost_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/s4wave/spacewave/net/keypem"
 	"github.com/s4wave/spacewave/net/peer"
 	"github.com/s4wave/spacewave/testbed"
+	"github.com/sirupsen/logrus"
 	"github.com/zeebo/blake3"
 	"golang.org/x/crypto/scrypt"
 )
@@ -41,6 +42,24 @@ func (c *observedDoneContext) Done() <-chan struct{} {
 		close(c.observed)
 	})
 	return c.Context.Done()
+}
+
+type sessionTransportFollowHook struct {
+	observed chan struct{}
+	once     sync.Once
+}
+
+func (h *sessionTransportFollowHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+func (h *sessionTransportFollowHook) Fire(entry *logrus.Entry) error {
+	if entry.Message == "session transport already exists, skipping creation" {
+		h.once.Do(func() {
+			close(h.observed)
+		})
+	}
+	return nil
 }
 
 func TestMountedPINUnlockRestoresLocalSessionStateLowCost(t *testing.T) {
@@ -408,6 +427,7 @@ func TestEnsureSessionTransportRetriesWhenExistingTransportClearsBeforeReady(t *
 	defer clearFakeState()
 
 	waitCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	done := make(chan error, 1)
 	go func() {
 		_, _, err := acc.ensureSessionTransport(waitCtx, sess.GetPrivKey(), "", "")
@@ -560,6 +580,180 @@ func TestEnsureSessionTransportPostUnlockStartDoesNotSupersedeExplicitCallers(t 
 		case <-ctx.Done():
 			t.Fatalf("%s transport did not finish: %v", name, ctx.Err())
 		}
+	}
+}
+
+func TestUnlockSessionDoesNotSupersedeExplicitSessionTransport(t *testing.T) {
+	if runtime.GOOS == "js" {
+		t.Skip("causal startup ordering test requires native HTTP server context and WebSocket support")
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	_, _, acc, sess, release := setupProviderAndSessionInternal(ctx, t)
+	defer release()
+
+	pin := []byte("2468")
+	sessionKey := sess.GetPrivKey()
+	configureLowCostPINLock(ctx, t, sess, pin)
+	if err := sess.LockSession(ctx); err != nil {
+		t.Fatalf("lock session: %v", err)
+	}
+	acc.StopSessionTransport()
+
+	server, firstRequestStarted, releaseFirstRequest := newBlockedSessionTransportServer(t)
+	defer server.Close()
+	defer releaseFirstRequest()
+
+	firstDone := make(chan error, 1)
+	go func() {
+		_, _, err := acc.ensureSessionTransport(ctx, sessionKey, server.URL, "")
+		firstDone <- err
+	}()
+	select {
+	case <-firstRequestStarted:
+	case <-ctx.Done():
+		t.Fatalf("explicit transport did not begin startup: %v", ctx.Err())
+	}
+
+	followObserved := make(chan struct{})
+	acc.le.Logger.AddHook(&sessionTransportFollowHook{observed: followObserved})
+	unlockDone := make(chan error, 1)
+	go func() {
+		unlockDone <- sess.UnlockSession(ctx, pin)
+	}()
+
+	firstPending := true
+	select {
+	case <-followObserved:
+	case err := <-firstDone:
+		firstPending = false
+		releaseFirstRequest()
+		if errors.Is(err, errSessionTransportSuperseded) {
+			t.Fatalf("explicit transport was superseded by unlock startup: %v", err)
+		}
+		if err != nil {
+			t.Fatalf("explicit transport failed before unlock followed it: %v", err)
+		}
+	case <-ctx.Done():
+		t.Fatalf("unlock startup did not select a transport policy: %v", ctx.Err())
+	}
+	releaseFirstRequest()
+
+	if firstPending {
+		select {
+		case err := <-firstDone:
+			if errors.Is(err, errSessionTransportSuperseded) {
+				t.Fatalf("explicit transport was superseded by unlock startup: %v", err)
+			}
+			if err != nil {
+				t.Fatalf("explicit transport failed: %v", err)
+			}
+		case <-ctx.Done():
+			t.Fatalf("explicit transport did not finish: %v", ctx.Err())
+		}
+	}
+	select {
+	case err := <-unlockDone:
+		if err != nil {
+			t.Fatalf("unlock session: %v", err)
+		}
+	case <-ctx.Done():
+		t.Fatalf("unlock session did not finish: %v", ctx.Err())
+	}
+}
+
+func TestEnsureSessionTransportWithoutReplacementRetriesAfterFollowedTransportIsSuperseded(t *testing.T) {
+	if runtime.GOOS == "js" {
+		t.Skip("causal startup ordering test requires native HTTP server context and WebSocket support")
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	acc, sessionKey, release := newPairingTransportAccount(ctx, t)
+	defer release()
+
+	server, firstRequestStarted, releaseFirstRequest := newBlockedSessionTransportServer(t)
+	defer server.Close()
+	defer releaseFirstRequest()
+
+	firstDone := make(chan error, 1)
+	go func() {
+		_, _, err := acc.ensureSessionTransport(ctx, sessionKey, server.URL, "")
+		firstDone <- err
+	}()
+	select {
+	case <-firstRequestStarted:
+	case <-ctx.Done():
+		t.Fatalf("first transport did not begin startup: %v", ctx.Err())
+	}
+
+	followerObserved := make(chan struct{})
+	followerCtx := &observedDoneContext{Context: ctx, observed: followerObserved}
+	followerDone := make(chan error, 1)
+	go func() {
+		_, _, err := acc.ensureSessionTransportWithoutReplacement(followerCtx, sessionKey, "", "")
+		followerDone <- err
+	}()
+	select {
+	case <-followerObserved:
+	case <-ctx.Done():
+		t.Fatalf("non-replacing caller did not follow the first transport: %v", ctx.Err())
+	}
+
+	if _, _, err := acc.ensureSessionTransport(ctx, sessionKey, "", ""); err != nil {
+		t.Fatalf("replacement transport failed: %v", err)
+	}
+	select {
+	case err := <-followerDone:
+		if err != nil {
+			t.Fatalf("non-replacing follower failed after supersession: %v", err)
+		}
+	case <-ctx.Done():
+		t.Fatalf("non-replacing follower did not retry: %v", ctx.Err())
+	}
+	select {
+	case err := <-firstDone:
+		if !errors.Is(err, errSessionTransportSuperseded) {
+			t.Fatalf("first transport returned %v, want superseded error", err)
+		}
+	case <-ctx.Done():
+		t.Fatalf("first transport did not report supersession: %v", ctx.Err())
+	}
+}
+
+func TestEnsureSessionTransportWithoutReplacementRetriesAfterStartedTransportIsSuperseded(t *testing.T) {
+	if runtime.GOOS == "js" {
+		t.Skip("causal startup ordering test requires native HTTP server context and WebSocket support")
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	acc, sessionKey, release := newPairingTransportAccount(ctx, t)
+	defer release()
+
+	server, firstRequestStarted, releaseFirstRequest := newBlockedSessionTransportServer(t)
+	defer server.Close()
+	defer releaseFirstRequest()
+
+	starterDone := make(chan error, 1)
+	go func() {
+		_, _, err := acc.ensureSessionTransportWithoutReplacement(ctx, sessionKey, server.URL, "")
+		starterDone <- err
+	}()
+	select {
+	case <-firstRequestStarted:
+	case <-ctx.Done():
+		t.Fatalf("non-replacing transport did not begin startup: %v", ctx.Err())
+	}
+
+	if _, _, err := acc.ensureSessionTransport(ctx, sessionKey, "", ""); err != nil {
+		t.Fatalf("replacement transport failed: %v", err)
+	}
+	select {
+	case err := <-starterDone:
+		if err != nil {
+			t.Fatalf("non-replacing starter failed after supersession: %v", err)
+		}
+	case <-ctx.Done():
+		t.Fatalf("non-replacing starter did not retry: %v", ctx.Err())
 	}
 }
 
@@ -982,6 +1176,49 @@ func stopMountedSessionTransportOwner(t *testing.T, acc *ProviderAccount, sess *
 	case <-ctx.Done():
 		t.Fatalf("mounted session owner did not stop: %v", ctx.Err())
 	}
+}
+func newBlockedSessionTransportServer(t *testing.T) (*httptest.Server, <-chan struct{}, func()) {
+	t.Helper()
+
+	firstRequestStarted := make(chan struct{})
+	releaseFirstRequest := make(chan struct{})
+	var requestOnce, releaseOnce sync.Once
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/signal/ticket":
+			requestOnce.Do(func() {
+				close(firstRequestStarted)
+			})
+			select {
+			case <-releaseFirstRequest:
+			case <-r.Context().Done():
+				return
+			}
+			data, err := (&api.SignalTicketResponse{Token: "test-token"}).MarshalVT()
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(data)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/signal/ws":
+			conn, err := websocket.Accept(w, r, nil)
+			if err != nil {
+				return
+			}
+			defer conn.Close(websocket.StatusNormalClosure, "")
+			<-r.Context().Done()
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	release := func() {
+		releaseOnce.Do(func() {
+			close(releaseFirstRequest)
+		})
+	}
+	return server, firstRequestStarted, release
 }
 
 func configureLowCostPINLock(ctx context.Context, t *testing.T, sess *Session, pin []byte) {

--- a/core/provider/local/session-lock-low-cost_test.go
+++ b/core/provider/local/session-lock-low-cost_test.go
@@ -462,6 +462,107 @@ func TestEnsureSessionTransportCoalescesSameConfiguration(t *testing.T) {
 	}
 }
 
+func TestEnsureSessionTransportPostUnlockStartDoesNotSupersedeExplicitCallers(t *testing.T) {
+	if runtime.GOOS == "js" {
+		t.Skip("causal startup ordering test requires native HTTP server context and WebSocket support")
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	acc, sessionKey, release := newPairingTransportAccount(ctx, t)
+	defer release()
+
+	var ticketRequests atomic.Int32
+	firstRequestStarted := make(chan struct{})
+	releaseFirstRequest := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/api/signal/ticket":
+			if ticketRequests.Add(1) == 1 {
+				close(firstRequestStarted)
+				select {
+				case <-releaseFirstRequest:
+				case <-r.Context().Done():
+					return
+				}
+			}
+			data, err := (&api.SignalTicketResponse{Token: "test-token"}).MarshalVT()
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(data)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/signal/ws":
+			conn, err := websocket.Accept(w, r, nil)
+			if err != nil {
+				return
+			}
+			defer conn.Close(websocket.StatusNormalClosure, "")
+			<-r.Context().Done()
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	firstDone := make(chan error, 1)
+	go func() {
+		_, _, err := acc.ensureSessionTransport(ctx, sessionKey, server.URL, "")
+		firstDone <- err
+	}()
+	select {
+	case <-firstRequestStarted:
+	case <-ctx.Done():
+		t.Fatalf("first explicit transport did not begin startup: %v", ctx.Err())
+	}
+
+	backgroundObserved := make(chan struct{})
+	backgroundCtx := &observedDoneContext{Context: ctx, observed: backgroundObserved}
+	backgroundDone := make(chan error, 1)
+	go func() {
+		_, _, err := acc.ensureSessionTransportWithoutReplacement(backgroundCtx, sessionKey, "", "")
+		backgroundDone <- err
+	}()
+	select {
+	case <-backgroundObserved:
+	case <-ctx.Done():
+		t.Fatalf("post-unlock transport did not reach its readiness wait: %v", ctx.Err())
+	}
+
+	secondObserved := make(chan struct{})
+	secondCtx := &observedDoneContext{Context: ctx, observed: secondObserved}
+	secondDone := make(chan error, 1)
+	go func() {
+		_, _, err := acc.ensureSessionTransport(secondCtx, sessionKey, server.URL, "")
+		secondDone <- err
+	}()
+	select {
+	case <-secondObserved:
+	case <-ctx.Done():
+		t.Fatalf("second explicit transport did not reach its readiness wait: %v", ctx.Err())
+	}
+	close(releaseFirstRequest)
+
+	for name, done := range map[string]<-chan error{
+		"first explicit":  firstDone,
+		"post-unlock":     backgroundDone,
+		"second explicit": secondDone,
+	} {
+		select {
+		case err := <-done:
+			if errors.Is(err, errSessionTransportSuperseded) {
+				t.Fatalf("%s transport was superseded: %v", name, err)
+			}
+			if err != nil {
+				t.Fatalf("%s transport failed: %v", name, err)
+			}
+		case <-ctx.Done():
+			t.Fatalf("%s transport did not finish: %v", name, ctx.Err())
+		}
+	}
+}
+
 func TestExistingSessionTransportWaitReturnsStateExit(t *testing.T) {
 	_, _, acc, sess, release := setupProviderAndSessionInternal(t.Context(), t)
 	defer release()

--- a/core/provider/local/session.go
+++ b/core/provider/local/session.go
@@ -144,7 +144,7 @@ func (s *Session) UnlockSession(ctx context.Context, pin []byte) error {
 	if s.tkr.cloudAccountID != "" {
 		relay = s.tkr.a.lookupCloudRelayEndpoint(transportCtx)
 	}
-	_, _, transportErr := s.tkr.a.ensureSessionTransport(transportCtx, privKey, relay.url, relay.signingEnvPrefix)
+	_, _, transportErr := s.tkr.a.ensureSessionTransportWithoutReplacement(transportCtx, privKey, relay.url, relay.signingEnvPrefix)
 	if transportErr != nil {
 		if errors.Is(transportErr, context.Canceled) {
 			return context.Canceled

--- a/core/provider/local/session.go
+++ b/core/provider/local/session.go
@@ -493,7 +493,7 @@ func (t *sessionTracker) executeSessionTracker(rctx context.Context) (rerr error
 	if t.cloudAccountID != "" {
 		relay = t.a.lookupCloudRelayEndpoint(ctx)
 	}
-	sts, created, err := t.a.ensureSessionTransport(ctx, sessionPriv, relay.url, relay.signingEnvPrefix)
+	sts, created, err := t.a.ensureSessionTransportWithoutReplacement(ctx, sessionPriv, relay.url, relay.signingEnvPrefix)
 	if created {
 		defer t.a.stopSessionTransportState(sts)
 	}


### PR DESCRIPTION
Mounted PIN unlock reused the replacement-capable transport ensure path. Lifecycle startup could therefore invalidate an explicit transport request that had already installed its state and return a superseded error to a caller.

The change gives lifecycle startup a non-replacing ensure policy: it follows an installed transport and retries when an explicit replacement wins, while explicit callers retain replacement semantics for newer configuration. Regression coverage blocks signaling startup during mounted unlock, exercises both followed and started retry interleavings, and verifies identical explicit ensures do not deliver superseded errors.