### PR TITLE
test(cli): keep the daemon startup socket path within sun_path

### DIFF
--- a/cmd/spacewave/cli/daemon-startup_test.go
+++ b/cmd/spacewave/cli/daemon-startup_test.go
@@ -17,9 +17,22 @@ import (
 	cli_entrypoint "github.com/s4wave/spacewave/bldr/cli/entrypoint"
 )
 
+// shortStatePath returns a state directory whose unix socket paths fit in
+// sun_path. t.TempDir() derives its name from the test, and a long test name
+// pushes the resulting socket path past the platform limit.
+func shortStatePath(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "sw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
 func TestInvalidDaemonIdleTimeoutReportsStartupError(t *testing.T) {
 	t.Setenv(daemonIdleTimeoutEnvVar, "not-a-duration")
-	statePath := t.TempDir()
+	statePath := shortStatePath(t)
 	pipeListener, err := pipesock.BuildPipeListener(newDaemonStartupPipeLogger(), statePath, "startup")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
TestInvalidDaemonIdleTimeoutReportsStartupError fails on macOS before it tests anything. t.TempDir() names its directory after the test, and this test's name is 46 characters, so the socket path underneath it reaches 124 bytes. Darwin binds at most 104, and the failure reads "bind: invalid argument" from the listener the test builds during setup.

A package that is permanently red teaches everyone to ignore its result, and this one holds the daemon startup contract.

This takes the state directory from a short pattern instead of the test name. The package now passes on macOS; it was red on master.

The opaque error itself is fixed upstream in aperturerobotics/util#113, which makes pipesock refuse an over-long path with a message naming the byte count, the platform limit, and the path.