### PR TITLE
fix(db): bound indexeddb prefix ranges at the prefix successor

### DIFF
--- a/db/store/kvtx/js/indexeddb/indexeddb.go
+++ b/db/store/kvtx/js/indexeddb/indexeddb.go
@@ -1,5 +1,4 @@
 //go:build js
-// +build js
 
 package store_kvtx_indexeddb
 

--- a/db/store/kvtx/js/indexeddb/indexeddb_test.go
+++ b/db/store/kvtx/js/indexeddb/indexeddb_test.go
@@ -1,5 +1,4 @@
 //go:build js
-// +build js
 
 package store_kvtx_indexeddb
 

--- a/db/store/kvtx/js/indexeddb/iterator.go
+++ b/db/store/kvtx/js/indexeddb/iterator.go
@@ -1,5 +1,4 @@
 //go:build js
-// +build js
 
 package store_kvtx_indexeddb
 
@@ -20,13 +19,18 @@ type kvtxIterator struct {
 	store *durable.DurableObjectStore
 	dir   idb.CursorDirection
 
-	// if prefix is set, upper is set
+	// if prefix is set, prefixVal is set
 	prefix    []byte
 	prefixVal safejs.Value
-	upperVal  safejs.Value // upper is the upper bound Uint8Array
-
+	// upper is the smallest key above the prefix range, nil if the prefix has
+	// no finite upper bound. If upper is set, upperVal is set.
+	upper    []byte
+	upperVal safejs.Value
 	// valid indicates the current position is valid
 	valid bool
+	// done indicates the iterator ran past its prefix range and has no
+	// further results until the next Seek.
+	done bool
 	// err contains any final error for the iterator
 	err error
 
@@ -59,28 +63,22 @@ func BuildKvtxIterator(ctx context.Context, store *durable.DurableObjectStore, p
 	}
 
 	if len(prefix) != 0 {
-		// Append the maximum value for a byte to the list to get the upper bound.
-		// This effectively restricts to the prefix.
-		prefixUpperBound := make([]byte, len(prefix)+1)
-		prefixUpperBound[len(prefixUpperBound)-1] = 255
-		copy(prefixUpperBound, prefix)
+		it.prefix = bytes.Clone(prefix)
+		it.upper = prefixUpperBound(prefix)
 
-		// Keep upper bound in the prefix slice, just out of the bounds.
-		it.prefix = prefixUpperBound[:len(prefix)]
-
-		upperBoundVal, err := jsbuf.CopyBytesToJs(prefixUpperBound)
+		prefixVal, err := jsbuf.CopyBytesToJs(it.prefix)
 		if err != nil {
 			return kvtx.NewErrIterator(err)
 		}
-
-		// remove the last index to get the lower bound w/o alloc
-		prefixVal, err := upperBoundVal.Call("subarray", 0, len(prefix))
-		if err != nil {
-			return kvtx.NewErrIterator(err)
-		}
-
-		it.upperVal = upperBoundVal
 		it.prefixVal = prefixVal
+
+		if it.upper != nil {
+			upperVal, err := jsbuf.CopyBytesToJs(it.upper)
+			if err != nil {
+				return kvtx.NewErrIterator(err)
+			}
+			it.upperVal = upperVal
+		}
 	}
 
 	return it
@@ -105,57 +103,40 @@ func (it *kvtxIterator) performOp(
 	err := it.store.StoreWithRetry(func(txn *idb.Transaction, store *idb.ObjectStore) error {
 		it.setTxn(txn)
 
+		if it.done {
+			return cb(txn, store, nil, nil)
+		}
+
 		// if necessary, open the cursor again.
 		var err error
 		req := it.req
 		if req == nil {
 			var keyRng *idb.KeyRange
-			if len(it.key) != 0 {
-				// if we are iterating, resume where we left off
-				if len(it.prefix) != 0 {
-					// Compare key with prefix bounds
-					keyVal := it.keyVal
-					if it.dir == idb.CursorPreviousUnique {
-						// For reverse iteration with prefix:
-						// If key > upper, use upper as the key
-						// If key < prefix, use prefix as the key
-						// Lower bound (prefix) is closed to include prefix
-						// Upper bound (current key) is closed to include current key
-						if bytes.Compare(it.key, it.prefix) < 0 {
-							keyVal = it.prefixVal
-						}
-						keyRng, err = idb.NewKeyRangeBound(it.prefixVal, keyVal, false, false)
-					} else {
-						// For forward iteration with prefix:
-						// If key < prefix, use prefix as the key
-						// If key > upper, use upper as the key
-						// Lower bound (current key) is closed to include current key
-						// Upper bound is open to exclude anything >= upper
-						if bytes.Compare(it.key, it.prefix) < 0 {
-							keyVal = it.prefixVal
-						} else if bytes.Compare(it.key, it.prefix[:len(it.prefix)+1]) >= 0 {
-							keyVal = it.prefixVal
-						}
-						keyRng, err = idb.NewKeyRangeBound(keyVal, it.upperVal, false, true)
-					}
-				} else {
-					if it.dir == idb.CursorPreviousUnique {
-						// For reverse iteration without prefix:
-						// Upper bound is closed to include current key
-						keyRng, err = idb.NewKeyRangeUpperBound(it.keyVal, false)
-					} else {
-						// For forward iteration without prefix:
-						// Lower bound is closed to include current key
-						keyRng, err = idb.NewKeyRangeLowerBound(it.keyVal, false)
-					}
+			if len(it.prefix) != 0 {
+				rng := buildPrefixRange(it.prefix, it.upper, it.key, it.dir == idb.CursorPreviousUnique)
+				if rng.done {
+					// The resume position lies past the prefix range in the
+					// direction of travel, so there is nothing left to read.
+					it.done = true
+					return cb(txn, store, nil, nil)
 				}
-			} else if len(it.prefix) != 0 {
-				// If we have a prefix but no current key (first iteration):
-				// Lower bound (prefix) is closed to include the prefix
-				// Upper bound is open to exclude anything >= upper
-				// the prefix exactly (all bytes equal to prefix). The upper bound is
-				// prefix + 0xFF which ensures we get all keys starting with prefix.
-				keyRng, err = idb.NewKeyRangeBound(it.prefixVal, it.upperVal, false, true)
+				// the lower bound is always set for a prefix range
+				lowerVal, _ := it.boundValue(rng.lower)
+				upperVal, hasUpper := it.boundValue(rng.upper)
+				if hasUpper {
+					keyRng, err = idb.NewKeyRangeBound(lowerVal, upperVal, false, rng.upperOpen)
+				} else {
+					keyRng, err = idb.NewKeyRangeLowerBound(lowerVal, false)
+				}
+			} else if len(it.key) != 0 {
+				// if we are iterating, resume where we left off
+				if it.dir == idb.CursorPreviousUnique {
+					// Upper bound is closed to include current key
+					keyRng, err = idb.NewKeyRangeUpperBound(it.keyVal, false)
+				} else {
+					// Lower bound is closed to include current key
+					keyRng, err = idb.NewKeyRangeLowerBound(it.keyVal, false)
+				}
 			}
 			if err != nil {
 				return err
@@ -192,6 +173,21 @@ func (it *kvtxIterator) performOp(
 		it.err = err
 	}
 	return err
+}
+
+// boundValue resolves a prefix range bound to the js value holding its key.
+// Returns false if the bound leaves that side of the range unbounded.
+func (it *kvtxIterator) boundValue(bound prefixBound) (safejs.Value, bool) {
+	switch bound {
+	case prefixBoundPrefix:
+		return it.prefixVal, true
+	case prefixBoundKey:
+		return it.keyVal, true
+	case prefixBoundUpper:
+		return it.upperVal, true
+	default:
+		return safejs.Undefined(), false
+	}
 }
 
 // setTxn updates the txn field clearing the state if the txn changed
@@ -322,6 +318,7 @@ func (it *kvtxIterator) Seek(k []byte) error {
 	it.cs = nil
 	it.firstRun = true
 	it.valid = false
+	it.done = false
 	it.hasVal = false
 	it.value = nil
 

--- a/db/store/kvtx/js/indexeddb/kvtx.go
+++ b/db/store/kvtx/js/indexeddb/kvtx.go
@@ -1,5 +1,4 @@
 //go:build js
-// +build js
 
 package store_kvtx_indexeddb
 

--- a/db/store/kvtx/js/indexeddb/prefix.go
+++ b/db/store/kvtx/js/indexeddb/prefix.go
@@ -1,0 +1,82 @@
+package store_kvtx_indexeddb
+
+import "bytes"
+
+// prefixUpperBound returns the smallest key above the contiguous prefix range.
+// A nil result means the prefix range has no finite upper bound.
+func prefixUpperBound(prefix []byte) []byte {
+	upper := bytes.Clone(prefix)
+	for idx := len(upper) - 1; idx >= 0; idx-- {
+		if upper[idx] != 0xff {
+			upper[idx]++
+			return upper[:idx+1]
+		}
+	}
+	return nil
+}
+
+// prefixBound identifies which key a prefix range bound is taken from.
+type prefixBound int
+
+const (
+	// prefixBoundNone selects no bound, leaving that side unbounded.
+	prefixBoundNone prefixBound = iota
+	// prefixBoundPrefix selects the prefix itself.
+	prefixBoundPrefix
+	// prefixBoundKey selects the key the iterator is resuming from.
+	prefixBoundKey
+	// prefixBoundUpper selects the prefix upper bound.
+	prefixBoundUpper
+)
+
+// prefixRange describes the key range a prefix iterator opens its cursor on.
+type prefixRange struct {
+	// lower is the bound the range starts at, always inclusive.
+	lower prefixBound
+	// upper is the bound the range ends at.
+	upper prefixBound
+	// upperOpen indicates the upper bound excludes its own value.
+	upperOpen bool
+	// done indicates the range cannot contain a key, so no cursor is opened.
+	done bool
+}
+
+// buildPrefixRange decides the range a prefix iterator opens its cursor on.
+//
+// key is the position the iterator resumes from, empty on the first run. A
+// caller may Seek to any key, so key is not necessarily inside the prefix
+// range. A key short of the range in the direction of travel clamps to the
+// near bound, while a key past the range leaves nothing to return.
+func buildPrefixRange(prefix, upper, key []byte, reverse bool) prefixRange {
+	// full is the whole prefix range, used on the first run and as the clamp.
+	full := prefixRange{lower: prefixBoundPrefix, upper: prefixBoundUpper, upperOpen: true}
+	if upper == nil {
+		// An all-0xFF prefix has no key above it, so the range runs to the end.
+		full.upper, full.upperOpen = prefixBoundNone, false
+	}
+	if len(key) == 0 {
+		return full
+	}
+
+	if reverse {
+		if bytes.Compare(key, prefix) < 0 {
+			return prefixRange{done: true}
+		}
+		if upper != nil && bytes.Compare(key, upper) >= 0 {
+			return full
+		}
+		// Resume below key, including key itself so it is read again.
+		return prefixRange{lower: prefixBoundPrefix, upper: prefixBoundKey}
+	}
+
+	if upper != nil && bytes.Compare(key, upper) >= 0 {
+		return prefixRange{done: true}
+	}
+	if bytes.Compare(key, prefix) < 0 {
+		return full
+	}
+	// Resume above key, including key itself so it is read again.
+	res := full
+	res.lower = prefixBoundKey
+	return res
+}

--- a/db/store/kvtx/js/indexeddb/prefix_test.go
+++ b/db/store/kvtx/js/indexeddb/prefix_test.go
@@ -1,0 +1,132 @@
+package store_kvtx_indexeddb
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestPrefixUpperBound(t *testing.T) {
+	tests := []struct {
+		name   string
+		prefix []byte
+		want   []byte
+		// unbounded expects no finite upper bound, reported as a nil result.
+		unbounded bool
+	}{
+		{name: "ascii", prefix: []byte("ab"), want: []byte("ac")},
+		{name: "carry", prefix: []byte{0x61, 0xff}, want: []byte{0x62}},
+		{name: "all max", prefix: []byte{0xff, 0xff}, unbounded: true},
+		{name: "empty", prefix: []byte{}, unbounded: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := prefixUpperBound(test.prefix)
+			if test.unbounded {
+				// nil and empty are distinct here: an empty upper bound would
+				// exclude every key rather than leaving the range unbounded.
+				if got != nil {
+					t.Fatalf("prefixUpperBound(%v) = %v, want no finite bound", test.prefix, got)
+				}
+				return
+			}
+			if got == nil || !bytes.Equal(got, test.want) {
+				t.Fatalf("prefixUpperBound(%v) = %v, want %v", test.prefix, got, test.want)
+			}
+		})
+	}
+}
+
+func TestPrefixUpperBoundRange(t *testing.T) {
+	prefix := []byte("ab")
+	upper := prefixUpperBound(prefix)
+	tests := []struct {
+		name string
+		key  []byte
+		want bool
+	}{
+		{name: "next byte max", key: []byte{'a', 'b', 0xff}, want: true},
+		{name: "next byte max with suffix", key: []byte{'a', 'b', 0xff, 0x00}, want: true},
+		{name: "preceding byte max", key: []byte{'a', 'b', 0xfe, 0xff}, want: true},
+		{name: "first key without prefix", key: []byte("ac"), want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := bytes.Compare(test.key, prefix) >= 0 &&
+				(upper == nil || bytes.Compare(test.key, upper) < 0)
+			if got != test.want {
+				t.Fatalf("key %v in range [%v, %v) = %t, want %t", test.key, prefix, upper, got, test.want)
+			}
+		})
+	}
+}
+
+func TestBuildPrefixRange(t *testing.T) {
+	prefix := []byte("ab")
+	upper := prefixUpperBound(prefix)
+	maxPrefix := []byte{0xff, 0xff}
+
+	full := prefixRange{lower: prefixBoundPrefix, upper: prefixBoundUpper, upperOpen: true}
+	fullUnbounded := prefixRange{lower: prefixBoundPrefix, upper: prefixBoundNone}
+
+	tests := []struct {
+		name    string
+		prefix  []byte
+		upper   []byte
+		key     []byte
+		reverse bool
+		want    prefixRange
+	}{
+		{name: "forward first run", prefix: prefix, upper: upper, want: full},
+		{name: "reverse first run", prefix: prefix, upper: upper, reverse: true, want: full},
+		{
+			name: "forward resume inside", prefix: prefix, upper: upper,
+			key:  []byte{'a', 'b', 0xff},
+			want: prefixRange{lower: prefixBoundKey, upper: prefixBoundUpper, upperOpen: true},
+		},
+		{
+			name: "reverse resume inside", prefix: prefix, upper: upper,
+			key: []byte{'a', 'b', 0xff}, reverse: true,
+			want: prefixRange{lower: prefixBoundPrefix, upper: prefixBoundKey},
+		},
+		// A forward seek short of the range clamps up to the prefix, while a
+		// reverse seek short of the range has nothing below it to return.
+		{name: "forward resume below", prefix: prefix, upper: upper, key: []byte("aa"), want: full},
+		{
+			name: "reverse resume below", prefix: prefix, upper: upper,
+			key: []byte("aa"), reverse: true, want: prefixRange{done: true},
+		},
+		// Mirrored for a seek past the range.
+		{
+			name: "forward resume above", prefix: prefix, upper: upper,
+			key: []byte("ac"), want: prefixRange{done: true},
+		},
+		{
+			name: "reverse resume above", prefix: prefix, upper: upper,
+			key: []byte("ac"), reverse: true, want: full,
+		},
+		// An all-0xFF prefix has no key above it, so nothing is ever past it.
+		{name: "unbounded first run", prefix: maxPrefix, want: fullUnbounded},
+		{
+			name: "unbounded forward resume", prefix: maxPrefix, key: []byte{0xff, 0xff, 0xff},
+			want: prefixRange{lower: prefixBoundKey, upper: prefixBoundNone},
+		},
+		{
+			name: "unbounded reverse resume", prefix: maxPrefix, key: []byte{0xff, 0xff, 0xff},
+			reverse: true, want: prefixRange{lower: prefixBoundPrefix, upper: prefixBoundKey},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := buildPrefixRange(test.prefix, test.upper, test.key, test.reverse)
+			if got != test.want {
+				t.Fatalf(
+					"buildPrefixRange(%v, %v, %v, %t) = %+v, want %+v",
+					test.prefix, test.upper, test.key, test.reverse, got, test.want,
+				)
+			}
+		})
+	}
+}

--- a/db/store/kvtx/js/indexeddb/tx.go
+++ b/db/store/kvtx/js/indexeddb/tx.go
@@ -1,5 +1,4 @@
 //go:build js
-// +build js
 
 package store_kvtx_indexeddb
 


### PR DESCRIPTION
The IndexedDB iterator built its prefix range upper bound by appending a single 0xFF byte to the prefix, then iterated the half-open range [prefix, prefix||0xFF). Any key carrying the prefix whose next byte is 0xFF sorts at or above that bound, so it was silently skipped. On binary keys that drops roughly one key in 256, with no error raised and no data missing anywhere except the browser backend.

This computes the prefix successor instead: clone the prefix, walk back to the rightmost byte below 0xFF, increment it, and truncate. An all-0xFF prefix and the empty prefix have no key above them, so the range becomes lower bound only. That matches CreateUpperBound in the sqlite backend and incrementPrefix in the badger backend, which already do this correctly.

The resume path used to recover the appended byte by reslicing the prefix past its own length, which only worked because the old code allocated the prefix and its bound as one slice. The successor is a separate slice, so the whole range decision moves into buildPrefixRange, which reports which of the three bounds each side of the range takes. That function holds no js types and is tested directly, which the iterator itself cannot be without a browser.

Working through the resume cases turned up a second defect. A caller may Seek to any key, so the resume position need not lie inside the prefix range. Seeking forward past the end of the range reset the lower bound back to the prefix, restarting iteration from the first key carrying the prefix rather than reporting the iterator exhausted, and reverse had the mirror of it below the range. Both now report done and hold it until the next Seek, while the two seeks landing short of the range in their own direction of travel still clamp to the near bound.

The first commit is the repo's own go fix pass over this package, which the pre-commit hook requires before it will accept anything else here.