### PR TITLE
fix(world): own transaction storage access

### DIFF
--- a/bldr/dist/compiler/bundle/bundle.go
+++ b/bldr/dist/compiler/bundle/bundle.go
@@ -105,7 +105,8 @@ func BundleManifestsKvfile(
 	// This optimizes the order of the values in the file to the order they will be accessed.
 	// This means that grabbing a 1MB chunk of the file is more likely to have related data.
 	// This is a significant optimization over key-sorted-order values.
-	return blkEng.AccessWorldState(ctx, nextRootRef, func(bls *bucket_lookup.Cursor) error {
+	return blkEng.AccessWorldState(ctx, nextRootRef, func(access *world.WorldAccess) error {
+		bls := access.Cursor()
 		_, bcs := bls.BuildTransaction(nil)
 		worldRoot, err := world_block.UnmarshalWorld(ctx, bcs)
 		if err != nil {

--- a/bldr/dist/entrypoint/release_fixture_test.go
+++ b/bldr/dist/entrypoint/release_fixture_test.go
@@ -21,7 +21,7 @@ import (
 	cdn_bstore_controller "github.com/s4wave/spacewave/core/cdn/bstore/controller"
 	cdn_world_controller "github.com/s4wave/spacewave/core/cdn/world/controller"
 	block_store_bucket "github.com/s4wave/spacewave/db/block/store/bucket"
-	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
+	"github.com/s4wave/spacewave/db/world"
 	"github.com/sirupsen/logrus"
 )
 
@@ -280,7 +280,8 @@ func TestBrowserReleasePublishedWorldFetchManifestPreflight(t *testing.T) {
 	if ref.GetEmpty() || ref.GetBucketId() == "" {
 		t.Fatalf("FetchManifest returned non-external ref: %#v", ref)
 	}
-	err = engine.AccessWorldState(ctx, ref, func(cursor *bucket_lookup.Cursor) error {
+	err = engine.AccessWorldState(ctx, ref, func(access *world.WorldAccess) error {
+		cursor := access.Cursor()
 		_, found, err := cursor.GetBlock(ctx, ref.GetRootRef())
 		if err != nil {
 			return err

--- a/bldr/manifest/pack/import.go
+++ b/bldr/manifest/pack/import.go
@@ -11,7 +11,6 @@ import (
 	bldr_manifest_world "github.com/s4wave/spacewave/bldr/manifest/world"
 	"github.com/s4wave/spacewave/db/block"
 	"github.com/s4wave/spacewave/db/bucket"
-	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
 	"github.com/s4wave/spacewave/db/world"
 	"github.com/s4wave/spacewave/net/hash"
 	"github.com/s4wave/spacewave/net/peer"
@@ -57,7 +56,8 @@ func importPackBlocks(ctx context.Context, ws world.WorldState, packBytes []byte
 	if err != nil {
 		return err
 	}
-	return ws.AccessWorldState(ctx, nil, func(bls *bucket_lookup.Cursor) error {
+	return ws.AccessWorldState(ctx, nil, func(access *world.WorldAccess) error {
+		bls := access.Cursor()
 		return rdr.ScanPrefixEntries(nil, func(entry *kvfile.IndexEntry, idx int) error {
 			if err := ctx.Err(); err != nil {
 				return err

--- a/bldr/manifest/pack/import_test.go
+++ b/bldr/manifest/pack/import_test.go
@@ -376,7 +376,8 @@ func storeTestManifest(
 	}
 	var initRef *bucket.ObjectRef
 	if bucketScopedManifest {
-		err := ws.AccessWorldState(ctx, nil, func(bls *bucket_lookup.Cursor) error {
+		err := ws.AccessWorldState(ctx, nil, func(access *world.WorldAccess) error {
+			bls := access.Cursor()
 			initRef = bls.GetRef().Clone()
 			return nil
 		})

--- a/bldr/manifest/pack/pack.go
+++ b/bldr/manifest/pack/pack.go
@@ -37,7 +37,8 @@ func PackManifestBundle(
 		if err := ValidateCleanObjectRef("manifest_pack_root", rootRef); err != nil {
 			return err
 		}
-		return ws.AccessWorldState(ctx, rootRef, func(bls *bucket_lookup.Cursor) error {
+		return ws.AccessWorldState(ctx, rootRef, func(access *world.WorldAccess) error {
+			bls := access.Cursor()
 			readXfrm := bls.GetTransformer()
 			if readXfrm == nil {
 				readXfrm = block_transform.NewTransformerWithSteps(nil)

--- a/bldr/manifest/world/access-manifest.go
+++ b/bldr/manifest/world/access-manifest.go
@@ -28,10 +28,10 @@ func AccessManifest(
 	) error,
 ) error {
 	if manifestRef != nil && manifestRef.GetBucketId() != "" {
-		return accessFunc(ctx, nil, func(root *bucket_lookup.Cursor) error {
-			if manifestRef.GetBucketId() == root.GetOpArgs().GetBucketId() {
+		return accessFunc(ctx, nil, func(root *world.WorldAccess) error {
+			if manifestRef.GetBucketId() == root.Cursor().GetOpArgs().GetBucketId() {
 				le.WithField("bucket-id", manifestRef.GetBucketId()).Debug("following manifest ref in current bucket")
-				manifest, err := root.FollowRef(ctx, manifestRef)
+				manifest, err := root.Cursor().FollowRef(ctx, manifestRef)
 				if err != nil {
 					return err
 				}
@@ -40,14 +40,14 @@ func AccessManifest(
 				return bldr_manifest.AccessManifest(ctx, le, manifest, cb)
 			}
 
-			opArgs := root.GetOpArgs()
+			opArgs := root.Cursor().GetOpArgs()
 			opArgs.BucketId = manifestRef.GetBucketId()
 			opArgs.VolumeId = ""
 			le.WithFields(logrus.Fields{
 				"bucket-id":      manifestRef.GetBucketId(),
-				"root-bucket-id": root.GetOpArgs().GetBucketId(),
+				"root-bucket-id": root.Cursor().GetOpArgs().GetBucketId(),
 			}).Debug("following manifest ref in external bucket")
-			manifest, err := root.FollowRefWithOpArgs(ctx, manifestRef, opArgs)
+			manifest, err := root.Cursor().FollowRefWithOpArgs(ctx, manifestRef, opArgs)
 			if err != nil {
 				return err
 			}
@@ -57,8 +57,8 @@ func AccessManifest(
 		})
 	}
 
-	return accessFunc(ctx, manifestRef, func(bls *bucket_lookup.Cursor) error {
-		return bldr_manifest.AccessManifest(ctx, le, bls, cb)
+	return accessFunc(ctx, manifestRef, func(bls *world.WorldAccess) error {
+		return bldr_manifest.AccessManifest(ctx, le, bls.Cursor(), cb)
 	})
 }
 
@@ -83,8 +83,8 @@ func AccessStartupManifest(
 		return AccessManifest(ctx, le, accessFunc, manifestRef, cb)
 	}
 
-	return accessFunc(ctx, nil, func(root *bucket_lookup.Cursor) error {
-		manifestCursor, err := followStartupManifestRef(ctx, root, manifestRef)
+	return accessFunc(ctx, nil, func(root *world.WorldAccess) error {
+		manifestCursor, err := followStartupManifestRef(ctx, root.Cursor(), manifestRef)
 		if err != nil {
 			return err
 		}

--- a/bldr/manifest/world/startup-graph-dump.go
+++ b/bldr/manifest/world/startup-graph-dump.go
@@ -9,7 +9,6 @@ import (
 	"github.com/aperturerobotics/cayley/quad"
 	bldr_manifest "github.com/s4wave/spacewave/bldr/manifest"
 	"github.com/s4wave/spacewave/db/bucket"
-	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
 	"github.com/s4wave/spacewave/db/world"
 	world_types "github.com/s4wave/spacewave/db/world/types"
 )
@@ -68,8 +67,8 @@ func dumpStartupManifestGraphForManifestID(
 
 func startupManifestGraphWorldBucketID(ctx context.Context, ws world.WorldState) (string, error) {
 	var bucketID string
-	err := ws.AccessWorldState(ctx, nil, func(root *bucket_lookup.Cursor) error {
-		bucketID = root.GetOpArgs().GetBucketId()
+	err := ws.AccessWorldState(ctx, nil, func(root *world.WorldAccess) error {
+		bucketID = root.Cursor().GetOpArgs().GetBucketId()
 		return nil
 	})
 	return bucketID, err

--- a/bldr/manifest/world/world.go
+++ b/bldr/manifest/world/world.go
@@ -213,8 +213,8 @@ func CanonicalizeManifestObjectRef(
 	if access == nil {
 		return nil, errors.New("manifest object ref transform config requires world access")
 	}
-	err := access(ctx, ref, func(bls *bucket_lookup.Cursor) error {
-		out.TransformConf = bls.GetTransformConf().Clone()
+	err := access(ctx, ref, func(bls *world.WorldAccess) error {
+		out.TransformConf = bls.Cursor().GetTransformConf().Clone()
 		out.TransformConfRef = nil
 		return nil
 	})
@@ -269,8 +269,8 @@ func SetManifest(
 		if !currRootRef.EqualVT(rootRef) {
 			if ManifestObjectRefsSameExecutable(currRootRef, rootRef) {
 				var worldBucketID string
-				err = ws.AccessWorldState(ctx, nil, func(bls *bucket_lookup.Cursor) error {
-					worldBucketID = bls.GetOpArgs().GetBucketId()
+				err = ws.AccessWorldState(ctx, nil, func(bls *world.WorldAccess) error {
+					worldBucketID = bls.Cursor().GetOpArgs().GetBucketId()
 					return nil
 				})
 				if err != nil {

--- a/bldr/manifest/world/world_test.go
+++ b/bldr/manifest/world/world_test.go
@@ -1744,8 +1744,8 @@ func TestSetManifestBucketRelocationDoesNotBumpLinkedRev(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 	var worldBucketID string
-	if err := ws.AccessWorldState(ctx, nil, func(cursor *bucket_lookup.Cursor) error {
-		worldBucketID = cursor.GetOpArgs().GetBucketId()
+	if err := ws.AccessWorldState(ctx, nil, func(access *world.WorldAccess) error {
+		worldBucketID = access.Cursor().GetOpArgs().GetBucketId()
 		return nil
 	}); err != nil {
 		t.Fatal(err.Error())
@@ -1891,8 +1891,8 @@ func TestSetManifestUpgradesExternalRefToIdentityEqualLocalWithoutBump(t *testin
 		t.Fatal(err.Error())
 	}
 	var worldBucketID string
-	if err := ws.AccessWorldState(ctx, nil, func(cursor *bucket_lookup.Cursor) error {
-		worldBucketID = cursor.GetOpArgs().GetBucketId()
+	if err := ws.AccessWorldState(ctx, nil, func(access *world.WorldAccess) error {
+		worldBucketID = access.Cursor().GetOpArgs().GetBucketId()
 		return nil
 	}); err != nil {
 		t.Fatal(err.Error())

--- a/bldr/plugin/host/scheduler/fetch-world-manifest_test.go
+++ b/bldr/plugin/host/scheduler/fetch-world-manifest_test.go
@@ -1862,7 +1862,8 @@ func TestProcessManifestWorldStateRunsDownloadAndExecuteForRemoteManifest(t *tes
 	}
 	ref := newTestStoredManifestRefInBucket(t, ctx, tb, remoteBucketID, "spacewave-core", "desktop/darwin/arm64", 2)
 	var worldBucketID string
-	if err := ws.AccessWorldState(ctx, nil, func(cursor *bucket_lookup.Cursor) error {
+	if err := ws.AccessWorldState(ctx, nil, func(access *world.WorldAccess) error {
+		cursor := access.Cursor()
 		worldBucketID = cursor.GetOpArgs().GetBucketId()
 		return nil
 	}); err != nil {
@@ -2022,7 +2023,8 @@ func TestProcessManifestWorldStateSuppressesNoCopyBucketWhileDynamicManifestCopi
 		t.Fatal("expected plugin host manifest store object")
 	}
 	var worldBucketID string
-	if err := ws.AccessWorldState(ctx, nil, func(cursor *bucket_lookup.Cursor) error {
+	if err := ws.AccessWorldState(ctx, nil, func(access *world.WorldAccess) error {
+		cursor := access.Cursor()
 		worldBucketID = cursor.GetOpArgs().GetBucketId()
 		return nil
 	}); err != nil {
@@ -2590,7 +2592,8 @@ func TestDownloadManifestCopiesRemoteDAGAndStoresLocalWorldRef(t *testing.T) {
 	}
 	ref := newTestStoredManifestRefWithDistInBucket(t, ctx, tb, remoteBucketID, "spacewave-core", "desktop/darwin/arm64", 2)
 	var worldBucketID string
-	if err := ws.AccessWorldState(ctx, nil, func(cursor *bucket_lookup.Cursor) error {
+	if err := ws.AccessWorldState(ctx, nil, func(access *world.WorldAccess) error {
+		cursor := access.Cursor()
 		worldBucketID = cursor.GetOpArgs().GetBucketId()
 		return nil
 	}); err != nil {
@@ -2937,7 +2940,8 @@ func TestDownloadManifestCopiesExternalVolumeDAGAndCachesSourceReads(t *testing.
 	defer lookupRel()
 
 	var worldBucketID string
-	if err := ws.AccessWorldState(ctx, nil, func(cursor *bucket_lookup.Cursor) error {
+	if err := ws.AccessWorldState(ctx, nil, func(access *world.WorldAccess) error {
+		cursor := access.Cursor()
 		worldBucketID = cursor.GetOpArgs().GetBucketId()
 		return nil
 	}); err != nil {
@@ -3173,7 +3177,8 @@ func TestWatchWorldManifestSkipsUnchangedSelectionInputs(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 	var worldBucketID string
-	if err := baseWS.AccessWorldState(ctx, nil, func(cursor *bucket_lookup.Cursor) error {
+	if err := baseWS.AccessWorldState(ctx, nil, func(access *world.WorldAccess) error {
+		cursor := access.Cursor()
 		worldBucketID = cursor.GetOpArgs().GetBucketId()
 		return nil
 	}); err != nil {
@@ -3595,7 +3600,8 @@ func TestDownloadManifestCopiesTransformedRemoteDAGAndStoresLocalWorldRef(t *tes
 		transformConf,
 	)
 	var worldBucketID string
-	if err := ws.AccessWorldState(ctx, nil, func(cursor *bucket_lookup.Cursor) error {
+	if err := ws.AccessWorldState(ctx, nil, func(access *world.WorldAccess) error {
+		cursor := access.Cursor()
 		worldBucketID = cursor.GetOpArgs().GetBucketId()
 		return nil
 	}); err != nil {
@@ -3850,7 +3856,8 @@ func storeTestWorldManifest(
 
 	meta := bldr_manifest.NewManifestMeta(manifestID, bldr_manifest.BuildType_RELEASE, platformID, rev)
 	var ref *bucket.ObjectRef
-	err := ws.AccessWorldState(ctx, nil, func(bls *bucket_lookup.Cursor) error {
+	err := ws.AccessWorldState(ctx, nil, func(access *world.WorldAccess) error {
+		bls := access.Cursor()
 		btx, bcs := bls.BuildTransaction(nil)
 		bcs.SetBlock(bldr_manifest.NewManifest(meta, "entrypoint"), true)
 		rootRef, _, err := btx.Write(ctx, true)
@@ -4042,7 +4049,7 @@ type accessCountingWorldState struct {
 func (s *accessCountingWorldState) AccessWorldState(
 	ctx context.Context,
 	ref *bucket.ObjectRef,
-	cb func(*bucket_lookup.Cursor) error,
+	cb func(*world.WorldAccess) error,
 ) error {
 	s.total.Add(1)
 	s.active.Add(1)

--- a/bldr/plugin/host/scheduler/watch-world-manifest.go
+++ b/bldr/plugin/host/scheduler/watch-world-manifest.go
@@ -12,7 +12,6 @@ import (
 	bldr_manifest_world "github.com/s4wave/spacewave/bldr/manifest/world"
 	plugin_host "github.com/s4wave/spacewave/bldr/plugin/host"
 	"github.com/s4wave/spacewave/db/bucket"
-	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
 	trace "github.com/s4wave/spacewave/db/traceutil"
 	"github.com/s4wave/spacewave/db/world"
 	world_control "github.com/s4wave/spacewave/db/world/control"
@@ -160,9 +159,9 @@ func (t *pluginInstance) processManifestWorldStateCore(
 		ctx,
 		// access the root of the world state
 		nil,
-		func(bls *bucket_lookup.Cursor) error {
+		func(bls *world.WorldAccess) error {
 			// get the bucket id of the world state
-			worldBucketID := bls.GetOpArgs().GetBucketId()
+			worldBucketID := bls.Cursor().GetOpArgs().GetBucketId()
 			trace.Log(ctx, "world-bucket-id", worldBucketID)
 
 			// Select an execute manifest that is local or backed by an

--- a/bldr/project/controller/publish.go
+++ b/bldr/project/controller/publish.go
@@ -13,7 +13,6 @@ import (
 	bldr_manifest_world "github.com/s4wave/spacewave/bldr/manifest/world"
 	bldr_project "github.com/s4wave/spacewave/bldr/project"
 	"github.com/s4wave/spacewave/db/bucket"
-	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
 	"github.com/s4wave/spacewave/db/world"
 	"github.com/sirupsen/logrus"
 )
@@ -201,12 +200,13 @@ func (c *Controller) PublishTargets(ctx context.Context, remote string, targets 
 						accessDestManifest := func(
 							ctx context.Context,
 							baseRef *bucket.ObjectRef,
-							cb func(*bucket_lookup.Cursor) error,
+							cb func(*world.WorldAccess) error,
 						) error {
 							return destRemoteTx.AccessWorldState(
 								ctx,
 								baseRef,
-								func(bls *bucket_lookup.Cursor) error {
+								func(access *world.WorldAccess) error {
+									bls := access.Cursor()
 									nextRef := bls.GetRef().Clone()
 									nextRef.BucketId = bls.GetOpArgs().GetBucketId()
 									nextRef.RootRef = nil
@@ -221,13 +221,7 @@ func (c *Controller) PublishTargets(ctx context.Context, remote string, targets 
 										nextRef.TransformConfRef = nil
 									}
 
-									nextCs, err := bls.FollowRef(ctx, nextRef)
-									if err != nil {
-										return err
-									}
-									defer nextCs.Release()
-
-									return cb(nextCs)
+									return destRemoteTx.AccessWorldState(ctx, nextRef, cb)
 								},
 							)
 						}

--- a/bldr/testbed/testbed.go
+++ b/bldr/testbed/testbed.go
@@ -20,7 +20,6 @@ import (
 	storage_inmem "github.com/s4wave/spacewave/bldr/storage/inmem"
 	storage_volume "github.com/s4wave/spacewave/bldr/storage/volume"
 	"github.com/s4wave/spacewave/db/bucket"
-	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
 	node_controller "github.com/s4wave/spacewave/db/node/controller"
 	"github.com/s4wave/spacewave/db/volume"
 	volume_controller "github.com/s4wave/spacewave/db/volume/controller"
@@ -358,7 +357,7 @@ func (d *Testbed) CreateManifestWithBilly(
 	distFs, assetsFs billy.Filesystem,
 	ts *timestamppb.Timestamp,
 ) (manifest *bldr_manifest.Manifest, manifestRef *bldr_manifest.ManifestRef, err error) {
-	err = d.GetWorldEngine().AccessWorldState(ctx, nil, func(bls *bucket_lookup.Cursor) error {
+	err = d.GetWorldEngine().AccessWorldState(ctx, nil, func(bls *world.WorldAccess) error {
 		btx, bcs := bls.BuildTransactionAtRef(nil, nil)
 
 		manifest, err = bldr_manifest.CreateManifestWithBilly(ctx, bcs, manifestMeta, entrypoint, distFs, assetsFs, ts)
@@ -371,7 +370,7 @@ func (d *Testbed) CreateManifestWithBilly(
 			return err
 		}
 
-		manifestObjRef := bls.GetRef().Clone()
+		manifestObjRef := bls.Cursor().GetRef().Clone()
 		manifestObjRef.RootRef = manifestBlockRef
 		manifestRef = bldr_manifest.NewManifestRef(manifestMeta, manifestObjRef)
 		return err

--- a/core/cdn/copy.go
+++ b/core/cdn/copy.go
@@ -164,8 +164,10 @@ func ensureCopiedWorldObject(
 
 	var dstRef *bucket.ObjectRef
 	var stats bucket_lookup.ObjectCopyStats
-	err = dst.AccessWorldState(ctx, nil, func(dstCursor *bucket_lookup.Cursor) error {
-		return srcObj.AccessWorldState(ctx, srcRef, func(srcCursor *bucket_lookup.Cursor) error {
+	err = dst.AccessWorldState(ctx, nil, func(dstAccess *world.WorldAccess) error {
+		dstCursor := dstAccess.Cursor()
+		return srcObj.AccessWorldState(ctx, srcRef, func(srcAccess *world.WorldAccess) error {
+			srcCursor := srcAccess.Cursor()
 			var copyErr error
 			dstRef, stats, copyErr = bucket_lookup.CopyObjectToBucketWithProgress(
 				ctx,

--- a/core/forge/exec/plugin-handler.go
+++ b/core/forge/exec/plugin-handler.go
@@ -130,7 +130,8 @@ func (h *pluginExecHandler) importOutputFiles(
 	files []*PluginExecOutputFile,
 ) (forge_value.ValueSlice, error) {
 	var outputs forge_value.ValueSlice
-	err := h.handle.AccessStorage(ctx, nil, func(cs *bucket_lookup.Cursor) error {
+	err := h.handle.AccessStorage(ctx, nil, func(access *world.WorldAccess) error {
+		cs := access.Cursor()
 		outputHandle, err := initPluginOutputMount(ctx, cs)
 		if err != nil {
 			return err

--- a/core/forge/exec/plugin_test.go
+++ b/core/forge/exec/plugin_test.go
@@ -20,6 +20,7 @@ import (
 	unixfs_billy "github.com/s4wave/spacewave/db/unixfs/billy"
 	unixfs_block "github.com/s4wave/spacewave/db/unixfs/block"
 	unixfs_block_fs "github.com/s4wave/spacewave/db/unixfs/block/fs"
+	"github.com/s4wave/spacewave/db/world"
 	forge_target "github.com/s4wave/spacewave/forge/target"
 	forge_value "github.com/s4wave/spacewave/forge/value"
 	"github.com/s4wave/spacewave/net/peer"
@@ -132,17 +133,12 @@ func (h *pluginExecHandleStub) GetTimestamp() *timestamp.Timestamp {
 func (h *pluginExecHandleStub) AccessStorage(
 	ctx context.Context,
 	ref *bucket.ObjectRef,
-	cb func(*bucket_lookup.Cursor) error,
+	cb func(*world.WorldAccess) error,
 ) error {
 	if h.cursor == nil {
 		return nil
 	}
-	if ref != nil && !ref.GetRootRef().GetEmpty() {
-		cs := h.cursor.Clone()
-		cs.SetRootRef(ref.GetRootRef())
-		return cb(cs)
-	}
-	return cb(h.cursor)
+	return world.NewAccessWorldStateFunc(h.cursor)(ctx, ref, cb)
 }
 
 func (h *pluginExecHandleStub) SetOutputs(

--- a/core/git/import.go
+++ b/core/git/import.go
@@ -11,13 +11,12 @@ import (
 	"github.com/pkg/errors"
 	"github.com/s4wave/spacewave/db/block"
 	"github.com/s4wave/spacewave/db/bucket"
-	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
 	git_block "github.com/s4wave/spacewave/db/git/block"
 	"github.com/s4wave/spacewave/db/world"
 )
 
 type worldStorageAccessor interface {
-	AccessWorldState(ctx context.Context, ref *bucket.ObjectRef, cb func(*bucket_lookup.Cursor) error) error
+	AccessWorldState(ctx context.Context, ref *bucket.ObjectRef, cb func(*world.WorldAccess) error) error
 }
 
 // CloneGitRepoToRef clones a remote Git repository and returns its completed repo ref.

--- a/core/provider/spacewave/launcher/controller/release-metadata.go
+++ b/core/provider/spacewave/launcher/controller/release-metadata.go
@@ -18,7 +18,6 @@ import (
 	spacewave_launcher "github.com/s4wave/spacewave/core/provider/spacewave/launcher"
 	spacewave_release "github.com/s4wave/spacewave/core/release"
 	"github.com/s4wave/spacewave/db/block"
-	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
 	unixfs_sync "github.com/s4wave/spacewave/db/unixfs/sync"
 	"github.com/s4wave/spacewave/db/world"
 	world_block "github.com/s4wave/spacewave/db/world/block"
@@ -543,7 +542,8 @@ func readReleaseMetadataSnapshot(
 ) (*spacewave_release.ReleaseMetadata, string, error) {
 	var metadata *spacewave_release.ReleaseMetadata
 	var headRef string
-	err := eng.AccessWorldState(ctx, nil, func(root *bucket_lookup.Cursor) error {
+	err := eng.AccessWorldState(ctx, nil, func(access *world.WorldAccess) error {
+		root := access.Cursor()
 		headRef = root.GetRef().MarshalString()
 		ws, err := world_block.BuildWorldStateFromCursor(
 			ctx,

--- a/core/resource/block/cursor/cursor.go
+++ b/core/resource/block/cursor/cursor.go
@@ -13,18 +13,41 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// RetainAuthorityFunc retains the storage authority backing a child resource.
+// The returned release function must be called exactly once.
+type RetainAuthorityFunc func() (func(), error)
+
 // BlockCursorResource wraps a block.Cursor for resource access.
 type BlockCursorResource struct {
-	le     *logrus.Entry
-	mux    srpc.Invoker
-	b      bus.Bus
-	tx     *block.Transaction
-	cursor *block.Cursor
+	le              *logrus.Entry
+	mux             srpc.Invoker
+	b               bus.Bus
+	tx              *block.Transaction
+	cursor          *block.Cursor
+	retainAuthority RetainAuthorityFunc
 }
 
 // NewBlockCursorResource creates a new BlockCursorResource.
 func NewBlockCursorResource(le *logrus.Entry, b bus.Bus, tx *block.Transaction, cursor *block.Cursor) *BlockCursorResource {
-	bcResource := &BlockCursorResource{le: le, b: b, tx: tx, cursor: cursor}
+	return NewBlockCursorResourceWithRetain(le, b, tx, cursor, nil)
+}
+
+// NewBlockCursorResourceWithRetain creates a block cursor resource that
+// retains backing storage authority for child cursors.
+func NewBlockCursorResourceWithRetain(
+	le *logrus.Entry,
+	b bus.Bus,
+	tx *block.Transaction,
+	cursor *block.Cursor,
+	retainAuthority RetainAuthorityFunc,
+) *BlockCursorResource {
+	bcResource := &BlockCursorResource{
+		le:              le,
+		b:               b,
+		tx:              tx,
+		cursor:          cursor,
+		retainAuthority: retainAuthority,
+	}
 	mux := srpc.NewMux()
 	_ = s4wave_block_cursor.SRPCRegisterBlockCursorResourceService(mux, bcResource)
 	bcResource.mux = mux
@@ -94,10 +117,23 @@ func (r *BlockCursorResource) FollowRef(ctx context.Context, req *s4wave_block_c
 	if newCursor == nil {
 		return nil, block.ErrNotFound
 	}
-
-	newResource := NewBlockCursorResource(r.le, r.b, r.tx, newCursor)
-	id, err := resourceCtx.AddResource(newResource.GetMux(), func() {})
+	releaseAuthority := func() {}
+	if r.retainAuthority != nil {
+		releaseAuthority, err = r.retainAuthority()
+		if err != nil {
+			return nil, err
+		}
+	}
+	newResource := NewBlockCursorResourceWithRetain(
+		r.le,
+		r.b,
+		r.tx,
+		newCursor,
+		r.retainAuthority,
+	)
+	id, err := resourceCtx.AddResource(newResource.GetMux(), releaseAuthority)
 	if err != nil {
+		releaseAuthority()
 		return nil, err
 	}
 

--- a/core/resource/block/transaction/transaction.go
+++ b/core/resource/block/transaction/transaction.go
@@ -14,16 +14,35 @@ import (
 
 // BlockTransactionResource wraps a block.Transaction for resource access.
 type BlockTransactionResource struct {
-	le         *logrus.Entry
-	b          bus.Bus
-	mux        srpc.Invoker
-	tx         *block.Transaction
-	rootCursor *block.Cursor
+	le              *logrus.Entry
+	b               bus.Bus
+	mux             srpc.Invoker
+	tx              *block.Transaction
+	rootCursor      *block.Cursor
+	retainAuthority resource_block_cursor.RetainAuthorityFunc
 }
 
 // NewBlockTransactionResource creates a new BlockTransactionResource.
 func NewBlockTransactionResource(le *logrus.Entry, b bus.Bus, tx *block.Transaction, rootCursor *block.Cursor) *BlockTransactionResource {
-	btResource := &BlockTransactionResource{le: le, b: b, tx: tx, rootCursor: rootCursor}
+	return NewBlockTransactionResourceWithRetain(le, b, tx, rootCursor, nil)
+}
+
+// NewBlockTransactionResourceWithRetain creates a transaction resource that
+// retains backing storage authority for child cursors.
+func NewBlockTransactionResourceWithRetain(
+	le *logrus.Entry,
+	b bus.Bus,
+	tx *block.Transaction,
+	rootCursor *block.Cursor,
+	retainAuthority resource_block_cursor.RetainAuthorityFunc,
+) *BlockTransactionResource {
+	btResource := &BlockTransactionResource{
+		le:              le,
+		b:               b,
+		tx:              tx,
+		rootCursor:      rootCursor,
+		retainAuthority: retainAuthority,
+	}
 	mux := srpc.NewMux()
 	_ = s4wave_block_transaction.SRPCRegisterBlockTransactionResourceService(mux, btResource)
 	btResource.mux = mux
@@ -53,9 +72,20 @@ func (r *BlockTransactionResource) Write(ctx context.Context, req *s4wave_block_
 			return nil, err
 		}
 
-		cursorResource := resource_block_cursor.NewBlockCursorResource(r.le, r.b, r.tx, rootCursor)
-		id, err := resourceCtx.AddResource(cursorResource.GetMux(), func() {})
+		releaseAuthority, err := r.retainChildAuthority()
 		if err != nil {
+			return nil, err
+		}
+		cursorResource := resource_block_cursor.NewBlockCursorResourceWithRetain(
+			r.le,
+			r.b,
+			r.tx,
+			rootCursor,
+			r.retainAuthority,
+		)
+		id, err := resourceCtx.AddResource(cursorResource.GetMux(), releaseAuthority)
+		if err != nil {
+			releaseAuthority()
 			return nil, err
 		}
 		resp.ResourceId = id
@@ -75,13 +105,31 @@ func (r *BlockTransactionResource) GetRootCursor(ctx context.Context, req *s4wav
 		return nil, block.ErrNotFound
 	}
 
-	cursorResource := resource_block_cursor.NewBlockCursorResource(r.le, r.b, r.tx, r.rootCursor)
-	id, err := resourceCtx.AddResource(cursorResource.GetMux(), func() {})
+	releaseAuthority, err := r.retainChildAuthority()
 	if err != nil {
+		return nil, err
+	}
+	cursorResource := resource_block_cursor.NewBlockCursorResourceWithRetain(
+		r.le,
+		r.b,
+		r.tx,
+		r.rootCursor,
+		r.retainAuthority,
+	)
+	id, err := resourceCtx.AddResource(cursorResource.GetMux(), releaseAuthority)
+	if err != nil {
+		releaseAuthority()
 		return nil, err
 	}
 
 	return &s4wave_block_transaction.GetRootCursorResponse{ResourceId: id}, nil
+}
+
+func (r *BlockTransactionResource) retainChildAuthority() (func(), error) {
+	if r.retainAuthority == nil {
+		return func() {}, nil
+	}
+	return r.retainAuthority()
 }
 
 // _ is a type assertion

--- a/core/resource/bucket/lookup/lookup.go
+++ b/core/resource/bucket/lookup/lookup.go
@@ -161,7 +161,13 @@ func (r *BucketLookupCursorResource) BuildTransaction(ctx context.Context, req *
 	}
 	tx, rootCursor := r.cursor.BuildTransaction(req.GetPutOpts())
 
-	txResource := resource_block_transaction.NewBlockTransactionResource(r.le, r.b, tx, rootCursor)
+	txResource := resource_block_transaction.NewBlockTransactionResourceWithRetain(
+		r.le,
+		r.b,
+		tx,
+		rootCursor,
+		retainOwnedCursor(txOwner),
+	)
 	txRelease := func() {}
 	if txOwner != nil {
 		txRelease = txOwner.Release
@@ -175,7 +181,13 @@ func (r *BucketLookupCursorResource) BuildTransaction(ctx context.Context, req *
 		return nil, err
 	}
 
-	cursorResource := resource_block_cursor.NewBlockCursorResource(r.le, r.b, tx, rootCursor)
+	cursorResource := resource_block_cursor.NewBlockCursorResourceWithRetain(
+		r.le,
+		r.b,
+		tx,
+		rootCursor,
+		retainOwnedCursor(cursorOwner),
+	)
 	cursorRelease := func() {}
 	if cursorOwner != nil {
 		cursorRelease = cursorOwner.Release
@@ -205,7 +217,13 @@ func (r *BucketLookupCursorResource) BuildTransactionAtRef(ctx context.Context, 
 	}
 	tx, rootCursor := r.cursor.BuildTransactionAtRef(req.GetPutOpts(), req.GetRef())
 
-	txResource := resource_block_transaction.NewBlockTransactionResource(r.le, r.b, tx, rootCursor)
+	txResource := resource_block_transaction.NewBlockTransactionResourceWithRetain(
+		r.le,
+		r.b,
+		tx,
+		rootCursor,
+		retainOwnedCursor(txOwner),
+	)
 	txRelease := func() {}
 	if txOwner != nil {
 		txRelease = txOwner.Release
@@ -219,7 +237,13 @@ func (r *BucketLookupCursorResource) BuildTransactionAtRef(ctx context.Context, 
 		return nil, err
 	}
 
-	cursorResource := resource_block_cursor.NewBlockCursorResource(r.le, r.b, tx, rootCursor)
+	cursorResource := resource_block_cursor.NewBlockCursorResourceWithRetain(
+		r.le,
+		r.b,
+		tx,
+		rootCursor,
+		retainOwnedCursor(cursorOwner),
+	)
 	cursorRelease := func() {}
 	if cursorOwner != nil {
 		cursorRelease = cursorOwner.Release
@@ -276,6 +300,19 @@ func (r *BucketLookupCursorResource) Release(ctx context.Context, req *s4wave_bu
 		r.cursor.Release()
 	}
 	return &s4wave_bucket_lookup.ReleaseResponse{}, nil
+}
+
+func retainOwnedCursor(owned *world.OwnedLookupCursor) resource_block_cursor.RetainAuthorityFunc {
+	if owned == nil {
+		return nil
+	}
+	return func() (func(), error) {
+		child, err := owned.Clone()
+		if err != nil {
+			return nil, err
+		}
+		return child.Release, nil
+	}
 }
 
 func (r *BucketLookupCursorResource) cloneTransactionOwners() (*world.OwnedLookupCursor, *world.OwnedLookupCursor, error) {

--- a/core/resource/bucket/lookup/lookup.go
+++ b/core/resource/bucket/lookup/lookup.go
@@ -12,6 +12,7 @@ import (
 	"github.com/s4wave/spacewave/db/block"
 	"github.com/s4wave/spacewave/db/blocktype"
 	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
+	"github.com/s4wave/spacewave/db/world"
 	s4wave_bucket_lookup "github.com/s4wave/spacewave/sdk/bucket/lookup"
 	"github.com/sirupsen/logrus"
 )
@@ -22,15 +23,34 @@ type BucketLookupCursorResource struct {
 	b      bus.Bus
 	mux    srpc.Invoker
 	cursor *bucket_lookup.Cursor
+	owned  *world.OwnedLookupCursor
 }
 
 // NewBucketLookupCursorResource creates a new BucketLookupCursorResource.
 func NewBucketLookupCursorResource(le *logrus.Entry, b bus.Bus, cursor *bucket_lookup.Cursor) *BucketLookupCursorResource {
-	blcResource := &BucketLookupCursorResource{le: le, b: b, cursor: cursor}
+	return (&BucketLookupCursorResource{le: le, b: b, cursor: cursor}).initMux()
+}
+
+// NewOwnedBucketLookupCursorResource creates a resource backed by an owned
+// cursor whose authority can be retained by child resources.
+func NewOwnedBucketLookupCursorResource(
+	le *logrus.Entry,
+	b bus.Bus,
+	owned *world.OwnedLookupCursor,
+) *BucketLookupCursorResource {
+	return (&BucketLookupCursorResource{
+		le:     le,
+		b:      b,
+		cursor: owned.Cursor(),
+		owned:  owned,
+	}).initMux()
+}
+
+func (r *BucketLookupCursorResource) initMux() *BucketLookupCursorResource {
 	mux := srpc.NewMux()
-	_ = s4wave_bucket_lookup.SRPCRegisterBucketLookupCursorResourceService(mux, blcResource)
-	blcResource.mux = mux
-	return blcResource
+	_ = s4wave_bucket_lookup.SRPCRegisterBucketLookupCursorResourceService(mux, r)
+	r.mux = mux
+	return r
 }
 
 // GetMux returns the rpc mux.
@@ -51,18 +71,30 @@ func (r *BucketLookupCursorResource) FollowRef(ctx context.Context, req *s4wave_
 		return nil, err
 	}
 
+	if r.owned != nil {
+		owned, err := r.owned.FollowRef(ctx, req.GetRef())
+		if err != nil {
+			return nil, err
+		}
+		newResource := NewOwnedBucketLookupCursorResource(r.le, r.b, owned)
+		id, err := resourceCtx.AddResource(newResource.GetMux(), owned.Release)
+		if err != nil {
+			owned.Release()
+			return nil, err
+		}
+		return &s4wave_bucket_lookup.FollowRefResponse{ResourceId: id}, nil
+	}
+
 	newCursor, err := r.cursor.FollowRef(ctx, req.GetRef())
 	if err != nil {
 		return nil, err
 	}
-
 	newResource := NewBucketLookupCursorResource(r.le, r.b, newCursor)
 	id, err := resourceCtx.AddResource(newResource.GetMux(), newCursor.Release)
 	if err != nil {
 		newCursor.Release()
 		return nil, err
 	}
-
 	return &s4wave_bucket_lookup.FollowRefResponse{ResourceId: id}, nil
 }
 
@@ -123,18 +155,35 @@ func (r *BucketLookupCursorResource) BuildTransaction(ctx context.Context, req *
 	if err != nil {
 		return nil, err
 	}
-
+	txOwner, cursorOwner, err := r.cloneTransactionOwners()
+	if err != nil {
+		return nil, err
+	}
 	tx, rootCursor := r.cursor.BuildTransaction(req.GetPutOpts())
 
 	txResource := resource_block_transaction.NewBlockTransactionResource(r.le, r.b, tx, rootCursor)
-	txID, err := resourceCtx.AddResource(txResource.GetMux(), func() {})
+	txRelease := func() {}
+	if txOwner != nil {
+		txRelease = txOwner.Release
+	}
+	txID, err := resourceCtx.AddResource(txResource.GetMux(), txRelease)
 	if err != nil {
+		txRelease()
+		if cursorOwner != nil {
+			cursorOwner.Release()
+		}
 		return nil, err
 	}
 
 	cursorResource := resource_block_cursor.NewBlockCursorResource(r.le, r.b, tx, rootCursor)
-	cursorID, err := resourceCtx.AddResource(cursorResource.GetMux(), func() {})
+	cursorRelease := func() {}
+	if cursorOwner != nil {
+		cursorRelease = cursorOwner.Release
+	}
+	cursorID, err := resourceCtx.AddResource(cursorResource.GetMux(), cursorRelease)
 	if err != nil {
+		cursorRelease()
+		resourceCtx.ReleaseResource(txID)
 		return nil, err
 	}
 
@@ -150,18 +199,35 @@ func (r *BucketLookupCursorResource) BuildTransactionAtRef(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-
+	txOwner, cursorOwner, err := r.cloneTransactionOwners()
+	if err != nil {
+		return nil, err
+	}
 	tx, rootCursor := r.cursor.BuildTransactionAtRef(req.GetPutOpts(), req.GetRef())
 
 	txResource := resource_block_transaction.NewBlockTransactionResource(r.le, r.b, tx, rootCursor)
-	txID, err := resourceCtx.AddResource(txResource.GetMux(), func() {})
+	txRelease := func() {}
+	if txOwner != nil {
+		txRelease = txOwner.Release
+	}
+	txID, err := resourceCtx.AddResource(txResource.GetMux(), txRelease)
 	if err != nil {
+		txRelease()
+		if cursorOwner != nil {
+			cursorOwner.Release()
+		}
 		return nil, err
 	}
 
 	cursorResource := resource_block_cursor.NewBlockCursorResource(r.le, r.b, tx, rootCursor)
-	cursorID, err := resourceCtx.AddResource(cursorResource.GetMux(), func() {})
+	cursorRelease := func() {}
+	if cursorOwner != nil {
+		cursorRelease = cursorOwner.Release
+	}
+	cursorID, err := resourceCtx.AddResource(cursorResource.GetMux(), cursorRelease)
 	if err != nil {
+		cursorRelease()
+		resourceCtx.ReleaseResource(txID)
 		return nil, err
 	}
 
@@ -178,6 +244,20 @@ func (r *BucketLookupCursorResource) Clone(ctx context.Context, req *s4wave_buck
 		return nil, err
 	}
 
+	if r.owned != nil {
+		owned, err := r.owned.Clone()
+		if err != nil {
+			return nil, err
+		}
+		clonedResource := NewOwnedBucketLookupCursorResource(r.le, r.b, owned)
+		id, err := resourceCtx.AddResource(clonedResource.GetMux(), owned.Release)
+		if err != nil {
+			owned.Release()
+			return nil, err
+		}
+		return &s4wave_bucket_lookup.CloneResponse{ResourceId: id}, nil
+	}
+
 	cloned := r.cursor.Clone()
 	clonedResource := NewBucketLookupCursorResource(r.le, r.b, cloned)
 	id, err := resourceCtx.AddResource(clonedResource.GetMux(), cloned.Release)
@@ -185,14 +265,33 @@ func (r *BucketLookupCursorResource) Clone(ctx context.Context, req *s4wave_buck
 		cloned.Release()
 		return nil, err
 	}
-
 	return &s4wave_bucket_lookup.CloneResponse{ResourceId: id}, nil
 }
 
 // Release releases the cursor resources.
 func (r *BucketLookupCursorResource) Release(ctx context.Context, req *s4wave_bucket_lookup.ReleaseRequest) (*s4wave_bucket_lookup.ReleaseResponse, error) {
-	r.cursor.Release()
+	if r.owned != nil {
+		r.owned.Release()
+	} else {
+		r.cursor.Release()
+	}
 	return &s4wave_bucket_lookup.ReleaseResponse{}, nil
+}
+
+func (r *BucketLookupCursorResource) cloneTransactionOwners() (*world.OwnedLookupCursor, *world.OwnedLookupCursor, error) {
+	if r.owned == nil {
+		return nil, nil, nil
+	}
+	txOwner, err := r.owned.Clone()
+	if err != nil {
+		return nil, nil, err
+	}
+	cursorOwner, err := r.owned.Clone()
+	if err != nil {
+		txOwner.Release()
+		return nil, nil, err
+	}
+	return txOwner, cursorOwner, nil
 }
 
 // Unmarshal fetches and unmarshals a block at the given reference.

--- a/core/resource/space/plugin-readiness_test.go
+++ b/core/resource/space/plugin-readiness_test.go
@@ -16,7 +16,7 @@ import (
 	plugin_space "github.com/s4wave/spacewave/core/plugin/space"
 	space_world "github.com/s4wave/spacewave/core/space/world"
 	space_world_ops "github.com/s4wave/spacewave/core/space/world/ops"
-	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
+	"github.com/s4wave/spacewave/db/world"
 	world_types "github.com/s4wave/spacewave/db/world/types"
 	s4wave_space "github.com/s4wave/spacewave/sdk/space"
 	"github.com/s4wave/spacewave/sdk/world/objecttype"
@@ -200,7 +200,8 @@ func createPluginReadinessManifest(
 		1,
 	)
 	var manifestRef *bldr_manifest.ManifestRef
-	if err := tb.Engine.AccessWorldState(ctx, nil, func(cursor *bucket_lookup.Cursor) error {
+	if err := tb.Engine.AccessWorldState(ctx, nil, func(access *world.WorldAccess) error {
+		cursor := access.Cursor()
 		transaction, blocks := cursor.BuildTransactionAtRef(nil, nil)
 		blocks.SetBlock(bldr_manifest.NewManifest(meta, "entrypoint"), true)
 		rootRef, _, err := transaction.Write(ctx, true)

--- a/core/resource/world/engine.go
+++ b/core/resource/world/engine.go
@@ -178,12 +178,16 @@ func (r *EngineResource) BuildStorageCursor(ctx context.Context, req *s4wave_wor
 		return nil, err
 	}
 
-	cursorResource := resource_bucket_lookup.NewBucketLookupCursorResource(r.le, r.b, cursor)
-	id, err := resourceCtx.AddResource(cursorResource.GetMux(), func() {
-		cursor.Release()
-	})
+	storage := world.NewWorldStorageFromCursorWithStore(cursor, nil)
+	owned, err := storage.BuildOwnedLookupCursor(ctx, nil)
+	world.RetireWorldStorage(storage)
 	if err != nil {
-		cursor.Release()
+		return nil, err
+	}
+	cursorResource := resource_bucket_lookup.NewOwnedBucketLookupCursorResource(r.le, r.b, owned)
+	id, err := resourceCtx.AddResource(cursorResource.GetMux(), owned.Release)
+	if err != nil {
+		owned.Release()
 		return nil, err
 	}
 

--- a/core/resource/world/engine.go
+++ b/core/resource/world/engine.go
@@ -8,7 +8,6 @@ import (
 	resource_server "github.com/s4wave/spacewave/bldr/resource/server"
 	resource_bucket_lookup "github.com/s4wave/spacewave/core/resource/bucket/lookup"
 	"github.com/s4wave/spacewave/db/bucket"
-	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
 	"github.com/s4wave/spacewave/db/world"
 	s4wave_world "github.com/s4wave/spacewave/sdk/world"
 	"github.com/sirupsen/logrus"
@@ -198,17 +197,14 @@ func (r *EngineResource) AccessWorldState(ctx context.Context, req *s4wave_world
 		return nil, err
 	}
 
-	var cursorResource *resource_bucket_lookup.BucketLookupCursorResource
-	err = r.engine.AccessWorldState(ctx, req.GetRef(), func(c *bucket_lookup.Cursor) error {
-		cursorResource = resource_bucket_lookup.NewBucketLookupCursorResource(r.le, r.b, c)
-		return nil
-	})
+	owned, err := r.engine.BuildOwnedLookupCursor(ctx, req.GetRef())
 	if err != nil {
 		return nil, err
 	}
-
-	id, err := resourceCtx.AddResource(cursorResource.GetMux(), func() {})
+	cursorResource := resource_bucket_lookup.NewBucketLookupCursorResource(r.le, r.b, owned.Cursor())
+	id, err := resourceCtx.AddResource(cursorResource.GetMux(), owned.Release)
 	if err != nil {
+		owned.Release()
 		return nil, err
 	}
 
@@ -228,9 +224,9 @@ func (r *EngineResource) loadWorldRootSnapshot(ctx context.Context) (*s4wave_wor
 	}
 	var rootRef *bucket.ObjectRef
 	var storageVolumeID string
-	err = wtx.AccessWorldState(ctx, nil, func(c *bucket_lookup.Cursor) error {
-		rootRef = c.GetRefWithOpArgs()
-		storageVolumeID = c.GetOpArgs().GetVolumeId()
+	err = wtx.AccessWorldState(ctx, nil, func(c *world.WorldAccess) error {
+		rootRef = c.Cursor().GetRefWithOpArgs()
+		storageVolumeID = c.Cursor().GetOpArgs().GetVolumeId()
 		return nil
 	})
 	if err != nil {

--- a/core/resource/world/engine.go
+++ b/core/resource/world/engine.go
@@ -201,7 +201,7 @@ func (r *EngineResource) AccessWorldState(ctx context.Context, req *s4wave_world
 	if err != nil {
 		return nil, err
 	}
-	cursorResource := resource_bucket_lookup.NewBucketLookupCursorResource(r.le, r.b, owned.Cursor())
+	cursorResource := resource_bucket_lookup.NewOwnedBucketLookupCursorResource(r.le, r.b, owned)
 	id, err := resourceCtx.AddResource(cursorResource.GetMux(), owned.Release)
 	if err != nil {
 		owned.Release()

--- a/core/resource/world/object-state.go
+++ b/core/resource/world/object-state.go
@@ -8,7 +8,6 @@ import (
 	"github.com/pkg/errors"
 	resource_server "github.com/s4wave/spacewave/bldr/resource/server"
 	resource_bucket_lookup "github.com/s4wave/spacewave/core/resource/bucket/lookup"
-	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
 	"github.com/s4wave/spacewave/db/world"
 	s4wave_world "github.com/s4wave/spacewave/sdk/world"
 	"github.com/sirupsen/logrus"
@@ -69,17 +68,14 @@ func (r *ObjectStateResource) AccessWorldState(ctx context.Context, req *s4wave_
 		return nil, err
 	}
 
-	var cursorResource *resource_bucket_lookup.BucketLookupCursorResource
-	err = r.obj.AccessWorldState(ctx, req.GetRef(), func(c *bucket_lookup.Cursor) error {
-		cursorResource = resource_bucket_lookup.NewBucketLookupCursorResource(r.le, r.b, c)
-		return nil
-	})
+	owned, err := r.obj.BuildOwnedLookupCursor(ctx, req.GetRef())
 	if err != nil {
 		return nil, err
 	}
-
-	id, err := resourceCtx.AddResource(cursorResource.GetMux(), func() {})
+	cursorResource := resource_bucket_lookup.NewBucketLookupCursorResource(r.le, r.b, owned.Cursor())
+	id, err := resourceCtx.AddResource(cursorResource.GetMux(), owned.Release)
 	if err != nil {
+		owned.Release()
 		return nil, err
 	}
 

--- a/core/resource/world/object-state.go
+++ b/core/resource/world/object-state.go
@@ -72,7 +72,7 @@ func (r *ObjectStateResource) AccessWorldState(ctx context.Context, req *s4wave_
 	if err != nil {
 		return nil, err
 	}
-	cursorResource := resource_bucket_lookup.NewBucketLookupCursorResource(r.le, r.b, owned.Cursor())
+	cursorResource := resource_bucket_lookup.NewOwnedBucketLookupCursorResource(r.le, r.b, owned)
 	id, err := resourceCtx.AddResource(cursorResource.GetMux(), owned.Release)
 	if err != nil {
 		owned.Release()

--- a/core/resource/world/owned-cursor_test.go
+++ b/core/resource/world/owned-cursor_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/s4wave/spacewave/db/testbed"
 	"github.com/s4wave/spacewave/db/world"
 	world_block "github.com/s4wave/spacewave/db/world/block"
+	s4wave_block_cursor "github.com/s4wave/spacewave/sdk/block/cursor"
+	s4wave_block_transaction "github.com/s4wave/spacewave/sdk/block/transaction"
 	s4wave_bucket_lookup "github.com/s4wave/spacewave/sdk/bucket/lookup"
 	s4wave_world "github.com/s4wave/spacewave/sdk/world"
 	"github.com/sirupsen/logrus"
@@ -27,6 +29,10 @@ type ownedCursorTestEngine struct {
 
 func (e *ownedCursorTestEngine) BuildOwnedLookupCursor(ctx context.Context, ref *bucket.ObjectRef) (*world.OwnedLookupCursor, error) {
 	return e.storage.BuildOwnedLookupCursor(ctx, ref)
+}
+
+func (e *ownedCursorTestEngine) BuildStorageCursor(ctx context.Context) (*bucket_lookup.Cursor, error) {
+	return e.storage.BuildStorageCursor(ctx)
 }
 
 type failingOwnedCursorResourceContext struct {
@@ -136,6 +142,67 @@ func TestEngineResourceOwnedCursorRegistrationTransfer(t *testing.T) {
 	}
 	if releases.Load() != 1 {
 		t.Fatalf("release count after child cleanup = %d, want 1", releases.Load())
+	}
+}
+
+func TestEngineResourceRawCursorGrandchildRetainsAuthority(t *testing.T) {
+	ctx := context.Background()
+	var releases atomic.Int32
+	storage := newOwnedCursorResourceTestStorage(&releases)
+	engine := &ownedCursorTestEngine{storage: storage}
+	resource := resource_world.NewEngineResource(nil, nil, engine, nil, nil)
+	resourceCtx := &worldStateOperationResourceContext{ctx: ctx}
+	callCtx := resource_server.WithResourceClientContext(ctx, resourceCtx)
+
+	resp, err := resource.BuildStorageCursor(callCtx, &s4wave_world.BuildStorageCursorRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	parentClient, err := resourceCtx.GetAttachedResource(resp.GetResourceId())
+	if err != nil {
+		t.Fatal(err)
+	}
+	parentService := s4wave_bucket_lookup.NewSRPCBucketLookupCursorResourceServiceClient(parentClient)
+	txResp, err := parentService.BuildTransaction(callCtx, &s4wave_bucket_lookup.BuildTransactionRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	txClient, err := resourceCtx.GetAttachedResource(txResp.GetTransactionResourceId())
+	if err != nil {
+		t.Fatal(err)
+	}
+	txService := s4wave_block_transaction.NewSRPCBlockTransactionResourceServiceClient(txClient)
+	rootResp, err := txService.GetRootCursor(callCtx, &s4wave_block_transaction.GetRootCursorRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	world.RetireWorldStorage(storage)
+	for _, resourceID := range []uint32{
+		resp.GetResourceId(),
+		txResp.GetCursorResourceId(),
+		txResp.GetTransactionResourceId(),
+	} {
+		if !resourceCtx.ReleaseResource(resourceID) {
+			t.Fatalf("resource %d cleanup was not registered", resourceID)
+		}
+	}
+	if releases.Load() != 0 {
+		t.Fatalf("release count with grandchild alive = %d, want 0", releases.Load())
+	}
+	rootClient, err := resourceCtx.GetAttachedResource(rootResp.GetResourceId())
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootService := s4wave_block_cursor.NewSRPCBlockCursorResourceServiceClient(rootClient)
+	if _, err := rootService.GetRef(ctx, &s4wave_block_cursor.GetRefRequest{}); err != nil {
+		t.Fatalf("grandchild cursor RPC: %v", err)
+	}
+	if !resourceCtx.ReleaseResource(rootResp.GetResourceId()) {
+		t.Fatal("grandchild resource cleanup was not registered")
+	}
+	if releases.Load() != 1 {
+		t.Fatalf("release count after grandchild cleanup = %d, want 1", releases.Load())
 	}
 }
 

--- a/core/resource/world/owned-cursor_test.go
+++ b/core/resource/world/owned-cursor_test.go
@@ -75,7 +75,6 @@ func TestEngineResourceOwnedCursorRegistrationTransfer(t *testing.T) {
 		t.Fatalf("release count after registration = %d, want 0", releases.Load())
 	}
 
-	world.RetireWorldStorage(storage)
 	client, err := resourceCtx.GetAttachedResource(resp.GetResourceId())
 	if err != nil {
 		t.Fatal(err)
@@ -83,16 +82,60 @@ func TestEngineResourceOwnedCursorRegistrationTransfer(t *testing.T) {
 	service := s4wave_bucket_lookup.NewSRPCBucketLookupCursorResourceServiceClient(client)
 	refResp, err := service.GetRef(ctx, &s4wave_bucket_lookup.GetRefRequest{})
 	if err != nil {
-		t.Fatalf("post-retirement cursor RPC: %v", err)
+		t.Fatal(err)
 	}
-	if refResp.GetRef().GetBucketId() != "resource-owner" {
-		t.Fatalf("resource bucket = %q, want resource-owner", refResp.GetRef().GetBucketId())
+	resourceCallCtx := resource_server.WithResourceClientContext(ctx, resourceCtx)
+	cloneResp, err := service.Clone(resourceCallCtx, &s4wave_bucket_lookup.CloneRequest{})
+	if err != nil {
+		t.Fatal(err)
 	}
+	followResp, err := service.FollowRef(resourceCallCtx, &s4wave_bucket_lookup.FollowRefRequest{Ref: refResp.GetRef()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	txResp, err := service.BuildTransaction(resourceCallCtx, &s4wave_bucket_lookup.BuildTransactionRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	world.RetireWorldStorage(storage)
 	if !resourceCtx.ReleaseResource(resp.GetResourceId()) {
-		t.Fatal("resource cleanup was not registered")
+		t.Fatal("parent resource cleanup was not registered")
+	}
+	if releases.Load() != 0 {
+		t.Fatalf("release count with child resources alive = %d, want 0", releases.Load())
+	}
+	for _, childID := range []uint32{cloneResp.GetResourceId(), followResp.GetResourceId()} {
+		child, err := resourceCtx.GetAttachedResource(childID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		childService := s4wave_bucket_lookup.NewSRPCBucketLookupCursorResourceServiceClient(child)
+		childRef, err := childService.GetRef(ctx, &s4wave_bucket_lookup.GetRefRequest{})
+		if err != nil {
+			t.Fatalf("child cursor RPC: %v", err)
+		}
+		if childRef.GetRef().GetBucketId() != "resource-owner" {
+			t.Fatalf("child resource bucket = %q, want resource-owner", childRef.GetRef().GetBucketId())
+		}
+	}
+	if !resourceCtx.ReleaseResource(cloneResp.GetResourceId()) {
+		t.Fatal("clone resource cleanup was not registered")
+	}
+	if releases.Load() != 0 {
+		t.Fatalf("release count with transaction children alive = %d, want 0", releases.Load())
+	}
+	for _, childID := range []uint32{
+		followResp.GetResourceId(),
+		txResp.GetTransactionResourceId(),
+		txResp.GetCursorResourceId(),
+	} {
+		if !resourceCtx.ReleaseResource(childID) {
+			t.Fatalf("child resource %d cleanup was not registered", childID)
+		}
 	}
 	if releases.Load() != 1 {
-		t.Fatalf("release count after cleanup = %d, want 1", releases.Load())
+		t.Fatalf("release count after child cleanup = %d, want 1", releases.Load())
 	}
 }
 

--- a/core/resource/world/owned-cursor_test.go
+++ b/core/resource/world/owned-cursor_test.go
@@ -1,0 +1,176 @@
+package resource_world_test
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/aperturerobotics/starpc/srpc"
+	resource_server "github.com/s4wave/spacewave/bldr/resource/server"
+	resource_world "github.com/s4wave/spacewave/core/resource/world"
+	"github.com/s4wave/spacewave/db/bucket"
+	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
+	bucket_mock "github.com/s4wave/spacewave/db/bucket/mock"
+	"github.com/s4wave/spacewave/db/testbed"
+	"github.com/s4wave/spacewave/db/world"
+	world_block "github.com/s4wave/spacewave/db/world/block"
+	s4wave_bucket_lookup "github.com/s4wave/spacewave/sdk/bucket/lookup"
+	s4wave_world "github.com/s4wave/spacewave/sdk/world"
+	"github.com/sirupsen/logrus"
+)
+
+type ownedCursorTestEngine struct {
+	world.Engine
+	storage world.WorldStorage
+}
+
+func (e *ownedCursorTestEngine) BuildOwnedLookupCursor(ctx context.Context, ref *bucket.ObjectRef) (*world.OwnedLookupCursor, error) {
+	return e.storage.BuildOwnedLookupCursor(ctx, ref)
+}
+
+type failingOwnedCursorResourceContext struct {
+	*worldStateOperationResourceContext
+	err error
+}
+
+func (c *failingOwnedCursorResourceContext) AddResource(srpc.Invoker, func()) (uint32, error) {
+	return 0, c.err
+}
+
+func newOwnedCursorResourceTestStorage(releases *atomic.Int32) world.WorldStorage {
+	return world.NewCursorWorldStorage(func(context.Context) (*bucket_lookup.Cursor, error) {
+		bkt := bucket_mock.NewMockBucket("resource-owner", nil)
+		return bucket_lookup.NewCursorWithRelease(
+			context.Background(),
+			nil,
+			nil,
+			nil,
+			bkt,
+			nil,
+			&bucket.ObjectRef{BucketId: "resource-owner"},
+			&bucket.BucketOpArgs{BucketId: "resource-owner"},
+			nil,
+			func() { releases.Add(1) },
+		), nil
+	})
+}
+
+func TestEngineResourceOwnedCursorRegistrationTransfer(t *testing.T) {
+	ctx := context.Background()
+	var releases atomic.Int32
+	storage := newOwnedCursorResourceTestStorage(&releases)
+	engine := &ownedCursorTestEngine{storage: storage}
+	resource := resource_world.NewEngineResource(nil, nil, engine, nil, nil)
+	resourceCtx := &worldStateOperationResourceContext{ctx: ctx}
+
+	resp, err := resource.AccessWorldState(
+		resource_server.WithResourceClientContext(ctx, resourceCtx),
+		&s4wave_world.AccessWorldStateRequest{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if releases.Load() != 0 {
+		t.Fatalf("release count after registration = %d, want 0", releases.Load())
+	}
+
+	world.RetireWorldStorage(storage)
+	client, err := resourceCtx.GetAttachedResource(resp.GetResourceId())
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := s4wave_bucket_lookup.NewSRPCBucketLookupCursorResourceServiceClient(client)
+	refResp, err := service.GetRef(ctx, &s4wave_bucket_lookup.GetRefRequest{})
+	if err != nil {
+		t.Fatalf("post-retirement cursor RPC: %v", err)
+	}
+	if refResp.GetRef().GetBucketId() != "resource-owner" {
+		t.Fatalf("resource bucket = %q, want resource-owner", refResp.GetRef().GetBucketId())
+	}
+	if !resourceCtx.ReleaseResource(resp.GetResourceId()) {
+		t.Fatal("resource cleanup was not registered")
+	}
+	if releases.Load() != 1 {
+		t.Fatalf("release count after cleanup = %d, want 1", releases.Load())
+	}
+}
+
+func TestEngineResourceOwnedCursorSurvivesEngineClose(t *testing.T) {
+	ctx := context.Background()
+	le := logrus.NewEntry(logrus.New())
+	tb, err := testbed.NewTestbed(ctx, le)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tb.Release()
+	base, err := tb.BuildEmptyCursor(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer base.Release()
+	engine, err := world_block.NewEngine(ctx, le, base, nil, nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	engineClosed := false
+	defer func() {
+		if !engineClosed {
+			_ = engine.Close()
+		}
+	}()
+
+	resource := resource_world.NewEngineResource(nil, nil, engine, nil, nil)
+	resourceCtx := &worldStateOperationResourceContext{ctx: ctx}
+	resp, err := resource.AccessWorldState(
+		resource_server.WithResourceClientContext(ctx, resourceCtx),
+		&s4wave_world.AccessWorldStateRequest{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := engine.Close(); err != nil {
+		t.Fatal(err)
+	}
+	engineClosed = true
+
+	client, err := resourceCtx.GetAttachedResource(resp.GetResourceId())
+	if err != nil {
+		t.Fatal(err)
+	}
+	service := s4wave_bucket_lookup.NewSRPCBucketLookupCursorResourceServiceClient(client)
+	refResp, err := service.GetRef(ctx, &s4wave_bucket_lookup.GetRefRequest{})
+	if err != nil {
+		t.Fatalf("post-close cursor RPC: %v", err)
+	}
+	if refResp.GetRef().GetBucketId() != base.GetOpArgs().GetBucketId() {
+		t.Fatalf("resource bucket = %q, want %q", refResp.GetRef().GetBucketId(), base.GetOpArgs().GetBucketId())
+	}
+	if !resourceCtx.ReleaseResource(resp.GetResourceId()) {
+		t.Fatal("resource cleanup was not registered")
+	}
+}
+
+func TestEngineResourceOwnedCursorRegistrationFailureReleases(t *testing.T) {
+	ctx := context.Background()
+	var releases atomic.Int32
+	storage := newOwnedCursorResourceTestStorage(&releases)
+	engine := &ownedCursorTestEngine{storage: storage}
+	resource := resource_world.NewEngineResource(nil, nil, engine, nil, nil)
+	wantErr := errors.New("registration failed")
+	resourceCtx := &failingOwnedCursorResourceContext{
+		worldStateOperationResourceContext: &worldStateOperationResourceContext{ctx: ctx},
+		err:                                wantErr,
+	}
+
+	_, err := resource.AccessWorldState(
+		resource_server.WithResourceClientContext(ctx, resourceCtx),
+		&s4wave_world.AccessWorldStateRequest{},
+	)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("registration error = %v, want %v", err, wantErr)
+	}
+	if releases.Load() != 1 {
+		t.Fatalf("release count after failed registration = %d, want 1", releases.Load())
+	}
+}

--- a/core/resource/world/tracked-world-state.go
+++ b/core/resource/world/tracked-world-state.go
@@ -233,7 +233,11 @@ func (t *TrackedWorldState) BuildStorageCursor(ctx context.Context) (*bucket_loo
 	return t.ws.BuildStorageCursor(ctx)
 }
 
-func (t *TrackedWorldState) AccessWorldState(ctx context.Context, ref *bucket.ObjectRef, cb func(*bucket_lookup.Cursor) error) error {
+func (t *TrackedWorldState) BuildOwnedLookupCursor(ctx context.Context, ref *bucket.ObjectRef) (*world.OwnedLookupCursor, error) {
+	return t.ws.BuildOwnedLookupCursor(ctx, ref)
+}
+
+func (t *TrackedWorldState) AccessWorldState(ctx context.Context, ref *bucket.ObjectRef, cb func(*world.WorldAccess) error) error {
 	return t.ws.AccessWorldState(ctx, ref, cb)
 }
 

--- a/core/resource/world/world-state.go
+++ b/core/resource/world/world-state.go
@@ -141,12 +141,16 @@ func (r *WorldStateResource) BuildStorageCursor(ctx context.Context, req *s4wave
 		return nil, err
 	}
 
-	cursorResource := resource_bucket_lookup.NewBucketLookupCursorResource(r.le, r.b, cursor)
-	id, err := resourceCtx.AddResource(cursorResource.GetMux(), func() {
-		cursor.Release()
-	})
+	storage := world.NewWorldStorageFromCursorWithStore(cursor, nil)
+	owned, err := storage.BuildOwnedLookupCursor(ctx, nil)
+	world.RetireWorldStorage(storage)
 	if err != nil {
-		cursor.Release()
+		return nil, err
+	}
+	cursorResource := resource_bucket_lookup.NewOwnedBucketLookupCursorResource(r.le, r.b, owned)
+	id, err := resourceCtx.AddResource(cursorResource.GetMux(), owned.Release)
+	if err != nil {
+		owned.Release()
 		return nil, err
 	}
 

--- a/core/resource/world/world-state.go
+++ b/core/resource/world/world-state.go
@@ -164,7 +164,7 @@ func (r *WorldStateResource) AccessWorldState(ctx context.Context, req *s4wave_w
 	if err != nil {
 		return nil, err
 	}
-	cursorResource := resource_bucket_lookup.NewBucketLookupCursorResource(r.le, r.b, owned.Cursor())
+	cursorResource := resource_bucket_lookup.NewOwnedBucketLookupCursorResource(r.le, r.b, owned)
 	id, err := resourceCtx.AddResource(cursorResource.GetMux(), owned.Release)
 	if err != nil {
 		owned.Release()

--- a/core/resource/world/world-state.go
+++ b/core/resource/world/world-state.go
@@ -11,7 +11,6 @@ import (
 	resource_bucket_lookup "github.com/s4wave/spacewave/core/resource/bucket/lookup"
 	"github.com/s4wave/spacewave/db/block"
 	"github.com/s4wave/spacewave/db/block/quad"
-	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
 	"github.com/s4wave/spacewave/db/world"
 	world_types "github.com/s4wave/spacewave/db/world/types"
 	"github.com/s4wave/spacewave/net/peer"
@@ -161,17 +160,14 @@ func (r *WorldStateResource) AccessWorldState(ctx context.Context, req *s4wave_w
 		return nil, err
 	}
 
-	var cursorResource *resource_bucket_lookup.BucketLookupCursorResource
-	err = r.ws.AccessWorldState(ctx, req.GetRef(), func(c *bucket_lookup.Cursor) error {
-		cursorResource = resource_bucket_lookup.NewBucketLookupCursorResource(r.le, r.b, c)
-		return nil
-	})
+	owned, err := r.ws.BuildOwnedLookupCursor(ctx, req.GetRef())
 	if err != nil {
 		return nil, err
 	}
-
-	id, err := resourceCtx.AddResource(cursorResource.GetMux(), func() {})
+	cursorResource := resource_bucket_lookup.NewBucketLookupCursorResource(r.le, r.b, owned.Cursor())
+	id, err := resourceCtx.AddResource(cursorResource.GetMux(), owned.Release)
 	if err != nil {
+		owned.Release()
 		return nil, err
 	}
 

--- a/core/sobject/world/engine/engine.go
+++ b/core/sobject/world/engine/engine.go
@@ -257,13 +257,16 @@ func (e *soEngine) BuildStorageCursor(ctx context.Context) (*bucket_lookup.Curso
 	return e.bengine.BuildStorageCursor(ctx)
 }
 
-// AccessWorldState builds a bucket lookup cursor with an optional ref.
-// If the ref is empty, returns a cursor pointing to the root world state.
-// The lookup cursor will be released after cb returns.
+// BuildOwnedLookupCursor builds an owned cursor at ref.
+func (e *soEngine) BuildOwnedLookupCursor(ctx context.Context, ref *bucket.ObjectRef) (*world.OwnedLookupCursor, error) {
+	return e.bengine.BuildOwnedLookupCursor(ctx, ref)
+}
+
+// AccessWorldState builds a borrowed access value with an optional ref.
 func (e *soEngine) AccessWorldState(
 	ctx context.Context,
 	ref *bucket.ObjectRef,
-	cb func(*bucket_lookup.Cursor) error,
+	cb func(*world.WorldAccess) error,
 ) error {
 	return e.bengine.AccessWorldState(ctx, ref, cb)
 }

--- a/core/sobject/world/engine/engine_test.go
+++ b/core/sobject/world/engine/engine_test.go
@@ -14,7 +14,6 @@ import (
 	provider_local "github.com/s4wave/spacewave/core/provider/local"
 	"github.com/s4wave/spacewave/core/sobject"
 	sobject_world_engine "github.com/s4wave/spacewave/core/sobject/world/engine"
-	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
 	"github.com/s4wave/spacewave/db/world"
 	world_block "github.com/s4wave/spacewave/db/world/block"
 	world_mock "github.com/s4wave/spacewave/db/world/mock"
@@ -149,7 +148,8 @@ func TestWorldEngineController(t *testing.T) {
 	}
 	le.Info("world engine test suite passed")
 
-	err = eng.AccessWorldState(ctx, nil, func(bls *bucket_lookup.Cursor) error {
+	err = eng.AccessWorldState(ctx, nil, func(access *world.WorldAccess) error {
+		bls := access.Cursor()
 		_, bcs := bls.BuildTransaction(nil)
 		wi, err := bcs.Unmarshal(ctx, world_block.NewWorldBlock)
 		if err != nil {

--- a/core/space/migration/planner.go
+++ b/core/space/migration/planner.go
@@ -542,7 +542,8 @@ func logicalSizeForRef(ctx context.Context, ws world.WorldState, root *bucket.Ob
 		return 0, false
 	}
 	var total uint64
-	err := ws.AccessWorldState(ctx, root, func(cursor *bucket_lookup.Cursor) error {
+	err := ws.AccessWorldState(ctx, root, func(access *world.WorldAccess) error {
+		cursor := access.Cursor()
 		return bucket_lookup.WalkObjectBlocks(ctx, bucket_lookup.NewWalkObjectBlocksWithRef(root.GetRootRef(), nil), func(entry *bucket_lookup.WalkObjectBlocksEntry) (bool, error) {
 			if entry == nil {
 				return true, nil
@@ -568,7 +569,8 @@ func logicalSizeForRef(ctx context.Context, ws world.WorldState, root *bucket.Ob
 }
 func owningBlockStoreID(ctx context.Context, ws world.WorldState, objects map[string]*ObjectDescriptor, label string) (string, error) {
 	var ownerID string
-	if err := ws.AccessWorldState(ctx, nil, func(cursor *bucket_lookup.Cursor) error {
+	if err := ws.AccessWorldState(ctx, nil, func(access *world.WorldAccess) error {
+		cursor := access.Cursor()
 		if cursor != nil && cursor.GetRef() != nil {
 			ownerID = cursor.GetRef().GetBucketId()
 		}

--- a/core/space/migration/planner_test.go
+++ b/core/space/migration/planner_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/s4wave/spacewave/db/block"
 	block_mock "github.com/s4wave/spacewave/db/block/mock"
 	"github.com/s4wave/spacewave/db/bucket"
-	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
 	kvtx_block "github.com/s4wave/spacewave/db/kvtx/block"
 	"github.com/s4wave/spacewave/db/world"
 	world_testbed "github.com/s4wave/spacewave/db/world/testbed"
@@ -231,7 +230,8 @@ func TestPlannerRemapsDescendantClosureKeys(t *testing.T) {
 func setObject(t *testing.T, ctx context.Context, ws world.WorldState, key, typeID string) {
 	t.Helper()
 	var root *bucket.ObjectRef
-	err := ws.AccessWorldState(ctx, nil, func(cursor *bucket_lookup.Cursor) error {
+	err := ws.AccessWorldState(ctx, nil, func(access *world.WorldAccess) error {
+		cursor := access.Cursor()
 		root = cursor.GetRef()
 		tx, blocks := cursor.BuildTransactionAtRef(nil, nil)
 		switch typeID {
@@ -260,7 +260,8 @@ func setObject(t *testing.T, ctx context.Context, ws world.WorldState, key, type
 func setObjectBlock(t *testing.T, ctx context.Context, ws world.WorldState, key, typeID string, payload block.Block) {
 	t.Helper()
 	var root *bucket.ObjectRef
-	err := ws.AccessWorldState(ctx, nil, func(cursor *bucket_lookup.Cursor) error {
+	err := ws.AccessWorldState(ctx, nil, func(access *world.WorldAccess) error {
+		cursor := access.Cursor()
 		root = cursor.GetRef()
 		tx, blocks := cursor.BuildTransactionAtRef(nil, nil)
 		blocks.SetBlock(payload, true)

--- a/db/bucket/lookup/cursor.go
+++ b/db/bucket/lookup/cursor.go
@@ -293,6 +293,13 @@ func (c *Cursor) Clone() *Cursor {
 	return c.clone()
 }
 
+// CloneWithRelease clones the cursor and assigns release to the clone.
+func (c *Cursor) CloneWithRelease(release func()) *Cursor {
+	nc := c.clone()
+	nc.rel = release
+	return nc
+}
+
 // CloneWithLocalOnlyReads clones the cursor and disables network lookup reads
 // for lookup-backed buckets.
 func (c *Cursor) CloneWithLocalOnlyReads() *Cursor {

--- a/db/opfs/chrometest/testprog/main.go
+++ b/db/opfs/chrometest/testprog/main.go
@@ -3595,8 +3595,10 @@ func runCopyWalkWrapperCopy(
 	maxConcurrency int,
 	label string,
 ) error {
-	return ws.AccessWorldState(ctx, nil, func(dest *bucket_lookup.Cursor) error {
-		return ws.AccessWorldState(ctx, srcObjRef, func(src *bucket_lookup.Cursor) error {
+	return ws.AccessWorldState(ctx, nil, func(destAccess *world.WorldAccess) error {
+		dest := destAccess.Cursor()
+		return ws.AccessWorldState(ctx, srcObjRef, func(srcAccess *world.WorldAccess) error {
+			src := srcAccess.Cursor()
 			le.Infof(
 				"copy-walk-wrapper %s: copying DAG bucket %s -> %s at concurrency %d",
 				label,

--- a/db/world/block/changelog-read.go
+++ b/db/world/block/changelog-read.go
@@ -5,7 +5,6 @@ import (
 	"slices"
 
 	"github.com/s4wave/spacewave/db/block"
-	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
 	"github.com/s4wave/spacewave/db/world"
 )
 
@@ -33,7 +32,7 @@ func ReadChangeLogEntries(
 	opts ChangeLogReadOptions,
 ) ([]*ChangeLogEntry, error) {
 	var entries []*ChangeLogEntry
-	err := access(ctx, nil, func(root *bucket_lookup.Cursor) error {
+	err := access(ctx, nil, func(root *world.WorldAccess) error {
 		_, rootBcs := root.BuildTransaction(nil)
 		var err error
 		entries, err = ReadChangeLogEntriesFromCursor(ctx, rootBcs, opts)

--- a/db/world/block/engine-root-access_test.go
+++ b/db/world/block/engine-root-access_test.go
@@ -5,12 +5,31 @@ import (
 	"runtime"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/s4wave/spacewave/db/bucket"
-	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
 	"github.com/s4wave/spacewave/db/testbed"
+	"github.com/s4wave/spacewave/db/tx"
+	"github.com/s4wave/spacewave/db/world"
+	world_mock "github.com/s4wave/spacewave/db/world/mock"
+	"github.com/s4wave/spacewave/net/peer"
 	"github.com/sirupsen/logrus"
 )
+
+type accessOnlyWorldOp struct {
+	*world_mock.MockWorldOp
+}
+
+func (o *accessOnlyWorldOp) ApplyWorldOp(
+	ctx context.Context,
+	_ *logrus.Entry,
+	state world.WorldState,
+	_ peer.ID,
+) (bool, error) {
+	return false, state.AccessWorldState(ctx, nil, func(*world.WorldAccess) error {
+		return nil
+	})
+}
 
 func TestEngineAccessWorldStateSameBucketConcurrentClose(t *testing.T) {
 	if runtime.GOMAXPROCS(0) < 2 {
@@ -56,7 +75,7 @@ func TestEngineAccessWorldStateSameBucketConcurrentClose(t *testing.T) {
 				}()
 				<-start
 				for {
-					err := eng.AccessWorldState(ctx, nil, func(*bucket_lookup.Cursor) error {
+					err := eng.AccessWorldState(ctx, nil, func(*world.WorldAccess) error {
 						enteredOnce.Do(func() { close(entered) })
 						return nil
 					})
@@ -109,7 +128,7 @@ func TestEngineAccessWorldStateReferencesAndCallbackBoundary(t *testing.T) {
 
 	testAccess := func(ref *bucket.ObjectRef) {
 		t.Helper()
-		if err := eng.AccessWorldState(ctx, ref, func(cursor *bucket_lookup.Cursor) error {
+		if err := eng.AccessWorldState(ctx, ref, func(cursor *world.WorldAccess) error {
 			if !eng.rmtx.TryLock() {
 				t.Fatal("callback ran while Engine.rmtx was held")
 			}
@@ -125,4 +144,178 @@ func TestEngineAccessWorldStateReferencesAndCallbackBoundary(t *testing.T) {
 
 	testAccess(nil)
 	testAccess(&bucket.ObjectRef{})
+}
+func TestTransactionWorldOperationDoesNotReenterEngineLock(t *testing.T) {
+	ctx := context.Background()
+	le := logrus.NewEntry(logrus.New())
+	tb, err := testbed.NewTestbed(ctx, le)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tb.Release()
+	base, err := tb.BuildEmptyCursor(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer base.Release()
+	eng, err := NewEngine(ctx, le, base, world_mock.LookupMockOp, nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer eng.Close()
+	tx, err := eng.NewTransaction(ctx, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Discard()
+
+	eng.rmtx.Lock()
+	done := make(chan error, 1)
+	go func() {
+		_, _, err := tx.ApplyWorldOp(ctx, &accessOnlyWorldOp{
+			MockWorldOp: world_mock.NewMockWorldOp("lock-reentry", "access"),
+		}, "")
+		done <- err
+	}()
+	timer := time.NewTimer(time.Second)
+	defer timer.Stop()
+	select {
+	case err := <-done:
+		eng.rmtx.Unlock()
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-timer.C:
+		eng.rmtx.Unlock()
+		<-done
+		t.Fatal("transaction world operation reentered Engine.rmtx")
+	}
+}
+
+func TestEngineTxAccessWorldStateNilPinsOpeningRoot(t *testing.T) {
+	ctx := context.Background()
+	le := logrus.NewEntry(logrus.New())
+	tb, err := testbed.NewTestbed(ctx, le)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tb.Release()
+
+	base, err := tb.BuildEmptyCursor(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer base.Release()
+
+	eng, err := NewEngine(ctx, le, base, world_mock.LookupMockOp, nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	writeTx, err := eng.NewTransaction(ctx, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	objectBlockRef, _, err := base.PutBlock(ctx, []byte("object root"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := writeTx.CreateObject(ctx, "pinned", &bucket.ObjectRef{RootRef: objectBlockRef}); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeTx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+	openingRoot := eng.GetRootRef()
+
+	readTx, err := eng.NewTransaction(ctx, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer readTx.Discard()
+	if !readTx.GetReadOnly() {
+		t.Fatal("read transaction reported writable")
+	}
+	if _, err := readTx.CreateObject(ctx, "read-only-write", &bucket.ObjectRef{}); err != tx.ErrNotWrite {
+		t.Fatalf("read-only write error = %v, want %v", err, tx.ErrNotWrite)
+	}
+	readObj, err := world.MustGetObject(ctx, readTx, "pinned")
+	if err != nil {
+		t.Fatal(err)
+	}
+	objectRoot, _, err := readObj.GetRootRef(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, ref := range []*bucket.ObjectRef{nil, {}} {
+		if err := readObj.AccessWorldState(ctx, ref, func(access *world.WorldAccess) error {
+			if got := access.Cursor().GetRefWithOpArgs(); !got.GetRootRef().EqualsRef(objectRoot.GetRootRef()) {
+				t.Fatalf("object access root = %v, want %v", got, objectRoot)
+			}
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	ownedObjectRoot, err := readObj.BuildOwnedLookupCursor(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := ownedObjectRoot.Cursor().GetRefWithOpArgs(); !got.GetRootRef().EqualsRef(objectRoot.GetRootRef()) {
+		t.Fatalf("owned object root = %v, want %v", got, objectRoot)
+	}
+	ownedObjectRoot.Release()
+	assertPinned := func(label string) {
+		t.Helper()
+		if err := readTx.AccessWorldState(ctx, nil, func(access *world.WorldAccess) error {
+			if got := access.Cursor().GetRefWithOpArgs(); !got.EqualsRef(openingRoot) {
+				t.Fatalf("%s root = %v, want opening root %v", label, got, openingRoot)
+			}
+			return nil
+		}); err != nil {
+			t.Fatalf("%s access: %v", label, err)
+		}
+	}
+	assertPinned("before head movement")
+
+	writeTx, err = eng.NewTransaction(ctx, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	obj, err := world.MustGetObject(ctx, writeTx, "pinned")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := obj.IncrementRev(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeTx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+	movingRoot := eng.GetRootRef()
+	if movingRoot.EqualsRef(openingRoot) {
+		t.Fatal("engine head did not move")
+	}
+	if err := eng.AccessWorldState(ctx, nil, func(access *world.WorldAccess) error {
+		if got := access.Cursor().GetRefWithOpArgs(); !got.EqualsRef(movingRoot) {
+			t.Fatalf("engine nil root = %v, want moving root %v", got, movingRoot)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := eng.AccessWorldState(ctx, &bucket.ObjectRef{}, func(access *world.WorldAccess) error {
+		if !access.Cursor().GetRef().GetEmpty() {
+			t.Fatalf("allocated-empty engine ref selected moving root: %v", access.Cursor().GetRef())
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	assertPinned("after head movement")
+
+	if err := eng.Close(); err != nil {
+		t.Fatal(err)
+	}
+	assertPinned("after engine close")
 }

--- a/db/world/block/engine-tx-object.go
+++ b/db/world/block/engine-tx-object.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/s4wave/spacewave/db/bucket"
-	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
 	"github.com/s4wave/spacewave/db/tx"
 	"github.com/s4wave/spacewave/db/world"
 	"github.com/s4wave/spacewave/net/peer"
@@ -42,20 +41,35 @@ func (t *EngineTxObjectState) GetRootRef(ctx context.Context) (*bucket.ObjectRef
 	return rref, outRev, err
 }
 
-// AccessWorldState builds a bucket lookup cursor with an optional ref.
-// If the ref is empty, will default to the object RootRef.
-// If the ref Bucket ID is empty, uses the same bucket + volume as the world.
-// The lookup cursor will be released after cb returns.
+// BuildOwnedLookupCursor builds an owned cursor at ref.
+func (t *EngineTxObjectState) BuildOwnedLookupCursor(ctx context.Context, ref *bucket.ObjectRef) (*world.OwnedLookupCursor, error) {
+	if ref.GetEmpty() {
+		var err error
+		ref, _, err = t.GetRootRef(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if ref == nil {
+			ref = &bucket.ObjectRef{}
+		}
+	}
+	return t.t.BuildOwnedLookupCursor(ctx, ref)
+}
+
+// AccessWorldState builds a borrowed access value with an optional ref.
 func (t *EngineTxObjectState) AccessWorldState(
 	ctx context.Context,
 	ref *bucket.ObjectRef,
-	cb func(*bucket_lookup.Cursor) error,
+	cb func(*world.WorldAccess) error,
 ) error {
 	if ref.GetEmpty() {
 		var err error
 		ref, _, err = t.GetRootRef(ctx)
 		if err != nil {
 			return err
+		}
+		if ref == nil {
+			ref = &bucket.ObjectRef{}
 		}
 	}
 	return t.t.AccessWorldState(ctx, ref, cb)

--- a/db/world/block/engine-tx-ops.go
+++ b/db/world/block/engine-tx-ops.go
@@ -16,22 +16,45 @@ import (
 // maxEngineTxTries is the maximum number of times to retry after discarded
 const maxEngineTxTries = 10
 
-// BuildStorageCursor builds a cursor to the world storage with an empty ref.
-// The cursor should be released independently of the WorldState.
-// Be sure to call Release on the cursor when done.
+// BuildStorageCursor builds a raw cursor to the transaction's world storage.
 func (e *EngineTx) BuildStorageCursor(ctx context.Context) (*bucket_lookup.Cursor, error) {
-	return e.engine.BuildStorageCursor(ctx)
+	state := e.worldState()
+	if state == nil {
+		return nil, tx.ErrDiscarded
+	}
+	return state.BuildStorageCursor(ctx)
 }
 
-// AccessWorldState builds a bucket lookup cursor with an optional ref.
-// If the ref is empty, returns empty cursor in the same bucket + volume as the world.
-// The lookup cursor will be released after cb returns.
+// BuildOwnedLookupCursor builds an owned cursor at ref.
+func (e *EngineTx) BuildOwnedLookupCursor(ctx context.Context, ref *bucket.ObjectRef) (*world.OwnedLookupCursor, error) {
+	state := e.worldState()
+	if state == nil {
+		return nil, tx.ErrDiscarded
+	}
+	return state.BuildOwnedLookupCursor(ctx, ref)
+}
+
+// AccessWorldState builds a borrowed access value with an optional ref.
 func (e *EngineTx) AccessWorldState(
 	ctx context.Context,
 	ref *bucket.ObjectRef,
-	cb func(*bucket_lookup.Cursor) error,
+	cb func(*world.WorldAccess) error,
 ) error {
-	return e.engine.AccessWorldState(ctx, ref, cb)
+	state := e.worldState()
+	if state == nil {
+		return tx.ErrDiscarded
+	}
+	return state.AccessWorldState(ctx, ref, cb)
+}
+
+func (e *EngineTx) worldState() *WorldState {
+	if e.writeTx != nil {
+		return e.writeTx.state
+	}
+	if e.readTx != nil {
+		return e.readTx.state
+	}
+	return nil
 }
 
 // ApplyWorldOp applies a batch operation at the world level.

--- a/db/world/block/engine-tx.go
+++ b/db/world/block/engine-tx.go
@@ -31,10 +31,12 @@ func newEngineTx(e *Engine, writeTx *Tx) *EngineTx {
 }
 
 // Fork forks the current world state into a completely separate world state.
-//
-// Creates a new block transaction.
 func (e *EngineTx) Fork(ctx context.Context) (world.WorldState, error) {
-	return e.engine.ForkBlockTransaction(ctx, true)
+	state := e.worldState()
+	if state == nil {
+		return nil, tx.ErrDiscarded
+	}
+	return state.Fork(ctx)
 }
 
 // Commit commits the transaction to storage.

--- a/db/world/block/engine.go
+++ b/db/world/block/engine.go
@@ -37,6 +37,8 @@ type Engine struct {
 	baseRoot *bucket_lookup.Cursor
 	// root is the root cursor in use
 	root *bucket_lookup.Cursor
+	// storage owns transaction-scoped lookup and store access.
+	storage world.WorldStorage
 	// readTx is the current read-only world instance
 	readTx *Tx
 	// writeTx is the current write tx
@@ -155,6 +157,7 @@ func NewEngine(
 			e.writeBlockStore = block.NewBufferedStore(ctx, rawWriteStore)
 		}
 	}
+	e.storage = world.NewWorldStorageFromCursorWithStore(e.baseRoot, e.writeBlockStore)
 
 	taskCtx, subtask := trace.NewTask(ctx, "hydra/world-block/engine/new/update-read-write-txns")
 	err := e.updateReadWriteTxns(taskCtx)
@@ -350,11 +353,11 @@ func (e *Engine) worldStateForRootRefLocked(ctx context.Context, ref *bucket.Obj
 	if err != nil {
 		return nil, err
 	}
-	defer nextRoot.Release()
 
 	store := nextRoot.GetBucket()
 	xfrm := nextRoot.GetTransformer()
 	_, bcs := nextRoot.BuildTransactionWithStore(nil, store)
+	stateStorage := world.NewWorldStorageFromCursorWithStore(nextRoot, store)
 	ws, err := NewWorldState(
 		ctx,
 		e.le,
@@ -364,11 +367,12 @@ func (e *Engine) worldStateForRootRefLocked(ctx context.Context, ref *bucket.Obj
 		store,
 		xfrm,
 		nil,
-		e,
+		stateStorage,
 		e.lookupOp,
 		e.verbose,
 	)
 	if err != nil {
+		world.RetireWorldStorage(stateStorage)
 		return nil, err
 	}
 	return ws, nil
@@ -403,20 +407,17 @@ func (e *Engine) NewBlockEngineTransaction(ctx context.Context, write bool) (*En
 				return nil, err
 			}
 		}
-		if e.writeCoordinator != nil {
-			world, err := e.buildWorldState(ctx, true)
-			if err != nil {
-				return nil, err
-			}
-			if e.readTx != nil {
-				e.readTx.Discard()
-				e.readTx = nil
-			}
-			engTx := newEngineTx(e, nil)
-			engTx.readTx = NewTx(world)
-			return engTx, nil
+		worldState, err := e.buildWorldState(ctx, true)
+		if err != nil {
+			return nil, err
 		}
-		return newEngineTx(e, nil), nil
+		if e.writeCoordinator != nil && e.readTx != nil {
+			e.readTx.Discard()
+			e.readTx = nil
+		}
+		engTx := newEngineTx(e, nil)
+		engTx.readTx = NewTx(worldState)
+		return engTx, nil
 	}
 
 	// Released in Discard or Commit
@@ -562,57 +563,70 @@ func (e *Engine) ForkBlockTransaction(ctx context.Context, write bool) (*Tx, err
 	return tx, nil
 }
 
-// BuildStorageCursor builds a cursor to the world storage with an empty ref.
+// BuildStorageCursor builds a raw cursor to the world storage with an empty ref.
 // The cursor should be released independently of the WorldState.
-// Be sure to call Release on the cursor when done.
 func (e *Engine) BuildStorageCursor(ctx context.Context) (*bucket_lookup.Cursor, error) {
 	e.rmtx.RLock()
-	defer e.rmtx.RUnlock()
 	if e.closed {
+		e.rmtx.RUnlock()
 		return nil, ErrEngineClosed
 	}
-	ncs := e.baseRoot.Clone()
-	ncs.SetRootRef(nil)
-	return ncs, nil
+	storage := e.storage
+	e.rmtx.RUnlock()
+	cursor, err := storage.BuildStorageCursor(ctx)
+	return cursor, e.mapStorageUnavailable(err)
 }
 
-// AccessWorldState builds a bucket lookup cursor with an optional ref.
-// If the ref Bucket ID is empty, uses the same bucket + volume as the world.
-// The lookup cursor will be released after cb returns.
-// The root clone is made while rmtx is held for the documented same-bucket
-// root path. Cursor.Clone does not retain a bucket-handle release owner, so
-// this does not establish a cross-bucket lifetime across Engine.Close.
-//
-// NOTE: this is the implementation of AccessWorldState for the world/block engine.
+// BuildOwnedLookupCursor builds an owned cursor at ref.
+func (e *Engine) BuildOwnedLookupCursor(ctx context.Context, ref *bucket.ObjectRef) (*world.OwnedLookupCursor, error) {
+	e.rmtx.RLock()
+	if e.closed {
+		e.rmtx.RUnlock()
+		return nil, ErrEngineClosed
+	}
+	if ref == nil {
+		ref = e.root.GetRefWithOpArgs()
+	} else {
+		ref = ref.Clone()
+	}
+	storage := e.storage
+	e.rmtx.RUnlock()
+	owned, err := storage.BuildOwnedLookupCursor(ctx, ref)
+	return owned, e.mapStorageUnavailable(err)
+}
+
+// AccessWorldState builds a borrowed access value with an optional ref.
 func (e *Engine) AccessWorldState(
 	ctx context.Context,
 	ref *bucket.ObjectRef,
-	cb func(*bucket_lookup.Cursor) error,
+	cb func(*world.WorldAccess) error,
 ) error {
 	e.rmtx.RLock()
 	if e.closed {
 		e.rmtx.RUnlock()
 		return ErrEngineClosed
 	}
-	ncs := e.root.Clone()
-	e.rmtx.RUnlock()
-	defer ncs.Release()
-
 	if ref == nil {
-		return cb(ncs)
+		ref = e.root.GetRefWithOpArgs()
+	} else {
+		ref = ref.Clone()
 	}
+	storage := e.storage
+	e.rmtx.RUnlock()
+	return e.mapStorageUnavailable(storage.AccessWorldState(ctx, ref, cb))
+}
 
-	subCtx, subCtxCancel := context.WithCancel(ctx)
-	defer subCtxCancel()
-
-	// follow the root block ref outside the engine lock
-	followed, err := ncs.FollowRef(subCtx, ref)
-	if err != nil {
+func (e *Engine) mapStorageUnavailable(err error) error {
+	if !errors.Is(err, world.ErrWorldStorageUnavailable) {
 		return err
 	}
-	defer followed.Release()
-
-	return cb(followed)
+	e.rmtx.RLock()
+	closed := e.closed
+	e.rmtx.RUnlock()
+	if closed {
+		return ErrEngineClosed
+	}
+	return err
 }
 
 // GetSeqno returns the current seqno of the world state.
@@ -726,10 +740,11 @@ func (e *Engine) Close() error {
 		e.root.Release()
 		e.root = nil
 	}
-	if e.baseRoot != nil {
-		e.baseRoot.Release()
-		e.baseRoot = nil
+	if e.storage != nil {
+		world.RetireWorldStorage(e.storage)
+		e.storage = nil
 	}
+	e.baseRoot = nil
 	e.rmtx.Unlock()
 	return nil
 }
@@ -774,26 +789,30 @@ func (e *Engine) buildWorldState(ctx context.Context, readOnly bool) (*WorldStat
 	defer task.End()
 
 	_, subtask := trace.NewTask(ctx, "hydra/world-block/engine/build-world-state/get-bucket")
-	// Both read and write transactions read and write through writeBlockStore so
-	// that, in the single-writer deferred path, reads see blocks that are
-	// committed in memory but not yet drained to durable storage (read your
-	// writes before Sync). It is the bucket store directly in coordinator and
-	// self-buffered modes.
+	// Both read and write transactions read through writeBlockStore so
+	// deferred writes remain visible before Sync.
 	store := e.writeBlockStore
 	worldStore := store
 	if !readOnly && e.writeCoordinator != nil {
 		worldStore = nil
 	}
 	subtask.End()
+	rootRef := e.root.GetRefWithOpArgs()
+	owned, err := e.storage.BuildOwnedLookupCursor(ctx, rootRef)
+	if err != nil {
+		return nil, err
+	}
+	raw := owned.Cursor()
 	_, subtask = trace.NewTask(ctx, "hydra/world-block/engine/build-world-state/get-transformer")
-	xfrm := e.root.GetTransformer()
+	xfrm := raw.GetTransformer()
 	subtask.End()
 	_, subtask = trace.NewTask(ctx, "hydra/world-block/engine/build-world-state/build-transaction")
-	btx, bcs := e.root.BuildTransactionWithStore(nil, store)
+	btx, bcs := raw.BuildTransactionWithStore(nil, store)
 	subtask.End()
 	if readOnly {
 		btx = nil
 	}
+	stateStorage := world.NewWorldStorageFromOwnedLookupCursor(owned, worldStore)
 	taskCtx, subtask := trace.NewTask(ctx, "hydra/world-block/engine/build-world-state/new-world-state")
 	ws, err := NewWorldState(
 		taskCtx,
@@ -803,12 +822,13 @@ func (e *Engine) buildWorldState(ctx context.Context, readOnly bool) (*WorldStat
 		worldStore,
 		xfrm,
 		nil,
-		e,
+		stateStorage,
 		e.lookupOp,
 		e.verbose,
 	)
 	subtask.End()
 	if err != nil {
+		world.RetireWorldStorage(stateStorage)
 		return nil, err
 	}
 	return ws, nil

--- a/db/world/block/engine/engine_test.go
+++ b/db/world/block/engine/engine_test.go
@@ -125,7 +125,8 @@ func TestWorldEngineController(t *testing.T) {
 	}
 	le.Info("world engine test suite passed")
 
-	err = eng.AccessWorldState(ctx, nil, func(bls *bucket_lookup.Cursor) error {
+	err = eng.AccessWorldState(ctx, nil, func(bls *world.WorldAccess) error {
+
 		_, bcs := bls.BuildTransaction(nil)
 		wi, err := bcs.Unmarshal(ctx, world_block.NewWorldBlock)
 		if err != nil {
@@ -589,7 +590,8 @@ func TestWorldEngineController_DisableChangelog(t *testing.T) {
 	}
 	le.Info("world engine test suite passed")
 
-	err = eng.AccessWorldState(ctx, nil, func(bls *bucket_lookup.Cursor) error {
+	err = eng.AccessWorldState(ctx, nil, func(bls *world.WorldAccess) error {
+
 		_, bcs := bls.BuildTransaction(nil)
 		wi, err := bcs.Unmarshal(ctx, world_block.NewWorldBlock)
 		if err != nil {
@@ -756,8 +758,8 @@ func TestWorldEngineWatchReload(t *testing.T) {
 		}
 		defer worldEngRef.Release()
 
-		return worldEng.AccessWorldState(ctx, nil, func(rootBls *bucket_lookup.Cursor) error {
-			worldObjRefFirstWrite = rootBls.GetRef()
+		return worldEng.AccessWorldState(ctx, nil, func(rootBls *world.WorldAccess) error {
+			worldObjRefFirstWrite = rootBls.Cursor().GetRef()
 			return nil
 		})
 	}(); err != nil {

--- a/db/world/block/mock.go
+++ b/db/world/block/mock.go
@@ -33,8 +33,8 @@ func BuildMockObject(ctx context.Context, ws world.WorldState, objKey string) (w
 		objKey = "test-obj-1"
 	}
 	var oref *bucket.ObjectRef
-	err := ws.AccessWorldState(ctx, nil, func(bls *bucket_lookup.Cursor) error {
-		oref = bls.GetRef() // note: clones the ref
+	err := ws.AccessWorldState(ctx, nil, func(bls *world.WorldAccess) error {
+		oref = bls.Cursor().GetRef() // note: clones the ref
 		obtx, obcs := bls.BuildTransactionAtRef(nil, nil)
 		exb := &block_mock.Example{Msg: "Hello from " + objKey}
 		obcs.SetBlock(exb, true)

--- a/db/world/block/object-state.go
+++ b/db/world/block/object-state.go
@@ -6,7 +6,6 @@ import (
 	"github.com/s4wave/spacewave/db/block"
 	block_gc "github.com/s4wave/spacewave/db/block/gc"
 	"github.com/s4wave/spacewave/db/bucket"
-	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
 	trace "github.com/s4wave/spacewave/db/traceutil"
 	"github.com/s4wave/spacewave/db/world"
 	"github.com/s4wave/spacewave/net/peer"
@@ -47,20 +46,35 @@ func (o *ObjectState) GetRootRef(ctx context.Context) (*bucket.ObjectRef, uint64
 	return root.GetRootRef(), root.GetRev(), nil
 }
 
-// AccessWorldState builds a bucket lookup cursor with an optional ref.
-// If the ref is empty, will default to the object RootRef.
-// If the ref Bucket ID is empty, uses the same bucket + volume as the world.
-// The lookup cursor will be released after cb returns.
+// BuildOwnedLookupCursor builds an owned cursor at ref.
+func (o *ObjectState) BuildOwnedLookupCursor(ctx context.Context, ref *bucket.ObjectRef) (*world.OwnedLookupCursor, error) {
+	if ref.GetEmpty() {
+		var err error
+		ref, _, err = o.GetRootRef(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if ref == nil {
+			ref = &bucket.ObjectRef{}
+		}
+	}
+	return o.w.BuildOwnedLookupCursor(ctx, ref)
+}
+
+// AccessWorldState builds a borrowed access value with an optional ref.
 func (o *ObjectState) AccessWorldState(
 	ctx context.Context,
 	ref *bucket.ObjectRef,
-	cb func(*bucket_lookup.Cursor) error,
+	cb func(*world.WorldAccess) error,
 ) error {
 	var err error
 	if ref.GetEmpty() {
 		ref, _, err = o.GetRootRef(ctx)
 		if err != nil {
 			return err
+		}
+		if ref == nil {
+			ref = &bucket.ObjectRef{}
 		}
 	}
 	return o.w.AccessWorldState(ctx, ref, cb)

--- a/db/world/block/tx-object-state.go
+++ b/db/world/block/tx-object-state.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/s4wave/spacewave/db/bucket"
-	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
 	"github.com/s4wave/spacewave/db/tx"
 	"github.com/s4wave/spacewave/db/world"
 	"github.com/s4wave/spacewave/net/peer"
@@ -46,14 +45,16 @@ func (t *TxObjectState) GetRootRef(ctx context.Context) (*bucket.ObjectRef, uint
 	return t.o.GetRootRef(ctx)
 }
 
-// AccessWorldState builds a bucket lookup cursor with an optional ref.
-// If the ref is empty, will default to the object RootRef.
-// If the ref Bucket ID is empty, uses the same bucket + volume as the world.
-// The lookup cursor will be released after cb returns.
+// BuildOwnedLookupCursor builds an owned cursor at ref.
+func (t *TxObjectState) BuildOwnedLookupCursor(ctx context.Context, ref *bucket.ObjectRef) (*world.OwnedLookupCursor, error) {
+	return t.o.BuildOwnedLookupCursor(ctx, ref)
+}
+
+// AccessWorldState builds a borrowed access value with an optional ref.
 func (t *TxObjectState) AccessWorldState(
 	ctx context.Context,
 	ref *bucket.ObjectRef,
-	cb func(*bucket_lookup.Cursor) error,
+	cb func(*world.WorldAccess) error,
 ) error {
 	return t.o.AccessWorldState(ctx, ref, cb)
 }

--- a/db/world/block/tx.go
+++ b/db/world/block/tx.go
@@ -111,13 +111,16 @@ func (t *Tx) BuildStorageCursor(ctx context.Context) (*bucket_lookup.Cursor, err
 	return t.state.BuildStorageCursor(ctx)
 }
 
-// AccessWorldState builds a bucket lookup cursor with an optional ref.
-// If the ref is empty, returns empty cursor in the same bucket + volume as the world.
-// The lookup cursor will be released after cb returns.
+// BuildOwnedLookupCursor builds an owned cursor at ref.
+func (t *Tx) BuildOwnedLookupCursor(ctx context.Context, ref *bucket.ObjectRef) (*world.OwnedLookupCursor, error) {
+	return t.state.BuildOwnedLookupCursor(ctx, ref)
+}
+
+// AccessWorldState builds a borrowed access value with an optional ref.
 func (t *Tx) AccessWorldState(
 	ctx context.Context,
 	ref *bucket.ObjectRef,
-	cb func(*bucket_lookup.Cursor) error,
+	cb func(*world.WorldAccess) error,
 ) error {
 	return t.state.AccessWorldState(ctx, ref, cb)
 }

--- a/db/world/block/tx/object-state.go
+++ b/db/world/block/tx/object-state.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/s4wave/spacewave/db/bucket"
-	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
 	"github.com/s4wave/spacewave/db/tx"
 	"github.com/s4wave/spacewave/db/world"
 	"github.com/s4wave/spacewave/net/peer"
@@ -49,9 +48,14 @@ func (t *ObjectState) GetRootRef(ctx context.Context) (*bucket.ObjectRef, uint64
 func (t *ObjectState) AccessWorldState(
 	ctx context.Context,
 	ref *bucket.ObjectRef,
-	cb func(*bucket_lookup.Cursor) error,
+	cb func(*world.WorldAccess) error,
 ) error {
 	return t.o.AccessWorldState(ctx, ref, cb)
+}
+
+// BuildOwnedLookupCursor builds an owned cursor at ref.
+func (t *ObjectState) BuildOwnedLookupCursor(ctx context.Context, ref *bucket.ObjectRef) (*world.OwnedLookupCursor, error) {
+	return t.o.BuildOwnedLookupCursor(ctx, ref)
 }
 
 // SetRootRef changes the root reference of the object.

--- a/db/world/block/tx/world-state.go
+++ b/db/world/block/tx/world-state.go
@@ -120,13 +120,18 @@ func (w *WorldState) BuildStorageCursor(ctx context.Context) (*bucket_lookup.Cur
 	return w.world.BuildStorageCursor(ctx)
 }
 
+// BuildOwnedLookupCursor builds an owned cursor at ref.
+func (w *WorldState) BuildOwnedLookupCursor(ctx context.Context, ref *bucket.ObjectRef) (*world.OwnedLookupCursor, error) {
+	return w.world.BuildOwnedLookupCursor(ctx, ref)
+}
+
 // AccessWorldState builds a bucket lookup cursor with an optional ref.
 // If the ref is empty, returns empty cursor in the same bucket + volume as the world.
 // The lookup cursor will be released after cb returns.
 func (w *WorldState) AccessWorldState(
 	ctx context.Context,
 	ref *bucket.ObjectRef,
-	cb func(*bucket_lookup.Cursor) error,
+	cb func(*world.WorldAccess) error,
 ) error {
 	return w.world.AccessWorldState(ctx, ref, cb)
 }

--- a/db/world/block/world.go
+++ b/db/world/block/world.go
@@ -243,10 +243,11 @@ func (t *WorldState) WaitSeqno(ctx context.Context, value uint64) (uint64, error
 	}
 }
 
-// BuildStorageCursor builds a cursor to the world storage with an empty ref.
-// The cursor should be released independently of the WorldState.
-// Be sure to call Release on the cursor when done.
+// BuildStorageCursor builds a raw cursor to the world storage with an empty ref.
 func (t *WorldState) BuildStorageCursor(ctx context.Context) (*bucket_lookup.Cursor, error) {
+	if t.discarded.Load() {
+		return nil, tx.ErrDiscarded
+	}
 	storage := t.storage
 	if storage == nil {
 		return nil, world.ErrWorldStorageUnavailable
@@ -254,14 +255,27 @@ func (t *WorldState) BuildStorageCursor(ctx context.Context) (*bucket_lookup.Cur
 	return storage.BuildStorageCursor(ctx)
 }
 
-// AccessWorldState builds a bucket lookup cursor with an optional ref.
-// If the ref is empty, returns empty cursor in the same bucket + volume as the world.
-// The lookup cursor will be released after cb returns.
+// BuildOwnedLookupCursor builds an owned cursor at ref.
+func (t *WorldState) BuildOwnedLookupCursor(ctx context.Context, ref *bucket.ObjectRef) (*world.OwnedLookupCursor, error) {
+	if t.discarded.Load() {
+		return nil, tx.ErrDiscarded
+	}
+	storage := t.storage
+	if storage == nil {
+		return nil, world.ErrWorldStorageUnavailable
+	}
+	return storage.BuildOwnedLookupCursor(ctx, ref)
+}
+
+// AccessWorldState builds a borrowed access value with an optional ref.
 func (t *WorldState) AccessWorldState(
 	ctx context.Context,
 	ref *bucket.ObjectRef,
-	cb func(*bucket_lookup.Cursor) error,
+	cb func(*world.WorldAccess) error,
 ) error {
+	if t.discarded.Load() {
+		return tx.ErrDiscarded
+	}
 	storage := t.storage
 	if storage == nil {
 		return world.ErrWorldStorageUnavailable
@@ -311,6 +325,11 @@ func (t *WorldState) Fork(ctx context.Context) (world.WorldState, error) {
 	if t.discarded.Load() {
 		return nil, tx.ErrDiscarded
 	}
+	owned, err := t.storage.BuildOwnedLookupCursor(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	childStorage := world.NewWorldStorageFromOwnedLookupCursor(owned, t.store)
 
 	bcs := t.bcs.DetachTransaction()
 	blk, _ := bcs.GetBlock()
@@ -319,6 +338,7 @@ func (t *WorldState) Fork(ctx context.Context) (world.WorldState, error) {
 		var ok bool
 		blkv, ok = blk.(*World)
 		if !ok {
+			world.RetireWorldStorage(childStorage)
 			return nil, block.ErrUnexpectedType
 		}
 	}
@@ -338,11 +358,12 @@ func (t *WorldState) Fork(ctx context.Context) (world.WorldState, error) {
 		t.store,
 		t.xfrm,
 		t.onSwept,
-		t.storage,
+		childStorage,
 		t.lookupOp,
 		t.verbose,
 	)
 	if err != nil {
+		world.RetireWorldStorage(childStorage)
 		return nil, err
 	}
 	return ows, nil
@@ -516,6 +537,9 @@ func (t *WorldState) Discard() {
 	if t.readRelease != nil {
 		t.readRelease()
 		t.readRelease = nil
+	}
+	if t.storage != nil {
+		world.RetireWorldStorage(t.storage)
 	}
 	t.objectExistsMemo = nil
 	t.seqnoBcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {

--- a/db/world/block/world_test.go
+++ b/db/world/block/world_test.go
@@ -16,7 +16,6 @@ import (
 	block_gc "github.com/s4wave/spacewave/db/block/gc"
 	block_mock "github.com/s4wave/spacewave/db/block/mock"
 	"github.com/s4wave/spacewave/db/bucket"
-	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
 	kvtx_block "github.com/s4wave/spacewave/db/kvtx/block"
 	"github.com/s4wave/spacewave/db/testbed"
 	"github.com/s4wave/spacewave/db/tx"
@@ -1237,12 +1236,12 @@ func TestWorldEngine_UpdateRootRef(t *testing.T) {
 
 	// change back to the original state
 	err = eng.SetRootRef(ctx, state1)
-	// use the same read tx to get the current rev
+	// the already-open read transaction remains pinned to state2
 	if err == nil {
 		var rev uint64
 		_, rev, err = obj1.GetRootRef(ctx)
-		if err == nil && rev != rev2-1 {
-			err = errors.Errorf("expected rev %d - 1 = %d but got %d", rev2, rev2-1, rev)
+		if err == nil && rev != rev2 {
+			err = errors.Errorf("expected pinned rev %d but got %d", rev2, rev)
 		}
 	}
 	if err != nil {
@@ -1607,8 +1606,9 @@ func TestWorldState_GC_SetRootRef(t *testing.T) {
 	}
 
 	// Build a new root block and set it.
-	err = ws.AccessWorldState(ctx, nil, func(bls *bucket_lookup.Cursor) error {
-		oref := bls.GetRef()
+	err = ws.AccessWorldState(ctx, nil, func(bls *world.WorldAccess) error {
+
+		oref := bls.Cursor().GetRef()
 		obtx, obcs := bls.BuildTransactionAtRef(nil, nil)
 		obcs.SetBlock(&block_mock.Example{Msg: "updated root"}, true)
 		var err error
@@ -1691,8 +1691,8 @@ func TestWorldState_GC_SetRootRef_OrphanBlock(t *testing.T) {
 	}
 
 	// SetRootRef to a new block.
-	err = ws.AccessWorldState(ctx, nil, func(bls *bucket_lookup.Cursor) error {
-		nref := bls.GetRef()
+	err = ws.AccessWorldState(ctx, nil, func(bls *world.WorldAccess) error {
+		nref := bls.Cursor().GetRef()
 		obtx, obcs := bls.BuildTransactionAtRef(nil, nil)
 		obcs.SetBlock(&block_mock.Example{Msg: "new root block"}, true)
 		var err error

--- a/db/world/control/handler.go
+++ b/db/world/control/handler.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/s4wave/spacewave/db/block"
 	"github.com/s4wave/spacewave/db/bucket"
-	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
 	"github.com/s4wave/spacewave/db/world"
 	"github.com/sirupsen/logrus"
 )
@@ -31,7 +30,7 @@ func NewWaitForStateHandler(
 		if obj == nil {
 			return cb(ctx, ws, nil, nil, rev)
 		}
-		berr = ws.AccessWorldState(ctx, rootRef, func(bls *bucket_lookup.Cursor) error {
+		berr = ws.AccessWorldState(ctx, rootRef, func(bls *world.WorldAccess) error {
 			_, bcs := bls.BuildTransaction(nil)
 			var err error
 			waitForChanges, err = cb(ctx, ws, obj, bcs, rev)

--- a/db/world/engine-state-object.go
+++ b/db/world/engine-state-object.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/s4wave/spacewave/db/bucket"
-	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
 	"github.com/s4wave/spacewave/net/peer"
 )
 
@@ -39,14 +38,35 @@ func (e *engineWorldStateObject) GetRootRef(ctx context.Context) (*bucket.Object
 	return outRef, outRev, err
 }
 
-// AccessWorldState builds a bucket lookup cursor with an optional ref.
-// If the ref is empty, will default to the object RootRef.
-// If the ref Bucket ID is empty, uses the same bucket + volume as the world.
-// The lookup cursor will be released after cb returns.
+// BuildOwnedLookupCursor builds an owned cursor at ref.
+func (e *engineWorldStateObject) BuildOwnedLookupCursor(ctx context.Context, ref *bucket.ObjectRef) (*OwnedLookupCursor, error) {
+	var owned *OwnedLookupCursor
+	err := e.e.performOp(ctx, false, func(tx Tx) error {
+		if ref.GetEmpty() {
+			obj, err := MustGetObject(ctx, tx, e.key)
+			if err != nil {
+				return err
+			}
+			ref, _, err = obj.GetRootRef(ctx)
+			if err != nil {
+				return err
+			}
+			if ref == nil {
+				ref = &bucket.ObjectRef{}
+			}
+		}
+		var err error
+		owned, err = tx.BuildOwnedLookupCursor(ctx, ref)
+		return err
+	})
+	return owned, err
+}
+
+// AccessWorldState builds a borrowed access value with an optional ref.
 func (e *engineWorldStateObject) AccessWorldState(
 	ctx context.Context,
 	ref *bucket.ObjectRef,
-	cb func(*bucket_lookup.Cursor) error,
+	cb func(*WorldAccess) error,
 ) error {
 	return e.e.performOp(ctx, false, func(tx Tx) error {
 		if ref.GetEmpty() {
@@ -57,6 +77,9 @@ func (e *engineWorldStateObject) AccessWorldState(
 			rootRef, _, err := obj.GetRootRef(ctx)
 			if err != nil {
 				return err
+			}
+			if rootRef == nil {
+				rootRef = &bucket.ObjectRef{}
 			}
 			ref = rootRef
 		}

--- a/db/world/engine-state.go
+++ b/db/world/engine-state.go
@@ -49,20 +49,21 @@ func (e *engineWorldState) WaitSeqno(ctx context.Context, value uint64) (uint64,
 	return e.e.WaitSeqno(ctx, value)
 }
 
-// BuildStorageCursor builds a cursor to the world storage with an empty ref.
-// The cursor should be released independently of the WorldState.
-// Be sure to call Release on the cursor when done.
+// BuildStorageCursor builds a raw cursor to the world storage with an empty ref.
 func (e *engineWorldState) BuildStorageCursor(ctx context.Context) (*bucket_lookup.Cursor, error) {
 	return e.e.BuildStorageCursor(ctx)
 }
 
-// AccessWorldState builds a bucket lookup cursor with an optional ref.
-// If the ref is empty, returns empty cursor in the same bucket + volume as the world.
-// The lookup cursor will be released after cb returns.
+// BuildOwnedLookupCursor builds an owned cursor at ref.
+func (e *engineWorldState) BuildOwnedLookupCursor(ctx context.Context, ref *bucket.ObjectRef) (*OwnedLookupCursor, error) {
+	return e.e.BuildOwnedLookupCursor(ctx, ref)
+}
+
+// AccessWorldState builds a borrowed access value with an optional ref.
 func (e *engineWorldState) AccessWorldState(
 	ctx context.Context,
 	ref *bucket.ObjectRef,
-	cb func(*bucket_lookup.Cursor) error,
+	cb func(*WorldAccess) error,
 ) error {
 	return e.e.AccessWorldState(ctx, ref, cb)
 }

--- a/db/world/lookup-owner.go
+++ b/db/world/lookup-owner.go
@@ -1,0 +1,346 @@
+package world
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+
+	"github.com/aperturerobotics/util/refcount"
+	"github.com/s4wave/spacewave/db/block"
+	"github.com/s4wave/spacewave/db/bucket"
+	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
+)
+
+// WorldAccess is the borrowed access value passed to WorldStorage callbacks.
+// Its cursor and transaction pair are valid only for the callback duration.
+type WorldAccess struct {
+	cursor  *bucket_lookup.Cursor
+	storage *cursorWorldStorage
+	btx     *block.Transaction
+	bcs     *block.Cursor
+}
+
+// Cursor returns the borrowed lookup cursor.
+func (a *WorldAccess) Cursor() *bucket_lookup.Cursor {
+	if a == nil {
+		return nil
+	}
+	return a.cursor
+}
+
+// BuildTransaction builds the owner-selected block transaction and cursor.
+func (a *WorldAccess) BuildTransaction(putOpts *block.PutOpts) (*block.Transaction, *block.Cursor) {
+	raw := a.Cursor()
+	if raw == nil {
+		return nil, nil
+	}
+	if a.btx == nil {
+		a.btx, a.bcs = raw.BuildTransactionAtRefWithStore(
+			putOpts,
+			raw.GetRef().GetRootRef(),
+			a.storage.storeFor(raw),
+		)
+	}
+	return a.btx, a.bcs
+}
+
+// BuildTransactionAtRef builds an owner-selected block transaction at ref.
+func (a *WorldAccess) BuildTransactionAtRef(putOpts *block.PutOpts, ref *block.BlockRef) (*block.Transaction, *block.Cursor) {
+	raw := a.Cursor()
+	if raw == nil {
+		return nil, nil
+	}
+	rootRef := raw.GetRef().GetRootRef()
+	if (ref.GetEmpty() && rootRef.GetEmpty()) || (ref != nil && ref.EqualsRef(rootRef)) {
+		return a.BuildTransaction(putOpts)
+	}
+	return raw.BuildTransactionAtRefWithStore(putOpts, ref, a.storage.storeFor(raw))
+}
+
+type lookupAuthority struct {
+	refs *refcount.RefCount[*bucket_lookup.Cursor]
+}
+
+func newLookupAuthority(raw *bucket_lookup.Cursor) (*lookupAuthority, refcount.RefLike, error) {
+	return newLookupAuthorityWithRelease(raw, raw.Release)
+}
+
+func newLookupAuthorityWithRelease(
+	raw *bucket_lookup.Cursor,
+	release func(),
+) (*lookupAuthority, refcount.RefLike, error) {
+	refs := refcount.NewRefCount(
+		context.Background(),
+		false,
+		nil,
+		nil,
+		func(context.Context, func()) (*bucket_lookup.Cursor, func(), error) {
+			return raw, release, nil
+		},
+	)
+	_, lease, err := refs.Wait(context.Background())
+	if err != nil {
+		return nil, nil, err
+	}
+	return &lookupAuthority{refs: refs}, lease, nil
+}
+
+func (a *lookupAuthority) retain(ctx context.Context) (refcount.RefLike, error) {
+	if a == nil || a.refs == nil {
+		return nil, ErrWorldStorageUnavailable
+	}
+	_, lease, err := a.refs.Wait(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return lease, nil
+}
+
+// OwnedLookupCursor owns a lookup cursor beyond a borrowed access callback.
+type OwnedLookupCursor struct {
+	raw   *bucket_lookup.Cursor
+	auth  *lookupAuthority
+	lease refcount.RefLike
+	once  sync.Once
+}
+
+func newOwnedLookupCursor(
+	raw *bucket_lookup.Cursor,
+	auth *lookupAuthority,
+	lease refcount.RefLike,
+) *OwnedLookupCursor {
+	return &OwnedLookupCursor{raw: raw, auth: auth, lease: lease}
+}
+
+func (c *OwnedLookupCursor) clone() (*OwnedLookupCursor, error) {
+	if c == nil || c.raw == nil || c.auth == nil {
+		return nil, ErrWorldStorageUnavailable
+	}
+	lease, err := c.auth.retain(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	return newOwnedLookupCursor(c.raw.Clone(), c.auth, lease), nil
+}
+
+// Cursor returns the borrowed raw cursor.
+func (c *OwnedLookupCursor) Cursor() *bucket_lookup.Cursor {
+	if c == nil {
+		return nil
+	}
+	return c.raw
+}
+
+// FollowRef follows ref and returns an independently owned cursor.
+func (c *OwnedLookupCursor) FollowRef(ctx context.Context, ref *bucket.ObjectRef) (*OwnedLookupCursor, error) {
+	if c == nil || c.raw == nil || c.auth == nil {
+		return nil, ErrWorldStorageUnavailable
+	}
+	parentLease, err := c.auth.retain(ctx)
+	if err != nil {
+		return nil, err
+	}
+	followed, err := c.raw.FollowRef(ctx, ref)
+	if err != nil {
+		parentLease.Release()
+		return nil, err
+	}
+	auth, lease, err := newLookupAuthorityWithRelease(followed, func() {
+		followed.Release()
+		parentLease.Release()
+	})
+	if err != nil {
+		followed.Release()
+		parentLease.Release()
+		return nil, err
+	}
+	return newOwnedLookupCursor(followed.Clone(), auth, lease), nil
+}
+
+// Release releases the owned cursor. It is idempotent.
+func (c *OwnedLookupCursor) Release() {
+	if c == nil {
+		return
+	}
+	c.once.Do(func() {
+		if c.raw != nil {
+			c.raw.Release()
+		}
+		if c.lease != nil {
+			c.lease.Release()
+		}
+		c.raw = nil
+		c.auth = nil
+		c.lease = nil
+	})
+}
+
+type cursorWorldStorage struct {
+	buildCursorFn BuildCursorFn
+	base          *OwnedLookupCursor
+	store         block.StoreOps
+	bucketID      string
+	mtx           sync.Mutex
+	retired       atomic.Bool
+	retireOnce    sync.Once
+}
+
+func (s *cursorWorldStorage) storeFor(cursor *bucket_lookup.Cursor) block.StoreOps {
+	if cursor != nil && cursor.GetOpArgs().GetBucketId() == s.bucketID && s.store != nil {
+		return s.store
+	}
+	if cursor == nil {
+		return s.store
+	}
+	return cursor.GetBucket()
+}
+
+func (s *cursorWorldStorage) buildOwned(ctx context.Context, ref *bucket.ObjectRef) (*OwnedLookupCursor, error) {
+	if s == nil {
+		return nil, ErrWorldStorageUnavailable
+	}
+	s.mtx.Lock()
+	if s.retired.Load() {
+		s.mtx.Unlock()
+		return nil, ErrWorldStorageUnavailable
+	}
+	if s.base != nil {
+		owned, err := s.base.clone()
+		s.mtx.Unlock()
+		if err != nil {
+			return nil, err
+		}
+		if ref != nil && !owned.Cursor().GetRef().EqualsRef(ref) {
+			followed, err := owned.FollowRef(ctx, ref)
+			owned.Release()
+			if err != nil {
+				return nil, err
+			}
+			owned = followed
+		}
+		return owned, nil
+	}
+	buildCursorFn := s.buildCursorFn
+	s.mtx.Unlock()
+	if buildCursorFn == nil {
+		return nil, ErrWorldStorageUnavailable
+	}
+	raw, err := buildCursorFn(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if raw == nil {
+		return nil, ErrWorldStorageUnavailable
+	}
+	s.mtx.Lock()
+	if s.retired.Load() {
+		s.mtx.Unlock()
+		raw.Release()
+		return nil, ErrWorldStorageUnavailable
+	}
+	auth, lease, err := newLookupAuthority(raw)
+	s.mtx.Unlock()
+	if err != nil {
+		raw.Release()
+		return nil, err
+	}
+	owned := newOwnedLookupCursor(raw.Clone(), auth, lease)
+	if ref != nil && !owned.Cursor().GetRef().EqualsRef(ref) {
+		followed, err := owned.FollowRef(ctx, ref)
+		owned.Release()
+		if err != nil {
+			return nil, err
+		}
+		owned = followed
+	}
+	return owned, nil
+}
+
+func (s *cursorWorldStorage) buildRaw(ctx context.Context) (*bucket_lookup.Cursor, error) {
+	if s == nil {
+		return nil, ErrWorldStorageUnavailable
+	}
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+	if s.retired.Load() {
+		return nil, ErrWorldStorageUnavailable
+	}
+	if s.base != nil {
+		raw := s.base.Cursor().Clone()
+		raw.SetRootRef(nil)
+		return raw, nil
+	}
+	if s.buildCursorFn == nil {
+		return nil, ErrWorldStorageUnavailable
+	}
+	return s.buildCursorFn(ctx)
+}
+
+func (s *cursorWorldStorage) access(ctx context.Context, ref *bucket.ObjectRef, cb func(*WorldAccess) error) (err error) {
+	owned, err := s.buildOwned(ctx, ref)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		owned.Release()
+		if recovered := recover(); recovered != nil {
+			panic(recovered)
+		}
+	}()
+	return cb(&WorldAccess{
+		cursor:  owned.Cursor(),
+		storage: s,
+	})
+}
+
+func (s *cursorWorldStorage) retire() {
+	if s == nil {
+		return
+	}
+	s.retireOnce.Do(func() {
+		s.mtx.Lock()
+		s.retired.Store(true)
+		if s.base != nil {
+			s.base.Release()
+			s.base = nil
+		}
+		s.mtx.Unlock()
+	})
+}
+
+// NewWorldStorageFromOwnedLookupCursor transfers owned to a transaction-scoped storage owner.
+func NewWorldStorageFromOwnedLookupCursor(owned *OwnedLookupCursor, store block.StoreOps) WorldStorage {
+	if owned == nil {
+		return nil
+	}
+	return &cursorWorldStorage{
+		base:     owned,
+		store:    store,
+		bucketID: owned.Cursor().GetOpArgs().GetBucketId(),
+	}
+}
+
+// NewWorldStorageFromCursorWithStore transfers cursor to a storage owner.
+func NewWorldStorageFromCursorWithStore(cursor *bucket_lookup.Cursor, store block.StoreOps) WorldStorage {
+	if cursor == nil {
+		return nil
+	}
+	auth, lease, err := newLookupAuthority(cursor)
+	if err != nil {
+		cursor.Release()
+		return nil
+	}
+	owned := newOwnedLookupCursor(cursor.Clone(), auth, lease)
+	return &cursorWorldStorage{
+		base:     owned,
+		store:    store,
+		bucketID: cursor.GetOpArgs().GetBucketId(),
+	}
+}
+
+// RetireWorldStorage retires a storage owner and releases its owner lease.
+func RetireWorldStorage(storage WorldStorage) {
+	if owner, ok := storage.(*cursorWorldStorage); ok {
+		owner.retire()
+	}
+}

--- a/db/world/lookup-owner.go
+++ b/db/world/lookup-owner.go
@@ -267,7 +267,12 @@ func (s *cursorWorldStorage) buildRaw(ctx context.Context) (*bucket_lookup.Curso
 		return nil, ErrWorldStorageUnavailable
 	}
 	if s.base != nil {
-		raw := s.base.Cursor().Clone()
+		owned, err := s.base.Clone()
+		if err != nil {
+			s.mtx.Unlock()
+			return nil, err
+		}
+		raw := owned.Cursor().CloneWithRelease(owned.Release)
 		raw.SetRootRef(nil)
 		s.mtx.Unlock()
 		return raw, nil

--- a/db/world/lookup-owner.go
+++ b/db/world/lookup-owner.go
@@ -112,7 +112,8 @@ func newOwnedLookupCursor(
 	return &OwnedLookupCursor{raw: raw, auth: auth, lease: lease}
 }
 
-func (c *OwnedLookupCursor) clone() (*OwnedLookupCursor, error) {
+// Clone returns an independently owned cursor at the same reference.
+func (c *OwnedLookupCursor) Clone() (*OwnedLookupCursor, error) {
 	if c == nil || c.raw == nil || c.auth == nil {
 		return nil, ErrWorldStorageUnavailable
 	}
@@ -205,7 +206,7 @@ func (s *cursorWorldStorage) buildOwned(ctx context.Context, ref *bucket.ObjectR
 		return nil, ErrWorldStorageUnavailable
 	}
 	if s.base != nil {
-		owned, err := s.base.clone()
+		owned, err := s.base.Clone()
 		s.mtx.Unlock()
 		if err != nil {
 			return nil, err
@@ -261,19 +262,37 @@ func (s *cursorWorldStorage) buildRaw(ctx context.Context) (*bucket_lookup.Curso
 		return nil, ErrWorldStorageUnavailable
 	}
 	s.mtx.Lock()
-	defer s.mtx.Unlock()
 	if s.retired.Load() {
+		s.mtx.Unlock()
 		return nil, ErrWorldStorageUnavailable
 	}
 	if s.base != nil {
 		raw := s.base.Cursor().Clone()
 		raw.SetRootRef(nil)
+		s.mtx.Unlock()
 		return raw, nil
 	}
-	if s.buildCursorFn == nil {
+	buildCursorFn := s.buildCursorFn
+	s.mtx.Unlock()
+	if buildCursorFn == nil {
 		return nil, ErrWorldStorageUnavailable
 	}
-	return s.buildCursorFn(ctx)
+	raw, err := buildCursorFn(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if raw == nil {
+		return nil, ErrWorldStorageUnavailable
+	}
+	s.mtx.Lock()
+	retired := s.retired.Load()
+	s.mtx.Unlock()
+	if retired {
+		raw.Release()
+		return nil, ErrWorldStorageUnavailable
+	}
+	raw.SetRootRef(nil)
+	return raw, nil
 }
 
 func (s *cursorWorldStorage) access(ctx context.Context, ref *bucket.ObjectRef, cb func(*WorldAccess) error) (err error) {

--- a/db/world/lookup-owner_test.go
+++ b/db/world/lookup-owner_test.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/s4wave/spacewave/db/block"
 	block_mock "github.com/s4wave/spacewave/db/block/mock"
@@ -266,7 +267,7 @@ func TestWorldStorageBorrowedAccessFinalizesEveryExit(t *testing.T) {
 	}
 }
 
-func TestWorldStorageBuilderRetireRejectsInFlightCursor(t *testing.T) {
+func TestWorldStorageOwnedBuilderRetireRejectsInFlightCursor(t *testing.T) {
 	ctx := context.Background()
 	bkt := bucket_mock.NewMockBucket("source", nil)
 	started := make(chan struct{})
@@ -291,6 +292,48 @@ func TestWorldStorageBuilderRetireRejectsInFlightCursor(t *testing.T) {
 	close(unblock)
 	if err := <-result; !errors.Is(err, ErrWorldStorageUnavailable) {
 		t.Fatalf("build completing after retire = %v, want %v", err, ErrWorldStorageUnavailable)
+	}
+	if releases.Load() != 1 {
+		t.Fatalf("release count = %d, want 1", releases.Load())
+	}
+}
+
+func TestWorldStorageRawBuilderDoesNotBlockRetire(t *testing.T) {
+	ctx := context.Background()
+	bkt := bucket_mock.NewMockBucket("source", nil)
+	started := make(chan struct{})
+	unblock := make(chan struct{})
+	var releases atomic.Int32
+	storage := NewCursorWorldStorage(func(context.Context) (*bucket_lookup.Cursor, error) {
+		close(started)
+		<-unblock
+		return newLookupOwnerTestCursor(bkt, "source", func() { releases.Add(1) }), nil
+	}).(*cursorWorldStorage)
+
+	result := make(chan error, 1)
+	go func() {
+		raw, err := storage.BuildStorageCursor(ctx)
+		if raw != nil {
+			raw.Release()
+		}
+		result <- err
+	}()
+	<-started
+	retired := make(chan struct{})
+	go func() {
+		storage.retire()
+		close(retired)
+	}()
+	select {
+	case <-retired:
+	case <-time.After(time.Second):
+		close(unblock)
+		<-retired
+		t.Fatal("raw cursor builder blocked storage retirement")
+	}
+	close(unblock)
+	if err := <-result; !errors.Is(err, ErrWorldStorageUnavailable) {
+		t.Fatalf("raw build completing after retire = %v, want %v", err, ErrWorldStorageUnavailable)
 	}
 	if releases.Load() != 1 {
 		t.Fatalf("release count = %d, want 1", releases.Load())

--- a/db/world/lookup-owner_test.go
+++ b/db/world/lookup-owner_test.go
@@ -1,0 +1,336 @@
+package world
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/s4wave/spacewave/db/block"
+	block_mock "github.com/s4wave/spacewave/db/block/mock"
+	"github.com/s4wave/spacewave/db/bucket"
+	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
+	bucket_mock "github.com/s4wave/spacewave/db/bucket/mock"
+)
+
+func newLookupOwnerTestCursor(bkt bucket.BucketOps, bucketID string, released func()) *bucket_lookup.Cursor {
+	return bucket_lookup.NewCursorWithRelease(
+		context.Background(),
+		nil,
+		nil,
+		nil,
+		bkt,
+		nil,
+		&bucket.ObjectRef{BucketId: bucketID},
+		&bucket.BucketOpArgs{BucketId: bucketID},
+		nil,
+		released,
+	)
+}
+
+func writeLookupOwnerTestBlock(t *testing.T, ctx context.Context, access *WorldAccess, msg string) *block.BlockRef {
+	t.Helper()
+	btx, bcs := access.BuildTransaction(nil)
+	bcs.SetBlock(&block_mock.Example{Msg: msg}, true)
+	ref, _, err := btx.Write(ctx, true)
+	if err != nil {
+		t.Fatalf("write block: %v", err)
+	}
+	return ref
+}
+
+func TestWorldStorageOwnerRoutesSelectedStores(t *testing.T) {
+	ctx := context.Background()
+	source := bucket_mock.NewMockBucket("source", nil)
+	destination := bucket_mock.NewMockBucket("destination", nil)
+	sourceOverlay := block.NewBufferedStore(ctx, source)
+	base := newLookupOwnerTestCursor(source, "source", nil)
+	storage := NewWorldStorageFromCursorWithStore(base, sourceOverlay).(*cursorWorldStorage)
+	defer storage.retire()
+
+	if err := storage.AccessWorldState(ctx, nil, func(access *WorldAccess) error {
+		pendingRef := writeLookupOwnerTestBlock(t, ctx, access, "pending")
+		if _, found, err := source.GetBlock(ctx, pendingRef); err != nil || found {
+			t.Fatalf("raw source lookup before Sync = (%v, %v), want not found", found, err)
+		}
+		if _, found, err := sourceOverlay.GetBlock(ctx, pendingRef); err != nil || !found {
+			t.Fatalf("source overlay lookup = (%v, %v), want found", found, err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("same-bucket access: %v", err)
+	}
+
+	rawRef, _, err := source.PutBlock(ctx, []byte("raw fallthrough"), nil)
+	if err != nil {
+		t.Fatalf("raw put: %v", err)
+	}
+	if err := storage.AccessWorldState(ctx, nil, func(access *WorldAccess) error {
+		_, bcs := access.BuildTransactionAtRef(nil, rawRef)
+		data, found, err := bcs.Fetch(ctx)
+		if err != nil || !found || string(data) != "raw fallthrough" {
+			t.Fatalf("overlay fallthrough = (%q, %v, %v)", data, found, err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("raw fallthrough access: %v", err)
+	}
+
+	destinationCursor := newLookupOwnerTestCursor(destination, "destination", nil)
+	crossAccess := &WorldAccess{cursor: destinationCursor, storage: storage}
+	crossRef := writeLookupOwnerTestBlock(t, ctx, crossAccess, "destination")
+	if _, found, err := destination.GetBlock(ctx, crossRef); err != nil || !found {
+		t.Fatalf("destination lookup = (%v, %v), want found", found, err)
+	}
+	if _, found, err := sourceOverlay.GetBlock(ctx, crossRef); err != nil || found {
+		t.Fatalf("source overlay cross-bucket lookup = (%v, %v), want not found", found, err)
+	}
+
+	explicitSameCursor := newLookupOwnerTestCursor(destination, "source", nil)
+	explicitSameAccess := &WorldAccess{cursor: explicitSameCursor, storage: storage}
+	explicitSameRef := writeLookupOwnerTestBlock(t, ctx, explicitSameAccess, "explicit same bucket")
+	if _, found, err := sourceOverlay.GetBlock(ctx, explicitSameRef); err != nil || !found {
+		t.Fatalf("explicit same-bucket overlay lookup = (%v, %v), want found", found, err)
+	}
+	if _, found, err := destination.GetBlock(ctx, explicitSameRef); err != nil || found {
+		t.Fatalf("explicit same-bucket destination lookup = (%v, %v), want not found", found, err)
+	}
+}
+
+func TestWorldStorageBuilderOwnedCursorFollowsRequestedRef(t *testing.T) {
+	ctx := context.Background()
+	bkt := bucket_mock.NewMockBucket("source", nil)
+	rootRef, _, err := bkt.PutBlock(ctx, []byte("requested root"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := newLookupOwnerTestCursor(bkt, "source", nil)
+	storage := NewCursorWorldStorage(func(context.Context) (*bucket_lookup.Cursor, error) {
+		return base.Clone(), nil
+	})
+	defer RetireWorldStorage(storage)
+
+	requested := &bucket.ObjectRef{BucketId: "source", RootRef: rootRef}
+	owned, err := storage.BuildOwnedLookupCursor(ctx, requested)
+	if err != nil {
+		t.Fatalf("build requested cursor: %v", err)
+	}
+	defer owned.Release()
+	if !owned.Cursor().GetRef().EqualsRef(requested) {
+		t.Fatalf("owned cursor ref = %v, want %v", owned.Cursor().GetRef(), requested)
+	}
+}
+
+func TestOwnedLookupCursorChildOutlivesParentAndStorage(t *testing.T) {
+	ctx := context.Background()
+	bkt := bucket_mock.NewMockBucket("source", nil)
+	var releases atomic.Int32
+	base := newLookupOwnerTestCursor(bkt, "source", func() { releases.Add(1) })
+	storage := NewWorldStorageFromCursorWithStore(base, bkt).(*cursorWorldStorage)
+
+	parent, err := storage.BuildOwnedLookupCursor(ctx, nil)
+	if err != nil {
+		t.Fatalf("build parent: %v", err)
+	}
+	child, err := parent.FollowRef(ctx, &bucket.ObjectRef{BucketId: "source"})
+	if err != nil {
+		t.Fatalf("follow child: %v", err)
+	}
+	storage.retire()
+	parent.Release()
+	parent.Release()
+	if releases.Load() != 0 {
+		t.Fatalf("release count with child alive = %d, want 0", releases.Load())
+	}
+	if child.Cursor() == nil || child.Cursor().GetOpArgs().GetBucketId() != "source" {
+		t.Fatal("child cursor did not remain usable")
+	}
+	child.Release()
+	child.Release()
+	if releases.Load() != 1 {
+		t.Fatalf("final release count = %d, want 1", releases.Load())
+	}
+	if _, err := storage.BuildOwnedLookupCursor(ctx, nil); !errors.Is(err, ErrWorldStorageUnavailable) {
+		t.Fatalf("build after retirement = %v, want %v", err, ErrWorldStorageUnavailable)
+	}
+}
+
+func TestOwnedLookupCursorCloneRetainsAuthorityChain(t *testing.T) {
+	bkt := bucket_mock.NewMockBucket("source", nil)
+	var sourceReleases atomic.Int32
+	source := newLookupOwnerTestCursor(bkt, "source", func() { sourceReleases.Add(1) })
+	_, sourceLease, err := newLookupAuthority(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var destinationReleases atomic.Int32
+	destination := newLookupOwnerTestCursor(bkt, "destination", func() { destinationReleases.Add(1) })
+	destinationAuth, destinationLease, err := newLookupAuthorityWithRelease(destination, func() {
+		destination.Release()
+		sourceLease.Release()
+	})
+	if err != nil {
+		sourceLease.Release()
+		t.Fatal(err)
+	}
+	base := newOwnedLookupCursor(destination.Clone(), destinationAuth, destinationLease)
+	storage := NewWorldStorageFromOwnedLookupCursor(base, bkt).(*cursorWorldStorage)
+	child, err := storage.BuildOwnedLookupCursor(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	storage.retire()
+	if got := destinationReleases.Load(); got != 0 {
+		t.Fatalf("destination release count with child alive = %d, want 0", got)
+	}
+	if got := sourceReleases.Load(); got != 0 {
+		t.Fatalf("source release count with child alive = %d, want 0", got)
+	}
+	child.Release()
+	if got := destinationReleases.Load(); got != 1 {
+		t.Fatalf("destination release count = %d, want 1", got)
+	}
+	if got := sourceReleases.Load(); got != 1 {
+		t.Fatalf("source release count = %d, want 1", got)
+	}
+}
+
+func TestAccessObjectNilStartsFromEmptyRoot(t *testing.T) {
+	ctx := context.Background()
+	bkt := bucket_mock.NewMockBucket("source", nil)
+	existingRef, _, err := bkt.PutBlock(ctx, []byte("existing root"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := newLookupOwnerTestCursor(bkt, "source", nil)
+	base.SetRootRef(existingRef)
+	storage := NewWorldStorageFromCursorWithStore(base, bkt)
+	defer RetireWorldStorage(storage)
+
+	var callbackStartedEmpty bool
+	out, err := AccessObject(ctx, storage.AccessWorldState, nil, func(bcs *block.Cursor) error {
+		callbackStartedEmpty = bcs.GetRef().GetEmpty()
+		bcs.SetBlock(&block_mock.Example{Msg: "created"}, true)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !callbackStartedEmpty {
+		t.Fatal("AccessObject(nil) callback did not start from an empty root")
+	}
+	if out.GetRootRef().GetEmpty() || out.GetRootRef().EqualsRef(existingRef) {
+		t.Fatalf("created root = %v, want a new non-empty root", out)
+	}
+}
+
+func TestWorldStorageBorrowedAccessFinalizesEveryExit(t *testing.T) {
+	ctx := context.Background()
+	bkt := bucket_mock.NewMockBucket("source", nil)
+	var releases atomic.Int32
+	storage := NewWorldStorageFromCursorWithStore(
+		newLookupOwnerTestCursor(bkt, "source", func() { releases.Add(1) }),
+		bkt,
+	).(*cursorWorldStorage)
+
+	assertActive := func(label string) {
+		t.Helper()
+		if releases.Load() != 0 {
+			t.Fatalf("%s released authority while owner remains active", label)
+		}
+	}
+	if err := storage.AccessWorldState(ctx, nil, func(*WorldAccess) error { return nil }); err != nil {
+		t.Fatalf("successful access: %v", err)
+	}
+	assertActive("success")
+	wantErr := errors.New("callback failure")
+	if err := storage.AccessWorldState(ctx, nil, func(*WorldAccess) error { return wantErr }); !errors.Is(err, wantErr) {
+		t.Fatalf("callback error = %v, want %v", err, wantErr)
+	}
+	assertActive("error")
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Fatal("expected callback panic")
+			}
+		}()
+		_ = storage.AccessWorldState(ctx, nil, func(*WorldAccess) error { panic("callback panic") })
+	}()
+	assertActive("panic")
+	storage.retire()
+	if releases.Load() != 1 {
+		t.Fatalf("final release count = %d, want 1", releases.Load())
+	}
+}
+
+func TestWorldStorageBuilderRetireRejectsInFlightCursor(t *testing.T) {
+	ctx := context.Background()
+	bkt := bucket_mock.NewMockBucket("source", nil)
+	started := make(chan struct{})
+	unblock := make(chan struct{})
+	var releases atomic.Int32
+	storage := NewCursorWorldStorage(func(context.Context) (*bucket_lookup.Cursor, error) {
+		close(started)
+		<-unblock
+		return newLookupOwnerTestCursor(bkt, "source", func() { releases.Add(1) }), nil
+	}).(*cursorWorldStorage)
+
+	result := make(chan error, 1)
+	go func() {
+		owned, err := storage.BuildOwnedLookupCursor(ctx, nil)
+		if owned != nil {
+			owned.Release()
+		}
+		result <- err
+	}()
+	<-started
+	storage.retire()
+	close(unblock)
+	if err := <-result; !errors.Is(err, ErrWorldStorageUnavailable) {
+		t.Fatalf("build completing after retire = %v, want %v", err, ErrWorldStorageUnavailable)
+	}
+	if releases.Load() != 1 {
+		t.Fatalf("release count = %d, want 1", releases.Load())
+	}
+}
+
+func TestWorldStorageConcurrentAccessAndRetire(t *testing.T) {
+	ctx := context.Background()
+	bkt := bucket_mock.NewMockBucket("source", nil)
+	var releases atomic.Int32
+	storage := NewWorldStorageFromCursorWithStore(
+		newLookupOwnerTestCursor(bkt, "source", func() { releases.Add(1) }),
+		bkt,
+	).(*cursorWorldStorage)
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for range 32 {
+		wg.Go(func() {
+			<-start
+			owned, err := storage.BuildOwnedLookupCursor(ctx, nil)
+			if err != nil {
+				if !errors.Is(err, ErrWorldStorageUnavailable) {
+					t.Errorf("build during retire: %v", err)
+				}
+				return
+			}
+			if owned.Cursor() == nil {
+				t.Error("successful build returned nil cursor")
+			}
+			owned.Release()
+		})
+	}
+	close(start)
+	storage.retire()
+	wg.Wait()
+	if releases.Load() != 1 {
+		t.Fatalf("release count = %d, want 1", releases.Load())
+	}
+	if _, err := storage.BuildOwnedLookupCursor(ctx, nil); !errors.Is(err, ErrWorldStorageUnavailable) {
+		t.Fatalf("build after retire = %v, want %v", err, ErrWorldStorageUnavailable)
+	}
+}

--- a/db/world/lookup-owner_test.go
+++ b/db/world/lookup-owner_test.go
@@ -157,6 +157,32 @@ func TestOwnedLookupCursorChildOutlivesParentAndStorage(t *testing.T) {
 	}
 }
 
+func TestRawStorageCursorOutlivesStorage(t *testing.T) {
+	ctx := context.Background()
+	bkt := bucket_mock.NewMockBucket("source", nil)
+	var releases atomic.Int32
+	storage := NewWorldStorageFromCursorWithStore(
+		newLookupOwnerTestCursor(bkt, "source", func() { releases.Add(1) }),
+		bkt,
+	).(*cursorWorldStorage)
+
+	raw, err := storage.BuildStorageCursor(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	storage.retire()
+	if releases.Load() != 0 {
+		t.Fatalf("release count with raw cursor alive = %d, want 0", releases.Load())
+	}
+	if raw.GetRef().GetRootRef() != nil {
+		t.Fatalf("raw storage cursor root = %v, want empty", raw.GetRef().GetRootRef())
+	}
+	raw.Release()
+	if releases.Load() != 1 {
+		t.Fatalf("release count after raw cursor cleanup = %d, want 1", releases.Load())
+	}
+}
+
 func TestOwnedLookupCursorCloneRetainsAuthorityChain(t *testing.T) {
 	bkt := bucket_mock.NewMockBucket("source", nil)
 	var sourceReleases atomic.Int32

--- a/db/world/object-state.go
+++ b/db/world/object-state.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/s4wave/spacewave/db/bucket"
-	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
 	"github.com/s4wave/spacewave/net/peer"
 )
 
@@ -18,14 +17,16 @@ type ObjectState interface {
 	// Returns the revision number.
 	GetRootRef(ctx context.Context) (*bucket.ObjectRef, uint64, error)
 
-	// AccessWorldState builds a bucket lookup cursor with an optional ref.
-	// If the ref is empty, will default to the object RootRef.
-	// If the ref Bucket ID is empty, uses the same bucket + volume as the world.
-	// The lookup cursor will be released after cb returns.
+	// BuildOwnedLookupCursor builds an owned cursor at ref.
+	// If ref is empty, it defaults to the object root.
+	BuildOwnedLookupCursor(ctx context.Context, ref *bucket.ObjectRef) (*OwnedLookupCursor, error)
+
+	// AccessWorldState builds a borrowed access value at ref.
+	// If ref is empty, it defaults to the object root.
 	AccessWorldState(
 		ctx context.Context,
 		ref *bucket.ObjectRef,
-		cb func(*bucket_lookup.Cursor) error,
+		cb func(*WorldAccess) error,
 	) error
 
 	// SetRootRef changes the root reference of the object.

--- a/db/world/refcount-engine.go
+++ b/db/world/refcount-engine.go
@@ -84,19 +84,12 @@ func (e *RefCountEngine) Sync(ctx context.Context) (bool, error) {
 // The cursor should be released independently of the WorldState.
 // Be sure to call Release on the cursor when done.
 func (e *RefCountEngine) BuildStorageCursor(ctx context.Context) (*bucket_lookup.Cursor, error) {
-	var bls *bucket_lookup.Cursor
-	err := e.rc.Access(ctx, func(ctx context.Context, val *Engine) error {
-		var err error
-		bls, err = (*val).BuildStorageCursor(ctx)
-		return err
-	})
+	engine, lease, err := e.rc.Wait(ctx)
 	if err != nil {
-		if bls != nil {
-			bls.Release()
-		}
 		return nil, err
 	}
-	return bls, nil
+	defer lease.Release()
+	return (*engine).BuildStorageCursor(ctx)
 }
 
 // BuildOwnedLookupCursor builds an owned cursor at ref.

--- a/db/world/refcount-engine.go
+++ b/db/world/refcount-engine.go
@@ -101,13 +101,12 @@ func (e *RefCountEngine) BuildStorageCursor(ctx context.Context) (*bucket_lookup
 
 // BuildOwnedLookupCursor builds an owned cursor at ref.
 func (e *RefCountEngine) BuildOwnedLookupCursor(ctx context.Context, ref *bucket.ObjectRef) (*OwnedLookupCursor, error) {
-	var owned *OwnedLookupCursor
-	err := e.rc.Access(ctx, func(ctx context.Context, val *Engine) error {
-		var err error
-		owned, err = (*val).BuildOwnedLookupCursor(ctx, ref)
-		return err
-	})
-	return owned, err
+	engine, lease, err := e.rc.Wait(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer lease.Release()
+	return (*engine).BuildOwnedLookupCursor(ctx, ref)
 }
 
 // AccessWorldState builds a borrowed access value with an optional ref.
@@ -116,9 +115,12 @@ func (e *RefCountEngine) AccessWorldState(
 	ref *bucket.ObjectRef,
 	cb func(*WorldAccess) error,
 ) error {
-	return e.rc.Access(ctx, func(ctx context.Context, val *Engine) error {
-		return (*val).AccessWorldState(ctx, ref, cb)
-	})
+	engine, lease, err := e.rc.Wait(ctx)
+	if err != nil {
+		return err
+	}
+	defer lease.Release()
+	return (*engine).AccessWorldState(ctx, ref, cb)
 }
 
 // GetSeqno returns the current seqno of the world state.

--- a/db/world/refcount-engine.go
+++ b/db/world/refcount-engine.go
@@ -99,13 +99,22 @@ func (e *RefCountEngine) BuildStorageCursor(ctx context.Context) (*bucket_lookup
 	return bls, nil
 }
 
-// AccessWorldState builds a bucket lookup cursor with an optional ref.
-// If the ref Bucket ID is empty, uses the same bucket + volume as the world.
-// The lookup cursor will be released after cb returns.
+// BuildOwnedLookupCursor builds an owned cursor at ref.
+func (e *RefCountEngine) BuildOwnedLookupCursor(ctx context.Context, ref *bucket.ObjectRef) (*OwnedLookupCursor, error) {
+	var owned *OwnedLookupCursor
+	err := e.rc.Access(ctx, func(ctx context.Context, val *Engine) error {
+		var err error
+		owned, err = (*val).BuildOwnedLookupCursor(ctx, ref)
+		return err
+	})
+	return owned, err
+}
+
+// AccessWorldState builds a borrowed access value with an optional ref.
 func (e *RefCountEngine) AccessWorldState(
 	ctx context.Context,
 	ref *bucket.ObjectRef,
-	cb func(*bucket_lookup.Cursor) error,
+	cb func(*WorldAccess) error,
 ) error {
 	return e.rc.Access(ctx, func(ctx context.Context, val *Engine) error {
 		return (*val).AccessWorldState(ctx, ref, cb)

--- a/db/world/world-state.go
+++ b/db/world/world-state.go
@@ -19,23 +19,23 @@ import (
 type AccessWorldStateFunc = func(
 	ctx context.Context,
 	ref *bucket.ObjectRef,
-	cb func(*bucket_lookup.Cursor) error,
+	cb func(*WorldAccess) error,
 ) error
 
 // WorldStorage allows accessing the world storage via bucket lookup.
 type WorldStorage interface {
-	// BuildStorageCursor builds a cursor to the world storage with an empty ref.
+	// BuildStorageCursor builds a raw cursor to the world storage with an empty ref.
 	// The cursor should be released independently of the WorldState.
-	// Be sure to call Release on the cursor when done.
 	BuildStorageCursor(ctx context.Context) (*bucket_lookup.Cursor, error)
 
-	// AccessWorldState builds a bucket lookup cursor with an optional ref.
-	// If the ref is empty, returns a cursor pointing to the root world state.
-	// The lookup cursor will be released after cb returns.
+	// BuildOwnedLookupCursor builds an owned cursor at ref.
+	BuildOwnedLookupCursor(ctx context.Context, ref *bucket.ObjectRef) (*OwnedLookupCursor, error)
+
+	// AccessWorldState builds a borrowed access value with an optional ref.
 	AccessWorldState(
 		ctx context.Context,
 		ref *bucket.ObjectRef,
-		cb func(*bucket_lookup.Cursor) error,
+		cb func(*WorldAccess) error,
 	) error
 }
 
@@ -309,13 +309,12 @@ func AccessObject(
 	defer task.End()
 
 	var outRef *bucket.ObjectRef
-	err := access(ctx, ref, func(bls *bucket_lookup.Cursor) error {
+	err := access(ctx, ref, func(access *WorldAccess) error {
 		_, subtask := trace.NewTask(ctx, "hydra/world/access-object/build-transaction")
-		btx, bcs := bls.BuildTransaction(nil)
+		btx, bcs := access.BuildTransaction(nil)
 		subtask.End()
 		if ref.GetRootRef().GetEmpty() {
 			_, subtask = trace.NewTask(ctx, "hydra/world/access-object/init-empty-root")
-			// bcs.SetBlock(nil, false)
 			bcs.SetRefAtCursor(nil, true)
 			subtask.End()
 		}
@@ -326,7 +325,7 @@ func AccessObject(
 			return berr
 		}
 		_, subtask = trace.NewTask(ctx, "hydra/world/access-object/clone-out-ref")
-		outRef = bls.GetRefWithOpArgs()
+		outRef = access.Cursor().GetRefWithOpArgs()
 		subtask.End()
 		_, subtask = trace.NewTask(ctx, "hydra/world/access-object/write-transaction")
 		outRef.RootRef, _, berr = btx.Write(ctx, true)

--- a/db/world/world-state_test.go
+++ b/db/world/world-state_test.go
@@ -530,10 +530,14 @@ func (e *staleRetryEngine) BuildStorageCursor(ctx context.Context) (*bucket_look
 	panic("unexpected BuildStorageCursor call")
 }
 
+func (e *staleRetryEngine) BuildOwnedLookupCursor(ctx context.Context, ref *bucket.ObjectRef) (*world.OwnedLookupCursor, error) {
+	panic("unexpected BuildOwnedLookupCursor call")
+}
+
 func (e *staleRetryEngine) AccessWorldState(
 	ctx context.Context,
 	ref *bucket.ObjectRef,
-	cb func(*bucket_lookup.Cursor) error,
+	cb func(*world.WorldAccess) error,
 ) error {
 	panic("unexpected AccessWorldState call")
 }
@@ -564,10 +568,14 @@ func (txs *staleRetryTx) BuildStorageCursor(ctx context.Context) (*bucket_lookup
 	panic("unexpected BuildStorageCursor call")
 }
 
+func (txs *staleRetryTx) BuildOwnedLookupCursor(ctx context.Context, ref *bucket.ObjectRef) (*world.OwnedLookupCursor, error) {
+	panic("unexpected BuildOwnedLookupCursor call")
+}
+
 func (txs *staleRetryTx) AccessWorldState(
 	ctx context.Context,
 	ref *bucket.ObjectRef,
-	cb func(*bucket_lookup.Cursor) error,
+	cb func(*world.WorldAccess) error,
 ) error {
 	panic("unexpected AccessWorldState call")
 }
@@ -668,18 +676,22 @@ type staleRetryObject struct {
 	rootRef *bucket.ObjectRef
 }
 
+func (obj *staleRetryObject) GetRootRef(ctx context.Context) (*bucket.ObjectRef, uint64, error) {
+	return obj.rootRef, 1, nil
+}
+
 func (obj *staleRetryObject) GetKey() string {
 	return obj.key
 }
 
-func (obj *staleRetryObject) GetRootRef(ctx context.Context) (*bucket.ObjectRef, uint64, error) {
-	return obj.rootRef, 1, nil
+func (obj *staleRetryObject) BuildOwnedLookupCursor(ctx context.Context, ref *bucket.ObjectRef) (*world.OwnedLookupCursor, error) {
+	panic("unexpected BuildOwnedLookupCursor call")
 }
 
 func (obj *staleRetryObject) AccessWorldState(
 	ctx context.Context,
 	ref *bucket.ObjectRef,
-	cb func(*bucket_lookup.Cursor) error,
+	cb func(*world.WorldAccess) error,
 ) error {
 	panic("unexpected object AccessWorldState call")
 }

--- a/db/world/world-storage.go
+++ b/db/world/world-storage.go
@@ -7,69 +7,50 @@ import (
 	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
 )
 
-// cursorWorldStorage implements WorldStorage with a object cursor.
-type cursorWorldStorage struct {
-	// buildCursorFn builds a new root cursor.
-	buildCursorFn BuildCursorFn
-}
-
-// BuildCursorFn builds a object cursor.
+// BuildCursorFn builds an object cursor.
 type BuildCursorFn func(ctx context.Context) (*bucket_lookup.Cursor, error)
 
-// NewCursorWorldStorage constructs a WorldStorage from a object cursor.
+// NewCursorWorldStorage constructs a WorldStorage from an object cursor builder.
 func NewCursorWorldStorage(buildCursor BuildCursorFn) WorldStorage {
 	return &cursorWorldStorage{buildCursorFn: buildCursor}
 }
 
-// NewWorldStorageFromCursor builds a WorldStorage from an existing cursor.
+// NewWorldStorageFromCursor builds a WorldStorage from an existing borrowed cursor.
 func NewWorldStorageFromCursor(cursor *bucket_lookup.Cursor) WorldStorage {
 	return NewCursorWorldStorage(func(ctx context.Context) (*bucket_lookup.Cursor, error) {
+		if cursor == nil {
+			return nil, ErrWorldStorageUnavailable
+		}
 		return cursor.Clone(), nil
 	})
 }
 
-// NewAccessWorldStateFunc constructs an AccessWorldStateFunc from a existing cursor
+// NewAccessWorldStateFunc constructs an AccessWorldStateFunc from an existing cursor.
 func NewAccessWorldStateFunc(cursor *bucket_lookup.Cursor) AccessWorldStateFunc {
 	st := NewWorldStorageFromCursor(cursor)
 	return st.AccessWorldState
 }
 
-// BuildStorageCursor builds a cursor to the world storage with an empty ref.
-// The cursor should be released independently of the WorldState.
-// Be sure to call Release on the cursor when done.
+// BuildStorageCursor builds a raw cursor to the world storage with an empty ref.
 func (s *cursorWorldStorage) BuildStorageCursor(ctx context.Context) (*bucket_lookup.Cursor, error) {
-	if s.buildCursorFn == nil {
-		return nil, ErrWorldStorageUnavailable
-	}
-	return s.buildCursorFn(ctx)
+	return s.buildRaw(ctx)
 }
 
-// AccessWorldState builds a bucket lookup cursor with an optional ref.
-// If the ref is empty, returns a cursor pointing to the root world state.
-// The lookup cursor will be released after cb returns.
+// BuildOwnedLookupCursor builds an owned lookup cursor at ref.
+func (s *cursorWorldStorage) BuildOwnedLookupCursor(ctx context.Context, ref *bucket.ObjectRef) (*OwnedLookupCursor, error) {
+	return s.buildOwned(ctx, ref)
+}
+
+// AccessWorldState builds a borrowed access value with an optional ref.
 func (s *cursorWorldStorage) AccessWorldState(
 	ctx context.Context,
 	ref *bucket.ObjectRef,
-	cb func(*bucket_lookup.Cursor) error,
+	cb func(*WorldAccess) error,
 ) error {
-	cursor, err := s.buildCursorFn(ctx)
-	if err != nil {
-		return err
+	if cb == nil {
+		return nil
 	}
-	defer cursor.Release()
-
-	ncs := cursor
-	if !cursor.GetRef().EqualsRef(ref) {
-		var err error
-		ncs, err = cursor.FollowRef(ctx, ref)
-		if err != nil {
-			return err
-		}
-		defer ncs.Release()
-	}
-
-	return cb(ncs)
+	return s.access(ctx, ref, cb)
 }
 
-// _ is a type assertion
 var _ WorldStorage = ((*cursorWorldStorage)(nil))

--- a/forge/execution/controller/controller-exec-handle.go
+++ b/forge/execution/controller/controller-exec-handle.go
@@ -5,7 +5,6 @@ import (
 
 	timestamp "github.com/aperturerobotics/protobuf-go-lite/types/known/timestamppb"
 	"github.com/s4wave/spacewave/db/bucket"
-	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
 	"github.com/s4wave/spacewave/db/world"
 	forge_execution "github.com/s4wave/spacewave/forge/execution"
 	execution_transaction "github.com/s4wave/spacewave/forge/execution/tx"
@@ -64,7 +63,7 @@ func (h *execControllerHandle) GetTimestamp() *timestamp.Timestamp {
 func (h *execControllerHandle) AccessStorage(
 	ctx context.Context,
 	ref *bucket.ObjectRef,
-	cb func(*bucket_lookup.Cursor) error,
+	cb func(*world.WorldAccess) error,
 ) error {
 	select {
 	case <-h.ctx.Done():

--- a/forge/lib/docker/controller_test.go
+++ b/forge/lib/docker/controller_test.go
@@ -9,7 +9,7 @@ import (
 
 	timestamp "github.com/aperturerobotics/protobuf-go-lite/types/known/timestamppb"
 	"github.com/s4wave/spacewave/db/bucket"
-	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
+	"github.com/s4wave/spacewave/db/world"
 	forge_value "github.com/s4wave/spacewave/forge/value"
 	"github.com/s4wave/spacewave/net/peer"
 )
@@ -215,7 +215,7 @@ func (noopExecHandle) GetTimestamp() *timestamp.Timestamp {
 func (noopExecHandle) AccessStorage(
 	ctx context.Context,
 	ref *bucket.ObjectRef,
-	cb func(*bucket_lookup.Cursor) error,
+	cb func(*world.WorldAccess) error,
 ) error {
 	return nil
 }

--- a/forge/lib/git/commit/controller_test.go
+++ b/forge/lib/git/commit/controller_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/go-git/go-git/v6/plumbing"
 	"github.com/go-git/go-git/v6/plumbing/object"
 	"github.com/s4wave/spacewave/db/bucket"
-	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
 	git_world "github.com/s4wave/spacewave/db/git/world"
 	hydra_testbed "github.com/s4wave/spacewave/db/testbed"
 	unixfs_world "github.com/s4wave/spacewave/db/unixfs/world"
@@ -45,7 +44,7 @@ func (h *captureHandle) GetTimestamp() *timestamp.Timestamp {
 	return h.ts
 }
 
-func (h *captureHandle) AccessStorage(ctx context.Context, ref *bucket.ObjectRef, cb func(*bucket_lookup.Cursor) error) error {
+func (h *captureHandle) AccessStorage(ctx context.Context, ref *bucket.ObjectRef, cb func(*world.WorldAccess) error) error {
 	return h.accessFunc(ctx, ref, cb)
 }
 

--- a/forge/lib/kvtx/block-config-input.go
+++ b/forge/lib/kvtx/block-config-input.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/s4wave/spacewave/db/block"
-	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
+	"github.com/s4wave/spacewave/db/world"
 	forge_target "github.com/s4wave/spacewave/forge/target"
 	forge_value "github.com/s4wave/spacewave/forge/value"
 )
@@ -25,7 +25,8 @@ func FetchConfigInput(
 		return nil, err
 	}
 	var confInput *ConfigInput
-	err = handle.AccessStorage(ctx, objRef, func(bls *bucket_lookup.Cursor) error {
+	err = handle.AccessStorage(ctx, objRef, func(access *world.WorldAccess) error {
+		bls := access.Cursor()
 		_, bcs := bls.BuildTransaction(nil)
 		var berr error
 		confInput, berr = UnmarshalConfigInput(ctx, bcs)

--- a/forge/lib/kvtx/controller.go
+++ b/forge/lib/kvtx/controller.go
@@ -8,8 +8,8 @@ import (
 	"github.com/aperturerobotics/controllerbus/directive"
 	"github.com/s4wave/spacewave/db/block"
 	"github.com/s4wave/spacewave/db/bucket"
-	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
 	kvtx_block "github.com/s4wave/spacewave/db/kvtx/block"
+	"github.com/s4wave/spacewave/db/world"
 	forge_target "github.com/s4wave/spacewave/forge/target"
 	forge_value "github.com/s4wave/spacewave/forge/value"
 
@@ -127,7 +127,8 @@ func (c *Controller) Execute(ctx context.Context) error {
 	err = c.handle.AccessStorage(
 		ctx,
 		rootRef,
-		func(cs *bucket_lookup.Cursor) error {
+		func(access *world.WorldAccess) error {
+			cs := access.Cursor()
 			if rootRef.GetEmpty() {
 				c.le.
 					WithField("store-type", kvtx_block.DefaultKeyValueStoreImpl.String()).

--- a/forge/lib/kvtx/op-queue.go
+++ b/forge/lib/kvtx/op-queue.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
-	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
 	"github.com/s4wave/spacewave/db/kvtx"
+	"github.com/s4wave/spacewave/db/world"
 	forge_target "github.com/s4wave/spacewave/forge/target"
 	forge_value "github.com/s4wave/spacewave/forge/value"
 )
@@ -173,7 +173,8 @@ func (q *OpQueue) resolveKeyInput(op *Op) ([]byte, error) {
 			}
 			err = q.handle.AccessStorage(
 				q.ctx, bktRef,
-				func(bls *bucket_lookup.Cursor) error {
+				func(access *world.WorldAccess) error {
+					bls := access.Cursor()
 					_, bcs := bls.BuildTransactionAtRef(nil, bktRef.GetRootRef())
 					var berr error
 					opKey, _, berr = bcs.Fetch(q.ctx)

--- a/forge/lib/v86/bun/controller.go
+++ b/forge/lib/v86/bun/controller.go
@@ -20,6 +20,7 @@ import (
 	unixfs_block_fs "github.com/s4wave/spacewave/db/unixfs/block/fs"
 	unixfs_tar "github.com/s4wave/spacewave/db/unixfs/tar"
 	v86fs "github.com/s4wave/spacewave/db/unixfs/v86fs"
+	"github.com/s4wave/spacewave/db/world"
 	forge_target "github.com/s4wave/spacewave/forge/target"
 	forge_value "github.com/s4wave/spacewave/forge/value"
 	"github.com/sirupsen/logrus"
@@ -187,8 +188,8 @@ func (c *Controller) Execute(ctx context.Context) error {
 	// Access storage to create mounts and run the VM.
 	// The entire subprocess execution happens inside the callback because
 	// the bucket_lookup.Cursor is only valid within its scope.
-	return c.handle.AccessStorage(ctx, nil, func(cs *bucket_lookup.Cursor) error {
-		// Initialize an empty directory as the output root.
+	return c.handle.AccessStorage(ctx, nil, func(access *world.WorldAccess) error {
+		cs := access.Cursor() // Initialize an empty directory as the output root.
 		outputHandle, err := initOutputMount(ctx, cs)
 		if err != nil {
 			return errors.Wrap(err, "init output mount")

--- a/forge/lib/v86/bun/integration_test.go
+++ b/forge/lib/v86/bun/integration_test.go
@@ -11,7 +11,6 @@ import (
 	timestamp "github.com/aperturerobotics/protobuf-go-lite/types/known/timestamppb"
 	billy_util "github.com/go-git/go-billy/v6/util"
 	"github.com/s4wave/spacewave/db/bucket"
-	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
 	"github.com/s4wave/spacewave/db/unixfs"
 	unixfs_billy "github.com/s4wave/spacewave/db/unixfs/billy"
 	unixfs_block "github.com/s4wave/spacewave/db/unixfs/block"
@@ -341,7 +340,8 @@ func verifyUnixFSOutput(
 	}
 
 	objRef := &bucket.ObjectRef{RootRef: bref.GetRootRef()}
-	err := tb.WorldState.AccessWorldState(ctx, objRef, func(cs *bucket_lookup.Cursor) error {
+	err := tb.WorldState.AccessWorldState(ctx, objRef, func(access *world.WorldAccess) error {
+		cs := access.Cursor()
 		fs := unixfs_block_fs.NewFS(ctx, unixfs_block.NodeType_NodeType_DIRECTORY, cs, nil)
 		defer fs.Release()
 		fh, err := unixfs.NewFSHandle(fs)

--- a/forge/target/exec-controller-access.go
+++ b/forge/target/exec-controller-access.go
@@ -6,7 +6,6 @@ import (
 
 	timestamp "github.com/aperturerobotics/protobuf-go-lite/types/known/timestamppb"
 	"github.com/s4wave/spacewave/db/bucket"
-	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
 	"github.com/s4wave/spacewave/db/world"
 	forge_value "github.com/s4wave/spacewave/forge/value"
 	"github.com/s4wave/spacewave/net/peer"
@@ -70,7 +69,7 @@ func (a *accessHandle) GetTargetWorld() (world.Engine, error) {
 func (a *accessHandle) AccessStorage(
 	ctx context.Context,
 	ref *bucket.ObjectRef,
-	cb func(*bucket_lookup.Cursor) error,
+	cb func(*world.WorldAccess) error,
 ) error {
 	return a.accessFunc(ctx, ref, cb)
 }

--- a/forge/target/exec-controller.go
+++ b/forge/target/exec-controller.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aperturerobotics/controllerbus/controller"
 	timestamp "github.com/aperturerobotics/protobuf-go-lite/types/known/timestamppb"
 	"github.com/s4wave/spacewave/db/bucket"
-	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
+	"github.com/s4wave/spacewave/db/world"
 	forge_value "github.com/s4wave/spacewave/forge/value"
 	"github.com/s4wave/spacewave/net/peer"
 )
@@ -42,7 +42,7 @@ type ExecControllerHandle interface {
 	AccessStorage(
 		ctx context.Context,
 		ref *bucket.ObjectRef,
-		cb func(*bucket_lookup.Cursor) error,
+		cb func(*world.WorldAccess) error,
 	) error
 	// SetOutputs changes the outputs according to the given ValueSlice.
 	// Note: the slice contents will be copied before the call returns.

--- a/forge/target/value.go
+++ b/forge/target/value.go
@@ -9,7 +9,6 @@ import (
 	"github.com/s4wave/spacewave/db/block"
 	"github.com/s4wave/spacewave/db/block/blob"
 	"github.com/s4wave/spacewave/db/bucket"
-	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
 	"github.com/s4wave/spacewave/db/world"
 	forge_value "github.com/s4wave/spacewave/forge/value"
 )
@@ -126,7 +125,7 @@ func StoreValueAsBlockRef(
 	err = handle.AccessStorage(
 		ctx,
 		nil,
-		func(bls *bucket_lookup.Cursor) error {
+		func(bls *world.WorldAccess) error {
 			var berr error
 			outValue, berr = CopyValueToBucket(ctx, handle, val)
 			return berr
@@ -160,7 +159,7 @@ func CopyValueToBucket(
 		err = handle.AccessStorage(
 			ctx,
 			bktRef,
-			func(bls *bucket_lookup.Cursor) error {
+			func(bls *world.WorldAccess) error {
 				_, bcs := bls.BuildTransactionAtRef(nil, outputRef)
 				// TODO: copy full reference graph
 				// for now, just copy the root block.
@@ -179,9 +178,9 @@ func CopyValueToBucket(
 		if err != nil {
 			return nil, err
 		}
-		err = handle.AccessStorage(ctx, nil, func(bls *bucket_lookup.Cursor) error {
+		err = handle.AccessStorage(ctx, nil, func(bls *world.WorldAccess) error {
 			var berr error
-			outputRef, _, berr = bls.PutBlock(ctx, rootBlockData, &block.PutOpts{Sync: true})
+			outputRef, _, berr = bls.Cursor().PutBlock(ctx, rootBlockData, &block.PutOpts{Sync: true})
 			return berr
 		})
 		if err != nil {

--- a/plugin/sql/handler.go
+++ b/plugin/sql/handler.go
@@ -11,7 +11,6 @@ import (
 	"github.com/s4wave/spacewave/db/block"
 	"github.com/s4wave/spacewave/db/blocktype"
 	"github.com/s4wave/spacewave/db/bucket"
-	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
 	s4wave_sql "github.com/s4wave/spacewave/db/sql"
 	sql_mysql "github.com/s4wave/spacewave/db/sql/mysql"
 	"github.com/s4wave/spacewave/db/world"
@@ -326,7 +325,8 @@ func (h *SQLHandler) seedSQLDatabase(ctx context.Context, ws world.WorldState) e
 	}
 
 	var committedRoot *bucket.ObjectRef
-	if err := obj.AccessWorldState(ctx, nil, func(root *bucket_lookup.Cursor) error {
+	if err := obj.AccessWorldState(ctx, nil, func(access *world.WorldAccess) error {
+		root := access.Cursor()
 		sqlRoot := root.Clone()
 		defer sqlRoot.Release()
 		store := sql_mysql.NewMysql(sqlRoot, func(next *bucket.ObjectRef) error {

--- a/sdk/kv/world/kv-set-root-op.go
+++ b/sdk/kv/world/kv-set-root-op.go
@@ -6,7 +6,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/s4wave/spacewave/db/block"
 	"github.com/s4wave/spacewave/db/bucket"
-	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
 	kvtx_block "github.com/s4wave/spacewave/db/kvtx/block"
 	"github.com/s4wave/spacewave/db/world"
 	world_types "github.com/s4wave/spacewave/db/world/types"
@@ -142,8 +141,8 @@ func (o *KvSetRootOp) rebaseRoot(
 	currentRoot *bucket.ObjectRef,
 ) (*bucket.ObjectRef, error) {
 	var nextRoot *bucket.ObjectRef
-	err := os.AccessWorldState(ctx, currentRoot, func(root *bucket_lookup.Cursor) error {
-		rootCursor := root.Clone()
+	err := os.AccessWorldState(ctx, currentRoot, func(access *world.WorldAccess) error {
+		rootCursor := access.Cursor().Clone()
 		defer rootCursor.Release()
 		store, err := kvtx_block.NewStore(ctx, le, rootCursor, func(root *bucket.ObjectRef) error {
 			nextRoot = root.Clone()

--- a/sdk/kv/world/objecttype.go
+++ b/sdk/kv/world/objecttype.go
@@ -42,11 +42,12 @@ func KvStoreFactory(
 	}
 
 	var store *WorldBackedStore
-	if err := obj.AccessWorldState(ctx, nil, func(root worldCursor) error {
-		var err error
-		store, err = NewWorldBackedStore(ctx, le, root.Clone(), ws, objectKey)
-		return err
-	}); err != nil {
+	owned, err := obj.BuildOwnedLookupCursor(ctx, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	store, err = NewWorldBackedStore(ctx, le, owned, ws, objectKey)
+	if err != nil {
 		return nil, nil, err
 	}
 	if store == nil {

--- a/sdk/kv/world/world-backed-store.go
+++ b/sdk/kv/world/world-backed-store.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/s4wave/spacewave/db/bucket"
-	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
 	"github.com/s4wave/spacewave/db/kvtx"
 	kvtx_block "github.com/s4wave/spacewave/db/kvtx/block"
 	"github.com/s4wave/spacewave/db/world"
@@ -16,14 +15,12 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type worldCursor = *bucket_lookup.Cursor
-
 // WorldBackedStore wraps a KVTX block store and commits root updates through world ops.
 type WorldBackedStore struct {
 	inner *kvtx_block.Store
 	ws    world.WorldState
 	key   string
-	root  *bucket_lookup.Cursor
+	root  *world.OwnedLookupCursor
 
 	mtx      sync.Mutex
 	writeMtx sync.Mutex
@@ -34,17 +31,24 @@ type WorldBackedStore struct {
 func NewWorldBackedStore(
 	ctx context.Context,
 	le *logrus.Entry,
-	root *bucket_lookup.Cursor,
+	root *world.OwnedLookupCursor,
 	ws world.WorldState,
 	objectKey string,
 ) (*WorldBackedStore, error) {
 	if ws == nil {
+		if root != nil {
+			root.Release()
+		}
 		return nil, objecttype.ErrWorldStateRequired
 	}
-	if root == nil {
+	if root == nil || root.Cursor() == nil {
+		if root != nil {
+			root.Release()
+		}
 		return nil, errors.New("kv/store: root cursor is required")
 	}
 	if objectKey == "" {
+		root.Release()
 		return nil, world.ErrEmptyObjectKey
 	}
 
@@ -53,7 +57,7 @@ func NewWorldBackedStore(
 		key:  objectKey,
 		root: root,
 	}
-	inner, err := kvtx_block.NewStore(ctx, le, root, st.captureCommittedRoot)
+	inner, err := kvtx_block.NewStore(ctx, le, root.Cursor(), st.captureCommittedRoot)
 	if err != nil {
 		root.Release()
 		return nil, err
@@ -68,7 +72,14 @@ func (s *WorldBackedStore) Close() {
 		return
 	}
 	s.root.Release()
-	s.root = nil
+}
+
+// GetRootRef returns the current KV root reference.
+func (s *WorldBackedStore) GetRootRef() *bucket.ObjectRef {
+	if s == nil || s.inner == nil {
+		return nil
+	}
+	return s.inner.GetRootRef()
 }
 
 // WatchPrefix streams current key/value snapshots for a prefix after world commits.

--- a/sdk/kv/world/world_backed_store_test.go
+++ b/sdk/kv/world/world_backed_store_test.go
@@ -3,6 +3,7 @@ package s4wave_kv_world_test
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 
 	"github.com/aperturerobotics/starpc/srpc"
@@ -10,6 +11,7 @@ import (
 	"github.com/s4wave/spacewave/db/block"
 	"github.com/s4wave/spacewave/db/bucket"
 	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
+	bucket_mock "github.com/s4wave/spacewave/db/bucket/mock"
 	"github.com/s4wave/spacewave/db/kvtx"
 	kvtx_block "github.com/s4wave/spacewave/db/kvtx/block"
 	kvtx_rpc "github.com/s4wave/spacewave/db/kvtx/rpc"
@@ -330,13 +332,99 @@ func openWorldBackedStore(
 	if err != nil {
 		t.Fatalf("MustGetObject(%s): %v", objectKey, err)
 	}
-	var store *s4wave_kv_world.WorldBackedStore
-	if err := obj.AccessWorldState(ctx, nil, func(root *bucket_lookup.Cursor) error {
-		var err error
-		store, err = s4wave_kv_world.NewWorldBackedStore(ctx, logrus.NewEntry(logrus.New()), root.Clone(), ws, objectKey)
-		return err
-	}); err != nil {
-		t.Fatalf("AccessWorldState(%s): %v", objectKey, err)
+	owned, err := obj.BuildOwnedLookupCursor(ctx, nil)
+	if err != nil {
+		t.Fatalf("BuildOwnedLookupCursor(%s): %v", objectKey, err)
+	}
+	store, err := s4wave_kv_world.NewWorldBackedStore(ctx, logrus.NewEntry(logrus.New()), owned, ws, objectKey)
+	if err != nil {
+		t.Fatalf("NewWorldBackedStore(%s): %v", objectKey, err)
 	}
 	return store, store.Close
+}
+
+func newOwnedKvTestCursor(t *testing.T, ctx context.Context, root *block.BlockRef, releases *atomic.Int32) *world.OwnedLookupCursor {
+	t.Helper()
+	bkt := bucket_mock.NewMockBucket("kv-owner", nil)
+	cursor := bucket_lookup.NewCursorWithRelease(
+		ctx,
+		nil,
+		nil,
+		nil,
+		bkt,
+		nil,
+		&bucket.ObjectRef{BucketId: "kv-owner", RootRef: root},
+		&bucket.BucketOpArgs{BucketId: "kv-owner"},
+		nil,
+		func() { releases.Add(1) },
+	)
+	storage := world.NewCursorWorldStorage(func(context.Context) (*bucket_lookup.Cursor, error) {
+		return cursor, nil
+	})
+	owned, err := storage.BuildOwnedLookupCursor(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return owned
+}
+
+func TestWorldBackedStoreOwnsCursorOnFailureAndClose(t *testing.T) {
+	ctx := context.Background()
+	var failureReleases atomic.Int32
+	failedOwned := newOwnedKvTestCursor(t, ctx, nil, &failureReleases)
+	if _, err := s4wave_kv_world.NewWorldBackedStore(ctx, nil, failedOwned, nil, "kv/failure"); err == nil {
+		t.Fatal("expected missing WorldState error")
+	}
+	if failureReleases.Load() != 1 {
+		t.Fatalf("constructor failure releases = %d, want 1", failureReleases.Load())
+	}
+
+	tb, err := testbed.Default(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tb.Release()
+	var closeReleases atomic.Int32
+	owned := newOwnedKvTestCursor(t, ctx, nil, &closeReleases)
+	store, err := s4wave_kv_world.NewWorldBackedStore(ctx, nil, owned, tb.WorldState, "kv/close")
+	if err != nil {
+		t.Fatal(err)
+	}
+	store.Close()
+	store.Close()
+	if closeReleases.Load() != 1 {
+		t.Fatalf("close releases = %d, want 1", closeReleases.Load())
+	}
+
+	invalidBucket := bucket_mock.NewMockBucket("kv-invalid", nil)
+	invalidRef, _, err := invalidBucket.PutBlock(ctx, []byte("not a kv root"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var innerFailureReleases atomic.Int32
+	invalidCursor := bucket_lookup.NewCursorWithRelease(
+		ctx,
+		nil,
+		nil,
+		nil,
+		invalidBucket,
+		nil,
+		&bucket.ObjectRef{BucketId: "kv-invalid", RootRef: invalidRef},
+		&bucket.BucketOpArgs{BucketId: "kv-invalid"},
+		nil,
+		func() { innerFailureReleases.Add(1) },
+	)
+	invalidStorage := world.NewCursorWorldStorage(func(context.Context) (*bucket_lookup.Cursor, error) {
+		return invalidCursor, nil
+	})
+	invalidOwned, err := invalidStorage.BuildOwnedLookupCursor(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s4wave_kv_world.NewWorldBackedStore(ctx, nil, invalidOwned, tb.WorldState, "kv/invalid"); err == nil {
+		t.Fatal("expected invalid inner store root error")
+	}
+	if innerFailureReleases.Load() != 1 {
+		t.Fatalf("inner constructor failure releases = %d, want 1", innerFailureReleases.Load())
+	}
 }

--- a/sdk/sql/query/world/resource.go
+++ b/sdk/sql/query/world/resource.go
@@ -262,36 +262,23 @@ func (r *SqlQueryResource) openRows(
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "sql/query: open target db object")
 	}
-	rootRef, _, err := obj.GetRootRef(ctx)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "sql/query: read target db root")
-	}
-	storageRoot, err := r.engine.BuildStorageCursor(ctx)
+	owned, err := obj.BuildOwnedLookupCursor(ctx, nil)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "sql/query: open target db storage cursor")
 	}
-	root, err := storageRoot.FollowRef(ctx, rootRef)
+	store, err := s4wave_sql_world.NewWorldBackedSql(ctx, owned, r.ws, targetKey)
 	if err != nil {
-		storageRoot.Release()
-		return nil, nil, errors.Wrap(err, "sql/query: follow target db root")
-	}
-	store, err := s4wave_sql_world.NewWorldBackedSql(ctx, root, r.ws, targetKey)
-	if err != nil {
-		root.Release()
-		storageRoot.Release()
 		return nil, nil, errors.Wrap(err, "sql/query: open target db store")
 	}
 	tx, err := store.NewSqlTransaction(ctx, false, "")
 	if err != nil {
 		store.Close()
-		storageRoot.Release()
 		return nil, nil, errors.Wrap(err, "sql/query: open target db read transaction")
 	}
 	ops, err := tx.GetSqlOps(ctx)
 	if err != nil {
 		tx.Discard()
 		store.Close()
-		storageRoot.Release()
 		return nil, nil, errors.Wrap(err, "sql/query: open target db SQL ops")
 	}
 	args := sql_rpc.SqlValuesToNamedValues(query.GetParameters())
@@ -302,20 +289,17 @@ func (r *SqlQueryResource) openRows(
 	if err != nil {
 		tx.Discard()
 		store.Close()
-		storageRoot.Release()
 		return nil, nil, errors.Wrap(err, "sql/query: execute target db query")
 	}
 	if rows == nil {
 		tx.Discard()
 		store.Close()
-		storageRoot.Release()
 		return nil, nil, errors.New("sql/query: query returned nil rows")
 	}
 	cleanup := func() {
 		rows.Close()
 		tx.Discard()
 		store.Close()
-		storageRoot.Release()
 	}
 	return rows, cleanup, nil
 }

--- a/sdk/sql/schema/world/resource.go
+++ b/sdk/sql/schema/world/resource.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aperturerobotics/starpc/srpc"
 	"github.com/pkg/errors"
 	resource_server "github.com/s4wave/spacewave/bldr/resource/server"
-	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
 	"github.com/s4wave/spacewave/db/world"
 	world_types "github.com/s4wave/spacewave/db/world/types"
 	s4wave_sql "github.com/s4wave/spacewave/sdk/sql"
@@ -116,12 +115,12 @@ func (r *SqlSchemaResource) openTargetRows(
 	if err != nil {
 		return nil, nil, err
 	}
-	var store *s4wave_sql_world.WorldBackedSql
-	if err := obj.AccessWorldState(ctx, nil, func(root *bucket_lookup.Cursor) error {
-		var err error
-		store, err = s4wave_sql_world.NewWorldBackedSql(ctx, root.Clone(), r.ws, targetKey)
-		return err
-	}); err != nil {
+	owned, err := obj.BuildOwnedLookupCursor(ctx, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	store, err := s4wave_sql_world.NewWorldBackedSql(ctx, owned, r.ws, targetKey)
+	if err != nil {
 		return nil, nil, err
 	}
 	tx, err := store.NewSqlTransaction(ctx, false, "")

--- a/sdk/sql/table-view/world/resource.go
+++ b/sdk/sql/table-view/world/resource.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aperturerobotics/starpc/srpc"
 	"github.com/pkg/errors"
 	resource_server "github.com/s4wave/spacewave/bldr/resource/server"
-	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
 	hydra_sql "github.com/s4wave/spacewave/db/sql"
 	sql_rpc "github.com/s4wave/spacewave/db/sql/rpc"
 	"github.com/s4wave/spacewave/db/world"
@@ -253,12 +252,12 @@ func (r *SqlTableViewResource) openTargetSqlOps(
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	var store *s4wave_sql_world.WorldBackedSql
-	if err := obj.AccessWorldState(ctx, nil, func(root *bucket_lookup.Cursor) error {
-		var err error
-		store, err = s4wave_sql_world.NewWorldBackedSql(ctx, root.Clone(), r.ws, targetKey)
-		return err
-	}); err != nil {
+	owned, err := obj.BuildOwnedLookupCursor(ctx, nil)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	store, err := s4wave_sql_world.NewWorldBackedSql(ctx, owned, r.ws, targetKey)
+	if err != nil {
 		return nil, nil, nil, err
 	}
 	tx, err := store.NewSqlTransaction(ctx, write, "")

--- a/sdk/sql/world/objecttype.go
+++ b/sdk/sql/world/objecttype.go
@@ -37,35 +37,20 @@ func SqlDbFactory(
 	if err != nil {
 		return nil, nil, err
 	}
-	rootRef, _, err := obj.GetRootRef(ctx)
+	owned, err := obj.BuildOwnedLookupCursor(ctx, nil)
 	if err != nil {
-		return nil, nil, err
-	}
-	storageRoot, err := ws.BuildStorageCursor(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	root, err := storageRoot.FollowRef(ctx, rootRef)
-	if err != nil {
-		storageRoot.Release()
 		return nil, nil, err
 	}
 
-	store, err := NewWorldBackedSql(ctx, root, ws, objectKey)
+	store, err := NewWorldBackedSql(ctx, owned, ws, objectKey)
 	if err != nil {
-		root.Release()
-		storageRoot.Release()
 		return nil, nil, err
 	}
 
 	mux := srpc.NewMux()
 	if err := sql_rpc.SRPCRegisterSql(mux, sql_rpc_server.NewStore(store)); err != nil {
 		store.Close()
-		storageRoot.Release()
 		return nil, nil, err
 	}
-	return mux, func() {
-		store.Close()
-		storageRoot.Release()
-	}, nil
+	return mux, store.Close, nil
 }

--- a/sdk/sql/world/sql-set-root-op.go
+++ b/sdk/sql/world/sql-set-root-op.go
@@ -8,7 +8,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/s4wave/spacewave/db/block"
 	"github.com/s4wave/spacewave/db/bucket"
-	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
 	sql_mysql "github.com/s4wave/spacewave/db/sql/mysql"
 	sql_rpc "github.com/s4wave/spacewave/db/sql/rpc"
 	"github.com/s4wave/spacewave/db/world"
@@ -149,8 +148,8 @@ func (o *SqlSetRootOp) rebaseRoot(
 	currentRoot *bucket.ObjectRef,
 ) (*bucket.ObjectRef, error) {
 	var nextRoot *bucket.ObjectRef
-	err := os.AccessWorldState(ctx, currentRoot, func(root *bucket_lookup.Cursor) error {
-		rootCursor := root.Clone()
+	err := os.AccessWorldState(ctx, currentRoot, func(access *world.WorldAccess) error {
+		rootCursor := access.Cursor().Clone()
 		defer rootCursor.Release()
 		db := sql_mysql.NewMysql(rootCursor, func(root *bucket.ObjectRef) error {
 			nextRoot = root.Clone()

--- a/sdk/sql/world/world-backed-sql.go
+++ b/sdk/sql/world/world-backed-sql.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/s4wave/spacewave/db/bucket"
-	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
 	hydra_sql "github.com/s4wave/spacewave/db/sql"
 	sql_mysql "github.com/s4wave/spacewave/db/sql/mysql"
 	"github.com/s4wave/spacewave/db/world"
@@ -15,14 +14,12 @@ import (
 	"github.com/s4wave/spacewave/sdk/world/objecttype"
 )
 
-type worldCursor = *bucket_lookup.Cursor
-
 // WorldBackedSql commits SQL roots through world operations.
 type WorldBackedSql struct {
 	inner    *sql_mysql.Mysql
 	ws       world.WorldState
 	key      string
-	root     worldCursor
+	root     *world.OwnedLookupCursor
 	mtx      sync.Mutex
 	writeMtx sync.Mutex
 	tx       *worldBackedSqlTx
@@ -31,17 +28,24 @@ type WorldBackedSql struct {
 // NewWorldBackedSql opens a world-backed SQL database.
 func NewWorldBackedSql(
 	_ context.Context,
-	root worldCursor,
+	root *world.OwnedLookupCursor,
 	ws world.WorldState,
 	objectKey string,
 ) (*WorldBackedSql, error) {
 	if ws == nil {
+		if root != nil {
+			root.Release()
+		}
 		return nil, objecttype.ErrWorldStateRequired
 	}
-	if root == nil {
+	if root == nil || root.Cursor() == nil {
+		if root != nil {
+			root.Release()
+		}
 		return nil, errors.New("sql/db: root cursor is required")
 	}
 	if objectKey == "" {
+		root.Release()
 		return nil, world.ErrEmptyObjectKey
 	}
 	st := &WorldBackedSql{
@@ -49,7 +53,7 @@ func NewWorldBackedSql(
 		key:  objectKey,
 		root: root,
 	}
-	st.inner = sql_mysql.NewMysql(root, st.captureCommittedRoot)
+	st.inner = sql_mysql.NewMysql(root.Cursor(), st.captureCommittedRoot)
 	return st, nil
 }
 
@@ -59,7 +63,6 @@ func (s *WorldBackedSql) Close() {
 		return
 	}
 	s.root.Release()
-	s.root = nil
 }
 
 // NewSqlTransaction opens a SQL transaction.

--- a/sdk/sql/world/world_backed_sql_test.go
+++ b/sdk/sql/world/world_backed_sql_test.go
@@ -5,12 +5,14 @@ import (
 	"database/sql/driver"
 	"errors"
 	"io"
+	"sync/atomic"
 	"testing"
 
 	"github.com/aperturerobotics/starpc/srpc"
 	"github.com/s4wave/spacewave/db/block"
 	"github.com/s4wave/spacewave/db/bucket"
 	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
+	bucket_mock "github.com/s4wave/spacewave/db/bucket/mock"
 	hydra_sql "github.com/s4wave/spacewave/db/sql"
 	sql_mysql "github.com/s4wave/spacewave/db/sql/mysql"
 	sql_rpc "github.com/s4wave/spacewave/db/sql/rpc"
@@ -280,13 +282,67 @@ func openWorldBackedSql(
 	if err != nil {
 		t.Fatalf("MustGetObject(%s): %v", objectKey, err)
 	}
-	var store *s4wave_sql_world.WorldBackedSql
-	if err := obj.AccessWorldState(ctx, nil, func(root *bucket_lookup.Cursor) error {
-		var err error
-		store, err = s4wave_sql_world.NewWorldBackedSql(ctx, root.Clone(), ws, objectKey)
-		return err
-	}); err != nil {
-		t.Fatalf("AccessWorldState(%s): %v", objectKey, err)
+	owned, err := obj.BuildOwnedLookupCursor(ctx, nil)
+	if err != nil {
+		t.Fatalf("BuildOwnedLookupCursor(%s): %v", objectKey, err)
+	}
+	store, err := s4wave_sql_world.NewWorldBackedSql(ctx, owned, ws, objectKey)
+	if err != nil {
+		t.Fatalf("NewWorldBackedSql(%s): %v", objectKey, err)
 	}
 	return store, store.Close
+}
+
+func newOwnedSqlTestCursor(t *testing.T, ctx context.Context, releases *atomic.Int32) *world.OwnedLookupCursor {
+	t.Helper()
+	bkt := bucket_mock.NewMockBucket("sql-owner", nil)
+	cursor := bucket_lookup.NewCursorWithRelease(
+		ctx,
+		nil,
+		nil,
+		nil,
+		bkt,
+		nil,
+		&bucket.ObjectRef{BucketId: "sql-owner"},
+		&bucket.BucketOpArgs{BucketId: "sql-owner"},
+		nil,
+		func() { releases.Add(1) },
+	)
+	storage := world.NewCursorWorldStorage(func(context.Context) (*bucket_lookup.Cursor, error) {
+		return cursor, nil
+	})
+	owned, err := storage.BuildOwnedLookupCursor(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return owned
+}
+
+func TestWorldBackedSqlOwnsCursorOnFailureAndClose(t *testing.T) {
+	ctx := context.Background()
+	var failureReleases atomic.Int32
+	failedOwned := newOwnedSqlTestCursor(t, ctx, &failureReleases)
+	if _, err := s4wave_sql_world.NewWorldBackedSql(ctx, failedOwned, nil, "sql/failure"); err == nil {
+		t.Fatal("expected missing WorldState error")
+	}
+	if failureReleases.Load() != 1 {
+		t.Fatalf("constructor failure releases = %d, want 1", failureReleases.Load())
+	}
+
+	tb, err := testbed.Default(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tb.Release()
+	var closeReleases atomic.Int32
+	owned := newOwnedSqlTestCursor(t, ctx, &closeReleases)
+	store, err := s4wave_sql_world.NewWorldBackedSql(ctx, owned, tb.WorldState, "sql/close")
+	if err != nil {
+		t.Fatal(err)
+	}
+	store.Close()
+	store.Close()
+	if closeReleases.Load() != 1 {
+		t.Fatalf("close releases = %d, want 1", closeReleases.Load())
+	}
 }

--- a/sdk/world/engine/bucket-lookup-cursor.go
+++ b/sdk/world/engine/bucket-lookup-cursor.go
@@ -13,6 +13,7 @@ import (
 	transform_all "github.com/s4wave/spacewave/db/block/transform/all"
 	"github.com/s4wave/spacewave/db/bucket"
 	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
+	"github.com/s4wave/spacewave/db/world"
 	"github.com/s4wave/spacewave/net/hash"
 	s4wave_bucket_lookup "github.com/s4wave/spacewave/sdk/bucket/lookup"
 )
@@ -63,7 +64,7 @@ func accessSDKBucketLookupCursor(
 	ctx context.Context,
 	client ResourceClient,
 	resourceID uint32,
-	cb func(*bucket_lookup.Cursor) error,
+	cb func(*world.WorldAccess) error,
 ) error {
 	ref := client.CreateResourceReference(resourceID)
 	cursor, err := newSDKBucketLookupCursor(ctx, ref)
@@ -71,8 +72,26 @@ func accessSDKBucketLookupCursor(
 		ref.Release()
 		return err
 	}
+	storage := world.NewWorldStorageFromCursor(cursor)
 	defer cursor.Release()
-	return cb(cursor)
+	return storage.AccessWorldState(ctx, nil, cb)
+}
+
+func buildOwnedSDKBucketLookupCursor(
+	ctx context.Context,
+	client ResourceClient,
+	resourceID uint32,
+) (*world.OwnedLookupCursor, error) {
+	ref := client.CreateResourceReference(resourceID)
+	cursor, err := newSDKBucketLookupCursor(ctx, ref)
+	if err != nil {
+		ref.Release()
+		return nil, err
+	}
+	storage := world.NewWorldStorageFromCursorWithStore(cursor, nil)
+	owned, err := storage.BuildOwnedLookupCursor(ctx, nil)
+	world.RetireWorldStorage(storage)
+	return owned, err
 }
 
 func buildSDKCursorTransform(

--- a/sdk/world/engine/engine.go
+++ b/sdk/world/engine/engine.go
@@ -108,8 +108,17 @@ func (e *SDKEngine) BuildStorageCursor(ctx context.Context) (*bucket_lookup.Curs
 	return cursor, nil
 }
 
+// BuildOwnedLookupCursor builds an owned cursor at ref.
+func (e *SDKEngine) BuildOwnedLookupCursor(ctx context.Context, ref *bucket.ObjectRef) (*world.OwnedLookupCursor, error) {
+	resp, err := e.service.AccessWorldState(ctx, &s4wave_world.AccessWorldStateRequest{Ref: ref})
+	if err != nil {
+		return nil, err
+	}
+	return buildOwnedSDKBucketLookupCursor(ctx, e.client, resp.GetResourceId())
+}
+
 // AccessWorldState builds a bucket lookup cursor with an optional ref.
-func (e *SDKEngine) AccessWorldState(ctx context.Context, ref *bucket.ObjectRef, cb func(*bucket_lookup.Cursor) error) error {
+func (e *SDKEngine) AccessWorldState(ctx context.Context, ref *bucket.ObjectRef, cb func(*world.WorldAccess) error) error {
 	resp, err := e.service.AccessWorldState(ctx, &s4wave_world.AccessWorldStateRequest{Ref: ref})
 	if err != nil {
 		return err

--- a/sdk/world/engine/object-state.go
+++ b/sdk/world/engine/object-state.go
@@ -5,7 +5,6 @@ import (
 
 	resource_client "github.com/s4wave/spacewave/bldr/resource/client"
 	"github.com/s4wave/spacewave/db/bucket"
-	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
 	"github.com/s4wave/spacewave/db/world"
 	"github.com/s4wave/spacewave/net/peer"
 	s4wave_world "github.com/s4wave/spacewave/sdk/world"
@@ -64,8 +63,17 @@ func (os *SDKObjectState) SetRootRef(ctx context.Context, rootRef *bucket.Object
 	return resp.Rev, nil
 }
 
+// BuildOwnedLookupCursor builds an owned cursor at ref.
+func (os *SDKObjectState) BuildOwnedLookupCursor(ctx context.Context, ref *bucket.ObjectRef) (*world.OwnedLookupCursor, error) {
+	resp, err := os.service.AccessWorldState(ctx, &s4wave_world.AccessWorldStateRequest{Ref: ref})
+	if err != nil {
+		return nil, err
+	}
+	return buildOwnedSDKBucketLookupCursor(ctx, os.client, resp.GetResourceId())
+}
+
 // AccessWorldState builds a bucket lookup cursor with an optional ref.
-func (os *SDKObjectState) AccessWorldState(ctx context.Context, ref *bucket.ObjectRef, cb func(*bucket_lookup.Cursor) error) error {
+func (os *SDKObjectState) AccessWorldState(ctx context.Context, ref *bucket.ObjectRef, cb func(*world.WorldAccess) error) error {
 	resp, err := os.service.AccessWorldState(ctx, &s4wave_world.AccessWorldStateRequest{Ref: ref})
 	if err != nil {
 		return err

--- a/sdk/world/engine/world-state.go
+++ b/sdk/world/engine/world-state.go
@@ -89,8 +89,17 @@ func (ws *SDKWorldState) BuildStorageCursor(ctx context.Context) (*bucket_lookup
 	return cursor, nil
 }
 
+// BuildOwnedLookupCursor builds an owned cursor at ref.
+func (ws *SDKWorldState) BuildOwnedLookupCursor(ctx context.Context, ref *bucket.ObjectRef) (*world.OwnedLookupCursor, error) {
+	resp, err := ws.service.AccessWorldState(ctx, &s4wave_world.AccessWorldStateRequest{Ref: ref})
+	if err != nil {
+		return nil, err
+	}
+	return buildOwnedSDKBucketLookupCursor(ctx, ws.client, resp.GetResourceId())
+}
+
 // AccessWorldState builds a bucket lookup cursor with an optional ref.
-func (ws *SDKWorldState) AccessWorldState(ctx context.Context, ref *bucket.ObjectRef, cb func(*bucket_lookup.Cursor) error) error {
+func (ws *SDKWorldState) AccessWorldState(ctx context.Context, ref *bucket.ObjectRef, cb func(*world.WorldAccess) error) error {
 	resp, err := ws.service.AccessWorldState(ctx, &s4wave_world.AccessWorldStateRequest{Ref: ref})
 	if err != nil {
 		return err

--- a/sdk/world/object-state.go
+++ b/sdk/world/object-state.go
@@ -5,7 +5,6 @@ import (
 
 	resource_client "github.com/s4wave/spacewave/bldr/resource/client"
 	"github.com/s4wave/spacewave/db/bucket"
-	bucket_lookup "github.com/s4wave/spacewave/db/bucket/lookup"
 	"github.com/s4wave/spacewave/db/world"
 	"github.com/s4wave/spacewave/net/peer"
 )
@@ -81,21 +80,20 @@ func (os *ObjectState) SetRootRef(ctx context.Context, rootRef *bucket.ObjectRef
 	return resp.Rev, nil
 }
 
-// AccessWorldState builds a bucket lookup cursor with an optional ref.
-// If the ref is empty, will default to the object RootRef.
-// If the ref Bucket ID is empty, uses the same bucket + volume as the world.
-// The lookup cursor will be released after cb returns.
-func (os *ObjectState) AccessWorldState(ctx context.Context, ref *bucket.ObjectRef, cb func(*bucket_lookup.Cursor) error) error {
+// BuildOwnedLookupCursor is unavailable for the remote object adapter.
+func (os *ObjectState) BuildOwnedLookupCursor(context.Context, *bucket.ObjectRef) (*world.OwnedLookupCursor, error) {
+	return nil, world.ErrWorldStorageUnavailable
+}
+
+// AccessWorldState builds a borrowed access value with an optional ref.
+func (os *ObjectState) AccessWorldState(ctx context.Context, ref *bucket.ObjectRef, cb func(*world.WorldAccess) error) error {
 	resp, err := os.service.AccessWorldState(ctx, &AccessWorldStateRequest{Ref: ref})
 	if err != nil {
 		return err
 	}
 
 	cursorRef := os.client.CreateResourceReference(resp.ResourceId)
-	defer cursorRef.Release()
-
-	// TODO: Need to create a proper bucket lookup cursor wrapper
-	// For now, return an error indicating this is not yet implemented
+	cursorRef.Release()
 	return nil
 }
 

--- a/sdk/world/object-state.go
+++ b/sdk/world/object-state.go
@@ -85,16 +85,9 @@ func (os *ObjectState) BuildOwnedLookupCursor(context.Context, *bucket.ObjectRef
 	return nil, world.ErrWorldStorageUnavailable
 }
 
-// AccessWorldState builds a borrowed access value with an optional ref.
-func (os *ObjectState) AccessWorldState(ctx context.Context, ref *bucket.ObjectRef, cb func(*world.WorldAccess) error) error {
-	resp, err := os.service.AccessWorldState(ctx, &AccessWorldStateRequest{Ref: ref})
-	if err != nil {
-		return err
-	}
-
-	cursorRef := os.client.CreateResourceReference(resp.ResourceId)
-	cursorRef.Release()
-	return nil
+// AccessWorldState is unavailable for the remote object adapter.
+func (os *ObjectState) AccessWorldState(context.Context, *bucket.ObjectRef, func(*world.WorldAccess) error) error {
+	return world.ErrWorldStorageUnavailable
 }
 
 // ApplyObjectOp applies a batch operation at the object level.

--- a/sdk/world/object-state_test.go
+++ b/sdk/world/object-state_test.go
@@ -1,0 +1,24 @@
+package s4wave_world
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/s4wave/spacewave/db/world"
+)
+
+func TestRemoteObjectStateAccessWorldStateReportsUnavailable(t *testing.T) {
+	obj := &ObjectState{}
+	called := false
+	err := obj.AccessWorldState(context.Background(), nil, func(*world.WorldAccess) error {
+		called = true
+		return nil
+	})
+	if !errors.Is(err, world.ErrWorldStorageUnavailable) {
+		t.Fatalf("AccessWorldState error = %v, want %v", err, world.ErrWorldStorageUnavailable)
+	}
+	if called {
+		t.Fatal("AccessWorldState called callback without a remote cursor adapter")
+	}
+}


### PR DESCRIPTION
World access callbacks previously rebuilt lookup cursors without carrying the engine's transaction-scoped store or an explicit lifetime owner. Same-bucket accesses could bypass deferred writes, cross-bucket accesses could target the wrong store, and resource or SDK escape points could outlive the cursor that backed them.

Introduce a WorldStorage owner that selects the engine write overlay for same-bucket access and the destination cursor store for cross-bucket access. Give escaped lookup cursors independent authority chains, retire transaction owners during discard and close, and resolve nil refs at the engine, transaction, or object boundary that owns their meaning.

Migrate resource, KV, SQL, forge, manifest, and SDK callers to borrowed callback access or explicitly owned cursors. Add race and lifetime coverage for close, retirement, callback exits, nested cursor ownership, store selection, and pinned transaction roots.