### PR TITLE
fix(unixfs): match Go file mode semantics in fs-node-type.ts

### DIFF
--- a/db/unixfs/fs-node-type.test.ts
+++ b/db/unixfs/fs-node-type.test.ts
@@ -14,6 +14,9 @@ const ModeDir = 0x80000000
 const ModeSymlink = 0x08000000
 const ModeIrregular = 0x00080000
 const ModePerm = 0o777
+const ModeSetuid = 0x00800000
+const ModeSetgid = 0x00400000
+const ModeSticky = 0x00100000
 
 describe('defaultPermissions', () => {
   it('returns 0o755 for directory', () => {
@@ -121,5 +124,34 @@ describe('nodeTypeToMode / fileModeToNodeType round-trip', () => {
     expect(restored.getIsSymlink()).toBe(true)
     expect(restored.getIsFile()).toBe(false)
     expect(restored.getIsDirectory()).toBe(false)
+  })
+})
+
+describe('Go fs.FileMode parity', () => {
+  it('produces the exact Go value for a 0o755 directory', () => {
+    // Go: 0o755 | fs.ModeDir == 2147484141 (unsigned 32-bit).
+    const mode = nodeTypeToMode(newFSCursorNodeType_Dir(), 0o755)
+    expect(mode).toBe(2147484141)
+    const restored = fileModeToNodeType(mode)
+    expect(restored.getIsDirectory()).toBe(true)
+  })
+
+  it('classifies a setuid regular file as a file', () => {
+    // Go fs.ModeType excludes setuid, so mode.IsRegular() is true.
+    const nt = fileModeToNodeType(ModeSetuid | 0o755)
+    expect(nt.getIsFile()).toBe(true)
+    expect(nt.getIsDirectory()).toBe(false)
+    expect(nt.getIsSymlink()).toBe(false)
+  })
+
+  it('classifies setgid and sticky regular files as files', () => {
+    expect(fileModeToNodeType(ModeSetgid | 0o644).getIsFile()).toBe(true)
+    expect(fileModeToNodeType(ModeSticky | 0o644).getIsFile()).toBe(true)
+  })
+
+  it('classifies a signed-int32 directory mode as a directory', () => {
+    // A consumer that stored the pre-fix signed value still classifies.
+    const nt = fileModeToNodeType(2147484141 | 0)
+    expect(nt.getIsDirectory()).toBe(true)
   })
 })

--- a/db/unixfs/fs-node-type.ts
+++ b/db/unixfs/fs-node-type.ts
@@ -8,18 +8,17 @@ const ModeSymlink = 0x08000000
 const ModeIrregular = 0x00080000
 // ModePerm is the permission bits mask (matching Go fs.ModePerm).
 const ModePerm = 0o777
-// ModeTypeMask is the type bits mask (matching Go fs.ModeType).
+// ModeTypeMask is the type bits mask (matching Go fs.ModeType), which
+// excludes setuid, setgid, and sticky: those bits do not change the node type.
 const ModeTypeMask =
-  ModeDir |
-  ModeSymlink |
-  ModeIrregular |
-  0x04000000 |
-  0x02000000 |
-  0x01000000 |
-  0x00800000 |
-  0x00400000 |
-  0x00200000 |
-  0x00100000
+  (ModeDir |
+    ModeSymlink |
+    ModeIrregular |
+    0x04000000 | // ModeDevice
+    0x02000000 | // ModeNamedPipe
+    0x01000000 | // ModeSocket
+    0x00200000) >>> // ModeCharDevice
+  0
 
 // fsCursorNodeType is a static node type value.
 class StaticFSCursorNodeType implements FSCursorNodeType {
@@ -78,16 +77,18 @@ export function defaultPermissions(nt: FSCursorNodeType): number {
 }
 
 // nodeTypeToMode converts a FSCursorNodeType into a mode value.
+// Modes are unsigned 32-bit values matching Go fs.FileMode, so the results
+// of the signed JS bitwise operators are coerced with >>> 0.
 export function nodeTypeToMode(
   nodeType: FSCursorNodeType,
   permissions: number,
 ): number {
   permissions = permissions & ModePerm
   if (nodeType.getIsSymlink()) {
-    return permissions | ModeSymlink
+    return (permissions | ModeSymlink) >>> 0
   }
   if (nodeType.getIsDirectory()) {
-    return permissions | ModeDir
+    return (permissions | ModeDir) >>> 0
   }
   if (nodeType.getIsFile()) {
     return permissions
@@ -98,6 +99,7 @@ export function nodeTypeToMode(
 // fileModeToNodeType converts a file mode to a FSCursorNodeType.
 // Throws if the mode represents an unsupported type.
 export function fileModeToNodeType(mode: number): FSCursorNodeType {
+  mode = mode >>> 0
   if ((mode & ModeDir) !== 0) {
     return newFSCursorNodeType_Dir()
   }


### PR DESCRIPTION
The hand-written TypeScript mirror of fs-node-type.go diverged from the Go semantics in two ways. JavaScript bitwise operators coerce to signed int32, so nodeTypeToMode returned a negative number for directories where Go's fs.FileMode arithmetic yields the unsigned value 2147484141 for 0o755 | fs.ModeDir, and any consumer that compares, serializes, or round-trips the mode as a number saw a different value on each side. The type mask also included the setuid, setgid, and sticky bits, which Go's fs.ModeType excludes, so a setuid regular file threw where Go classifies it as a regular file.

This coerces the results of the mode arithmetic to unsigned 32-bit values with >>> 0, normalizes the input mode in fileModeToNodeType the same way, and drops setuid, setgid, and sticky from ModeTypeMask to match fs.ModeType. Regression tests assert the exact Go directory mode value and the regular-file classification of setuid, setgid, and sticky modes. Exported names and signatures are unchanged.