### PR TITLE
fix(world): sample the watch seqno before checking revisions

### DIFF
--- a/core/resource/world/tracked-world-state.go
+++ b/core/resource/world/tracked-world-state.go
@@ -345,7 +345,18 @@ func watchTrackedChanges(ctx context.Context, snapshot *s4wave_world.TrackedWorl
 
 	// Loop: wait for world changes, then check if tracked resources changed
 	for {
-		// First check: see if any tracked resources already changed
+		// Sample the seqno before reading the revisions it describes. The engine
+		// publishes a commit's seqno and its object revisions under one lock, so
+		// every commit the check below can miss lands above currentSeqno and the
+		// wait then returns immediately. Sampling after the check would hand the
+		// wait a seqno that already covers the missed commit, parking the watch
+		// until some later unrelated commit arrived.
+		currentSeqno, err := ws.GetSeqno(ctx)
+		if err != nil {
+			return err
+		}
+
+		// See if any tracked resources already changed
 		changed, err := checkTrackedChanges(ctx, snapshot, ws)
 		if err != nil {
 			return err
@@ -356,11 +367,6 @@ func watchTrackedChanges(ctx context.Context, snapshot *s4wave_world.TrackedWorl
 		}
 
 		// Nothing changed yet, wait for world seqno to increment
-		currentSeqno, err := ws.GetSeqno(ctx)
-		if err != nil {
-			return err
-		}
-
 		_, err = ws.WaitSeqno(ctx, currentSeqno+1)
 		if err != nil {
 			return err

--- a/core/resource/world/tracked-world-state_test.go
+++ b/core/resource/world/tracked-world-state_test.go
@@ -1,0 +1,112 @@
+//go:build !js
+
+package resource_world_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	resource_world "github.com/s4wave/spacewave/core/resource/world"
+	"github.com/s4wave/spacewave/db/world"
+)
+
+// commitDuringCheckWorldState commits one change to objectKey from inside the
+// tracked-revision check, after the check has already read the revisions.
+//
+// That places the commit in the window between the revision check and the
+// seqno the watch waits on, which is the ordering a loaded runner produces on
+// its own when the watch routine is descheduled between those two reads.
+type commitDuringCheckWorldState struct {
+	world.WorldState
+
+	engine    world.Engine
+	objectKey string
+	committed bool
+}
+
+func (w *commitDuringCheckWorldState) GetObjectRootRefsBatch(ctx context.Context, keys []string) ([]*world.ObjectRootRef, error) {
+	refs, err := world.GetObjectRootRefsBatch(ctx, w.WorldState, keys)
+	if err != nil {
+		return nil, err
+	}
+	if !w.committed {
+		w.committed = true
+		if err := w.commitObjectRevision(ctx); err != nil {
+			return nil, err
+		}
+	}
+	return refs, nil
+}
+
+func (w *commitDuringCheckWorldState) commitObjectRevision(ctx context.Context) error {
+	tx, err := w.engine.NewTransaction(ctx, true)
+	if err != nil {
+		return err
+	}
+	defer tx.Discard()
+
+	obj, found, err := tx.GetObject(ctx, w.objectKey)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return world.ErrObjectNotFound
+	}
+	if _, err := obj.IncrementRev(ctx); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+func TestTrackedWorldStateCommitDuringRevisionCheck(t *testing.T) {
+	ctx := t.Context()
+	tb, tbCleanup := setupWorldTestbed(ctx, t)
+	defer tbCleanup()
+
+	const objectKey = "tracked-watch/commit-during-check"
+	writeTx, err := tb.Engine.NewTransaction(ctx, true)
+	if err != nil {
+		t.Fatalf("NewTransaction initial: %v", err)
+	}
+	if _, err := writeTx.CreateObject(ctx, objectKey, nil); err != nil {
+		writeTx.Discard()
+		t.Fatalf("CreateObject initial: %v", err)
+	}
+	if err := writeTx.Commit(ctx); err != nil {
+		writeTx.Discard()
+		t.Fatalf("Commit initial: %v", err)
+	}
+	writeTx.Discard()
+
+	readTx, err := tb.Engine.NewTransaction(ctx, false)
+	if err != nil {
+		t.Fatalf("NewTransaction read: %v", err)
+	}
+	defer readTx.Discard()
+	seqno, err := readTx.GetSeqno(ctx)
+	if err != nil {
+		t.Fatalf("GetSeqno read: %v", err)
+	}
+
+	watchWs := &commitDuringCheckWorldState{
+		WorldState: world.NewEngineWorldState(tb.Engine, false),
+		engine:     tb.Engine,
+		objectKey:  objectKey,
+	}
+
+	trackedCtx, trackedCancel := context.WithCancel(ctx)
+	defer trackedCancel()
+	trackedWs := resource_world.NewTrackedWorldState(readTx, watchWs, seqno, trackedCtx)
+	defer trackedWs.Close()
+
+	if _, _, err := trackedWs.GetObject(ctx, objectKey); err != nil {
+		t.Fatalf("GetObject tracked: %v", err)
+	}
+
+	waitCtx, waitCancel := context.WithTimeout(ctx, 10*time.Second)
+	defer waitCancel()
+	if err := trackedWs.WaitForChanges(waitCtx); err != nil {
+		t.Fatalf("WaitForChanges after commit racing the revision check: %v", err)
+	}
+}


### PR DESCRIPTION
watchTrackedChanges checked whether any tracked object had changed and only then read the world seqno it would wait on. A commit landing between those two reads was invisible to the check and already covered by the seqno, so WaitSeqno parked for a change that had already happened. The watch then stayed asleep until some later unrelated commit incremented the seqno again, and with no other writer it never woke.

Read the seqno first, before the revision check. The engine publishes a commit's seqno and its object revisions under one lock, so any commit the check can miss necessarily lands above the sampled seqno and the wait returns immediately. Old behavior: a watch could miss a commit that raced its own revision check and block indefinitely. New behavior: every commit either shows up in the check or wakes the wait. The owner is core/resource/world; there is no persisted state and no wire change, so nothing needs migration.

The regression test wraps the WorldState so that one commit lands from inside the revision check, in exactly the window the fix closes. That is the ordering a loaded runner produces on its own when the watch routine is descheduled between the two reads.