### PR TITLE
fix(js): preserve absolute entrypoint output paths

### DIFF
--- a/bldr/plugin/compiler/js/compiler-path_test.go
+++ b/bldr/plugin/compiler/js/compiler-path_test.go
@@ -1,0 +1,30 @@
+package bldr_plugin_compiler_js
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRelativeEntrypointOutputPathPreservesAbsoluteOutput(t *testing.T) {
+	sourceRoot := filepath.Join(t.TempDir(), "source")
+	outputRoot := filepath.Join(t.TempDir(), "dist")
+	outputPath := filepath.Join(outputRoot, "plugin-HASH.mjs")
+
+	relFromSource, err := filepath.Rel(sourceRoot, outputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if relFromSource == "." || !strings.HasPrefix(relFromSource, ".."+string(filepath.Separator)) {
+		t.Fatalf("test output path %q is not outside source root %q", outputPath, sourceRoot)
+	}
+
+	got, err := relativeEntrypointOutputPath(outputRoot, outputPath)
+	if err != nil {
+		t.Fatalf("relativeEntrypointOutputPath() error = %v", err)
+	}
+	const want = "plugin-HASH.mjs"
+	if got != want {
+		t.Fatalf("relativeEntrypointOutputPath(%q, %q) = %q, want %q", outputRoot, outputPath, got, want)
+	}
+}

--- a/bldr/plugin/compiler/js/compiler.go
+++ b/bldr/plugin/compiler/js/compiler.go
@@ -630,8 +630,8 @@ func (c *Controller) BuildManifest(
 		return nil, errors.Errorf("unable to find output path for entrypoint %s in esbuild metafile", entrypointTsRelativePath)
 	}
 
-	// The path in the metafile is relative to distSourceDir
-	compiledEntrypointRelPath, err := filepath.Rel(outDistPath, filepath.Join(distSourcePath, entrypointOutputPath))
+	// The path in the metafile is relative to outDistPath.
+	compiledEntrypointRelPath, err := relativeEntrypointOutputPath(outDistPath, entrypointOutputPath)
 	if err != nil {
 		return nil, err
 	}
@@ -739,6 +739,14 @@ func (c *Controller) BuildManifest(
 	}
 
 	return builderResult, nil
+}
+
+// relativeEntrypointOutputPath converts an esbuild metafile output path to a path relative to outDistPath.
+func relativeEntrypointOutputPath(outDistPath, entrypointOutputPath string) (string, error) {
+	if !filepath.IsAbs(entrypointOutputPath) {
+		entrypointOutputPath = filepath.Join(outDistPath, filepath.FromSlash(entrypointOutputPath))
+	}
+	return filepath.Rel(outDistPath, entrypointOutputPath)
 }
 
 // CreateEntrypointsFromViteOutputs matches Vite outputs to JS modules and creates backend/frontend entrypoints.


### PR DESCRIPTION
Esbuild can report an absolute metafile output path when the output directory is absolute. The JS compiler previously joined the dist source root onto that path before relativizing it, producing invalid cross-drive paths on Windows.

Preserve absolute output paths and resolve only relative metafile paths against the output directory. Add a Linux regression test that asserts the resulting manifest-relative path.