### PR TITLE
docs(db): name concrete types in comments

### DIFF
--- a/db/block/block.pb.go
+++ b/db/block/block.pb.go
@@ -29,7 +29,7 @@ const (
 	StoreFeature_STORE_FEATURE_NATIVE_BATCH_EXISTS StoreFeature = 2
 	// STORE_FEATURE_SELF_BUFFERED means the store has its own read-through
 	// pending buffer, so the world block engine must not wrap it in a
-	// BufferedStore. Volume remains the durability barrier owner for
+	// BufferedStore. Volume.Sync remains the durability barrier for
 	// volume-backed stores.
 	StoreFeature_STORE_FEATURE_SELF_BUFFERED StoreFeature = 32
 )

--- a/db/block/block.pb.ts
+++ b/db/block/block.pb.ts
@@ -47,7 +47,7 @@ export enum StoreFeature {
   /**
    * STORE_FEATURE_SELF_BUFFERED means the store has its own read-through
    * pending buffer, so the world block engine must not wrap it in a
-   * BufferedStore. Volume remains the durability barrier owner for
+   * BufferedStore. Volume.Sync remains the durability barrier for
    * volume-backed stores.
    *
    * @generated from enum value: STORE_FEATURE_SELF_BUFFERED = 32;

--- a/db/block/block.proto
+++ b/db/block/block.proto
@@ -48,7 +48,7 @@ enum StoreFeature {
   reserved "STORE_FEATURE_NATIVE_BACKGROUND_PUT", "STORE_FEATURE_NATIVE_FLUSH", "STORE_FEATURE_NATIVE_DEFER_FLUSH";
   // STORE_FEATURE_SELF_BUFFERED means the store has its own read-through
   // pending buffer, so the world block engine must not wrap it in a
-  // BufferedStore. Volume remains the durability barrier owner for
+  // BufferedStore. Volume.Sync remains the durability barrier for
   // volume-backed stores.
   STORE_FEATURE_SELF_BUFFERED = 32;
 }

--- a/db/block/decoded-block-cache-options.go
+++ b/db/block/decoded-block-cache-options.go
@@ -7,7 +7,7 @@ const (
 	defaultDecodedBlockCacheBufferItems int64 = 64
 )
 
-// DecodedBlockCacheOptions configures a decoded-block cache owner.
+// DecodedBlockCacheOptions configures a DecodedBlockCache.
 type DecodedBlockCacheOptions struct {
 	// MaxCost is the Ristretto cache budget.
 	MaxCost int64

--- a/db/block/decoded-block-cache.go
+++ b/db/block/decoded-block-cache.go
@@ -88,7 +88,7 @@ func NewDecodedBlockCache() *DecodedBlockCache {
 	return cache
 }
 
-// NewDecodedBlockCacheWithOptions constructs a decoded-block cache owner.
+// NewDecodedBlockCacheWithOptions constructs a decoded-block cache with opts.
 func NewDecodedBlockCacheWithOptions(opts DecodedBlockCacheOptions) (*DecodedBlockCache, error) {
 	opts = opts.normalize()
 	cache := &DecodedBlockCache{
@@ -125,7 +125,7 @@ func NewDecodedBlockCacheWithOptions(opts DecodedBlockCacheOptions) (*DecodedBlo
 	return cache, nil
 }
 
-// WithDecodedBlockCache attaches an owner-provided decoded-block cache to ctx.
+// WithDecodedBlockCache attaches a decoded-block cache to ctx.
 func WithDecodedBlockCache(ctx context.Context, cache *DecodedBlockCache) context.Context {
 	if cache == nil {
 		return ctx

--- a/db/block/file/handle.go
+++ b/db/block/file/handle.go
@@ -172,8 +172,8 @@ func (r *Handle) Read(p []byte) (n int, err error) {
 			r.currentRangeIdx = 0
 			r.nextEval = 0
 			if err == io.EOF && blobReadN > 0 && r.idx == readEnd {
-				// EOF with bytes at the planned boundary hands selection back to
-				// the file owner so the next covering span can be chosen.
+				// EOF with bytes read at the planned boundary continues the
+				// loop so evaluateCurrentRange selects the next covering span.
 				continue
 			}
 			if n > 0 {

--- a/db/block/gc/refgraph.go
+++ b/db/block/gc/refgraph.go
@@ -119,9 +119,9 @@ func (rg *RefGraph) RemoveRef(ctx context.Context, subject, object string) error
 	return rg.handle.RemoveQuad(ctx, q)
 }
 
-// ApplyRefBatch serializes one bounded ownership transition under the RefGraph
-// owner lock. It applies additions before removals, treats missing exact
-// removals as no-ops, and derives orphan marks from the resulting owner set.
+// ApplyRefBatch serializes one bounded ownership transition under writeMu. It
+// applies additions before removals, treats missing exact removals as no-ops,
+// and derives orphan marks from the resulting owner set.
 // Preparation and application are bounded together so each slice commits
 // before preparation of the next slice begins.
 func (rg *RefGraph) ApplyRefBatch(ctx context.Context, adds, removes []RefEdge) error {

--- a/db/block/gc/rpc/client/refgraph.go
+++ b/db/block/gc/rpc/client/refgraph.go
@@ -179,7 +179,7 @@ func (r *RefGraph) RemoveObjectRoot(ctx context.Context, objectKey string, ref *
 }
 
 // ApplyRefBatch sends one bounded ownership transition to the server-side
-// RefGraph owner.
+// RefGraph.
 func (r *RefGraph) ApplyRefBatch(ctx context.Context, adds, removes []block_gc.RefEdge) error {
 	resp, err := r.client.ApplyRefBatch(ctx, &block_gc_rpc.ApplyRefBatchRequest{
 		Adds:    refEdgesToRPC(adds),

--- a/db/block/gc/rpc/server/refgraph.go
+++ b/db/block/gc/rpc/server/refgraph.go
@@ -50,7 +50,7 @@ func (s *RefGraph) RemoveRef(
 	return resp, nil
 }
 
-// ApplyRefBatch forwards one bounded ownership transition to the RefGraph owner.
+// ApplyRefBatch forwards one bounded ownership transition to the wrapped RefGraphOps.
 func (s *RefGraph) ApplyRefBatch(
 	ctx context.Context,
 	req *block_gc_rpc.ApplyRefBatchRequest,

--- a/db/block/store-feature.go
+++ b/db/block/store-feature.go
@@ -7,7 +7,7 @@ const (
 	StoreFeatureNativeBatchExists = StoreFeature_STORE_FEATURE_NATIVE_BATCH_EXISTS
 	// StoreFeatureSelfBuffered means the store has its own read-through pending
 	// buffer, so the world block engine must not wrap it in a BufferedStore.
-	// Volume remains the durability barrier owner for volume-backed stores.
+	// Volume.Sync remains the durability barrier for volume-backed stores.
 	StoreFeatureSelfBuffered = StoreFeature_STORE_FEATURE_SELF_BUFFERED
 )
 

--- a/db/block/store-rw.go
+++ b/db/block/store-rw.go
@@ -60,7 +60,7 @@ func (b *StoreRW) BeginReadOperation(ctx context.Context) (StoreOps, func(), err
 	return NewStoreRW(readHandle, readHandle), release, nil
 }
 
-// EnsureDecodedBlockCacheFresh forwards decoded-cache freshness to the read owner.
+// EnsureDecodedBlockCacheFresh forwards decoded-cache freshness to the read handle.
 func (b *StoreRW) EnsureDecodedBlockCacheFresh(ctx context.Context) error {
 	freshener, ok := b.readHandle.(DecodedBlockCacheFreshener)
 	if !ok {

--- a/db/block/store.go
+++ b/db/block/store.go
@@ -94,7 +94,8 @@ func EndDeferFlush(ctx context.Context, store StoreOps) error {
 // DecodedBlockCacheFreshener is implemented by stores whose decoded-cache hits
 // depend on external freshness state that ordinary block reads would refresh.
 type DecodedBlockCacheFreshener interface {
-	// EnsureDecodedBlockCacheFresh updates owner state before decoded-cache lookup.
+	// EnsureDecodedBlockCacheFresh refreshes the external freshness state
+	// before a decoded-cache lookup.
 	EnsureDecodedBlockCacheFresh(ctx context.Context) error
 }
 

--- a/db/block/store/store-read-through.go
+++ b/db/block/store/store-read-through.go
@@ -16,8 +16,8 @@ type StoreSource func() block.StoreOps
 // StoreReadThrough reads from a primary source, then an optional lower source.
 // When writeback is enabled, lower hits are synchronously written to primary.
 //
-// This owner is separate from block.StoreOverlay because StoreOverlay readback
-// is intentionally asynchronous.
+// StoreReadThrough is separate from block.StoreOverlay because StoreOverlay
+// readback is asynchronous.
 type StoreReadThrough struct {
 	primary   StoreSource
 	lower     StoreSource

--- a/db/kvtx/batch.go
+++ b/db/kvtx/batch.go
@@ -8,7 +8,8 @@ type BatchTxOps interface {
 	GetBatch(ctx context.Context, keys [][]byte) (values [][]byte, found []bool, err error)
 }
 
-// GetBatch reads multiple keys with the owner's batch path when available.
+// GetBatch reads multiple keys with BatchTxOps.GetBatch when ops implements it
+// and with GetBatchFallback when it does not.
 func GetBatch(ctx context.Context, ops TxOps, keys [][]byte) ([][]byte, []bool, error) {
 	if batch, ok := ops.(BatchTxOps); ok {
 		return batch.GetBatch(ctx, keys)

--- a/db/opfs/opfs.go
+++ b/db/opfs/opfs.go
@@ -1059,14 +1059,18 @@ func (BrowserDriver) SyncAvailable() bool {
 	return method.Type() == js.TypeFunction
 }
 
-// PreferSyncAccessHandles reports whether the current runtime supports sync
-// access handles for writes.
+// PreferSyncAccessHandles reports whether writes should take the sync access
+// handle path, which needs both SyncAvailable and a build that does not use
+// the TinyGo helpers. A TinyGo DedicatedWorker exposing createSyncAccessHandle
+// reports false, and its writes go through the async path.
 func PreferSyncAccessHandles() bool {
 	return DefaultDriver.PreferSyncAccessHandles()
 }
 
-// PreferSyncAccessHandles reports whether the current runtime supports sync
-// access handles for writes.
+// PreferSyncAccessHandles reports whether writes should take the sync access
+// handle path, which needs both SyncAvailable and a build that does not use
+// the TinyGo helpers. A TinyGo DedicatedWorker exposing createSyncAccessHandle
+// reports false, and its writes go through the async path.
 func (d BrowserDriver) PreferSyncAccessHandles() bool {
 	return d.SyncAvailable() && !jsutil.UseTinyGoHelpers()
 }

--- a/db/opfs/opfs.go
+++ b/db/opfs/opfs.go
@@ -97,7 +97,7 @@ type BrowserDriver struct{}
 // DefaultDriver selects the process-local browser OPFS driver by default.
 var DefaultDriver Driver = BrowserDriver{}
 
-// ErrorKind classifies browser OPFS failures into storage-owner outcomes.
+// ErrorKind classifies a browser OPFS failure by its DOMException name.
 type ErrorKind int
 
 const (
@@ -1059,14 +1059,14 @@ func (BrowserDriver) SyncAvailable() bool {
 	return method.Type() == js.TypeFunction
 }
 
-// PreferSyncAccessHandles reports whether OPFS owners should use sync access
-// handles for writes in the current runtime.
+// PreferSyncAccessHandles reports whether the current runtime supports sync
+// access handles for writes.
 func PreferSyncAccessHandles() bool {
 	return DefaultDriver.PreferSyncAccessHandles()
 }
 
-// PreferSyncAccessHandles reports whether OPFS owners should use sync access
-// handles for writes in the current runtime.
+// PreferSyncAccessHandles reports whether the current runtime supports sync
+// access handles for writes.
 func (d BrowserDriver) PreferSyncAccessHandles() bool {
 	return d.SyncAvailable() && !jsutil.UseTinyGoHelpers()
 }

--- a/db/volume/js/opfs/blockshard/broadcast.go
+++ b/db/volume/js/opfs/blockshard/broadcast.go
@@ -196,9 +196,12 @@ func scopedBroadcastChannelName(scope string) string {
 	if scope == "" {
 		return BroadcastChannelName
 	}
-	// scope is the Engine lock prefix, which names one OPFS blockshard
-	// directory. Scoping the channel name to it keeps another Engine on the
-	// same origin from advancing this Engine's shard generations and forcing a
+	// scope is the caller-supplied Engine lock prefix, used here as a channel
+	// namespace. Two Engines constructed with the same prefix share the
+	// channel even when they open different OPFS blockshard directories, so a
+	// caller that wants per-directory isolation keeps the prefix unique per
+	// directory. Scoping the channel name keeps Engines with different
+	// prefixes from advancing each other's shard generations and forcing a
 	// refresh on every read.
 	return BroadcastChannelName + ":" + scope
 }

--- a/db/volume/js/opfs/blockshard/broadcast.go
+++ b/db/volume/js/opfs/blockshard/broadcast.go
@@ -196,8 +196,9 @@ func scopedBroadcastChannelName(scope string) string {
 	if scope == "" {
 		return BroadcastChannelName
 	}
-	// Lock prefixes identify the OPFS blockshard storage owner. Broadcasts stay
-	// within that owner so another engine on the same origin cannot advance this
-	// engine's shard generations and force refreshes on every read.
+	// scope is the Engine lock prefix, which names one OPFS blockshard
+	// directory. Scoping the channel name to it keeps another Engine on the
+	// same origin from advancing this Engine's shard generations and forcing a
+	// refresh on every read.
 	return BroadcastChannelName + ":" + scope
 }

--- a/db/volume/js/opfs/blockshard/engine.go
+++ b/db/volume/js/opfs/blockshard/engine.go
@@ -308,8 +308,8 @@ func (e *Engine) Sync(ctx context.Context) error {
 // CompactOnce runs at most one compaction plan per shard.
 //
 // Compaction is storage maintenance, so foreground writes do not run it
-// inline. Maintenance owners can call CompactOnce when they have a lifecycle
-// slot for background OPFS work.
+// inline. Callers run CompactOnce from a goroutine dedicated to background
+// OPFS work.
 func (e *Engine) CompactOnce(ctx context.Context) error {
 	ctx, task := trace.NewTask(ctx, "hydra/opfs-blockshard/compact-once")
 	defer task.End()

--- a/db/world/block/engine-tx-ops.go
+++ b/db/world/block/engine-tx-ops.go
@@ -281,7 +281,8 @@ func (e *EngineTx) refreshReadSnapshot(ctx context.Context) error {
 		}
 	}
 
-	// Revalidate transaction ownership after acquiring the Engine lock.
+	// Recheck the Engine closed flag and this transaction's release flag under
+	// the Engine lock.
 	locked := e.engine.bcast.Lock()
 	if e.engine.closed {
 		locked.Unlock()

--- a/db/world/block/engine-tx.go
+++ b/db/world/block/engine-tx.go
@@ -57,7 +57,8 @@ func (e *EngineTx) CommitBlockTransaction(ctx context.Context) (*bucket.ObjectRe
 		e.Discard()
 		return nil, tx.ErrNotWrite
 	}
-	// Claim lifecycle ownership before moving the lease out of Engine state.
+	// Set rel before moving the lease out of Engine state. A commit that finds
+	// rel already set returns ErrDiscarded.
 	if e.rel.Swap(true) {
 		return nil, tx.ErrDiscarded
 	}
@@ -194,8 +195,9 @@ func (e *EngineTx) Discard() {
 	e.engine.drainRetirement(context.Background(), retirement)
 }
 
-// detachLocked removes this transaction from Engine ownership without waiting
-// for its transaction locks or coordinator lease.
+// detachLocked removes this transaction from Engine.coordinatorTxs and
+// Engine.writeTx without waiting for its transaction locks or coordinator
+// lease.
 func (e *EngineTx) detachLocked() engineRetirement {
 	// Mark the transaction discarded before removing its Engine registrations.
 	e.rel.Store(true)
@@ -206,7 +208,8 @@ func (e *EngineTx) detachLocked() engineRetirement {
 		lease:   e.lease,
 	}
 	e.lease = nil
-	// Clear Engine writer ownership without releasing its serialized turn here.
+	// Move Engine.writeTxRel into the retirement, which releases the serialized
+	// write turn after the Engine lock drops.
 	if e.engine.writeTx == e {
 		e.engine.writeTx = nil
 		retirement.writeTxRel = e.engine.writeTxRel

--- a/db/world/block/engine.go
+++ b/db/world/block/engine.go
@@ -645,7 +645,8 @@ func (e *Engine) NewBlockEngineTransaction(ctx context.Context, write bool) (*En
 		return nil, err
 	}
 
-	// Publish writer ownership only after its complete state is ready.
+	// Assign Engine.writeTx only after the EngineTx carries its base head ref
+	// and lease.
 	engTx := newEngineTx(e, NewTx(world))
 	engTx.baseHeadRef = baseHeadRef
 	engTx.lease = lease
@@ -731,8 +732,8 @@ func (e *Engine) BuildStorageCursor(ctx context.Context) (*bucket_lookup.Cursor,
 // If the ref Bucket ID is empty, uses the same bucket + volume as the world.
 // The lookup cursor will be released after cb returns.
 // The root clone is made while bcast is held for the documented same-bucket
-// root path. Cursor.Clone does not retain a bucket-handle release owner, so
-// this does not establish a cross-bucket lifetime across Engine.Close.
+// root path. Cursor.Clone copies the bucket handle without taking a release
+// func, so this does not establish a cross-bucket lifetime across Engine.Close.
 //
 // NOTE: this is the implementation of AccessWorldState for the world/block engine.
 func (e *Engine) AccessWorldState(

--- a/db/world/block/world.go
+++ b/db/world/block/world.go
@@ -692,7 +692,7 @@ func (t *WorldState) GarbageCollect(ctx context.Context) (*block_gc.Stats, error
 	}
 	// A World ref graph covers one retained root, while the physical store is
 	// shared by engine snapshots, transactions, forks, and coordinated heads.
-	// Only a store-scoped reachability owner may authorize physical deletion.
+	// CollectGraphOnly prunes the ref graph and deletes no blocks.
 	c := block_gc.NewCollector(t.refGraph, t.store, t.onSwept)
 	return c.CollectGraphOnly(ctx)
 }

--- a/db/world/util.go
+++ b/db/world/util.go
@@ -93,8 +93,8 @@ type releasableObjectState interface {
 	Release()
 }
 
-// ReleaseObjectState releases object-state implementations with explicit
-// resource ownership.
+// ReleaseObjectState calls Release on obj when the ObjectState implementation
+// has a Release method.
 func ReleaseObjectState(obj ObjectState) {
 	if obj == nil {
 		return


### PR DESCRIPTION
A set of comments across db described components as an "owner" instead of naming the type or method that does the work: a constructor that "constructs a decoded-block cache owner", a forwarder that "forwards decoded-cache freshness to the read owner", a helper that "reads multiple keys with the owner's batch path", and an Engine comment that published "writer ownership".

These now say what the code does. NewDecodedBlockCacheWithOptions constructs a cache with opts. StoreRW forwards freshness to its read handle. kvtx.GetBatch dispatches to BatchTxOps.GetBatch or GetBatchFallback. Engine assigns writeTx once the EngineTx carries its base head ref and lease, and detachLocked names Engine.coordinatorTxs and Engine.writeTx. Cursor.Clone copies the bucket handle without taking a release func. The blockshard broadcast comment names the Engine lock prefix that scopes the channel name. Volume.Sync replaces "the durability barrier owner" in the StoreFeature docs and in block.proto, so block.pb.go and block.pb.ts carry the regenerated text.

The GC ref graph keeps "owner" and "ownership" throughout, since a RefEdge is a subject-to-object ownership edge, the incoming-reference sets really are owner sets, and gcgraph holds a graph-wide ownership lock. The unix file owner uid in unixfs/fuse stays as well.

Comments only. No identifier, signature, or behavior changed.