### PR TITLE
fix(gc): drop resident IRI reference cache

### DIFF
--- a/db/block/gc/refgraph-iri-state_test.go
+++ b/db/block/gc/refgraph-iri-state_test.go
@@ -1,0 +1,49 @@
+package block_gc
+
+import (
+	"context"
+	"reflect"
+	"strconv"
+	"testing"
+)
+
+// TestResolveIRIRefKeysDoesNotRetainResolvedIRIs pins that resolving names does
+// not add history-sized state to a RefGraph. Cayley owns the durable name index;
+// each operation should retain only its bounded result set.
+func TestResolveIRIRefKeysDoesNotRetainResolvedIRIs(t *testing.T) {
+	ctx := context.Background()
+	rg := newTestRefGraph(t)
+
+	const iriCount = 128
+	edges := make([]RefEdge, iriCount)
+	for i := range edges {
+		edges[i] = RefEdge{
+			Subject: "resident-state/subject/" + strconv.Itoa(i),
+			Object:  "resident-state/object/" + strconv.Itoa(i),
+		}
+	}
+	if err := rg.ApplyRefBatch(ctx, edges, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	for i, edge := range edges {
+		keys, err := rg.resolveIRIRefKeys(ctx, []string{edge.Subject})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(keys) != 1 {
+			t.Fatalf("resolving %q returned %d ref keys, want 1", edge.Subject, len(keys))
+		}
+		if got := residentIRIRefKeyCount(rg); got != 0 {
+			t.Fatalf("resident IRI ref-key state grew to %d after resolving %d distinct IRIs", got, i+1)
+		}
+	}
+}
+
+func residentIRIRefKeyCount(rg *RefGraph) int {
+	field := reflect.ValueOf(rg).Elem().FieldByName("iriRefKeys")
+	if !field.IsValid() {
+		return 0
+	}
+	return field.Len()
+}

--- a/db/block/gc/refgraph.go
+++ b/db/block/gc/refgraph.go
@@ -3,7 +3,6 @@ package block_gc
 import (
 	"context"
 	"io"
-	"maps"
 	"sync"
 
 	"github.com/aperturerobotics/cayley"
@@ -28,9 +27,7 @@ import (
 type RefGraph struct {
 	handle *cayley.Handle
 
-	writeMu    sync.Mutex
-	mu         sync.Mutex
-	iriRefKeys map[string]any
+	writeMu sync.Mutex
 }
 
 const (
@@ -521,18 +518,10 @@ func (rg *RefGraph) HasIncomingRefsExcluding(
 func (rg *RefGraph) resolveIRIRefKeys(ctx context.Context, iris []string) (map[any]struct{}, error) {
 	excludedSet := make(map[any]struct{}, len(iris))
 	toResolve := make([]quad.Value, 0, len(iris))
-	toResolveIRIs := make([]string, 0, len(iris))
 
-	rg.mu.Lock()
 	for _, iri := range iris {
-		if key, ok := rg.iriRefKeys[iri]; ok {
-			excludedSet[key] = struct{}{}
-			continue
-		}
-		toResolveIRIs = append(toResolveIRIs, iri)
 		toResolve = append(toResolve, quad.IRI(iri))
 	}
-	rg.mu.Unlock()
 
 	if len(toResolve) == 0 {
 		return excludedSet, nil
@@ -559,52 +548,14 @@ func (rg *RefGraph) resolveIRIRefKeys(ctx context.Context, iris []string) (map[a
 		return nil, err
 	}
 
-	_, subtask = trace.NewTask(ctx, "hydra/block-gc/refgraph/has-incoming-refs-excluding/resolve-excluded/cache-refs")
-	rg.mu.Lock()
-	for i, ref := range resolved {
+	for _, ref := range resolved {
 		if ref == nil {
 			continue
 		}
-		key := refs.ToKey(ref)
-		iri := toResolveIRIs[i]
-		if rg.iriRefKeys == nil {
-			rg.iriRefKeys = make(map[string]any)
-		}
-		rg.iriRefKeys[iri] = key
-		excludedSet[key] = struct{}{}
+		excludedSet[refs.ToKey(ref)] = struct{}{}
 	}
-	rg.mu.Unlock()
-	subtask.End()
 
 	return excludedSet, nil
-}
-
-// CloneIRIRefKeys returns a snapshot of the positive IRI ref-key cache.
-func (rg *RefGraph) CloneIRIRefKeys() map[string]any {
-	rg.mu.Lock()
-	defer rg.mu.Unlock()
-
-	if len(rg.iriRefKeys) == 0 {
-		return nil
-	}
-	out := make(map[string]any, len(rg.iriRefKeys))
-	maps.Copy(out, rg.iriRefKeys)
-	return out
-}
-
-// ImportIRIRefKeys seeds the positive IRI ref-key cache.
-func (rg *RefGraph) ImportIRIRefKeys(keys map[string]any) {
-	if len(keys) == 0 {
-		return
-	}
-
-	rg.mu.Lock()
-	defer rg.mu.Unlock()
-
-	if rg.iriRefKeys == nil {
-		rg.iriRefKeys = make(map[string]any, len(keys))
-	}
-	maps.Copy(rg.iriRefKeys, keys)
 }
 
 // GetOutgoingRefs returns all targets of gc/ref edges from the given node.

--- a/db/world/block/world-gc-init_test.go
+++ b/db/world/block/world-gc-init_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	block_gc "github.com/s4wave/spacewave/db/block/gc"
 	"github.com/s4wave/spacewave/db/testbed"
 	"github.com/sirupsen/logrus"
 )
@@ -56,45 +55,4 @@ func TestBuildGCTreeInitFlag(t *testing.T) {
 	}
 	_ = refGraph.Close()
 	gcTree.Discard()
-}
-
-// TestSetBlockTransactionCarriesRefGraphIRIRefKeys keeps the positive IRI
-// ref-key cache across writable refgraph rebuilds.
-func TestSetBlockTransactionCarriesRefGraphIRIRefKeys(t *testing.T) {
-	ctx := context.Background()
-	le := logrus.NewEntry(logrus.New())
-
-	tb, err := testbed.NewTestbed(ctx, le)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-	ocs, err := tb.BuildEmptyCursor(ctx)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-	t.Cleanup(ocs.Release)
-
-	ws, err := BuildMockWorldState(ctx, le, true, ocs, false)
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-	if ws.refGraph == nil {
-		t.Fatal("expected writable world state to build a refgraph")
-	}
-
-	cached := map[string]any{
-		block_gc.NodeUnreferenced: "cached-unreferenced",
-		block_gc.ObjectIRI("foo"): "cached-object",
-	}
-	ws.refGraph.ImportIRIRefKeys(cached)
-
-	if err := ws.SetBlockTransaction(ctx, ws.btx, ws.bcs); err != nil {
-		t.Fatal(err.Error())
-	}
-	got := ws.refGraph.CloneIRIRefKeys()
-	for iri, key := range cached {
-		if got[iri] != key {
-			t.Fatalf("expected cached key for %q to survive rebuild", iri)
-		}
-	}
 }

--- a/db/world/block/world.go
+++ b/db/world/block/world.go
@@ -37,8 +37,6 @@ const (
 
 type worldRefGraph interface {
 	block_gc.RefGraphOps
-	CloneIRIRefKeys() map[string]any
-	ImportIRIRefKeys(map[string]any)
 }
 
 // WorldState implements world state backed by a block graph.
@@ -387,11 +385,6 @@ func (t *WorldState) setBlockTransaction(
 		return err
 	}
 
-	var refGraphIRIRefKeys map[string]any
-	if t.refGraph != nil {
-		refGraphIRIRefKeys = t.refGraph.CloneIRIRefKeys()
-	}
-
 	// Build GC ref graph for writable transactions with a store.
 	var gcTree kvtx.BlockTx
 	var refGraph *block_gc.RefGraph
@@ -407,7 +400,6 @@ func (t *WorldState) setBlockTransaction(
 			objTree.Discard()
 			return err
 		}
-		refGraph.ImportIRIRefKeys(refGraphIRIRefKeys)
 	}
 
 	// Build the deferred GC journal tree at sub-block 6.


### PR DESCRIPTION
Cayley already owns the durable name index used to resolve GC reference keys. Resolve each exclusion set from that index without retaining historical IRI mappings, and remove the cache transfer across world-state rebuilds so resident state stays bounded by the current operation.