### PR TITLE
test(db): compile js GC integration test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,9 @@ jobs:
       - name: Test Go
         if: ${{ matrix.member.test_go_script != '' }}
         run: bun run ${{ matrix.member.test_go_script }}
+      - name: Vet db Go tests for js/wasm
+        if: ${{ matrix.member.name == 'db' }}
+        run: GOOS=js GOARCH=wasm go vet ./db/block/gc/...
 
       - name: Test Js
         if: ${{ matrix.member.test_js_script != '' }}

--- a/db/block/gc/gc-integration_test.go
+++ b/db/block/gc/gc-integration_test.go
@@ -220,7 +220,11 @@ func TestGCIntegrationSweepUnreachable(t *testing.T) {
 	if !ok {
 		t.Fatal("bad block IRI 1")
 	}
-	ops.bufferBlockRefs(ref0, []*block.BlockRef{ref1})
+	if _, _, err := ops.PutBlock(ctx, []byte("block-0"), &block.PutOpts{
+		Refs: []*block.BlockRef{ref1},
+	}); err != nil {
+		t.Fatal(err)
+	}
 	if err := ops.FlushPending(ctx); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The js GC integration test never compiled because it called the unexported bufferBlockRefs method from package block_gc_test. The test now records the block0 -> block1 edge through GCStoreOps.PutBlock and PutOpts.Refs, preserving the public write contract without exporting a test-only method.

The database member of member-ci in .github/workflows/ci.yml now runs GOOS=js GOARCH=wasm go vet ./db/block/gc/... so Go test files are type-checked in CI. The original call fails this step with ops.bufferBlockRefs undefined (cannot refer to unexported method bufferBlockRefs); the source was restored and the step passes.

This gets the file type-checked, which is all it gets. The two integration tests still do not execute: they require OPFS sync access handles, which exist only in a browser, and the chrome harness in db/opfs/chrometest builds its own testprog rather than this package's test binary. Under go_js_wasm_exec both report "sync access handles not available" and skip. Wiring them into a real browser run is separate work.