### PR TITLE
docs: name concrete types in comments outside core paths

### DIFF
--- a/app/EditorShell.tsx
+++ b/app/EditorShell.tsx
@@ -132,7 +132,7 @@ function EditorShellContent() {
     return () => window.removeEventListener('hashchange', handleHashChange)
   }, [])
 
-  // Keep ShellTabStrip (and its single OptimizedLayout owner) mounted for
+  // Keep ShellTabStrip (and the single OptimizedLayout it renders) mounted for
   // both URL modes. Its model handoff preserves FlexLayout's tab nodes and
   // therefore the mounted per-tab application trees.
   return (

--- a/app/ShellFlexLayout.tsx
+++ b/app/ShellFlexLayout.tsx
@@ -357,8 +357,8 @@ function ShellTabStripInner({
   const initializedRef = useRef(false)
 
   // A deep link or back/forward navigation can supply a new grid structure
-  // without remounting this owner. Replace only the model; tab nodes retain
-  // their stable IDs and OptimizedLayout remains mounted.
+  // without remounting ShellTabStripInner. Replace only the model; tab nodes
+  // retain their stable IDs and OptimizedLayout remains mounted.
   useEffect(() => {
     const path = getAppPath()
     if (!path.startsWith('/g/')) {
@@ -627,7 +627,7 @@ function ShellTabStripInner({
         ) {
           return
         }
-        // Selection follows the user across panes. The tab owner drives the
+        // Selection follows the user across panes. The selected tab drives the
         // document title, the command session, and the toolbar actions, so a
         // selection left behind here points all three at the wrong pane.
         const selectedId = getSelectedTabId(newModel)

--- a/app/ShellGridLayout.tsx
+++ b/app/ShellGridLayout.tsx
@@ -162,7 +162,7 @@ export function ShellGridLayout() {
     [],
   )
 
-  // Handle model changes without replacing the grid layout owner.
+  // Handle model changes without replacing the mounted grid Layout.
   const handleModelChange = useCallback(
     (newModel: Model) => {
       setModel(newModel)

--- a/app/canvas/graphLinkPolicy.ts
+++ b/app/canvas/graphLinkPolicy.ts
@@ -28,7 +28,7 @@ export class GraphLinkPredicatePolicy {
     }
 
     // TODO: Replace this TypeScript predicate table with ObjectType metadata
-    // ownership once graph edge ownership is exposed by object types.
+    // once object types declare their owner-managed graph edges.
     if (ownerManagedPredicates.has(link.predicate)) {
       return {
         viewable: true,

--- a/app/docs/markdown-overrides.tsx
+++ b/app/docs/markdown-overrides.tsx
@@ -15,7 +15,8 @@ function DocsTable(props: React.TableHTMLAttributes<HTMLTableElement>) {
 // docsMarkdownOverrides is the shared markdown-to-jsx configuration for every
 // docs surface: internal-link handling, syntax-highlighted code blocks, and
 // overflow-safe tables. Both the docs site and the in-app documentation viewer
-// render markdown through this single owner so their prose behaves identically.
+// render markdown through this one configuration so their prose behaves
+// identically.
 export const docsMarkdownOverrides = {
   overrides: {
     a: { component: MarkdownLink },

--- a/app/provider/spacewave/VerifyEmailPage.tsx
+++ b/app/provider/spacewave/VerifyEmailPage.tsx
@@ -61,7 +61,7 @@ export function VerifyEmailPage() {
     setAddExpanded(false)
   }, [addEmail, newEmail])
 
-  // Onboarding Status is the route-status owner for account-level email
+  // Onboarding Status decides route status for account-level email
   // verification; the email list may still be one fetch behind that gate.
   const accountEmailVerified = onboarding?.emailVerified ?? false
   const hasVerifiedEmail = emails?.some((e) => e.verified) ?? false

--- a/app/quickstart/create.ts
+++ b/app/quickstart/create.ts
@@ -1212,7 +1212,7 @@ async function initKvQuickstart(
     await store.withTransaction(
       true,
       async (tx) => {
-        // eslint-disable-next-line react-doctor/async-parallel -- transaction writes stay ordered on one transaction owner.
+        // eslint-disable-next-line react-doctor/async-parallel -- transaction writes stay ordered on one transaction.
         await tx.set(encoder.encode('hello'), encoder.encode('world'))
         await tx.set(
           encoder.encode('profile.json'),

--- a/app/session/SessionUploadManagerContext.tsx
+++ b/app/session/SessionUploadManagerContext.tsx
@@ -14,14 +14,14 @@ import { useSessionNavigate } from '@s4wave/web/contexts/contexts.js'
 // SessionUploadManagerContext holds the one upload manager for a session UI
 // tree. It is null outside a provider so presentation-only surfaces (display,
 // debug harnesses) that mount a UnixFS browser without a session simply have no
-// upload owner rather than crashing.
+// upload manager rather than crashing.
 const SessionUploadManagerContext = createContext<UploadManager | null>(null)
 
-// SessionUploadManagerProvider owns file uploads for a session, above the object
-// viewers that start them. Uploads and their feedback survive navigating between
-// objects or finishing a wizard because this owner outlives any single viewer;
-// in-flight uploads are aborted only on session teardown, when this provider
-// unmounts.
+// SessionUploadManagerProvider holds the UploadManager for a session, above the
+// object viewers that start uploads. Uploads and their feedback survive
+// navigating between objects or finishing a wizard because this provider
+// outlives any single viewer; in-flight uploads are aborted only on session
+// teardown, when this provider unmounts.
 export function SessionUploadManagerProvider({
   children,
 }: {

--- a/app/unixfs/UnixFSBrowser.tsx
+++ b/app/unixfs/UnixFSBrowser.tsx
@@ -84,7 +84,7 @@ export interface UnixFSBrowserProps {
   worldState: Resource<IWorldState>
   // browserBody replaces the browser's default file list/file viewer body.
   browserBody?: ComponentType<UnixFSBrowserBodyProps>
-  // directoryHeader renders owner-specific content above the generic file list.
+  // directoryHeader renders caller-supplied content above the file list.
   directoryHeader?: ComponentType<UnixFSBrowserDirectoryHeaderProps>
 }
 

--- a/app/unixfs/gallery.ts
+++ b/app/unixfs/gallery.ts
@@ -386,7 +386,7 @@ class WatchedGalleryDir {
           try {
             this.children.set(
               entry.name,
-              // eslint-disable-next-line react-doctor/async-await-in-loop -- directory watchers are attached sequentially to preserve child owner order.
+              // eslint-disable-next-line react-doctor/async-await-in-loop -- directory watchers are attached sequentially to preserve child entry order.
               await this.scope.watchChildDir(this, entry.name, entryPath),
             )
           } catch (err) {

--- a/app/wizard/VmCreationProgressScreen.tsx
+++ b/app/wizard/VmCreationProgressScreen.tsx
@@ -74,7 +74,7 @@ function getProgressDetail(
 }
 
 // VmCreationProgressScreen renders the event-driven CDN copy and VM creation
-// stages without implying a byte fraction the copy owner cannot provide.
+// stages without implying a byte fraction the copy events cannot provide.
 export function VmCreationProgressScreen({
   progress,
   vmName,

--- a/bldr/devtool/start-web-ws.go
+++ b/bldr/devtool/start-web-ws.go
@@ -80,8 +80,9 @@ func (a *DevtoolArgs) ExecuteWebWsProject(ctx context.Context) (err error) {
 	}
 	defer pluginStorageCtrlRef.Release()
 
-	// Web-server mode still loads the web plugin for package/RPC ownership, but
-	// the devtool serves the browser shell and must not embed a native renderer.
+	// Web-server mode still loads the web plugin so it registers its packages
+	// and RPCs, but the devtool serves the browser shell and must not embed a
+	// native renderer.
 	if err := os.Setenv(web_plugin_compiler.SkipNativeWebRendererEnvVar, "true"); err != nil {
 		return err
 	}

--- a/bldr/plugin/host/logs/hub.go
+++ b/bldr/plugin/host/logs/hub.go
@@ -35,7 +35,7 @@ func WithRetainedEventLimit(limit uint32) HubOption {
 	}
 }
 
-// WithClock sets the clock used for owner-assigned event timestamps.
+// WithClock sets the clock Hub reads when it timestamps an event.
 func WithClock(now func() time.Time) HubOption {
 	return func(h *Hub) {
 		h.now = now
@@ -58,7 +58,7 @@ func NewHub(opts ...HubOption) *Hub {
 	return h
 }
 
-// Emit appends an event and assigns owner-controlled metadata.
+// Emit appends an event and fills in the metadata Hub assigns.
 func (h *Hub) Emit(event *StructuredLogEvent) (*EmitStructuredLogResponse, error) {
 	if event == nil {
 		return nil, errors.New("structured log event cannot be nil")

--- a/bldr/plugin/host/scheduler/controller.go
+++ b/bldr/plugin/host/scheduler/controller.go
@@ -84,8 +84,8 @@ type Controller struct {
 	pluginStatusMtx sync.Mutex
 	// pluginStatus stores live plugin instance states by pluginInstanceKey.
 	pluginStatus map[string]*bldr_plugin.PluginStatus
-	// pluginManifestRecoveryStatus stores owner-owned retained Manifest
-	// selection and eligibility facts by pluginInstanceKey.
+	// pluginManifestRecoveryStatus stores retained Manifest selection and
+	// eligibility facts by pluginInstanceKey.
 	pluginManifestRecoveryStatus map[string]*PluginManifestRecoveryStatus
 }
 

--- a/bldr/plugin/host/scheduler/plugin-instance.go
+++ b/bldr/plugin/host/scheduler/plugin-instance.go
@@ -57,7 +57,7 @@ type pluginInstance struct {
 	// downloadManifestRoutine is the routine to download the contents of a manifest to a local bucket
 	// this routine only runs if watchWorldManifestRoutine triggers it.
 	downloadManifestRoutine *routine.StateRoutineContainer[*bldr_manifest.ManifestSnapshot]
-	// manifestCopyStatus exposes the owner-local copy class for tests and diagnostics.
+	// manifestCopyStatus exposes this instance's copy class for tests and diagnostics.
 	manifestCopyStatus *ccontainer.CContainer[*manifestCopyStatus]
 	// executePluginRoutine is the routine to execute a plugin with a manifest.
 	executePluginRoutine *routine.StateRoutineContainer[*executePluginArgs]

--- a/bldr/resource/server/context.go
+++ b/bldr/resource/server/context.go
@@ -10,7 +10,7 @@ import (
 // ResourceClientContext is the value attached to a Context containing
 // information about the Resource RPC request.
 type ResourceClientContext interface {
-	// Context returns the resource owner lifetime context.
+	// Context returns the lifetime context of the Resource RPC request.
 	Context() context.Context
 	// AddResource adds a child resource with a release callback.
 	AddResource(mux srpc.Invoker, releaseFn func()) (uint32, error)

--- a/bldr/resource/server/tracked-client.go
+++ b/bldr/resource/server/tracked-client.go
@@ -23,7 +23,8 @@ type RemoteResourceClient struct {
 	adoptionAckEnabled bool
 	// resources contains the map of resources owned by this client.
 	resources map[uint32]*trackedResource
-	// pendingAdoptions maps invocation-created resources to their owner.
+	// pendingAdoptions maps invocation-created resources to the
+	// resourceRPCContext that created them.
 	pendingAdoptions map[uint32]*resourceRPCContext
 	// adoptedAdoptions maps acknowledged resources to their invocation until commit.
 	adoptedAdoptions map[uint32]*resourceRPCContext

--- a/bldr/web/bldr/boot-downloads.ts
+++ b/bldr/web/bldr/boot-downloads.ts
@@ -121,9 +121,9 @@ export function failBootDownload(id: string, error?: string): void {
 }
 
 // streamResponseWithBootProgress reads a fetch Response body to completion while
-// reporting per-chunk byte progress under id. It is the single owner of the
-// getReader accounting loop so producers never hand-roll byte counting; it
-// returns the collected chunks for the caller to assemble (Blob, module URL,
+// reporting per-chunk byte progress under id. It holds the only getReader
+// accounting loop so producers never hand-roll byte counting; it returns the
+// collected chunks for the caller to assemble (Blob, module URL,
 // WebAssembly compile, ...). totalHint wins over content-length when a decoded
 // size is known ahead of the compressed transfer length.
 export async function streamResponseWithBootProgress(

--- a/bldr/web/bldr/dedicated-worker-host-owner.ts
+++ b/bldr/web/bldr/dedicated-worker-host-owner.ts
@@ -111,7 +111,7 @@ export class DedicatedWorkerHostOwner {
     })
 
     void navigator.locks.query().then((snapshot) => {
-      // A grant can beat the query; only a still-pending owner can attach to
+      // A grant can beat the query; only a still-pending role can attach to
       // the already-held standing lock.
       if (this.role !== 'pending') {
         return

--- a/bldr/web/bldr/opfs-worker.ts
+++ b/bldr/web/bldr/opfs-worker.ts
@@ -274,7 +274,7 @@ async function opWriteFile(args: unknown): Promise<number> {
 
 // Async file opens keep only FileSystemFileHandle tokens. Sync access handles pin
 // exclusive OPFS locks, so holding one across bbolt read/write calls can block
-// later writable sessions from the same storage owner.
+// later writable sessions against the same OPFS file.
 async function opOpenFile(
   args: unknown,
   create: boolean,

--- a/bldr/web/bldr/service-worker.ts
+++ b/bldr/web/bldr/service-worker.ts
@@ -130,7 +130,7 @@ export type BrowserFetchSourceKind =
   | 'bldr-runtime'
   | 'native-fetch'
 
-// BrowserFetchSource records the typed owner for a ServiceWorker request.
+// BrowserFetchSource records the typed origin of a ServiceWorker request.
 export interface BrowserFetchSource {
   kind: BrowserFetchSourceKind
   path: string
@@ -958,7 +958,7 @@ async function matchStaticPluginAsset(
 }
 
 // Static plugin assets are warm-cached by promoted browser-release generation.
-// Content identity and ETag validation remain a follow-on owner API.
+// Content identity and ETag validation remain a follow-on API.
 async function revalidateStaticPluginAsset(
   source: BrowserFetchSource,
   asset: StaticPluginAsset,
@@ -1274,7 +1274,7 @@ async function handleDedicatedRuntimeHostConnectRequest(
   })
 }
 
-// handleServiceWorkerMessage routes a page message to the ServiceWorker owner.
+// handleServiceWorkerMessage routes a page message to its ServiceWorker handler.
 export function handleServiceWorkerMessage(
   ev: ExtendableMessageEvent,
   deps: ServiceWorkerMessageDeps,
@@ -1402,7 +1402,7 @@ function isNavigationRequest(request: Request): boolean {
   )
 }
 
-// classifyBrowserFetchSource returns the ServiceWorker owner for a request.
+// classifyBrowserFetchSource returns the BrowserFetchSource for a request.
 export function classifyBrowserFetchSource(
   request: Request,
   matchPrefixes: readonly string[] = BLDR_URI_PREFIXES,

--- a/bldr/web/bldr/storage-durability-owner.ts
+++ b/bldr/web/bldr/storage-durability-owner.ts
@@ -1,7 +1,8 @@
 // PersistenceStatus is the latest observed browser eviction-protection state.
 export type PersistenceStatus = 'unknown' | 'persisted' | 'not-persisted'
 
-// StorageManagerLike is the subset of navigator.storage this owner requires.
+// StorageManagerLike is the subset of navigator.storage that
+// StorageDurabilityOwner reads.
 export interface StorageManagerLike {
   persisted(): Promise<boolean>
   persist(): Promise<boolean>

--- a/bldr/web/bldr/web-document-tracker.ts
+++ b/bldr/web/bldr/web-document-tracker.ts
@@ -115,9 +115,9 @@ export class WebDocumentTracker {
       | null,
     logicalClientId?: string,
     // onOpfsBridgeLost fires when the WebDocument hosting the OPFS bridge worker
-    // is removed, or the broker reports that worker died. The owner re-hosts the
-    // bridge. Removing a non-host WebDocument does not fire it, so an unrelated
-    // tab close never invalidates a healthy mounted volume's handles.
+    // is removed, or the broker reports that worker died. The handler re-hosts
+    // the bridge. Removing a non-host WebDocument does not fire it, so an
+    // unrelated tab close never invalidates a healthy mounted volume's handles.
     private readonly onOpfsBridgeLost?: (() => Promise<void> | void) | null,
   ) {
     this.clientUuid = clientUuid

--- a/bldr/web/bldr/web-document.ts
+++ b/bldr/web/bldr/web-document.ts
@@ -791,8 +791,8 @@ export class WebDocument extends SimpleEventEmitter<WebDocumentEvents> {
   // workers at a time. The holder keeps the lock until close so other tabs use
   // the same worker instance through the WebRuntime instead of forcing handoff.
   private pluginSingletonReady: Promise<void> = Promise.resolve()
-  // pluginSingletonLockEnabled records whether this document participates in
-  // ownership of the dedicated plugin worker singleton.
+  // pluginSingletonLockEnabled records whether this document contends for the
+  // dedicated plugin worker singleton lock.
   private pluginSingletonLockEnabled = false
   // singletonAbort aborts the singleton lock request on close.
   private singletonAbort?: AbortController
@@ -829,13 +829,13 @@ export class WebDocument extends SimpleEventEmitter<WebDocumentEvents> {
   }
 
   // readStoragePersistenceStatus refreshes browser cleanup protection through
-  // the document-owned durability owner.
+  // storageDurabilityOwner.
   public readStoragePersistenceStatus(): Promise<PersistenceStatus> {
     return this.storageDurabilityOwner.readStatus()
   }
 
-  // requestStoragePersistence requests browser cleanup protection through the
-  // document-owned durability owner.
+  // requestStoragePersistence requests browser cleanup protection through
+  // storageDurabilityOwner.
   public requestStoragePersistence(): Promise<void> {
     return this.storageDurabilityOwner.requestProtection()
   }
@@ -1065,7 +1065,7 @@ export class WebDocument extends SimpleEventEmitter<WebDocumentEvents> {
         this.webRuntimeId,
         this.webDocumentUuid,
       )
-      // Every dedicated document participates in plugin singleton ownership.
+      // Every dedicated document contends for the plugin singleton lock.
       // Attached documents must wait for the elected runtime host's workers
       // instead of starting a private plugin host that cannot join the runtime.
       this.enablePluginSingletonLock()
@@ -2117,7 +2117,7 @@ export class WebDocument extends SimpleEventEmitter<WebDocumentEvents> {
     this.pluginSingletonLockEnabled = true
     if (!shouldUseWebDocumentLivenessLock()) {
       // There is no timer fallback here: backgrounded tabs throttle timers, and
-      // plugin startup needs a real cross-tab singleton owner.
+      // plugin startup needs a real cross-tab singleton lock.
       this.pluginSingletonReady = Promise.reject(
         new Error('Web Locks unavailable for dedicated plugin workers'),
       )
@@ -2626,7 +2626,8 @@ export class WebDocument extends SimpleEventEmitter<WebDocumentEvents> {
   // requesterId, waits for it to report ready, and returns the client
   // MessagePort. After startup, a worker error tears the worker down and invokes
   // onWorkerDied so the requester can re-host (the dead worker leaves the
-  // transferred client port with no owner, hanging in-flight bridge requests).
+  // transferred client port with nothing reading it, hanging in-flight bridge
+  // requests).
   // Returns null when a concurrent request already superseded this worker (the
   // superseding request owns the response). Throws when the worker fails to
   // start.
@@ -2719,10 +2720,10 @@ export class WebDocument extends SimpleEventEmitter<WebDocumentEvents> {
         clientPort.close()
         return null
       }
-      // A post-startup OPFS worker error leaves the transferred client port with
-      // no live owner. Tear the dead worker down and notify the requester to
-      // re-host. Guard on identity so a worker already replaced by a re-host does
-      // not trigger a second teardown.
+      // A post-startup OPFS worker error leaves the transferred client port
+      // with nothing reading it. Tear the dead worker down and notify the
+      // requester to re-host. Guard on identity so a worker already replaced by
+      // a re-host does not trigger a second teardown.
       worker.onerror = (ev: ErrorEvent) => {
         reportWorkerError(ev)
         if (this.opfsWorkers.get(requesterId) !== worker) {

--- a/bldr/web/bldr/web-runtime.ts
+++ b/bldr/web/bldr/web-runtime.ts
@@ -160,7 +160,7 @@ class WebRuntimeClientInstance {
     return this.state === 'closed'
   }
 
-  // clientId returns the stable logical id used for routing and ownership.
+  // clientId returns the stable logical id WebRuntime routes and keys locks by.
   public get clientId(): string {
     return this.host.getClientId(this.init)
   }

--- a/bldr/web/bundler/vite/compiler/vite.go
+++ b/bldr/web/bundler/vite/compiler/vite.go
@@ -21,9 +21,9 @@ func BuildViteBundleMeta(bundles []*ViteBundleMeta) ([]*ViteBundleMeta, error) {
 
 		existingBundle, exists := bundleMap[bundleID]
 		if exists {
-			// Merge duplicate bundle declarations into the bundle owner. Project
-			// config may define the entrypoints while compiler shortcuts add
-			// runtime externals for the same id.
+			// Merge duplicate bundle declarations into the existing bundle.
+			// Project config may define the entrypoints while compiler shortcuts
+			// add runtime externals for the same id.
 			existingBundle.Entrypoints = append(existingBundle.Entrypoints, bundle.GetEntrypoints()...)
 			existingBundle.ExternalPkgs = appendMissingStrings(existingBundle.ExternalPkgs, bundle.GetExternalPkgs())
 			existingBundle.ViteConfigPaths = appendMissingStrings(existingBundle.ViteConfigPaths, bundle.GetViteConfigPaths())

--- a/bldr/web/bundler/web-pkg-refs.go
+++ b/bldr/web/bundler/web-pkg-refs.go
@@ -57,7 +57,7 @@ func (sl WebPkgRefConfigSlice) AppendWebPkgRefConfig(addConf *WebPkgRefConfig) (
 // MergeWebPkgRefConfigImports merges declared config imports into resolved web
 // package refs. Config imports are package-root-relative entry files and apply
 // everywhere a WebPkgRefConfig is consumed; callers that already resolved package
-// roots use this owner helper instead of rebuilding the merge policy locally.
+// roots call this instead of rebuilding the merge policy locally.
 func MergeWebPkgRefConfigImports(refs web_pkg.WebPkgRefSlice, configs []*WebPkgRefConfig) web_pkg.WebPkgRefSlice {
 	if len(refs) == 0 || len(configs) == 0 {
 		return refs

--- a/bldr/web/electron/main/app.ts
+++ b/bldr/web/electron/main/app.ts
@@ -378,11 +378,11 @@ export class BldrElectronApp {
         )
         return
       }
-      // The renderer key dispatcher owns command keybindings, so no main-process
-      // shortcut registry may claim the leader or the palette key. This route
-      // exposes that ownership as an observable state, since a key injected
-      // through the debugging protocol reaches the renderer whether or not a
-      // native owner would have stolen it first.
+      // The renderer key dispatcher handles command keybindings, so no
+      // main-process shortcut registry may claim the leader or the palette key.
+      // This route reports what globalShortcut currently holds, since a key
+      // injected through the debugging protocol reaches the renderer whether or
+      // not a native shortcut would have stolen it first.
       if (req.method === 'GET' && url.pathname === '/globalshortcut-state') {
         sendE2EJSON(res, 200, {
           leaderRegistered:

--- a/bldr/web/entrypoint/browser/bundle/bundle-cache.go
+++ b/bldr/web/entrypoint/browser/bundle/bundle-cache.go
@@ -466,8 +466,8 @@ func runEsbuildBundle(opts esbuild.BuildOptions) (esbuild.BuildResult, []string,
 	return result, inputs, nil
 }
 
-// esbuildOptionsDigest hashes every output-affecting BuildOptions field used by
-// the browser bundle owner. Unknown typed plugin state is not cacheable.
+// esbuildOptionsDigest hashes every output-affecting BuildOptions field the
+// browser bundle build sets. Unknown typed plugin state is not cacheable.
 func esbuildOptionsDigest(opts esbuild.BuildOptions) ([]byte, bool) {
 	if len(opts.MangleCache) != 0 {
 		return nil, false

--- a/bldr/web/entrypoint/browser/bundle/bundle.go
+++ b/bldr/web/entrypoint/browser/bundle/bundle.go
@@ -419,7 +419,7 @@ function absPath(path){
   return path.startsWith('/')?path:'/'+path;
 }
 // Boot download registry: the pre-module mirror of the bldr boot-downloads
-// owner. Producers report streamed bytes per boot asset; the static loading
+// registry. Producers report streamed bytes per boot asset; the static loading
 // shell renders one bar per download and the same snapshot/event feed the
 // React loading screen once it mounts. No polling: every change dispatches
 // bootDownloadEvent.

--- a/bldr/web/pkg/routine-group.go
+++ b/bldr/web/pkg/routine-group.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 )
 
-// RoutineGroup tracks routines that must stop before their owner closes.
+// RoutineGroup tracks routines so StopAccepting and Wait can drain them.
 type RoutineGroup struct {
 	mtx    sync.Mutex
 	wg     sync.WaitGroup

--- a/bldr/web/runtime/controller/controller.go
+++ b/bldr/web/runtime/controller/controller.go
@@ -285,7 +285,7 @@ func (c *Controller) ServePluginHTTP(pluginID string, rw http.ResponseWriter, re
 }
 
 // setNoCacheHeaders keeps controller headers non-load-bearing for plugin asset
-// freshness; generation-scoped ServiceWorker cache ownership handles warm reads.
+// freshness; the generation-scoped ServiceWorker cache handles warm reads.
 func setNoCacheHeaders(hdr http.Header) {
 	hdr.Set("Cache-Control", "no-cache, no-store, must-revalidate")
 	hdr.Set("Pragma", "no-cache")

--- a/bldr/web/runtime/opfs-bridge-client.ts
+++ b/bldr/web/runtime/opfs-bridge-client.ts
@@ -19,8 +19,8 @@ type OpfsBridgeResponse = {
 }
 
 // OpfsBridgeClient correlates id-tagged requests to a DedicatedWorker OPFS
-// bridge over a MessagePort, exposing a promise-based request(). It is the only
-// owner of the bridge transport; closing it rejects in-flight requests so a
+// bridge over a MessagePort, exposing a promise-based request(). It holds the
+// bridge MessagePort exclusively; closing it rejects in-flight requests so a
 // port swap (re-host) fails the Go side deterministically instead of hanging.
 export class OpfsBridgeClient {
   private readonly pending = new Map<

--- a/bldr/web/runtime/runtime.ts
+++ b/bldr/web/runtime/runtime.ts
@@ -253,8 +253,8 @@ export interface WebDocumentToClient {
   // this intent the two close signals are indistinguishable, and either choice
   // is wrong for the other case.
   terminal?: true
-  // closeAckPort receives a message after the client owner removes this
-  // WebDocument and completes its close handling.
+  // closeAckPort receives a message after the client removes this WebDocument
+  // and completes its close handling.
   closeAckPort?: MessagePort
   // bridgePort is the MessagePort to use for WebRTC bridge commands.
   bridgePort?: MessagePort

--- a/bldr/web/runtime/wasm/plugin-wasm.ts
+++ b/bldr/web/runtime/wasm/plugin-wasm.ts
@@ -711,7 +711,7 @@ function callGoCallback(cb: () => void): boolean {
   const consoleError = console.error
   let released = false
   console.error = (...args: unknown[]) => {
-    // Go may release a callback before this owner invokes it. Filter that
+    // Go may release a callback before callGoCallback invokes it. Filter that
     // known callback edge only inside the invocation, never for the whole worker.
     if (args.some(isReleasedGoCallbackError)) {
       released = true

--- a/cmd/spacewave/cli/daemon-accept.go
+++ b/cmd/spacewave/cli/daemon-accept.go
@@ -86,7 +86,7 @@ func serveDaemonListener(
 }
 
 // acceptDaemonListener accepts incoming daemon connections and tracks their
-// lifecycle. It returns a drain function once accepting stops so the owner can
+// lifecycle. It returns a drain function once accepting stops so the caller can
 // release the listener, let a shutdown requester read its acknowledgement, and
 // only then close any remaining clients synchronously.
 func acceptDaemonListener(

--- a/cmd/spacewave/cli/daemon-control.go
+++ b/cmd/spacewave/cli/daemon-control.go
@@ -20,7 +20,7 @@ const (
 )
 
 // daemonControlHandler wraps the shared daemon-control handler and records the
-// granted connection so the serve owner can wait for that requester to read its
+// granted connection so the serve loop can wait for that requester to read its
 // acknowledgement and close before draining.
 type daemonControlHandler struct {
 	*listener_control.Handler

--- a/core/cdn/bstore/block-store.go
+++ b/core/cdn/bstore/block-store.go
@@ -263,7 +263,7 @@ func (s *CdnBlockStore) SetPointer(ptr *cdn.CdnRootPointer) {
 // EnsureDecodedBlockCacheFresh refreshes pointer state before decoded cache reads.
 func (s *CdnBlockStore) EnsureDecodedBlockCacheFresh(ctx context.Context) error {
 	// Decoded cache hits can otherwise bypass ensurePointer entirely. Keep CDN
-	// pointer TTL freshness on the store owner, before any decoded object reuse.
+	// pointer TTL freshness in CdnBlockStore, before any decoded object reuse.
 	_, _, err := s.ensurePointer(ctx)
 	return err
 }
@@ -274,7 +274,7 @@ func (s *CdnBlockStore) setPointer(ctx context.Context, ptr *cdn.CdnRootPointer)
 		if s.memCache != nil {
 			s.memCache.reset()
 		}
-		// Pointer, manifest, and decoded-cache epoch publish under one owner lock.
+		// Pointer, manifest, and decoded-cache epoch publish under one bcast lock.
 		// Reads take the same lock while snapshotting the manifest so they cannot
 		// pair an old pointer decision with a new manifest view.
 		s.invalidateDecodedBlocks(ctx)
@@ -368,9 +368,9 @@ func (s *CdnBlockStore) invalidateDecodedBlocks(ctx context.Context) {
 	if s.decodedBlocks == nil {
 		return
 	}
-	// A CDN pointer swap changes the manifest owner under the store. Decoded
-	// hits must be equivalent to reading through the current manifest, not an
-	// older CDN root that happened to decode the same ref earlier.
+	// A CDN pointer swap replaces the manifest under the store. Decoded hits
+	// must be equivalent to reading through the current manifest, not an older
+	// CDN root that happened to decode the same ref earlier.
 	s.decodedBlocks.InvalidateAll(ctx)
 }
 

--- a/core/cdn/sharedobject/engine.go
+++ b/core/cdn/sharedobject/engine.go
@@ -38,7 +38,8 @@ type WorldEngine struct {
 	Cursor *bucket_lookup.Cursor
 	// decodedBlocks is the decoded-block cache borrowed by this CDN object engine.
 	decodedBlocks *block.DecodedBlockCache
-	// ownDecodedBlocks is true only for explicit fallback cache ownership.
+	// ownDecodedBlocks is true when WorldEngine built decodedBlocks itself and
+	// closes it on Release.
 	ownDecodedBlocks bool
 
 	// refresh runs the head-ref watcher goroutine; owned by Release.

--- a/core/forge/dashboard/ops-quickstart.go
+++ b/core/forge/dashboard/ops-quickstart.go
@@ -56,7 +56,7 @@ func (o *InitForgeQuickstartOp) ApplyWorldOp(
 		return false, err
 	}
 
-	// Parse the session peer ID for entity ownership.
+	// Parse the session peer ID that authors every world op below.
 	sessionPeerID, err := confparse.ParsePeerID(o.GetSessionPeerId())
 	if err != nil {
 		return false, err

--- a/core/forge/exec/v86.go
+++ b/core/forge/exec/v86.go
@@ -62,8 +62,8 @@ type v86Handler struct {
 	loadInvoker v86InvokerFactory
 }
 
-// Execute requests desired RUNNING and waits for its process owner to report
-// observed RUNNING or a terminal failure.
+// Execute requests desired RUNNING and waits for the v86 execution stream to
+// report observed RUNNING or a terminal failure.
 func (h *v86Handler) Execute(ctx context.Context) error {
 	if h.b == nil {
 		return errors.New("v86 exec requires bus")

--- a/core/provider/local/factory.go
+++ b/core/provider/local/factory.go
@@ -59,7 +59,7 @@ func (t *Factory) Construct(
 	}
 
 	// The local provider does not use a provider-level Peer. Account and session
-	// operations resolve the volume peer at their storage owner.
+	// operations resolve the volume peer through their volume.
 	return provider_controller.NewProviderControllerWithoutPeer(
 		le,
 		t.bus,

--- a/core/provider/local/p2p-sync.go
+++ b/core/provider/local/p2p-sync.go
@@ -300,9 +300,9 @@ func (a *ProviderAccount) StartP2PSync(ctx context.Context, sessionTransport *tr
 		return a.awaitP2PSyncStart(ctx, waitState)
 	}
 
-	// Startup belongs to every owner of the state, not to the caller that
+	// Startup belongs to every holder of the state, not to the caller that
 	// happened to create it. Running it here would tie it to that caller's
-	// goroutine, so a caller whose context is canceled while later owners keep
+	// goroutine, so a caller whose context is canceled while later holders keep
 	// the state alive could not return until startup finished on its own.
 	go a.runP2PSyncStart(state, previous, previousRetained, sessionTransport, childBus)
 	return a.awaitP2PSyncStart(ctx, state)
@@ -310,7 +310,7 @@ func (a *ProviderAccount) StartP2PSync(ctx context.Context, sessionTransport *tr
 
 // awaitP2PSyncStart waits for the shared startup to finish or for the caller's
 // own context to end, whichever comes first. Giving up releases this caller's
-// ownership without stopping the run; it ends only when the last owner leaves.
+// reference without stopping the run; it ends only when the last holder leaves.
 func (a *ProviderAccount) awaitP2PSyncStart(ctx context.Context, state *p2pSyncState) error {
 	for {
 		var waitCh <-chan struct{}

--- a/core/provider/spacewave/account-fetcher.go
+++ b/core/provider/spacewave/account-fetcher.go
@@ -18,12 +18,12 @@ import (
 // accountStateCacheKey is the ObjectStore key for the account state cache.
 const accountStateCacheKey = "account-state-cache"
 
-// accountFetcherRetryOwner owns transient retry delay for accountFetcher.
+// accountFetcherRetryOwner holds the transient retry delay for accountFetcher.
 //
 // The wake channel is captured with the account snapshot that produced the
 // failed fetch. If account epoch or session-client readiness changes while a
-// request is in flight, that channel closes and the retry owner skips the
-// remaining backoff so the fetcher can re-check current account state.
+// request is in flight, that channel closes and the remaining backoff is
+// skipped so the fetcher can re-check current account state.
 type accountFetcherRetryOwner struct {
 	bo cbackoff.BackOff
 }

--- a/core/provider/spacewave/account.go
+++ b/core/provider/spacewave/account.go
@@ -75,7 +75,7 @@ type ProviderAccount struct {
 	sessionClientSessionID string
 	// sessionTransports contains direct transports keyed by mounted Session ID.
 	sessionTransports map[string]*sessionTransportState
-	// transportComposition is the per-Session direct-transport selection owner.
+	// transportComposition selects the direct transport for each Session.
 	transportComposition transportCompositionOwner
 	// conf is the provider configuration
 	conf *Config
@@ -90,11 +90,11 @@ type ProviderAccount struct {
 	soListCtr *ccontainer.CContainer[*sobject.SharedObjectList]
 	// soListRc owns SO list fetches so all callers share one invalidatable path.
 	soListRc *refcount.RefCount[struct{}]
-	// soListBcast guards the SO list owner fields below.
+	// soListBcast guards the SO list fields below.
 	soListBcast broadcast.Broadcast
 	// soListAccess indicates subscription status permits SO list access.
 	soListAccess bool
-	// soListInvalidate restarts the SO list owner when the cache is stale.
+	// soListInvalidate restarts soListRc when the cache is stale.
 	soListInvalidate func()
 	// writeTicketOwnersMtx guards writeTicketOwners and writeTicketOwnersCtx.
 	writeTicketOwnersMtx sync.Mutex

--- a/core/provider/spacewave/bstore.go
+++ b/core/provider/spacewave/bstore.go
@@ -62,9 +62,10 @@ type BlockStore struct {
 	refreshRemote func(ctx context.Context) error
 	// remoteSequence returns the local manifest's last-seen remote sequence.
 	remoteSequence func(ctx context.Context) (uint64, error)
-	// cacheStore is the account-owned non-dirty local cache read/write owner.
+	// cacheStore is the account-owned local cache store used for non-dirty reads
+	// and writes.
 	cacheStore block.StoreOps
-	// cloudStore is the account-owned Cloud read owner.
+	// cloudStore is the account-owned Cloud read store.
 	cloudStore block.StoreOps
 }
 
@@ -119,9 +120,9 @@ func (b *BlockStore) PutBlock(ctx context.Context, data []byte, opts *block.PutO
 
 // PutBlockBatch forwards batched writes to the inner store.
 func (b *BlockStore) PutBlockBatch(ctx context.Context, entries []*block.PutBatchEntry) error {
-	// Tombstone publication and decoded-cache ownership are separate lower
-	// owners; invalidate on both sides so in-flight decoded stores cannot cross
-	// the mutation boundary.
+	// Tombstone publication and the decoded cache are separate lower stores;
+	// invalidate on both sides so in-flight decoded stores cannot cross the
+	// mutation boundary.
 	b.invalidateBatchTombstones(ctx, entries)
 	if err := b.store.PutBlockBatch(ctx, entries); err != nil {
 		return err
@@ -147,7 +148,7 @@ func (b *BlockStore) GetBlockExistsBatch(ctx context.Context, refs []*block.Bloc
 
 // RmBlock forwards to the inner store.
 func (b *BlockStore) RmBlock(ctx context.Context, ref *block.BlockRef) error {
-	// Delete publication and decoded-cache ownership are separate lower owners;
+	// Delete publication and the decoded cache are separate lower stores;
 	// invalidate on both sides so in-flight decoded stores cannot cross the
 	// mutation boundary.
 	b.InvalidateDecodedBlockRef(ctx, ref)
@@ -530,7 +531,7 @@ func (s *sourceTrackingStore) BeginReadOperation(ctx context.Context) (block.Sto
 	}, release, nil
 }
 
-// GetBlock records cache, direct, or Cloud ownership for a successful read.
+// GetBlock records the cache, direct, or Cloud source of a successful read.
 func (s *sourceTrackingStore) GetBlock(ctx context.Context, ref *block.BlockRef) ([]byte, bool, error) {
 	cached := false
 	if s.upperCache {
@@ -774,7 +775,7 @@ func (r *publicReadRemote) Refresh(ctx context.Context) error {
 	}
 	entries := clonePackfileEntries(ptr.GetPacks())
 	// Invalidate before publishing the refreshed manifest. Reads can observe the
-	// lower store and Entries snapshot from separate owners, and stale decoded
+	// lower store and Entries snapshot from separate sources, and stale decoded
 	// blocks must not survive into either new view.
 	r.decodedBlocks.InvalidateAll(ctx)
 	r.lower.UpdateManifest(entries)

--- a/core/provider/spacewave/client.go
+++ b/core/provider/spacewave/client.go
@@ -258,7 +258,7 @@ type SignedHTTPClient struct {
 	priv crypto.PrivKey
 	// peerID is the peer ID (base58 encoded for headers)
 	peerID peer.ID
-	// sign signs payloads when private key material lives behind another owner.
+	// sign signs payloads when the private key is held elsewhere.
 	sign SigningFunc
 }
 
@@ -759,7 +759,7 @@ func (c *EntityClient) RegisterSessionWithRequest(ctx context.Context, req *api.
 }
 
 // RollbackSessionRegistration removes a just-created APP/DEVICE registration
-// row through the Cloud registration rollback owner. Reused rows and USER
+// row through the Cloud registration rollback endpoint. Reused rows and USER
 // sessions are preserved by the Cloud endpoint.
 func (c *EntityClient) RollbackSessionRegistration(ctx context.Context, sessionPeerID string) error {
 	_, err := c.doDelete(ctx, "/api/account/session/"+url.PathEscape(sessionPeerID)+"/registration", SeedReasonMutation)

--- a/core/provider/spacewave/entitykeystore/entity-keypair-step-up.go
+++ b/core/provider/spacewave/entitykeystore/entity-keypair-step-up.go
@@ -12,7 +12,7 @@ type EntityKeypairStepUp struct {
 	rc    *refcount.RefCount[struct{}]
 }
 
-// NewEntityKeypairStepUp creates a step-up retention owner.
+// NewEntityKeypairStepUp constructs an EntityKeypairStepUp reading from store.
 func NewEntityKeypairStepUp(ctx context.Context, store func() *EntityKeyStore) *EntityKeypairStepUp {
 	stepUp := &EntityKeypairStepUp{
 		store: store,

--- a/core/provider/spacewave/launcher/fetch-status.go
+++ b/core/provider/spacewave/launcher/fetch-status.go
@@ -17,7 +17,7 @@ type FetchStatus struct {
 	HasConfig bool
 	// SelectedConfigRev is the revision currently selected by the launcher.
 	SelectedConfigRev uint64
-	// SelectedConfigSource names the owner/source of the selected DistConfig.
+	// SelectedConfigSource names the source of the selected DistConfig.
 	SelectedConfigSource string
 	// FetchedConfigRev is the most recent valid endpoint DistConfig revision.
 	FetchedConfigRev uint64

--- a/core/provider/spacewave/org-list.go
+++ b/core/provider/spacewave/org-list.go
@@ -69,7 +69,7 @@ func (a *ProviderAccount) PublishCreatedOrganization(org *api.OrgResponse) {
 	})
 }
 
-// QueueOrganizationSync schedules the keyed organization sync owner.
+// QueueOrganizationSync schedules the keyed organization sync routine.
 func (a *ProviderAccount) QueueOrganizationSync(orgID string) {
 	if orgID == "" || a.orgSyncs == nil {
 		return

--- a/core/provider/spacewave/packfile/store/publication.go
+++ b/core/provider/spacewave/packfile/store/publication.go
@@ -21,7 +21,7 @@ import (
 // bytes land in the span store), find the target entry, compute the
 // semantic neighborhood window, ensure those bytes are resident, admit
 // every fully-contained block into the catalog, and either return the target
-// bytes immediately or wait for verification when the owner requires it.
+// bytes immediately or wait for verification when verifyBeforeServe is set.
 func (e *PackReader) getBlock(ctx context.Context, key []byte) ([]byte, bool, error) {
 	keyStr := string(key)
 

--- a/core/provider/spacewave/packfile/store/verify-queue-tinygo-scheduler.go
+++ b/core/provider/spacewave/packfile/store/verify-queue-tinygo-scheduler.go
@@ -12,9 +12,9 @@ func defaultVerifyConcurrency() int {
 
 // goroutineVerifyExecutor runs each enqueued job on a fresh goroutine.
 //
-// TinyGo cooperative schedulers can run verification in background tasks. The
-// PackReader owner prepares jobs under its broadcast lock and enqueues them
-// only after releasing that lock, so this executor matches the production queue
+// TinyGo cooperative schedulers can run verification in background tasks.
+// PackReader prepares jobs under its broadcast lock and enqueues them only
+// after releasing that lock, so this executor matches the production queue
 // shape without relying on recursive lock avoidance.
 type goroutineVerifyExecutor struct{}
 

--- a/core/provider/spacewave/seedflight/seed.go
+++ b/core/provider/spacewave/seedflight/seed.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Seed coordinates concurrent callers around a single fetch invocation.
-// The owner runs the fetch function while waiters block on the supplied
+// The first caller runs the fetch function while waiters block on the supplied
 // broadcast and observe the same result; once the fetch completes, a later Run
 // call fires fetch again.
 //
@@ -28,7 +28,7 @@ func (s *Seed) Run(
 }
 
 // RunWhenReady runs fetchFn at most once across concurrent callers, skipping
-// the fetch when readyFn reports that the owner's cache is already usable.
+// the fetch when readyFn reports that the guarded cache is already usable.
 // readyFn runs while bcast's lock is held.
 func (s *Seed) RunWhenReady(
 	ctx context.Context,

--- a/core/provider/spacewave/session-shared-object.go
+++ b/core/provider/spacewave/session-shared-object.go
@@ -155,7 +155,7 @@ func (b *BlockStore) newSessionBlockStore(
 }
 
 // sessionBlockStore keeps writes and durability on the account-owned store
-// while routing reads through the Session cache, child DEX, and Cloud owners.
+// while routing reads through the Session cache, child DEX, and Cloud stores.
 type sessionBlockStore struct {
 	*BlockStore
 	readStore block_store.Store

--- a/core/provider/spacewave/so-list.go
+++ b/core/provider/spacewave/so-list.go
@@ -45,7 +45,7 @@ func (a *ProviderAccount) hasSharedObjectListAccess() bool {
 	return allowed
 }
 
-// invalidateSharedObjectList restarts the SO list owner when a full snapshot is stale.
+// invalidateSharedObjectList restarts soListRc when a full snapshot is stale.
 func (a *ProviderAccount) invalidateSharedObjectList() {
 	var invalidate func()
 	a.soListBcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
@@ -84,7 +84,7 @@ func (a *ProviderAccount) setSharedObjectListInvalidator(invalidate func()) {
 	})
 }
 
-// EnsureSharedObjectListLoaded resolves the SO list owner and waits for the current snapshot.
+// EnsureSharedObjectListLoaded resolves soListRc and waits for the current snapshot.
 func (a *ProviderAccount) EnsureSharedObjectListLoaded(ctx context.Context) error {
 	_, rel, err := a.soListRc.Resolve(ctx)
 	if err != nil {

--- a/core/provider/spacewave/sync-telemetry.go
+++ b/core/provider/spacewave/sync-telemetry.go
@@ -26,7 +26,7 @@ type SyncTelemetrySnapshot = synctelemetry.Snapshot
 // SyncTelemetryBlockStoreSnapshot describes one mounted block store.
 type SyncTelemetryBlockStoreSnapshot = synctelemetry.BlockStoreSnapshot
 
-// SyncTelemetryBlockSource identifies the owner-observed source of a block read.
+// SyncTelemetryBlockSource identifies the observed source of a block read.
 type SyncTelemetryBlockSource = synctelemetry.BlockSource
 
 const (

--- a/core/provider/spacewave/synctelemetry/store.go
+++ b/core/provider/spacewave/synctelemetry/store.go
@@ -22,7 +22,7 @@ const (
 	UploadPhaseError
 )
 
-// BlockSource identifies the owner-observed source of a block read.
+// BlockSource identifies the observed source of a block read.
 type BlockSource uint8
 
 const (
@@ -183,7 +183,7 @@ type FetchStatsProvider interface {
 	SnapshotStats() packfile_store.PackfileStoreStats
 }
 
-// StatsChangedProvider notifies the telemetry owner when fetch-side stats change.
+// StatsChangedProvider notifies the telemetry Store when fetch-side stats change.
 type StatsChangedProvider interface {
 	SetStatsChangedCallback(func())
 }

--- a/core/provider/spacewave/transport-composition.go
+++ b/core/provider/spacewave/transport-composition.go
@@ -68,7 +68,8 @@ type transportCompositionOwner struct {
 	sessions map[string]*transportCompositionSession
 
 	// Hooks keep the state machine independently testable. Production hooks bind
-	// the owner to the account's SessionTransport and P2P lifecycle maps.
+	// transportCompositionOwner to the account's SessionTransport and P2P
+	// lifecycle maps.
 	startDirect    func(context.Context, string, crypto.PrivKey, string) (transportCompositionLinkSource, error)
 	stopDirect     func(string)
 	transportState func(string) (bool, <-chan struct{})

--- a/core/resource/desktop/statusprojector/projection/session-projection.go
+++ b/core/resource/desktop/statusprojector/projection/session-projection.go
@@ -21,7 +21,8 @@ type SessionProjection struct {
 	AttentionItems []*desktop_runtime.DesktopRuntimeAttentionItem
 }
 
-// SessionProjectionRow carries one Session row snapshot into the projection owner.
+// SessionProjectionRow carries one Session row snapshot into
+// BuildSessionProjection.
 type SessionProjectionRow struct {
 	Entry          *session.SessionListEntry
 	Metadata       *session.SessionMetadata

--- a/core/resource/listener/control/takeover.go
+++ b/core/resource/listener/control/takeover.go
@@ -13,10 +13,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// SocketInUseError reports that a live listener already owns the
+// SocketInUseError reports that a live listener already holds the
 // daemon socket and takeover was not requested. The condition is
 // permanent for the refusing process: retrying without takeover
-// cannot succeed while the owner lives.
+// cannot succeed while that listener lives.
 type SocketInUseError struct {
 	// Path is the contended socket path.
 	Path string
@@ -89,7 +89,7 @@ func prepareSocket(
 
 		// A yielded process can exit before its completion response
 		// reaches us. Connection failure is the event; a fresh dial
-		// distinguishes that completed exit from a still-live owner.
+		// distinguishes that completed exit from a still-live listener.
 		_ = conn.Close()
 		probe, probeErr := net.Dial("unix", sockPath)
 		if probeErr == nil {

--- a/core/resource/listener/execute.go
+++ b/core/resource/listener/execute.go
@@ -92,8 +92,8 @@ func (c *Controller) Execute(ctx context.Context) error {
 		yielded, err := c.serveOnce(ctx, le, invokers[0], absPath, broker, status, allowTakeover)
 		if err != nil {
 			if listener_control.IsSocketInUse(err) {
-				// Another live daemon owns the socket. Retrying under the
-				// controller backoff loop cannot succeed while the owner
+				// Another live daemon holds the socket. Retrying under the
+				// controller backoff loop cannot succeed while that daemon
 				// lives and would leave this daemon running without its
 				// front door, so surface the conflict as process-fatal
 				// and stop the restart loop.
@@ -126,10 +126,10 @@ func handoffBlocksListener(handoff yield_policy.HandoffState) bool {
 
 // serveOnce prepares the socket, listens, and serves until either the
 // serve context is canceled externally or a daemon-control Shutdown
-// is honored. When allowTakeover is true a live socket owner is asked
-// to yield; otherwise a live owner is refused with a typed in-use
-// error. The returned bool is true when the listener yielded cleanly
-// so the caller can enter the reclaim-wait loop.
+// is honored. When allowTakeover is true the live socket holder is
+// asked to yield; otherwise it is refused with a typed in-use error.
+// The returned bool is true when the listener yielded cleanly so the
+// caller can enter the reclaim-wait loop.
 func (c *Controller) serveOnce(
 	parentCtx context.Context,
 	le *logrus.Entry,
@@ -154,7 +154,7 @@ func (c *Controller) serveOnce(
 	if err != nil {
 		if stderrors.Is(err, syscall.EADDRINUSE) {
 			// Two daemons can both pass the availability check before
-			// either binds. The bind loser is the same live-owner
+			// either binds. The bind loser hits the same live-holder
 			// conflict as the pre-bind refusal, so classify it the
 			// same way and let the caller surface it fatally.
 			return false, &listener_control.SocketInUseError{Path: absPath}
@@ -223,7 +223,7 @@ func (c *Controller) serveOnce(
 
 // acceptCountingListener serves accepted clients independently while reporting
 // accept/close transitions to the status broker. It returns a drain function
-// after accepting stops so the owner can release the listener synchronously,
+// after accepting stops so the caller can release the listener synchronously,
 // finish a takeover acknowledgement, and only then close active clients.
 func acceptCountingListener(
 	ctx context.Context,

--- a/core/resource/root/server.go
+++ b/core/resource/root/server.go
@@ -37,7 +37,8 @@ type CoreRootServer struct {
 	releaseStateAtomStoreIndex func()
 	// stateAtomStoreClosed rejects lazy store acquisition after shutdown.
 	stateAtomStoreClosed bool
-	// stateAtomStoreIndexBuilder overrides the external acquisition in owner tests.
+	// stateAtomStoreIndexBuilder overrides the external acquisition in
+	// CoreRootServer tests.
 	stateAtomStoreIndexBuilder func(context.Context) (*session.StateAtomStoreIndex, func(), error)
 	// cdnRegistry owns the process-scoped map of CdnInstances.
 	cdnRegistry *resource_cdn.Registry

--- a/core/resource/session/session.go
+++ b/core/resource/session/session.go
@@ -189,7 +189,7 @@ func (r *SessionResource) Close() {
 //
 // No-op when the session's provider is not spacewave (local-only never
 // receives cdn-root-changed). Safe to call once per SessionResource; a
-// second call releases the second subscription to preserve single ownership.
+// second call releases the second subscription so one remains.
 func (r *SessionResource) SetCdnRootChangedHook(hook func(spaceID string)) {
 	if hook == nil {
 		return

--- a/core/resource/session/spacewave-session.go
+++ b/core/resource/session/spacewave-session.go
@@ -754,7 +754,7 @@ func (r *SpacewaveSessionResource) CreateOrganization(
 
 	// Publish the cloud response synchronously so cached org-list readers cannot
 	// observe a stale list after this RPC returns. Root SO bootstrap and the full
-	// cloud refresh run through the ProviderAccount org-sync keyed owner.
+	// cloud refresh run through the ProviderAccount keyed org-sync routine.
 	orgID := info.GetId()
 	r.swAcc.PublishCreatedOrganization(&info)
 	r.swAcc.QueueOrganizationSync(orgID)
@@ -2567,7 +2567,7 @@ func (r *SpacewaveSessionResource) SetPrimaryEmail(
 //     against the SO config chain locally (the chain entry from step 1) and
 //     run the standard mailbox-driven enrollment via ProcessMailboxEntry.
 //
-// Local-vs-cloud ownership boundary:
+// Local-vs-cloud authority boundary:
 //
 //   - Local (spacewave package): builds and signs the SOInviteMessage,
 //     verifies the message, drives mailbox processing, and applies invite

--- a/core/resource/session/status.go
+++ b/core/resource/session/status.go
@@ -217,7 +217,7 @@ func (r *StatusResource) WatchNetworkStats(
 
 // ReportRecoveryStatus stores renderer-owned runtime recovery facts for status
 // composition. The report is volatile diagnostic state; it never mutates
-// release, Manifest, package, boot, or asset-serving owners.
+// release, Manifest, package, boot, or asset-serving state.
 func (r *StatusResource) ReportRecoveryStatus(
 	_ context.Context,
 	req *s4wave_status.ReportRecoveryStatusRequest,
@@ -242,7 +242,7 @@ func (r *StatusResource) ReportRecoveryStatus(
 	return &s4wave_status.ReportRecoveryStatusResponse{}, nil
 }
 
-// WatchRecoveryStatus streams owner-owned runtime recovery status snapshots.
+// WatchRecoveryStatus streams the recorded runtime recovery status snapshots.
 func (r *StatusResource) WatchRecoveryStatus(
 	_ *s4wave_status.WatchRecoveryStatusRequest,
 	strm s4wave_status.SRPCSystemStatusService_WatchRecoveryStatusStream,

--- a/core/resource/space/sharingstate/state.go
+++ b/core/resource/space/sharingstate/state.go
@@ -56,7 +56,7 @@ type State struct {
 	bcast                   broadcast.Broadcast
 }
 
-// NewState returns a sharing watch state owner.
+// NewState constructs a State from the first sharing snapshot.
 func NewState(
 	soState *sobject.SOState,
 	mailboxEntries []*MailboxEntry,

--- a/core/session/controller/controller.go
+++ b/core/session/controller/controller.go
@@ -361,7 +361,7 @@ func (c *Controller) UpdateSessionMetadata(ctx context.Context, ref *session.Ses
 	}
 
 	// Retry classification: external to RunTransaction. The callback emits
-	// invalid-entry handling; the owner publishes the update after commit.
+	// invalid-entry handling; Controller publishes the update after commit.
 
 	otx, err := objStore.NewTransaction(ctx, true)
 	if err != nil {

--- a/core/sobject/errors.go
+++ b/core/sobject/errors.go
@@ -100,7 +100,7 @@ var (
 	// ErrJournalSupersessionImmutable is returned when a lineage successor changes its predecessor.
 	ErrJournalSupersessionImmutable = errors.New("shared object journal supersession is immutable")
 
-	// ErrJournalStorageRequired is returned when a journal storage owner is missing.
+	// ErrJournalStorageRequired is returned when journal storage is missing.
 	ErrJournalStorageRequired = errors.New("shared object journal storage is required")
 
 	// ErrJournalScopeMismatch is returned when a key belongs to another journal scope.

--- a/core/sobject/journal-crypto.go
+++ b/core/sobject/journal-crypto.go
@@ -55,7 +55,7 @@ type JournalCrypto struct {
 	nonces map[[journalNonceSize]byte]struct{}
 }
 
-// NewJournalCrypto constructs an at-rest crypto owner for one journal scope.
+// NewJournalCrypto constructs a JournalCrypto for one journal scope.
 // The scope identifier is fixed-width so derived keys cannot cross domains.
 func NewJournalCrypto(scopeID []byte, authority JournalKeyAuthority) (*JournalCrypto, error) {
 	if len(scopeID) != journalScopeIDSize {

--- a/core/sobject/journal-frame.go
+++ b/core/sobject/journal-frame.go
@@ -428,7 +428,7 @@ func (s *FileJournalStorage) Close() error {
 	return s.file.Close()
 }
 
-// memoryJournalStorage is an in-memory JournalStorage for owner-local tests.
+// memoryJournalStorage is an in-memory JournalStorage for tests in this package.
 type memoryJournalStorage struct {
 	mu sync.Mutex
 

--- a/core/sobject/provider.go
+++ b/core/sobject/provider.go
@@ -41,7 +41,7 @@ type SharedObjectProvider interface {
 	AccessSharedObjectList(ctx context.Context, released func()) (ccontainer.Watchable[*SharedObjectList], func(), error)
 
 	// RefreshSharedObjectList invalidates and reloads the current shared object
-	// list snapshot when the provider has a remote list owner.
+	// list snapshot when the provider has a remote list source.
 	RefreshSharedObjectList(ctx context.Context) error
 }
 

--- a/core/sobject/world/engine/controller.go
+++ b/core/sobject/world/engine/controller.go
@@ -45,7 +45,7 @@ type Controller struct {
 	// sfs is the step factory set
 	sfs *block_transform.StepFactorySet
 	// staticLookupOp is an optional in-process lookup chain supplied by
-	// domain owners that know this engine's built-in operation surface.
+	// domain packages that know this engine's built-in operation surface.
 	staticLookupOpMu sync.RWMutex
 	staticLookupOp   world.LookupOp
 

--- a/core/space/migration/builtins.go
+++ b/core/space/migration/builtins.go
@@ -69,7 +69,7 @@ func BuiltInRegistry() (*Registry, error) {
 	return registry, nil
 }
 
-// Keep imports for built-in world ObjectType packages visible to the registry owner.
+// Keep imports for built-in world ObjectType packages visible to the registry.
 var _ = s4wave_org_world.OrganizationType
 var _ = s4wave_device_world.DeviceType
 var _ = s4wave_terminal_world.TerminalType

--- a/core/space/migration/descriptor.go
+++ b/core/space/migration/descriptor.go
@@ -6,7 +6,8 @@ import (
 	"github.com/s4wave/spacewave/db/world"
 )
 
-// ReferenceKind identifies the owner and rewrite semantics for one embedded identity.
+// ReferenceKind identifies the identity namespace and rewrite semantics for
+// one embedded identity.
 type ReferenceKind int32
 
 const (

--- a/core/space/migration/handler.go
+++ b/core/space/migration/handler.go
@@ -14,7 +14,8 @@ type SchemaInspector func(context.Context, *ObjectDescriptor) (*Inspection, erro
 // SchemaRewriter decodes, rewrites, and serializes one registered payload.
 type SchemaRewriter func(context.Context, *ObjectDescriptor, *IdentityMap) (*RewriteResult, error)
 
-// TypedHandler is a built-in handler with explicit reference-field ownership.
+// TypedHandler is a built-in handler that declares which reference fields it
+// rewrites.
 type TypedHandler struct {
 	typeID              string
 	classification      Classification

--- a/core/space/migration/planner.go
+++ b/core/space/migration/planner.go
@@ -18,7 +18,8 @@ import (
 	s4wave_canvas_world "github.com/s4wave/spacewave/sdk/canvas/world"
 )
 
-// PlannerInput describes the two World owners and read-only preview inputs.
+// PlannerInput describes the source and destination Worlds and read-only
+// preview inputs.
 type PlannerInput struct {
 	SourceSpaceID       string
 	DestinationSpaceID  string

--- a/core/space/world/objecttypes/inventory.go
+++ b/core/space/world/objecttypes/inventory.go
@@ -3,7 +3,7 @@ package objecttypes
 import "slices"
 
 // BuiltInObjectTypeIDs returns the compiled ObjectType table keys. The table
-// is build-tag-specific, so runtime dispatch and inventory share one owner.
+// is build-tag-specific, so runtime dispatch and inventory read the same map.
 func BuiltInObjectTypeIDs() []string {
 	ids := make([]string, 0, len(compiledObjectTypes))
 	for typeID := range compiledObjectTypes {

--- a/core/transport/transport.go
+++ b/core/transport/transport.go
@@ -45,13 +45,13 @@ type SessionTransport struct {
 	bridgeFilter bus_bridge.FilterFn
 	// startupTimeout bounds the readiness phase for every consumer.
 	startupTimeout time.Duration
-	// startupDeadlineCtx is the owner budget shared by every readiness waiter.
+	// startupDeadlineCtx is the startup budget shared by every readiness waiter.
 	startupDeadlineCtx context.Context
-	// startupDeadlineCancel stops the owner budget after a terminal outcome.
+	// startupDeadlineCancel stops the startup budget after a terminal outcome.
 	startupDeadlineCancel context.CancelFunc
 	// startupDeadlineStarted prevents retries and waiters from resetting the budget.
 	startupDeadlineStarted bool
-	// cancel cancels the owner context after startup stop admission.
+	// cancel cancels the SessionTransport context after startup stop admission.
 	cancel context.CancelFunc
 	// startupStopped admits timeout cancellation before Execute publishes cancel.
 	startupStopped bool
@@ -65,7 +65,7 @@ type SessionTransport struct {
 	startupErr error
 	// startupStage records the last startup stage entered.
 	startupStage string
-	// startupRetryable keeps per-attempt failures private to a retry owner.
+	// startupRetryable keeps per-attempt failures private to the retrying caller.
 	startupRetryable bool
 }
 
@@ -84,16 +84,16 @@ func WithStartupTimeout(timeout time.Duration) SessionTransportOption {
 }
 
 // WithBridgeDirectiveFilter excludes matching directives from the generic
-// child-to-parent bridge while preserving the transport package's ownership.
+// child-to-parent bridge while SessionTransport keeps forwarding the rest.
 func WithBridgeDirectiveFilter(filter bus_bridge.FilterFn) SessionTransportOption {
 	return func(t *SessionTransport) {
 		t.bridgeFilter = filter
 	}
 }
 
-// WithStartupRetry enables retry-owner startup semantics. Execute attempts
-// leave transient failures to the retry owner, while AwaitReady reports only
-// the transport's admitted terminal outcome.
+// WithStartupRetry enables retrying startup semantics. Execute attempts leave
+// transient failures to the retrying caller, while AwaitReady reports only the
+// transport's admitted terminal outcome.
 func WithStartupRetry() SessionTransportOption {
 	return func(t *SessionTransport) {
 		t.startupRetryable = true

--- a/e2e/electron/harness.go
+++ b/e2e/electron/harness.go
@@ -129,7 +129,7 @@ func Boot(ctx context.Context, le *logrus.Entry) (_ *Harness, retErr error) {
 	)
 
 	// Resolve the socket through the listener config so the harness reads the
-	// same owner the daemon does, after SPACEWAVE_DATA_DIR is exported.
+	// same path the daemon does, after SPACEWAVE_DATA_DIR is exported.
 	listenerConf := &resource_listener.Config{StorageProjectId: spacewaveProjectID}
 	cliSocketPath, err := listenerConf.DetermineSocketPath()
 	if err != nil {

--- a/e2e/wasm/harness.go
+++ b/e2e/wasm/harness.go
@@ -1285,11 +1285,12 @@ func reapHarnessCacheOffStateRoots(le *logrus.Entry, parent, currentStateRoot, s
 func shouldReapHarnessCacheOffStateRoot(stateRoot string, entry os.DirEntry, now time.Time, currentOwner harnessStateRootOwner) (bool, error) {
 	owner, err := readHarnessStateRootOwner(stateRoot)
 	if err == nil {
-		// The marker token is kept in the live Harness owner and disambiguates
-		// stale roots that claim this process's PID after PID reuse. A stale
-		// root whose PID has been recycled by another live process is preserved;
-		// portable start-time checks are not available across this harness's
-		// supported darwin/linux test hosts, so liveness wins over cleanup.
+		// The marker token is kept in the live Harness state-root marker and
+		// disambiguates stale roots that claim this process's PID after PID
+		// reuse. A stale root whose PID has been recycled by another live
+		// process is preserved; portable start-time checks are not available
+		// across this harness's supported darwin/linux test hosts, so liveness
+		// wins over cleanup.
 		if owner.pid == currentOwner.pid && owner.token != currentOwner.token {
 			return true, nil
 		}
@@ -1302,7 +1303,7 @@ func shouldReapHarnessCacheOffStateRoot(stateRoot string, entry os.DirEntry, now
 	if err != nil {
 		return false, err
 	}
-	// Pre-fix cache-off roots have no owner marker. The 24h threshold only
+	// Pre-fix cache-off roots have no state-root marker. The 24h threshold only
 	// reaps stale markerless wasm roots after the stable cache-on root name has
 	// been excluded; young markerless roots may belong to an older live binary.
 	return now.Sub(info.ModTime()) > harnessMarkerlessStateRootMaxAge, nil

--- a/e2e/wasm/multi-session-scenario.go
+++ b/e2e/wasm/multi-session-scenario.go
@@ -51,7 +51,7 @@ func CreateMultiSessionScenario(t testing.TB, h *Harness, session *TestSession) 
 	return scenario
 }
 
-// GetSession returns the browser context and Resource SDK owner.
+// GetSession returns the browser context and Resource SDK session.
 func (s *MultiSessionScenario) GetSession() *TestSession { return s.session }
 
 // GetFirstSessionIndex returns the PIN-backed drive session index.

--- a/forge/execution/claim.go
+++ b/forge/execution/claim.go
@@ -2,7 +2,7 @@ package forge_execution
 
 import "github.com/pkg/errors"
 
-// Validate checks that the claim identifies an owner and fencing epoch.
+// Validate checks that the claim identifies a claim id and fencing epoch.
 func (c *Claim) Validate() error {
 	if c.GetClaimId() == "" {
 		return errors.New("claim_id cannot be empty")

--- a/forge/execution/controller/config.go
+++ b/forge/execution/controller/config.go
@@ -51,7 +51,7 @@ func (c *Config) Validate() error {
 	return nil
 }
 
-// BuildUniqueID builds the durable execution owner ID.
+// BuildUniqueID builds the durable execution controller ID.
 func (c *Config) BuildUniqueID() string {
 	h := blake3.NewDeriveKey("forge/execution/controller: config: unique id")
 	_, _ = h.WriteString(c.GetEngineId())

--- a/forge/execution/tx/claim-held-error.go
+++ b/forge/execution/tx/claim-held-error.go
@@ -8,7 +8,7 @@ type ClaimHeldError struct {
 	Epoch   uint64
 }
 
-// Error returns the claim ownership conflict.
+// Error names the claim holding the execution and its epoch.
 func (e *ClaimHeldError) Error() string {
 	return "execution claim held by " + e.ClaimID + " at epoch " + strconv.FormatUint(e.Epoch, 10)
 }

--- a/forge/execution/tx/claim.go
+++ b/forge/execution/tx/claim.go
@@ -6,7 +6,7 @@ import (
 )
 
 // implicitClaim fences legacy transaction callers to the current process. It
-// must not become a durable controller owner ID that survives reconstruction.
+// must not become a durable controller ID that survives reconstruction.
 var implicitClaim = &forge_execution.Claim{
 	ClaimId: uuid.NewV4().String(),
 	Epoch:   1,

--- a/sdk/cdn/cdn.ts
+++ b/sdk/cdn/cdn.ts
@@ -37,7 +37,7 @@ export class Cdn extends Resource {
 
   // copyV86ImageToSpace copies a V86Image (metadata block plus the five asset
   // edges) from this CDN Space into a user-owned destination Space and streams
-  // the server owner's block-copy accounting.
+  // the server's block-copy accounting.
   //
   // Asset UnixFS blocks are content-addressed; the destination block store
   // dedupes them against the CDN block store without re-upload.

--- a/sdk/device/device.go
+++ b/sdk/device/device.go
@@ -12,7 +12,7 @@ import (
 const DeviceTypeID = "spacewave/device"
 
 const (
-	// DeviceCapabilityKindFilesystem identifies filesystem-owner access exposed by a Device.
+	// DeviceCapabilityKindFilesystem identifies filesystem access exposed by a Device.
 	DeviceCapabilityKindFilesystem = "filesystem"
 	// DeviceCapabilityKindForgeWorker identifies Forge Worker execution exposed by a Device.
 	DeviceCapabilityKindForgeWorker = "forge-worker"
@@ -95,7 +95,8 @@ func (d *Device) Validate() error {
 }
 
 // IsSelectable reports whether the Device has enough identity and setup state
-// for another owner to present it as an execution or resource target.
+// for Forge or a workflow builder to present it as an execution or resource
+// target.
 func (d *Device) IsSelectable() bool {
 	if d == nil {
 		return false
@@ -122,7 +123,8 @@ func (d *Device) FindCapabilityByKind(kind string) *DeviceCapability {
 }
 
 // DeviceCapabilityIsSelectable reports whether a capability can be selected by
-// another owner without taking over the capability's execution state.
+// Forge or a workflow builder without taking over the capability's execution
+// state.
 func DeviceCapabilityIsSelectable(cap *DeviceCapability) bool {
 	if cap == nil {
 		return false
@@ -190,7 +192,7 @@ func (d *Device) FindSelectableCheckoutRoot(name string) *DeviceCapability {
 }
 
 // DeviceCheckoutRootCanRead reports whether a checkout root may be opened for
-// reads through its linked filesystem owner.
+// reads through its linked filesystem object.
 func DeviceCheckoutRootCanRead(checkoutRoot *DeviceCheckoutRootCapability) bool {
 	if checkoutRoot == nil || !checkoutRoot.GetReadAvailable() {
 		return false
@@ -221,7 +223,7 @@ func DeviceCapabilityCanWriteCheckoutRoot(cap *DeviceCapability) bool {
 }
 
 // FindReadableCheckoutRoot returns a selectable checkout-root capability with a
-// linked filesystem owner object that can be opened through the Resource SDK.
+// linked filesystem object that can be opened through the Resource SDK.
 func (d *Device) FindReadableCheckoutRoot(name string) *DeviceCapability {
 	cap := d.FindSelectableCheckoutRoot(name)
 	if cap == nil || !DeviceCheckoutRootCanRead(cap.GetCheckoutRoot()) {
@@ -235,7 +237,7 @@ func (d *Device) FindReadableCheckoutRoot(name string) *DeviceCapability {
 }
 
 // FindWritableCheckoutRoot returns a selectable checkout-root capability with a
-// linked filesystem owner object that may be opened for writes after approval.
+// linked filesystem object that may be opened for writes after approval.
 func (d *Device) FindWritableCheckoutRoot(name string) *DeviceCapability {
 	cap := d.FindSelectableCheckoutRoot(name)
 	if cap == nil || !DeviceCapabilityCanWriteCheckoutRoot(cap) {
@@ -249,7 +251,7 @@ func (d *Device) FindWritableCheckoutRoot(name string) *DeviceCapability {
 }
 
 // FindSelectableForgeWorker returns a selectable Forge Worker capability linked
-// to the owner object that records execution state, logs, and results.
+// to the Worker object that records execution state, logs, and results.
 func (d *Device) FindSelectableForgeWorker() *DeviceCapability {
 	if d == nil {
 		return nil

--- a/sdk/device/device.ts
+++ b/sdk/device/device.ts
@@ -24,7 +24,7 @@ export const DeviceCapabilityKindForgeWorker = 'forge-worker'
 export const DeviceCapabilityKindTerminal = 'terminal'
 
 // isDeviceSelectable reports whether a Device can be presented as a target by
-// another owner such as Forge or a workflow builder.
+// Forge or a workflow builder.
 export function isDeviceSelectable(device: Device | null | undefined): boolean {
   return (
     (device?.peerId ?? '').trim() !== '' &&

--- a/sdk/device/resource.go
+++ b/sdk/device/resource.go
@@ -104,7 +104,7 @@ func (r *DeviceResource) ReportDeviceStatus(ctx context.Context, req *ReportDevi
 	return nil, errors.New("device status reports are daemon-owned and unavailable through typed object resources")
 }
 
-// AccessCheckoutRoot opens a selected checkout-root filesystem owner as an
+// AccessCheckoutRoot opens the selected checkout root's filesystem object as an
 // FSHandle resource. Write access requires explicit capability and approval
 // metadata before Device creates a writer-backed UnixFS cursor.
 func (r *DeviceResource) AccessCheckoutRoot(ctx context.Context, req *AccessCheckoutRootRequest) (*AccessCheckoutRootResponse, error) {

--- a/sdk/forge/world/worker-factory.go
+++ b/sdk/forge/world/worker-factory.go
@@ -57,7 +57,7 @@ func forgeWorkerFactory(
 		return nil, nil, err
 	}
 	if len(workerPeerID) == 0 {
-		// Worker has no linked keypair; cannot determine owner.
+		// Worker has no linked keypair; cannot determine which session runs it.
 		return nil, func() {}, nil
 	}
 

--- a/sdk/status/status.ts
+++ b/sdk/status/status.ts
@@ -51,7 +51,7 @@ export class SystemStatus {
   }
 
   // reportRecoveryStatus publishes renderer-owned recovery facts to the
-  // session-local status owner.
+  // session-local status resource.
   public async reportRecoveryStatus(
     req: ReportRecoveryStatusRequest,
     abortSignal?: AbortSignal,

--- a/web/contexts/SpaceContainerContext.tsx
+++ b/web/contexts/SpaceContainerContext.tsx
@@ -48,7 +48,7 @@ export interface SpaceContainerContextValue {
   navigateToRoot: () => void
   // navigateToObjects is the NavigateToObjectsFunc for the space.
   navigateToObjects: NavigateToObjectsFunc
-  // switchObjectAtCurrentPosition replaces the object at the nearest position owner.
+  // switchObjectAtCurrentPosition replaces the object at the current route position.
   switchObjectAtCurrentPosition?: SwitchObjectAtCurrentPositionFunc
   // buildObjectUrls builds urls for the given object keys.
   buildObjectUrls: BuildObjectUrlsFunc

--- a/web/frame/bottom-bar-context.tsx
+++ b/web/frame/bottom-bar-context.tsx
@@ -71,7 +71,7 @@ export interface BottomBarItem {
   contextMenuLabel?: string
   /** Optional key that triggers secondary action re-registration when it changes */
   contextMenuKey?: React.Key
-  /** Typed secondary actions rendered by the frame context-menu owner */
+  /** Typed secondary actions rendered by the frame's context menu */
   contextMenuItems?: readonly BottomBarContextMenuItem[]
   /** Optional handler called when the breadcrumb separator to the right of this item is clicked */
   onBreadcrumbClick?: () => void

--- a/web/hooks/useUnixFSHandle.tsx
+++ b/web/hooks/useUnixFSHandle.tsx
@@ -43,8 +43,8 @@ export function useUnixFSHandle(
   )
 }
 
-// resolveUnixFSHandle resolves a display path while preserving ownership of the
-// root handle resource.
+// resolveUnixFSHandle resolves a display path without releasing the root
+// handle resource.
 export async function resolveUnixFSHandle(
   root: FSHandle,
   path: string,

--- a/web/title/DocumentTitleContext.tsx
+++ b/web/title/DocumentTitleContext.tsx
@@ -118,7 +118,7 @@ export function getRouteDocumentTitleParts(
   return lastSegment ? { view: humanizeRouteSegment(lastSegment) } : {}
 }
 
-// DocumentTitleProvider is the only owner that writes document.title.
+// DocumentTitleProvider is the only component that writes document.title.
 export function DocumentTitleProvider({ children }: { children: ReactNode }) {
   const [candidates, setCandidates] = useState(
     () => new Map<string, DocumentTitleCandidate>(),
@@ -165,7 +165,7 @@ export function DocumentTitleProvider({ children }: { children: ReactNode }) {
   )
 }
 
-// useDocumentTitle publishes context to the document-local title owner.
+// useDocumentTitle publishes title parts to DocumentTitleProvider.
 export function useDocumentTitle(
   parts: DocumentTitleParts,
   options: UseDocumentTitleOptions = {},


### PR DESCRIPTION
Comments across app, bldr, cmd, core, e2e, forge, sdk, and web describe components as owning things: "the cache owner", "the lifecycle owner", "a live socket owner". Those phrasings name nothing the compiler checks, so a reader cannot follow the comment back to the code it describes.

Each one now names the type, function, or field that does the work, keeping every factual claim the comment already made. Where a comment recorded a real constraint such as a locking order or which caller may invoke a path, that constraint stays and is stated with the nouns the code defines. Ownership that belongs to the product domain keeps its wording: shared object owner roles, organization and billing account owners, owner-side account and mailbox mutations, and POSIX file mode descriptions. Identifiers keep their spelling everywhere, so comments naming DedicatedWorkerHostOwner, storageDurabilityOwner, or readOwner still use those names.

The change touches comments only.