### PR TITLE
test(gc): prove deduplicated bucket ownership

### DIFF
--- a/db/block/gc/ownership-bench_test.go
+++ b/db/block/gc/ownership-bench_test.go
@@ -1,0 +1,70 @@
+package block_gc_test
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/s4wave/spacewave/db/block"
+	block_gc "github.com/s4wave/spacewave/db/block/gc"
+	store_kvkey "github.com/s4wave/spacewave/db/store/kvkey"
+	store_kvtx "github.com/s4wave/spacewave/db/store/kvtx"
+	store_kvtx_inmem "github.com/s4wave/spacewave/db/store/kvtx/inmem"
+	common_kvtx "github.com/s4wave/spacewave/db/volume/common/kvtx"
+)
+
+func BenchmarkGCStoreOpsDeduplicatedParentBatch(b *testing.B) {
+	ctx := context.Background()
+	kvKey, err := store_kvkey.NewKVKey(store_kvkey.DefaultConfig())
+	if err != nil {
+		b.Fatal(err)
+	}
+	vol, err := common_kvtx.NewVolume(
+		ctx,
+		"gc-deduplicated-owner-benchmark",
+		kvKey,
+		store_kvtx_inmem.NewStore(),
+		&store_kvtx.Config{},
+		false,
+		false,
+		nil,
+		nil,
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(func() {
+		if err := vol.Close(); err != nil {
+			b.Fatal(err)
+		}
+	})
+
+	const batchSize = 128
+	entries := make([]*block.PutBatchEntry, batchSize)
+	for i := range entries {
+		data := append([]byte("deduplicated parent benchmark block "), []byte(strconv.Itoa(i))...)
+		ref, err := block.BuildBlockRef(data, nil)
+		if err != nil {
+			b.Fatal(err)
+		}
+		entries[i] = &block.PutBatchEntry{Ref: ref, Data: data}
+	}
+	if err := vol.PutBlockBatch(ctx, entries); err != nil {
+		b.Fatal(err)
+	}
+	store := block_gc.NewGCStoreOpsWithParent(
+		vol,
+		vol.GetRefGraph(),
+		block_gc.BucketIRI("benchmark-parent"),
+	)
+
+	b.ResetTimer()
+	for range b.N {
+		if err := store.PutBlockBatch(ctx, entries); err != nil {
+			b.Fatal(err)
+		}
+		if err := store.FlushPending(ctx); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/db/block/gc/ownership_test.go
+++ b/db/block/gc/ownership_test.go
@@ -3,6 +3,7 @@ package block_gc_test
 import (
 	"bytes"
 	"context"
+	"slices"
 	"testing"
 
 	"github.com/s4wave/spacewave/db/block"
@@ -85,6 +86,16 @@ func TestGCStoreOpsDeduplicatedBlockRetainsBucketOwner(t *testing.T) {
 				}
 				return ref
 			}
+			assertOwns := func(name, parent string, ref *block.BlockRef) {
+				t.Helper()
+				outgoing, err := rg.GetOutgoingRefs(ctx, parent)
+				if err != nil {
+					t.Fatalf("get %s ownership edges: %v", name, err)
+				}
+				if !slices.Contains(outgoing, block_gc.BlockIRI(ref)) {
+					t.Fatalf("%s did not record its block ownership edge", name)
+				}
+			}
 
 			refA := put(bucketA)
 			if err := bucketA.FlushPending(ctx); err != nil {
@@ -119,6 +130,7 @@ func TestGCStoreOpsDeduplicatedBlockRetainsBucketOwner(t *testing.T) {
 			if !bytes.Equal(got, data) {
 				t.Fatal("surviving bucket block data changed")
 			}
+			assertOwns("bucket B", bucketBIRI, refB)
 		})
 	}
 }


### PR DESCRIPTION
GCStoreOps records a parent ownership edge for every non-empty put, including one whose bytes already exist in the volume from another bucket. The existing regression test proved only that the surviving bucket's block escaped collection, which a staging edge under the unreferenced node also satisfies, so an edge written against the wrong parent passed.

The test now asserts the surviving bucket's outgoing edges contain the block. Pointing the flush at the unreferenced node instead of the parent fails on the ownership assertion while the physical-survival assertion still passes.

A benchmark covers the deduplicated batch path. A 128-block deduplicated parent batch on an Apple M3 Pro runs at a 917,275 ns/op median against 562,773 ns/op when the edge write is skipped, 2.77 us per block, measured across PutBlockBatch and FlushPending.