### PR TITLE
fix(local): order source release before startup completion

### DIFF
--- a/core/provider/local/p2p-sync.go
+++ b/core/provider/local/p2p-sync.go
@@ -316,7 +316,7 @@ func (a *ProviderAccount) awaitP2PSyncStart(ctx context.Context, state *p2pSyncS
 		var waitCh <-chan struct{}
 		var complete bool
 		state.bcast.HoldLock(func(_ func(), getWaitCh func() <-chan struct{}) {
-			complete = state.startComplete
+			complete = state.startComplete && (state.startErr != nil || !state.lowerSourceHeld)
 			if !complete {
 				waitCh = getWaitCh()
 			}
@@ -417,8 +417,8 @@ func (a *ProviderAccount) runP2PSyncStart(
 		break
 	}
 	if err == nil {
-		state.markStartupExited()
 		a.releaseP2PSyncLowerSource(state)
+		state.markStartupExited()
 		if previous != nil {
 			a.retireP2PSyncState(previous)
 		}


### PR DESCRIPTION
A replacement now releases its lower P2P source before successful startup is returned. The previous ordering made startup completion observable while source selection still retained the prior source, allowing reads to use the lower source after startup. The fix waits for lower-source ownership to be released and preserves the regression test.