### PR TITLE
fix(bldr): own js builder work directories

### DIFF
--- a/bldr/plugin/compiler/js/compiler.go
+++ b/bldr/plugin/compiler/js/compiler.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/aperturerobotics/controllerbus/bus"
 	"github.com/aperturerobotics/controllerbus/controller"
@@ -54,6 +55,74 @@ var controllerDescrip = "js plugin compiler controller"
 type Controller struct {
 	*bus.BusController[*Config]
 	preBuildHooks []preBuildHookEntry
+
+	workDirMtx    sync.Mutex
+	ownedWorkDirs map[string]string
+	buildWg       sync.WaitGroup
+	closing       bool
+}
+
+func (c *Controller) acquireWorkingPath(originalWorkingPath string) (string, func(), error) {
+	c.workDirMtx.Lock()
+	defer c.workDirMtx.Unlock()
+
+	if c.closing {
+		return "", nil, errors.New("js compiler is closed")
+	}
+	if c.ownedWorkDirs == nil {
+		c.ownedWorkDirs = make(map[string]string)
+	}
+
+	originalWorkingPath = filepath.Clean(originalWorkingPath)
+	workingPath := c.ownedWorkDirs[originalWorkingPath]
+	if workingPath == "" {
+		workingRoot, err := os.MkdirTemp("", "spacewave-js-build-")
+		if err != nil {
+			return "", nil, errors.Wrap(err, "create js builder working directory")
+		}
+		workingPath = filepath.Join(workingRoot, "work")
+		if filepath.IsAbs(originalWorkingPath) {
+			err = os.Rename(originalWorkingPath, workingPath)
+			if err != nil && !os.IsNotExist(err) {
+				_ = os.RemoveAll(workingRoot)
+				return "", nil, errors.Wrap(err, "take ownership of js builder working directory")
+			}
+		}
+		if err := os.MkdirAll(workingPath, 0o755); err != nil {
+			_ = os.RemoveAll(workingRoot)
+			return "", nil, errors.Wrap(err, "create js builder working directory")
+		}
+		c.ownedWorkDirs[originalWorkingPath] = workingPath
+	}
+	c.buildWg.Add(1)
+	return workingPath, c.buildWg.Done, nil
+}
+
+// Close releases owned build directories after active builds have stopped.
+func (c *Controller) Close() error {
+	c.workDirMtx.Lock()
+	if c.closing {
+		c.workDirMtx.Unlock()
+		return nil
+	}
+	c.closing = true
+	c.workDirMtx.Unlock()
+
+	c.buildWg.Wait()
+
+	c.workDirMtx.Lock()
+	workingPaths := make([]string, 0, len(c.ownedWorkDirs))
+	for originalWorkingPath, workingPath := range c.ownedWorkDirs {
+		workingPaths = append(workingPaths, workingPath)
+		delete(c.ownedWorkDirs, originalWorkingPath)
+	}
+	c.workDirMtx.Unlock()
+	for _, workingPath := range workingPaths {
+		if err := os.RemoveAll(filepath.Dir(workingPath)); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // preBuildHookEntry pairs a pre-build hook with its optional provenance declaration.
@@ -185,10 +254,18 @@ func (c *Controller) BuildManifest(
 		le.Warnf("skipping build for non-js platform: %v", buildPlatform.GetInputPlatformID())
 		return nil, nil
 	}
+	// BuildManifest may outlive the controller reference that supplied the
+	// workspace, so mutable outputs live under a builder-owned root.
+	builderConf = builderConf.CloneVT()
+	workingPath, releaseWorkingPath, err := c.acquireWorkingPath(builderConf.GetWorkingPath())
+	if err != nil {
+		return nil, err
+	}
+	defer releaseWorkingPath()
+	builderConf.WorkingPath = workingPath
 	le.Debug("building js plugin")
 
 	// output paths, dist is unused for JS compiler
-	workingPath := builderConf.GetWorkingPath()
 	// Note: outDistPath is not typically used by the JS compiler itself,
 	// but we create it for consistency and potential future use.
 	outDistPath := filepath.Join(workingPath, "dist")

--- a/bldr/plugin/compiler/js/compiler_test.go
+++ b/bldr/plugin/compiler/js/compiler_test.go
@@ -4,6 +4,7 @@ package bldr_plugin_compiler_js_test
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -216,6 +217,62 @@ func TestPluginCompilerJs(t *testing.T) {
 	}
 
 	le.Infof("plugin successfully called host rpc with message: %v", string(calledMsgDat))
+}
+
+func TestPluginCompilerJsOwnsWorkingPathDuringBuild(t *testing.T) {
+	ctrl, err := bldr_plugin_compiler_js.NewController(logrus.NewEntry(logrus.New()), nil, &bldr_plugin_compiler_js.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	workDir := t.TempDir()
+	args := &bldr_manifest_builder.BuildManifestArgs{
+		BuilderConfig: &bldr_manifest_builder.BuilderConfig{
+			ManifestMeta:   bldr_manifest.NewManifestMeta("test-plugin", bldr_manifest.BuildType_DEV, "js", 1),
+			SourcePath:     t.TempDir(),
+			DistSourcePath: t.TempDir(),
+			WorkingPath:    workDir,
+		},
+	}
+	buildStarted := make(chan struct{})
+	continueBuild := make(chan struct{})
+	sentinelErr := errors.New("stop after working-directory ownership check")
+	ctrl.AddPreBuildHook(func(
+		_ context.Context,
+		builderConf *bldr_manifest_builder.BuilderConfig,
+		_ world.Engine,
+	) (*bldr_plugin_compiler_js.PreBuildHookResult, error) {
+		close(buildStarted)
+		<-continueBuild
+		if err := os.WriteFile(filepath.Join(builderConf.GetWorkingPath(), "marker"), []byte("builder-owned"), 0o644); err != nil {
+			return nil, err
+		}
+		return nil, sentinelErr
+	})
+
+	buildErr := make(chan error, 1)
+	go func() {
+		_, err := ctrl.BuildManifest(context.Background(), args, nil)
+		buildErr <- err
+	}()
+
+	<-buildStarted
+	if err := os.RemoveAll(workDir); err != nil {
+		t.Fatal(err)
+	}
+	close(continueBuild)
+
+	select {
+	case err := <-buildErr:
+		if !errors.Is(err, sentinelErr) {
+			t.Fatalf("BuildManifest error = %v, want sentinel after builder-owned write", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("BuildManifest did not finish after releasing the build seam")
+	}
+	if err := ctrl.Close(); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestPluginCompilerJsStartupCacheRequiresStaticInputs(t *testing.T) {


### PR DESCRIPTION
JavaScript plugin builds used the workspace supplied by the builder configuration directly. BuildManifest can outlive the controller reference that supplied that workspace, so concurrent or late builds could share mutable work directories and cleanup could race active builds.

The JS compiler now clones each build configuration, assigns each original working path to a compiler-owned temporary directory, tracks active builds, rejects acquisitions after close, and removes owned directories only after builds finish. Coverage holds a build open through close and verifies the working path is released after completion.