### PR TITLE
fix(world): clone root under access lock

### DIFF
--- a/db/world/block/engine-root-access_test.go
+++ b/db/world/block/engine-root-access_test.go
@@ -1,0 +1,128 @@
+package world_block
+
+import (
+	"context"
+	"runtime"
+	"sync"
+	"testing"
+
+	"github.com/s4wave/spacewave/db/bucket"
+	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
+	"github.com/s4wave/spacewave/db/testbed"
+	"github.com/sirupsen/logrus"
+)
+
+func TestEngineAccessWorldStateSameBucketConcurrentClose(t *testing.T) {
+	if runtime.GOMAXPROCS(0) < 2 {
+		t.Skip("requires concurrent execution")
+	}
+
+	ctx := context.Background()
+	le := logrus.NewEntry(logrus.New())
+	tb, err := testbed.NewTestbed(ctx, le)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tb.Release()
+
+	base, err := tb.BuildEmptyCursor(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer base.Release()
+
+	const rounds = 32
+	const workers = 16
+	for range rounds {
+		eng, err := NewEngine(ctx, le, base, nil, nil, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		start := make(chan struct{})
+		entered := make(chan struct{})
+		var enteredOnce sync.Once
+		var wg sync.WaitGroup
+		var panicMu sync.Mutex
+		var panics []any
+		for range workers {
+			wg.Go(func() {
+				defer func() {
+					if recovered := recover(); recovered != nil {
+						panicMu.Lock()
+						panics = append(panics, recovered)
+						panicMu.Unlock()
+					}
+				}()
+				<-start
+				for {
+					err := eng.AccessWorldState(ctx, nil, func(*bucket_lookup.Cursor) error {
+						enteredOnce.Do(func() { close(entered) })
+						return nil
+					})
+					if err == ErrEngineClosed {
+						return
+					}
+					if err != nil {
+						t.Errorf("access failed: %v", err)
+						return
+					}
+				}
+			})
+		}
+		close(start)
+		<-entered
+		if err := eng.Close(); err != nil {
+			t.Fatal(err)
+		}
+		wg.Wait()
+
+		panicMu.Lock()
+		panicsFound := append([]any(nil), panics...)
+		panicMu.Unlock()
+		if len(panicsFound) != 0 {
+			t.Fatalf("concurrent close caused %d panic(s), first: %v", len(panicsFound), panicsFound[0])
+		}
+	}
+}
+
+func TestEngineAccessWorldStateReferencesAndCallbackBoundary(t *testing.T) {
+	ctx := context.Background()
+	le := logrus.NewEntry(logrus.New())
+	tb, err := testbed.NewTestbed(ctx, le)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tb.Release()
+
+	base, err := tb.BuildEmptyCursor(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer base.Release()
+
+	eng, err := NewEngine(ctx, le, base, nil, nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer eng.Close()
+
+	testAccess := func(ref *bucket.ObjectRef) {
+		t.Helper()
+		if err := eng.AccessWorldState(ctx, ref, func(cursor *bucket_lookup.Cursor) error {
+			if !eng.rmtx.TryLock() {
+				t.Fatal("callback ran while Engine.rmtx was held")
+			}
+			eng.rmtx.Unlock()
+			if cursor == nil {
+				t.Fatal("callback received nil cursor")
+			}
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	testAccess(nil)
+	testAccess(&bucket.ObjectRef{})
+}

--- a/db/world/block/engine.go
+++ b/db/world/block/engine.go
@@ -579,6 +579,9 @@ func (e *Engine) BuildStorageCursor(ctx context.Context) (*bucket_lookup.Cursor,
 // AccessWorldState builds a bucket lookup cursor with an optional ref.
 // If the ref Bucket ID is empty, uses the same bucket + volume as the world.
 // The lookup cursor will be released after cb returns.
+// The root clone is made while rmtx is held for the documented same-bucket
+// root path. Cursor.Clone does not retain a bucket-handle release owner, so
+// this does not establish a cross-bucket lifetime across Engine.Close.
 //
 // NOTE: this is the implementation of AccessWorldState for the world/block engine.
 func (e *Engine) AccessWorldState(
@@ -587,28 +590,29 @@ func (e *Engine) AccessWorldState(
 	cb func(*bucket_lookup.Cursor) error,
 ) error {
 	e.rmtx.RLock()
-	closed := e.closed
-	e.rmtx.RUnlock()
-	if closed {
+	if e.closed {
+		e.rmtx.RUnlock()
 		return ErrEngineClosed
 	}
+	ncs := e.root.Clone()
+	e.rmtx.RUnlock()
+	defer ncs.Release()
+
 	if ref == nil {
-		ncs := e.root.Clone()
-		defer ncs.Release()
 		return cb(ncs)
 	}
 
 	subCtx, subCtxCancel := context.WithCancel(ctx)
 	defer subCtxCancel()
 
-	// follow the root block ref
-	ncs, err := e.root.FollowRef(subCtx, ref)
+	// follow the root block ref outside the engine lock
+	followed, err := ncs.FollowRef(subCtx, ref)
 	if err != nil {
 		return err
 	}
-	defer ncs.Release()
+	defer followed.Release()
 
-	return cb(ncs)
+	return cb(followed)
 }
 
 // GetSeqno returns the current seqno of the world state.


### PR DESCRIPTION
AccessWorldState released the engine read lock before cloning its root, which let concurrent Close release and clear that pointer in the gap. Clone the documented same-bucket root under the same closed-check lock boundary, then run reference following and callbacks after unlock. Focused regressions cover the concurrent close race plus nil and non-nil callback behavior under the race detector. Cross-bucket handle retention remains a separate lifetime contract because Cursor.Clone does not retain its release owner.