### PR TITLE
fix(db): seek bolt prefix iterators

### DIFF
--- a/db/store/kvtx/bolt/iterator.go
+++ b/db/store/kvtx/bolt/iterator.go
@@ -12,9 +12,10 @@ import (
 
 // Iterator iterates over a bbolt cursor.
 type Iterator struct {
-	bkt     *bbolt.Cursor
-	prefix  []byte
-	reverse bool
+	bkt       *bbolt.Cursor
+	prefix    []byte
+	prefixEnd []byte
+	reverse   bool
 
 	err error
 	oob bool
@@ -28,7 +29,17 @@ type Iterator struct {
 // Note: additional special care is taken to ensure the prefix is respected.
 func NewIterator(bkt *bbolt.Cursor, prefix []byte, sort, reverse bool) *Iterator {
 	_ = sort // always sorted in Bolt
-	return &Iterator{bkt: bkt, prefix: prefix, reverse: reverse, end: true}
+	var prefixEnd []byte
+	if reverse {
+		prefixEnd = prefixUpperBound(prefix)
+	}
+	return &Iterator{
+		bkt:       bkt,
+		prefix:    prefix,
+		prefixEnd: prefixEnd,
+		reverse:   reverse,
+		end:       true,
+	}
 }
 
 // Err returns any error that has closed the iterator.
@@ -82,21 +93,14 @@ func (i *Iterator) Next() bool {
 		return false
 	}
 	if i.end {
-		if i.reverse {
-			i.key, i.val = i.bkt.Last()
-		} else {
-			i.key, i.val = i.bkt.First()
-		}
+		i.seekPrefixBoundary()
 		i.end = false
+	} else if i.reverse {
+		i.key, i.val = i.bkt.Prev()
 	} else {
-		if i.reverse {
-			i.key, i.val = i.bkt.Prev()
-		} else {
-			i.key, i.val = i.bkt.Next()
-		}
+		i.key, i.val = i.bkt.Next()
 	}
-	i.oob = len(i.key) == 0
-	i.skipPrefixMismatch()
+	i.updateBounds()
 	return !i.oob
 }
 
@@ -108,48 +112,82 @@ func (i *Iterator) Seek(k []byte) error {
 	}
 	i.key, i.val, i.end = nil, nil, false
 
-	if i.reverse {
-		// In reverse mode:
-		// 1. If k is nil/empty, seek to last key
-		// 2. Otherwise seek to k and move back one if we land after k
-		if len(k) == 0 {
-			i.key, i.val = i.bkt.Last()
-		} else {
-			i.key, i.val = i.bkt.Seek(k)
-			if bytes.Compare(i.key, k) > 0 {
-				i.key, i.val = i.bkt.Prev()
-			}
-		}
+	if len(k) == 0 {
+		i.seekPrefixBoundary()
+	} else if i.reverse {
+		i.seekReverse(k)
 	} else {
-		if len(k) == 0 {
-			i.key, i.val = i.bkt.First()
-		} else {
-			i.key, i.val = i.bkt.Seek(k)
+		if len(i.prefix) != 0 && bytes.Compare(k, i.prefix) < 0 {
+			k = i.prefix
 		}
+		i.key, i.val = i.bkt.Seek(k)
 	}
 
-	i.oob = len(i.key) == 0
-	i.skipPrefixMismatch()
+	i.updateBounds()
 	return nil
 }
 
-// skipPrefixMismatch skips any keys that do not match the prefix.
-func (i *Iterator) skipPrefixMismatch() {
-	if i.oob || len(i.prefix) == 0 {
+func (i *Iterator) seekPrefixBoundary() {
+	if len(i.prefix) == 0 {
+		if i.reverse {
+			i.key, i.val = i.bkt.Last()
+		} else {
+			i.key, i.val = i.bkt.First()
+		}
 		return
 	}
-	for len(i.key) != 0 && !bytes.HasPrefix(i.key, i.prefix) {
-		if i.reverse {
-			i.key, i.val = i.bkt.Prev()
-		} else {
-			i.key, i.val = i.bkt.Next()
+	if !i.reverse {
+		i.key, i.val = i.bkt.Seek(i.prefix)
+		return
+	}
+
+	if len(i.prefixEnd) == 0 {
+		i.key, i.val = i.bkt.Last()
+		return
+	}
+	i.key, i.val = i.bkt.Seek(i.prefixEnd)
+	if len(i.key) == 0 {
+		i.key, i.val = i.bkt.Last()
+	} else {
+		i.key, i.val = i.bkt.Prev()
+	}
+}
+
+func (i *Iterator) seekReverse(k []byte) {
+	if len(i.prefix) != 0 {
+		if bytes.Compare(k, i.prefix) < 0 {
+			return
 		}
-		// out of bounds or prefix seen
-		if len(i.key) == 0 {
-			break
+		if len(i.prefixEnd) != 0 && bytes.Compare(k, i.prefixEnd) >= 0 {
+			i.seekPrefixBoundary()
+			return
 		}
 	}
-	i.oob = len(i.key) == 0
+
+	i.key, i.val = i.bkt.Seek(k)
+	if len(i.key) == 0 {
+		i.key, i.val = i.bkt.Last()
+	} else if bytes.Compare(i.key, k) > 0 {
+		i.key, i.val = i.bkt.Prev()
+	}
+}
+
+func (i *Iterator) updateBounds() {
+	i.oob = len(i.key) == 0 ||
+		(len(i.prefix) != 0 && !bytes.HasPrefix(i.key, i.prefix))
+}
+
+// prefixUpperBound returns the smallest key above the contiguous prefix range.
+// A nil result means the prefix range has no finite upper bound.
+func prefixUpperBound(prefix []byte) []byte {
+	upper := bytes.Clone(prefix)
+	for idx := len(upper) - 1; idx >= 0; idx-- {
+		if upper[idx] != 0xff {
+			upper[idx]++
+			return upper[:idx+1]
+		}
+	}
+	return nil
 }
 
 // Close closes the iterator.

--- a/db/store/kvtx/bolt/iterator_test.go
+++ b/db/store/kvtx/bolt/iterator_test.go
@@ -1,0 +1,288 @@
+//go:build !js && !wasip1
+
+package store_kvtx_bolt
+
+import (
+	"bytes"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	bdb "github.com/aperturerobotics/bbolt"
+)
+
+var iteratorTestBucket = []byte("iterator-test")
+
+func TestIteratorPrefixBounds(t *testing.T) {
+	keys := [][]byte{
+		[]byte("aaa/1"),
+		[]byte("aaa/2"),
+		[]byte("bbb/other"),
+		[]byte("mmm/1"),
+		[]byte("mmm/2"),
+		[]byte("yyy/other"),
+		[]byte("zzz/1"),
+		[]byte("zzz/2"),
+	}
+	db := openIteratorTestDB(t, keys)
+
+	cases := []struct {
+		name   string
+		prefix []byte
+		want   []string
+	}{
+		{name: "prefix at bucket start", prefix: []byte("aaa/"), want: []string{"aaa/1", "aaa/2"}},
+		{name: "prefix in bucket middle", prefix: []byte("mmm/"), want: []string{"mmm/1", "mmm/2"}},
+		{name: "prefix at bucket end", prefix: []byte("zzz/"), want: []string{"zzz/1", "zzz/2"}},
+		{name: "empty prefix", want: []string{"aaa/1", "aaa/2", "bbb/other", "mmm/1", "mmm/2", "yyy/other", "zzz/1", "zzz/2"}},
+	}
+
+	for _, tc := range cases {
+		for _, reverse := range []bool{false, true} {
+			for _, startWithNext := range []bool{false, true} {
+				direction := "forward"
+				want := tc.want
+				if reverse {
+					direction = "reverse"
+					want = reverseStrings(tc.want)
+				}
+				start := "Seek(nil)"
+				if startWithNext {
+					start = "Next"
+				}
+				t.Run(tc.name+"/"+direction+"/"+start, func(t *testing.T) {
+					got := collectIteratorKeys(t, db, tc.prefix, reverse, startWithNext)
+					if strings.Join(got, ",") != strings.Join(want, ",") {
+						t.Fatalf("prefix iteration returned %q, want %q", got, want)
+					}
+				})
+			}
+		}
+	}
+
+	t.Run("empty bucket", func(t *testing.T) {
+		emptyDB := openIteratorTestDB(t, nil)
+		for _, reverse := range []bool{false, true} {
+			if got := collectIteratorKeys(t, emptyDB, []byte("mmm/"), reverse, false); len(got) != 0 {
+				t.Fatalf("empty bucket prefix iteration returned %q", got)
+			}
+			if got := collectIteratorKeys(t, emptyDB, nil, reverse, true); len(got) != 0 {
+				t.Fatalf("empty bucket unprefixed iteration returned %q", got)
+			}
+		}
+	})
+
+	t.Run("seek before prefix", func(t *testing.T) {
+		err := db.View(func(tx *bdb.Tx) error {
+			bucket := tx.Bucket(iteratorTestBucket)
+			forward := NewIterator(bucket.Cursor(), []byte("mmm/"), true, false)
+			if err := forward.Seek([]byte("aaa/9")); err != nil {
+				return err
+			}
+			if !forward.Valid() || string(forward.Key()) != "mmm/1" {
+				t.Fatalf("forward seek before prefix landed on %q, want %q", forward.Key(), "mmm/1")
+			}
+
+			reverse := NewIterator(bucket.Cursor(), []byte("mmm/"), true, true)
+			if err := reverse.Seek([]byte("aaa/9")); err != nil {
+				return err
+			}
+			if reverse.Valid() {
+				t.Fatalf("reverse seek before prefix landed on %q, want invalid", reverse.Key())
+			}
+
+			reverse = NewIterator(bucket.Cursor(), []byte("mmm/"), true, true)
+			if err := reverse.Seek([]byte("yyy/other")); err != nil {
+				return err
+			}
+			if !reverse.Valid() || string(reverse.Key()) != "mmm/2" {
+				t.Fatalf("reverse seek after prefix landed on %q, want %q", reverse.Key(), "mmm/2")
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("reverse prefix without successor", func(t *testing.T) {
+		binaryDB := openIteratorTestDB(t, [][]byte{{0xfe}, {0xff, 0x00}, {0xff, 0x01}})
+		err := binaryDB.View(func(tx *bdb.Tx) error {
+			iterator := NewIterator(tx.Bucket(iteratorTestBucket).Cursor(), []byte{0xff}, true, true)
+			if err := iterator.Seek(nil); err != nil {
+				return err
+			}
+			var got [][]byte
+			for ; iterator.Valid(); iterator.Next() {
+				got = append(got, bytes.Clone(iterator.Key()))
+			}
+			want := [][]byte{{0xff, 0x01}, {0xff, 0x00}}
+			if len(got) != len(want) || !bytes.Equal(got[0], want[0]) || !bytes.Equal(got[1], want[1]) {
+				t.Fatalf("reverse 0xff prefix returned %x, want %x", got, want)
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func TestIteratorPrefixSeekCost(t *testing.T) {
+	const iterations = 64
+
+	for _, reverse := range []bool{false, true} {
+		direction := "forward"
+		if reverse {
+			direction = "reverse"
+		}
+		t.Run(direction, func(t *testing.T) {
+			small := measurePrefixSeek(t, 100, iterations, reverse)
+			large := measurePrefixSeek(t, 100_000, iterations, reverse)
+			t.Logf("100 filler: %s total for %d seeks", small, iterations)
+			t.Logf("100000 filler: %s total for %d seeks", large, iterations)
+
+			if large > small*20 {
+				t.Fatalf("prefix seek cost grew more than 20x with unrelated filler: 100 keys=%s, 100000 keys=%s", small, large)
+			}
+		})
+	}
+}
+
+func BenchmarkIteratorPrefixSeek(b *testing.B) {
+	for _, filler := range []int{1_000, 10_000, 50_000, 100_000} {
+		b.Run("filler="+strconv.Itoa(filler), func(b *testing.B) {
+			db := openPrefixSeekDB(b, filler, false)
+			tx, err := db.Begin(false)
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.Cleanup(func() { _ = tx.Rollback() })
+			bucket := tx.Bucket(iteratorTestBucket)
+
+			b.ResetTimer()
+			for range b.N {
+				iterator := NewIterator(bucket.Cursor(), []byte("zzz/"), true, false)
+				if err := iterator.Seek(nil); err != nil {
+					b.Fatal(err)
+				}
+				if !iterator.Valid() || string(iterator.Key()) != "zzz/only" {
+					b.Fatalf("prefix seek landed on %q", iterator.Key())
+				}
+			}
+		})
+	}
+}
+
+func collectIteratorKeys(t *testing.T, db *bdb.DB, prefix []byte, reverse, startWithNext bool) []string {
+	t.Helper()
+	var got []string
+	err := db.View(func(tx *bdb.Tx) error {
+		iterator := NewIterator(tx.Bucket(iteratorTestBucket).Cursor(), prefix, true, reverse)
+		if startWithNext {
+			iterator.Next()
+		} else if err := iterator.Seek(nil); err != nil {
+			return err
+		}
+		for ; iterator.Valid(); iterator.Next() {
+			got = append(got, string(iterator.Key()))
+		}
+		return iterator.Err()
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return got
+}
+
+func reverseStrings(values []string) []string {
+	reversed := make([]string, len(values))
+	for idx := range values {
+		reversed[len(values)-idx-1] = values[idx]
+	}
+	return reversed
+}
+
+func measurePrefixSeek(t *testing.T, filler, iterations int, reverse bool) time.Duration {
+	t.Helper()
+	db := openPrefixSeekDB(t, filler, reverse)
+	tx, err := db.Begin(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback()
+	bucket := tx.Bucket(iteratorTestBucket)
+
+	targetPrefix, targetKey := prefixSeekTarget(reverse)
+	for range 4 {
+		iterator := NewIterator(bucket.Cursor(), targetPrefix, true, reverse)
+		if err := iterator.Seek(nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	started := time.Now()
+	for range iterations {
+		iterator := NewIterator(bucket.Cursor(), targetPrefix, true, reverse)
+		if err := iterator.Seek(nil); err != nil {
+			t.Fatal(err)
+		}
+		if !iterator.Valid() || !bytes.Equal(iterator.Key(), targetKey) {
+			t.Fatalf("prefix seek landed on %q", iterator.Key())
+		}
+	}
+	return time.Since(started)
+}
+
+func openPrefixSeekDB(tb testing.TB, filler int, reverse bool) *bdb.DB {
+	tb.Helper()
+	fillerPrefix := []byte("aaa/")
+	if reverse {
+		fillerPrefix = []byte("zzz/")
+	}
+	keys := make([][]byte, 0, filler+1)
+	for idx := range filler {
+		key := append(bytes.Clone(fillerPrefix), strconv.AppendInt(nil, int64(idx), 10)...)
+		keys = append(keys, key)
+	}
+	_, targetKey := prefixSeekTarget(reverse)
+	keys = append(keys, targetKey)
+	return openIteratorTestDB(tb, keys)
+}
+
+func prefixSeekTarget(reverse bool) ([]byte, []byte) {
+	if reverse {
+		return []byte("aaa/"), []byte("aaa/only")
+	}
+	return []byte("zzz/"), []byte("zzz/only")
+}
+
+func openIteratorTestDB(tb testing.TB, keys [][]byte) *bdb.DB {
+	tb.Helper()
+	db, err := bdb.Open(filepath.Join(tb.TempDir(), "iterator.db"), 0o600, nil)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	tb.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			tb.Errorf("close iterator test database: %v", err)
+		}
+	})
+	if err := db.Update(func(tx *bdb.Tx) error {
+		bucket, err := tx.CreateBucketIfNotExists(iteratorTestBucket)
+		if err != nil {
+			return err
+		}
+		for _, key := range keys {
+			if err := bucket.Put(key, []byte{1}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		tb.Fatal(err)
+	}
+	return db
+}


### PR DESCRIPTION
db/store/kvtx/bolt.Iterator started nil seeks and first Next calls at the bucket First or Last key and then skipped every nonmatching key one at a time. Bolt keys are sorted, so the walk repeated work a single seek answers, and a seek that landed past the prefix range walked to the end of the bucket before reporting no result. Cost scaled with the size of the whole bucket rather than the prefix range, which made every world commit that consults the GC ref graph index pay a full scan per absent key.

Seek the prefix lower bound going forward, and the prefix successor followed by one step back going in reverse. Stop as soon as the cursor leaves the contiguous prefix range. Forward seek keys below the prefix clamp to the first prefixed key. Reverse seek keys below the prefix return no result, since no prefixed key is less than or equal to them, and keys above the range clamp to its last key. An empty prefix keeps whole-bucket behavior.

Prefix results and their ordering are unchanged. Reverse Seek now honors its advertised less-than-or-equal contract, which it broke when the key sought fell above the prefix range.

Measured against a 3.7 million key bucket from a real store, an absent prefix lookup took 362160 cursor steps and 36ms before the change and 25 microseconds after it. A daemon that took 96 seconds to reach ready on that store now takes 1 second.
