### PR TITLE
fix(db): bound startup prefix and root work

### DIFF
--- a/db/block/gc/refgraph-open-cost_test.go
+++ b/db/block/gc/refgraph-open-cost_test.go
@@ -6,6 +6,8 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/aperturerobotics/cayley/graph"
+	cayley_kv "github.com/aperturerobotics/cayley/graph/kv"
 	"github.com/s4wave/spacewave/db/kvtx"
 	store_kvtx_inmem "github.com/s4wave/spacewave/db/store/kvtx/inmem"
 )
@@ -25,6 +27,279 @@ func TestNewRefGraphOpenCostIsIndependentOfEdgeCount(t *testing.T) {
 			small, large,
 		)
 	}
+}
+
+func TestAddRefDuplicateDoesNotCommit(t *testing.T) {
+	ctx := context.Background()
+	store := store_kvtx_inmem.NewStore()
+	seed, err := NewRefGraph(ctx, store, []byte("gc/"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := seed.AddRef(ctx, "owner", "target"); err != nil {
+		t.Fatal(err)
+	}
+	if err := seed.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	counted := &countingStore{Store: store}
+	rg, err := NewRefGraph(ctx, counted, []byte("gc/"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rg.Close()
+
+	before := counted.commits.Load()
+	if err := rg.AddRef(ctx, "owner", "target"); err != nil {
+		t.Fatal(err)
+	}
+	if got := counted.commits.Load(); got != before {
+		t.Fatalf("duplicate AddRef committed %d transaction(s)", got-before)
+	}
+	if err := rg.AddRef(ctx, "owner", "other-target"); err != nil {
+		t.Fatal(err)
+	}
+	if got := counted.commits.Load(); got <= before {
+		t.Fatal("new AddRef did not commit a transaction")
+	}
+}
+func TestAddRefDuplicateReadCostIsIndependentOfEdgeChurn(t *testing.T) {
+	small := addRefDuplicateReadCostForChurn(t, 1)
+	large := addRefDuplicateReadCostForChurn(t, 32)
+	if small != large {
+		t.Fatalf("adding a duplicate ref read %d keys after 1 churn cycle and %d after 32", small, large)
+	}
+}
+
+func addRefDuplicateReadCostForChurn(t *testing.T, churn int) int64 {
+	t.Helper()
+	ctx := context.Background()
+	store := store_kvtx_inmem.NewStore()
+	seed, err := NewRefGraph(ctx, store, []byte("gc/"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := seed.ApplyRefBatch(ctx, []RefEdge{
+		{Subject: "owner", Object: "owner-anchor"},
+		{Subject: "target-anchor", Object: "target"},
+		{Subject: "owner", Object: "target"},
+	}, nil); err != nil {
+		t.Fatal(err)
+	}
+	for range churn {
+		if err := seed.RemoveRef(ctx, "owner", "target"); err != nil {
+			t.Fatal(err)
+		}
+		if err := seed.AddRef(ctx, "owner", "target"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := seed.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	counted := &countingStore{Store: store}
+	rg, err := NewRefGraph(ctx, counted, []byte("gc/"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rg.Close()
+
+	before := counted.reads.Load()
+	if err := rg.AddRef(ctx, "owner", "target"); err != nil {
+		t.Fatal(err)
+	}
+	return counted.reads.Load() - before
+}
+
+func TestAddRefNewEdgeReadCostIsIndependentOfTargetFanIn(t *testing.T) {
+	small := addRefReadCostForTargetFanIn(t, 1)
+	large := addRefReadCostForTargetFanIn(t, 128)
+	if small != large {
+		t.Fatalf("adding a new ref read %d keys at fan-in 1 and %d at fan-in 128", small, large)
+	}
+}
+func TestHasRefRejectsSubjectIDPrefixCollision(t *testing.T) {
+	ctx := context.Background()
+	store := store_kvtx_inmem.NewStore()
+	rg, err := NewRefGraph(ctx, store, []byte("gc/"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rg.Close()
+
+	const subjectCount = 256
+	edges := make([]RefEdge, subjectCount+1)
+	subjects := make([]string, subjectCount)
+	for i := range subjects {
+		subjects[i] = "subject/" + strconv.Itoa(i)
+		edges[i] = RefEdge{Subject: subjects[i], Object: "seed-target"}
+	}
+	edges[subjectCount] = RefEdge{Subject: "target", Object: "seed-target"}
+	if err := rg.ApplyRefBatch(ctx, edges, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	qs, ok := graph.Unwrap(rg.handle.QuadStore).(*cayley_kv.QuadStore)
+	if !ok {
+		t.Fatalf("unexpected quad store %T", graph.Unwrap(rg.handle.QuadStore))
+	}
+	names := append([]string{PredGCRef, "target"}, subjects...)
+	ids, err := resolveIRIRefIDs(ctx, qs, names)
+	if err != nil {
+		t.Fatal(err)
+	}
+	absent, collisions := findSubjectPrefixCollisions(ids, subjects, 1)
+	if absent == "" {
+		t.Fatal("fixture did not produce a subject ID prefix collision")
+	}
+	existing := collisions[0]
+
+	if err := rg.AddRef(ctx, existing, "target"); err != nil {
+		t.Fatal(err)
+	}
+	if found, err := rg.hasRef(ctx, absent, "target"); err != nil {
+		t.Fatal(err)
+	} else if found {
+		t.Fatalf("edge %q -> target matched existing edge %q -> target", absent, existing)
+	}
+	if err := rg.AddRef(ctx, absent, "target"); err != nil {
+		t.Fatal(err)
+	}
+	if found, err := rg.hasRef(ctx, absent, "target"); err != nil {
+		t.Fatal(err)
+	} else if !found {
+		t.Fatalf("edge %q -> target was not stored", absent)
+	}
+}
+func TestAddRefAbsentEdgeReadCostIsIndependentOfDeletedPrefixCollisions(t *testing.T) {
+	small := addRefReadCostForDeletedPrefixCollisions(t, 1)
+	large := addRefReadCostForDeletedPrefixCollisions(t, 32)
+	if small != large {
+		t.Fatalf("adding an absent ref read %d keys with 1 deleted prefix collision and %d with 32", small, large)
+	}
+}
+
+func addRefReadCostForDeletedPrefixCollisions(t *testing.T, collisionCount int) int64 {
+	t.Helper()
+	ctx := context.Background()
+	store := store_kvtx_inmem.NewStore()
+	seed, err := NewRefGraph(ctx, store, []byte("gc/"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const subjectCount = 1024
+	edges := make([]RefEdge, subjectCount+1)
+	subjects := make([]string, subjectCount)
+	for i := range subjects {
+		subjects[i] = "deleted-collision/subject/" + strconv.Itoa(i)
+		edges[i] = RefEdge{Subject: subjects[i], Object: "seed-target"}
+	}
+	edges[subjectCount] = RefEdge{Subject: "target", Object: "seed-target"}
+	if err := seed.ApplyRefBatch(ctx, edges, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	qs, ok := graph.Unwrap(seed.handle.QuadStore).(*cayley_kv.QuadStore)
+	if !ok {
+		t.Fatalf("unexpected quad store %T", graph.Unwrap(seed.handle.QuadStore))
+	}
+	names := append([]string{PredGCRef, "target"}, subjects...)
+	ids, err := resolveIRIRefIDs(ctx, qs, names)
+	if err != nil {
+		t.Fatal(err)
+	}
+	absent, collisions := findSubjectPrefixCollisions(ids, subjects, collisionCount)
+	if absent == "" {
+		t.Fatalf("fixture did not produce %d subject ID prefix collisions", collisionCount)
+	}
+	collisionEdges := make([]RefEdge, len(collisions))
+	for i, subject := range collisions {
+		collisionEdges[i] = RefEdge{Subject: subject, Object: "target"}
+	}
+	if err := seed.ApplyRefBatch(ctx, collisionEdges, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := seed.ApplyRefBatch(ctx, nil, collisionEdges); err != nil {
+		t.Fatal(err)
+	}
+	if err := seed.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	counted := &countingStore{Store: store}
+	rg, err := NewRefGraph(ctx, counted, []byte("gc/"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rg.Close()
+
+	before := counted.reads.Load()
+	if err := rg.AddRef(ctx, absent, "target"); err != nil {
+		t.Fatal(err)
+	}
+	return counted.reads.Load() - before
+}
+
+func findSubjectPrefixCollisions(
+	ids map[string]uint64,
+	subjects []string,
+	limit int,
+) (string, []string) {
+	index := cayley_kv.DefaultQuadIndexes[1]
+	for _, candidate := range subjects {
+		candidateKey := index.Key([]uint64{ids["target"], ids[PredGCRef], ids[candidate]})
+		collisions := make([]string, 0, limit)
+		for _, extension := range subjects {
+			extensionKey := index.Key([]uint64{ids["target"], ids[PredGCRef], ids[extension]})
+			if extensionKey.Compare(candidateKey) != 0 && extensionKey.HasPrefix(candidateKey) {
+				collisions = append(collisions, extension)
+				if len(collisions) == limit {
+					return candidate, collisions
+				}
+			}
+		}
+	}
+	return "", nil
+}
+
+func addRefReadCostForTargetFanIn(t *testing.T, fanIn int) int64 {
+	t.Helper()
+	ctx := context.Background()
+	store := store_kvtx_inmem.NewStore()
+	seed, err := NewRefGraph(ctx, store, []byte("gc/"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	edges := make([]RefEdge, fanIn+1)
+	for idx := range edges {
+		edges[idx] = RefEdge{
+			Subject: "owner/" + strconv.Itoa(idx),
+			Object:  "target",
+		}
+	}
+	edges[fanIn] = RefEdge{Subject: "new-owner", Object: "seed-target"}
+	if err := seed.ApplyRefBatch(ctx, edges, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := seed.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	counted := &countingStore{Store: store}
+	rg, err := NewRefGraph(ctx, counted, []byte("gc/"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rg.Close()
+
+	before := counted.reads.Load()
+	if err := rg.AddRef(ctx, "new-owner", "target"); err != nil {
+		t.Fatal(err)
+	}
+	return counted.reads.Load() - before
 }
 
 // openCostForEdgeCount seeds edgeCount gc/ref edges into a fresh store, then
@@ -65,7 +340,8 @@ func openCostForEdgeCount(t *testing.T, ctx context.Context, edgeCount int) int6
 // countingStore counts the keys read through every transaction it hands out.
 type countingStore struct {
 	kvtx.Store
-	reads atomic.Int64
+	reads   atomic.Int64
+	commits atomic.Int64
 }
 
 func (s *countingStore) NewTransaction(ctx context.Context, write bool) (kvtx.Tx, error) {
@@ -89,6 +365,14 @@ func (t *countingTx) Get(ctx context.Context, key []byte) ([]byte, bool, error) 
 func (t *countingTx) Exists(ctx context.Context, key []byte) (bool, error) {
 	t.store.reads.Add(1)
 	return t.Tx.Exists(ctx, key)
+}
+
+func (t *countingTx) Commit(ctx context.Context) error {
+	if err := t.Tx.Commit(ctx); err != nil {
+		return err
+	}
+	t.store.commits.Add(1)
+	return nil
 }
 
 func (t *countingTx) ScanPrefix(ctx context.Context, prefix []byte, cb func(key, value []byte) error) error {

--- a/db/block/gc/refgraph.go
+++ b/db/block/gc/refgraph.go
@@ -2,13 +2,18 @@ package block_gc
 
 import (
 	"context"
+	"encoding/binary"
 	"io"
+	"strconv"
 	"sync"
 
 	"github.com/aperturerobotics/cayley"
 	"github.com/aperturerobotics/cayley/graph"
 	cayley_kv "github.com/aperturerobotics/cayley/graph/kv"
+	cayley_proto "github.com/aperturerobotics/cayley/graph/proto"
 	"github.com/aperturerobotics/cayley/graph/refs"
+	cayley_hkv "github.com/aperturerobotics/cayley/kv"
+	cayley_flat "github.com/aperturerobotics/cayley/kv/flat"
 	"github.com/aperturerobotics/cayley/quad"
 	"github.com/aperturerobotics/cayley/query/shape"
 	"github.com/pkg/errors"
@@ -26,6 +31,7 @@ import (
 // open.
 type RefGraph struct {
 	handle *cayley.Handle
+	store  kvtx.Store
 
 	writeMu sync.Mutex
 }
@@ -71,7 +77,7 @@ func NewRefGraph(ctx context.Context, store kvtx.Store, prefix []byte) (*RefGrap
 	if err != nil {
 		return nil, errors.Wrap(err, "new ref graph")
 	}
-	return &RefGraph{handle: h}, nil
+	return &RefGraph{handle: h, store: prefixed}, nil
 }
 
 // RegisterEntityChain registers a chain of gc/ref edges between nodes.
@@ -98,13 +104,20 @@ func (rg *RefGraph) AddRef(ctx context.Context, subject, object string) error {
 	ctx, task := trace.NewTask(ctx, "hydra/block-gc/refgraph/add-ref")
 	defer task.End()
 	trace.Log(ctx, "hydra/block-gc/refgraph/add-ref/shape", "edges=1")
+	found, err := rg.hasRef(ctx, subject, object)
+	if err != nil {
+		return errors.Wrap(err, "check existing ref edge")
+	}
+	if found {
+		return nil
+	}
 
 	taskCtx, subtask := trace.NewTask(ctx, "hydra/block-gc/refgraph/add-ref/build-quad")
 	q := quad.Make(quad.IRI(subject), quad.IRI(PredGCRef), quad.IRI(object), nil)
 	subtask.End()
 
 	taskCtx, subtask = trace.NewTask(taskCtx, "hydra/block-gc/refgraph/add-ref/add-quad")
-	err := rg.handle.AddQuad(taskCtx, q)
+	err = rg.handle.AddQuad(taskCtx, q)
 	subtask.End()
 	return err
 }
@@ -397,9 +410,9 @@ func (rg *RefGraph) filterExistingRemoves(
 	return existing, nil
 }
 
-// hasRef reports whether the durable graph holds the exact gc/ref edge. On the
-// native kv store it walks the object index for the target, so the read is
-// bounded by that object's in-degree rather than by the size of the graph.
+// hasRef reports whether the durable graph holds the exact gc/ref edge. It
+// reads the complete object-predicate-subject posting key rather than scanning
+// keys that share its unpadded base62 prefix.
 func (rg *RefGraph) hasRef(ctx context.Context, subject, object string) (bool, error) {
 	qs, ok := graph.Unwrap(rg.handle.QuadStore).(*cayley_kv.QuadStore)
 	if !ok {
@@ -414,24 +427,57 @@ func (rg *RefGraph) hasRef(ctx context.Context, subject, object string) (bool, e
 		return false, nil
 	}
 
-	var found bool
-	err = iterateIncomingIndexRefs(ctx, qs, objectID, predID,
-		func(ref cayley_kv.Int64Value, hasLive func() (bool, error)) error {
-			if uint64(ref) != subjectID {
-				return nil
-			}
-			live, err := hasLive()
-			if err != nil {
-				return err
-			}
-			if !live {
-				return nil
-			}
-			found = true
-			return io.EOF
-		},
-	)
-	return found, errors.Wrap(err, "iterate exact ref edge candidates")
+	indexKey := cayley_flat.KeyEscape(cayley_kv.DefaultQuadIndexes[1].Key(
+		[]uint64{objectID, predID, subjectID},
+	))
+	tx, err := rg.store.NewTransaction(ctx, false)
+	if err != nil {
+		return false, errors.Wrap(err, "open exact ref edge transaction")
+	}
+	defer tx.Discard()
+
+	postings, found, err := tx.Get(ctx, indexKey)
+	if err != nil {
+		return false, errors.Wrap(err, "read exact ref edge index")
+	}
+	if !found {
+		return false, nil
+	}
+	quadIDs := make([]uint64, 0, 1)
+	for len(postings) != 0 {
+		quadID, n := binary.Uvarint(postings)
+		if n <= 0 {
+			return false, errors.New("decode exact ref edge index")
+		}
+		quadIDs = append(quadIDs, quadID)
+		postings = postings[n:]
+	}
+	for i := len(quadIDs) - 1; i >= 0; i-- {
+		quadID := quadIDs[i]
+		logKey := cayley_flat.KeyEscape(cayley_hkv.Key{
+			[]byte("l"),
+			[]byte(strconv.FormatUint(quadID, 10)),
+		})
+		data, found, err := tx.Get(ctx, logKey)
+		if err != nil {
+			return false, errors.Wrap(err, "read exact ref edge primitive")
+		}
+		if !found {
+			return false, errors.Errorf("exact ref edge primitive %d is missing", quadID)
+		}
+		var prim cayley_proto.Primitive
+		if err := prim.UnmarshalVT(data); err != nil {
+			return false, errors.Wrap(err, "decode exact ref edge primitive")
+		}
+		if !prim.Deleted &&
+			prim.Object == objectID &&
+			prim.Predicate == predID &&
+			prim.Subject == subjectID &&
+			prim.Label == 0 {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func (rg *RefGraph) hasRefGeneric(ctx context.Context, subject, object string) (bool, error) {

--- a/db/store/kvtx/bolt/iterator_test.go
+++ b/db/store/kvtx/bolt/iterator_test.go
@@ -4,6 +4,7 @@ package store_kvtx_bolt
 
 import (
 	"bytes"
+	"context"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -148,6 +149,48 @@ func TestIteratorPrefixSeekCost(t *testing.T) {
 				t.Fatalf("prefix seek cost grew more than 20x with unrelated filler: 100 keys=%s, 100000 keys=%s", small, large)
 			}
 		})
+	}
+}
+
+func TestBoltScanPrefixSeekCost(t *testing.T) {
+	const iterations = 64
+	measure := func(filler int) time.Duration {
+		db := openPrefixSeekDB(t, filler, false)
+		rawTx, err := db.Begin(false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer rawTx.Rollback()
+		tx := NewTx(rawTx, iteratorTestBucket)
+		scan := func() {
+			count := 0
+			err := tx.ScanPrefix(context.Background(), []byte("zzz/"), func(_, _ []byte) error {
+				count++
+				return nil
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if count != 1 {
+				t.Fatalf("ScanPrefix matched %d keys, want 1", count)
+			}
+		}
+		for range 4 {
+			scan()
+		}
+		started := time.Now()
+		for range iterations {
+			scan()
+		}
+		return time.Since(started)
+	}
+
+	small := measure(100)
+	large := measure(100_000)
+	t.Logf("100 filler: %s total for %d scans", small, iterations)
+	t.Logf("100000 filler: %s total for %d scans", large, iterations)
+	if large > small*20 {
+		t.Fatalf("prefix scan cost grew more than 20x with unrelated filler: 100 keys=%s, 100000 keys=%s", small, large)
 	}
 }
 

--- a/db/store/kvtx/bolt/tx.go
+++ b/db/store/kvtx/bolt/tx.go
@@ -12,7 +12,6 @@ import (
 
 	bdb "github.com/aperturerobotics/bbolt"
 	bdberrors "github.com/aperturerobotics/bbolt/errors"
-	rbt "github.com/emirpasic/gods/trees/redblacktree"
 	"github.com/s4wave/spacewave/db/kvtx"
 )
 
@@ -103,29 +102,19 @@ func (t *Tx) ScanPrefix(ctx context.Context, prefix []byte, cb func(key, value [
 		return err
 	}
 
-	write := t.txn.Writable()
-	emittedKeys := rbt.NewWith(func(i, j any) int {
-		return bytes.Compare(i.([]byte), j.([]byte))
-	})
-	checkElem := func(k, v []byte) error {
-		if len(prefix) != 0 {
-			if !bytes.HasPrefix(k, prefix) {
-				return nil
-			}
-		}
-
-		if !write {
-			if _, ok := emittedKeys.Get(k); ok {
-				return nil
-			}
-			emittedKeys.Put(k, struct{}{})
-		}
-
-		return cb(k, v)
+	cur := bkt.Cursor()
+	var key, value []byte
+	if len(prefix) == 0 {
+		key, value = cur.First()
+	} else {
+		key, value = cur.Seek(prefix)
 	}
-
-	// TODO: use a cursor for the prefix instead of ForEach.
-	return bkt.ForEach(checkElem)
+	for ; key != nil && (len(prefix) == 0 || bytes.HasPrefix(key, prefix)); key, value = cur.Next() {
+		if err := cb(key, value); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // ScanPrefixKeys iterates over keys with a prefix.

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ replace (
 
 require (
 	github.com/aperturerobotics/abseil-cpp v0.0.0-20260131110040-4bb56e2f9017 // indirect
-	github.com/aperturerobotics/bbolt v0.0.0-20260802102853-331472f62805 // master
+	github.com/aperturerobotics/bbolt v0.0.0-20260803053248-633a6560e3d0 // master
 	github.com/aperturerobotics/bldr-saucer v0.4.4
 	github.com/aperturerobotics/cayley v0.15.1-0.20260705021747-c5ec5d20d2b6 // master
 	github.com/aperturerobotics/cli v1.1.0 // v1.1.0
@@ -86,7 +86,10 @@ require (
 	modernc.org/sqlite v1.55.0
 )
 
-require github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342 // indirect
+require (
+	github.com/emirpasic/gods v1.18.1 // indirect
+	github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342 // indirect
+)
 
 require (
 	github.com/cloudflare/circl v1.6.4
@@ -96,7 +99,6 @@ require (
 	github.com/dolthub/go-mysql-server v0.20.0
 	github.com/dolthub/vitess v0.0.0-20260617012411-2f308f6cdc23
 	github.com/dustin/go-humanize v1.0.1
-	github.com/emirpasic/gods v1.18.1
 	github.com/fatih/color v1.19.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-git/go-billy/v6 v6.0.0-alpha.2.0.20260728104803-133d4f9bfd41 // main

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/aperturerobotics/abseil-cpp v0.0.0-20260131110040-4bb56e2f9017 h1:3U7
 github.com/aperturerobotics/abseil-cpp v0.0.0-20260131110040-4bb56e2f9017/go.mod h1:lNSJTKECIUFAnfeSqy01kXYTYe1BHubW7198jNX3nEw=
 github.com/aperturerobotics/badger-go/v4 v4.0.0-20260705010846-938e2bd5962c h1:QgIjJf2X9yhzKRDtpRpbAY0kZ7fVtFsmOcYhzaSC/Wk=
 github.com/aperturerobotics/badger-go/v4 v4.0.0-20260705010846-938e2bd5962c/go.mod h1:gDH4T/6RmW0rqh0ja0bFlZ+0vWGFgtgS8zb2/mKuyT0=
-github.com/aperturerobotics/bbolt v0.0.0-20260802102853-331472f62805 h1:LsiBJ8CpeYJwaZOZoPMx3qC8FUeMueZRDrqn11+wTA0=
-github.com/aperturerobotics/bbolt v0.0.0-20260802102853-331472f62805/go.mod h1:uP4X3ycuVlQftt6tTDe6smymYXZ9hf/TtUScVRn4760=
+github.com/aperturerobotics/bbolt v0.0.0-20260803053248-633a6560e3d0 h1:LHiXjE2LyVpbL+qAiOTjBylV2Tp9wEu+M2S+ToFzU20=
+github.com/aperturerobotics/bbolt v0.0.0-20260803053248-633a6560e3d0/go.mod h1:uP4X3ycuVlQftt6tTDe6smymYXZ9hf/TtUScVRn4760=
 github.com/aperturerobotics/bldr-saucer v0.4.4 h1:kQvjAAQcdydvX2EYWipQW1vOBUe88F/27WaVU7mKRoE=
 github.com/aperturerobotics/bldr-saucer v0.4.4/go.mod h1:yH40259UVahR/9DU9c+Sg0+HGm5OtTWHV7CeEzneVho=
 github.com/aperturerobotics/cayley v0.15.1-0.20260705021747-c5ec5d20d2b6 h1:KmxQugbTP9Pz3aw6U+3nKhKcZpFHb9W8lepxKscFF+k=


### PR DESCRIPTION
Session startup scanned every unrelated Bolt key before reaching the linked-cloud setting, then committed a durable RefGraph transaction for bucket-root edges that already existed. Those two costs made the first fixed-key request scale with the shared store.

Seek direct Bolt prefix scans at their lower bound and stop when the cursor leaves the range. Check exact RefGraph membership under the existing write lock so duplicate additions return before Cayley starts a write transaction.

The changes preserve prefix results, edge state, APIs, and the storage format.