### PR TITLE
style(go): expose function flow with code paragraphs

### DIFF
--- a/auth/derive/derive-keypair.go
+++ b/auth/derive/derive-keypair.go
@@ -27,16 +27,19 @@ type deriveKeypairResolver struct {
 // The resolver will not be retried after returning an error.
 // Values will be maintained from the previous call.
 func (o *deriveKeypairResolver) Resolve(ctx context.Context, handler directive.ResolverHandler) error {
-	// if we already resolved the keypair, return.
+	// Return immediately when the keypair has already been resolved.
 	if handler.CountValues(false) != 0 {
 		return nil
 	}
 
+	// Derive the requested keypair through the controller's auth services.
 	keypairList := o.dir.DeriveEntityKeypairList()
 	res, err := DeriveEntityKeypair(ctx, o.c.bus, o.c.le, keypairList)
 	if err != nil {
 		return err
 	}
+
+	// Publish a derived peer when the request produced one.
 	if res != nil {
 		_, _ = handler.AddValue(res)
 	}
@@ -50,18 +53,20 @@ func DeriveEntityKeypair(
 	le *logrus.Entry,
 	keypairList []*identity.EntityKeypair,
 ) (peer.Peer, error) {
+	// Track the last failure while trying each configured keypair.
 	var lastErr error
 KeypairLoop:
+	// Process keypairs until one authenticates successfully.
 	for kpi, ekp := range keypairList {
 		kp := ekp.GetKeypair()
 		methodID := kp.GetAuthMethodId()
 		expectedPeerID := kp.GetPeerId()
 		if !AuthMethodIdSupported(methodID) || len(expectedPeerID) < 12 {
-			// Currently only triplesec is supported.
+			// Skip keypairs whose method or peer identifier is unsupported.
 			continue
 		}
 
-		// Lookup auth method.
+		// Resolve the authentication method for this keypair.
 		authMethod, err := auth_method.ExAuthLookupMethod(ctx, b, methodID, true)
 		if err == nil && authMethod == nil {
 			err = errors.Errorf("auth method not found: %s", methodID)
@@ -76,7 +81,7 @@ KeypairLoop:
 			continue
 		}
 
-		// Unmarshal params
+		// Decode and validate the stored authentication parameters.
 		params, err := authMethod.UnmarshalParameters(kp.GetAuthMethodParams())
 		if err != nil {
 			le.
@@ -87,6 +92,7 @@ KeypairLoop:
 			continue
 		}
 
+		// Build the user-facing reason for the password prompt.
 		var reasonBuf strings.Builder
 		if ekp.GetEntityEmpty() {
 			reasonBuf.WriteString("unlock ")
@@ -109,6 +115,7 @@ KeypairLoop:
 			reasonBuf.WriteString(domainID)
 		}
 
+		// Prepare prompt metadata and surface any prior keypair failure.
 		reasonDetail := reasonBuf.String()
 		reason := strings.Join([]string{
 			ControllerID,
@@ -121,7 +128,7 @@ KeypairLoop:
 			showErr = errors.Wrap(showErr, "Other keypair failed")
 		}
 
-		// Ask user for password, repeatedly if incorrect.
+		// Prompt for a password until this keypair succeeds or is skipped.
 		for {
 			passwordTxt, err := identity.ExPromptPassword(
 				ctx,
@@ -145,7 +152,7 @@ KeypairLoop:
 				continue KeypairLoop
 			}
 
-			// Attempt to derive keypair
+			// Authenticate the password and verify the resulting peer identity.
 			var incorrectPw bool
 			privKey, err := authMethod.Authenticate(params, []byte(passwordTxt))
 			if err == nil {
@@ -177,7 +184,7 @@ KeypairLoop:
 				continue
 			}
 
-			// otherwise we have successfully derived the peer.
+			// Construct and return the authenticated peer.
 			npeer, err := peer.NewPeer(privKey)
 			if err != nil {
 				le.
@@ -200,7 +207,6 @@ func (c *Controller) resolveDeriveEntityKeypair(
 	di directive.Instance,
 	dir identity.DeriveEntityKeypair,
 ) (directive.Resolver, error) {
-	// Return resolver.
 	return &deriveKeypairResolver{c: c, ctx: ctx, di: di, dir: dir}, nil
 }
 

--- a/auth/derive/derive.go
+++ b/auth/derive/derive.go
@@ -56,11 +56,15 @@ func (c *Controller) HandleDirective(
 	ctx context.Context,
 	di directive.Instance,
 ) ([]directive.Resolver, error) {
+	// Inspect the directive type requested by the bus.
 	dir := di.GetDirective()
 	switch d := dir.(type) {
 	case identity.DeriveEntityKeypair:
+		// Return a resolver for keypair derivation requests.
 		return directive.R(c.resolveDeriveEntityKeypair(ctx, di, d))
 	}
+
+	// Leave unsupported directives unresolved.
 	return nil, nil
 }
 

--- a/auth/examples/authtester/main.go
+++ b/auth/examples/authtester/main.go
@@ -30,18 +30,22 @@ func main() {
 }
 
 func runAuthTester(c *cli.Context) error {
+	// Initialize the authentication test context and logger.
 	ctx := context.Background()
 	log := logrus.New()
 	log.SetLevel(logrus.DebugLevel)
 	le := logrus.NewEntry(log)
 
-	// the root command starts interactive authentication.
+	// Collect credentials through the shared login prompt.
+	// The root command starts interactive authentication.
 	username, password, err := common.RunLoginPrompt()
 	if err != nil {
 		return err
 	}
 
+	// Construct the password method and derive its parameters.
 	le.Info("scrypt...")
+
 	var handler auth_method.Handler // TODO
 	authMethod, err := auth_method_password.NewMethod(ctx, le, handler)
 	if err != nil {
@@ -51,6 +55,8 @@ func runAuthTester(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+
+	// Authenticate and derive the peer identity.
 	privKey, err := authMethod.Authenticate(
 		params,
 		[]byte(password),
@@ -62,10 +68,13 @@ func runAuthTester(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+
+	// Derive the test entity identifier and serialize its parameters.
 	// aperture domain uuid for v0
 	domainUUID, _ := uuid.FromString("1e4a7ac8-d1d9-4172-8d73-601e501f2382")
 	entityUUID := uuid.NewV5(domainUUID, username)
 
+	// Serialize and report the authentication parameters.
 	authParamsDat, err := params.MarshalVT()
 	if err != nil {
 		return err
@@ -76,6 +85,7 @@ func runAuthTester(c *cli.Context) error {
 		WithField("entity-uuid", entityUUID).
 		Info("authenticated and derived private key")
 
+	// Sign the derived peer identifier as the final authentication check.
 	dat, err := privKey.Sign([]byte(peerID.String()))
 	if err != nil {
 		return err

--- a/auth/examples/common/interactive.go
+++ b/auth/examples/common/interactive.go
@@ -14,16 +14,19 @@ func RunLoginPrompt() (
 	password string,
 	err error,
 ) {
+	// Prompt for the username.
 	username, err = (&promptui.Prompt{Label: "Username"}).Run()
 	if err != nil {
 		return
 	}
 
+	// Prompt for the password.
 	password, err = (&promptui.Prompt{Label: "Password", Mask: '*'}).Run()
 	if err != nil {
 		return
 	}
 
+	// Reject empty credentials.
 	if username == "" || password == "" {
 		err = errors.New("username and password cannot be empty")
 	}

--- a/auth/examples/logintester/main.go
+++ b/auth/examples/logintester/main.go
@@ -58,24 +58,27 @@ func main() {
 }
 
 func runAuthTester(c *cli.Context) error {
+	// Initialize the test context and logger.
 	ctx := context.Background()
 	log := logrus.New()
 	log.SetLevel(logrus.DebugLevel)
 	le := logrus.NewEntry(log)
 
+	// Construct the password authentication method.
 	var handler auth_method.Handler // TODO
 	authMethod, err := auth_method_password.NewMethod(ctx, le, handler)
 	if err != nil {
 		return err
 	}
 
+	// Define the test entity and domain identifiers.
 	entityID := "testuser"
 	domainID := "aperture.app"
 	domainName := "Aperture App"
 	hardcodedPassword := "testpassword"
 	entityUUID := uuid.NewV4().String()
 
-	// generate the user private key with the password in advance
+	// Derive the test entity keypair from its password.
 	paramsSrc, userPrivKey, err := auth_method_password.BuildParametersWithUsernamePassword(
 		entityID,
 		[]byte(hardcodedPassword),
@@ -84,11 +87,13 @@ func runAuthTester(c *cli.Context) error {
 		return err
 	}
 
+	// Serialize the authentication parameters for the entity record.
 	authMethodParams, err := paramsSrc.MarshalVT()
 	if err != nil {
 		return err
 	}
 
+	// Build the target entity record with its private key.
 	targetEntitySrc, err := identity.EntityWithPrivKey(
 		domainID,
 		entityID, entityUUID,
@@ -100,7 +105,7 @@ func runAuthTester(c *cli.Context) error {
 		return err
 	}
 
-	// Build testbed
+	// Build the client testbed and register its controllers.
 	tb, err := testbed.NewTestbed(
 		ctx,
 		le.WithField("testbed", "auth-client"),
@@ -109,16 +114,19 @@ func runAuthTester(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+
+	// Add core and transport factories to the client testbed.
 	core.AddFactories(tb.Bus, tb.StaticResolver)
 	tb.StaticResolver.AddFactory(inproc.NewFactory(tb.Bus))
 
+	// Resolve the client peer identity from its private key.
 	privKey := tb.PrivKey
 	peerID, err := peer.IDFromPrivateKey(privKey)
 	if err != nil {
 		return err
 	}
 
-	// Build testbed for the "auth server"
+	// Build the testbed that hosts the authentication server.
 	tbServer, err := testbed.NewTestbed(
 		ctx,
 		le.WithField("testbed", "auth-server"),
@@ -130,7 +138,7 @@ func runAuthTester(c *cli.Context) error {
 	core.AddFactories(tbServer.Bus, tbServer.StaticResolver)
 	tbServer.StaticResolver.AddFactory(inproc.NewFactory(tbServer.Bus))
 
-	// Start the auth server.
+	// Start the authentication server controller.
 	serverPrivKey := tbServer.PrivKey
 	serverPeerID, err := peer.IDFromPrivateKey(serverPrivKey)
 	if err != nil {
@@ -153,7 +161,7 @@ func runAuthTester(c *cli.Context) error {
 
 	serverPeerIDs := []string{serverPeerID.String()}
 
-	// Static auth list (simulating a auth database)
+	// Publish the target entity through the static authentication list.
 	_, _, staticRef, err := loader.WaitExecControllerRunning(
 		ctx,
 		tbServer.Bus,
@@ -171,6 +179,7 @@ func runAuthTester(c *cli.Context) error {
 	}
 	defer staticRef.Release()
 
+	// Start the server-side in-process transport.
 	tp2i, _, tp2Ref, err := loader.WaitExecControllerRunning(
 		ctx,
 		tbServer.Bus,
@@ -190,6 +199,7 @@ func runAuthTester(c *cli.Context) error {
 	}
 	tp2 := tp2k.(*inproc.Inproc)
 
+	// Start the client-side in-process transport and dial the server.
 	tp1i, _, tp1Ref, err := loader.WaitExecControllerRunning(
 		ctx,
 		tb.Bus,
@@ -214,10 +224,11 @@ func runAuthTester(c *cli.Context) error {
 	}
 	tp1 := tp1k.(*inproc.Inproc)
 
+	// Connect both in-process transports.
 	tp2.ConnectToInproc(ctx, tp1)
 	tp1.ConnectToInproc(ctx, tp2)
 
-	// Execute the client.
+	// Execute the client controller against the authentication server.
 	_, _, clientRef, err := bus.ExecOneOff(
 		ctx,
 		tb.Bus,
@@ -240,7 +251,7 @@ func runAuthTester(c *cli.Context) error {
 	}
 	defer clientRef.Release()
 
-	// 1. Input username
+	// Collect the username used for the authentication lookup.
 	if username == "" {
 		username, err = (&promptui.Prompt{Label: "Username"}).Run()
 		if err != nil {
@@ -251,7 +262,7 @@ func runAuthTester(c *cli.Context) error {
 		return errors.New("username cannot be empty")
 	}
 
-	// 2. Lookup username auth record from active domain.
+	// Look up the username record from the active domain.
 	entityRecordInter, _, di, err := bus.ExecOneOff(
 		ctx,
 		tb.Bus,
@@ -264,6 +275,7 @@ func runAuthTester(c *cli.Context) error {
 	}
 	di.Release()
 
+	// Validate the lookup result and capture the entity record.
 	entityRecordValue := entityRecordInter.GetValue().(identity.IdentityLookupEntityValue)
 	if entityRecordValue.IsNotFound() {
 		return errors.New("authentication failed: entity not found")
@@ -274,7 +286,7 @@ func runAuthTester(c *cli.Context) error {
 	entity := entityRecordValue.GetEntity()
 	le.Infof("got authentication entity with uuid %s", entity.GetEntityUuid())
 
-	// 3. authenticate against the record
+	// Select the keypair registered for this authentication method.
 	var selectedKeypair *identity.Keypair
 	for i, kpd := range entity.GetEntityKeypairSet().GetEntityKeypairs() {
 		ekp := &identity.EntityKeypair{}
@@ -292,7 +304,7 @@ func runAuthTester(c *cli.Context) error {
 		return errors.New("no keypairs match auth method")
 	}
 
-	// Gather the password for the username/password method.
+	// Collect and normalize the password for authentication.
 	if password == "" {
 		password, err = (&promptui.Prompt{Label: "Password", Mask: '*'}).Run()
 		if err != nil {
@@ -307,11 +319,13 @@ func runAuthTester(c *cli.Context) error {
 	}
 	le.Debugf("%q", password)
 
+	// Decode the selected keypair's authentication parameters.
 	selectedParams, err := authMethod.UnmarshalParameters(selectedKeypair.GetAuthMethodParams())
 	if err != nil {
 		return err
 	}
 
+	// Authenticate the password and derive the peer identity.
 	derivedPrivKey, err := authMethod.Authenticate(selectedParams, []byte(password))
 	if err != nil {
 		return err
@@ -320,6 +334,8 @@ func runAuthTester(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+
+	// Verify that the derived peer matches the selected keypair.
 	derivedPeerIDStr := derivedPeerID.String()
 	if derivedPeerIDStr != selectedKeypair.GetPeerId() {
 		return errors.Errorf(
@@ -329,6 +345,7 @@ func runAuthTester(c *cli.Context) error {
 		)
 	}
 
+	// Report successful authentication for the derived peer.
 	le.Infof("successfully derived private key for peer id %s", derivedPeerIDStr)
 	return nil
 }

--- a/auth/method/controller/controller-lookup-method.go
+++ b/auth/method/controller/controller-lookup-method.go
@@ -20,22 +20,25 @@ type authLookupMethodResolver struct {
 // The resolver will not be retried after returning an error.
 // Values will be maintained from the previous call.
 func (o *authLookupMethodResolver) Resolve(ctx context.Context, handler directive.ResolverHandler) error {
-	// if we already resolved the keypair, return.
+	// Return immediately when the method has already been published.
 	if handler.CountValues(false) != 0 {
 		return nil
 	}
 
+	// Match the requested method against this controller's method ID.
 	c := o.c
 	methodID := o.dir.AuthLookupMethodID()
 	if o.c.methodID != methodID {
 		return nil
 	}
 
+	// Resolve the active authentication method from the controller.
 	method, err := c.GetAuthMethod(ctx)
 	if err != nil {
 		return err
 	}
 
+	// Publish the resolved method to the directive handler.
 	_, _ = handler.AddValue(method)
 	return nil
 }

--- a/auth/method/controller/controller.go
+++ b/auth/method/controller/controller.go
@@ -81,11 +81,13 @@ func (c *Controller) GetControllerInfo() *controller.Info {
 // Returning nil ends execution.
 // Returning an error triggers a retry with backoff.
 func (c *Controller) Execute(ctx context.Context) error {
+	// Bind the execution context used by method lookups.
 	c.ctx = ctx
-	// Acquire a handle to the node.
+
+	// Log the start of authentication method loading.
 	c.le.Debug("loading authentication method")
 
-	// Construct the auth method.
+	// Construct the authentication method for this controller run.
 	tpt, err := c.ctor(
 		ctx,
 		c.le,
@@ -94,20 +96,25 @@ func (c *Controller) Execute(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	// Publish the method while the controller keeps it active.
 	defer tpt.Close()
 	c.methodCh <- tpt
 
+	// Run the method and wait for cancellation when it completes cleanly.
 	err = tpt.Execute(ctx)
 	if err == nil {
 		select {
 		case <-ctx.Done():
 			err = ctx.Err()
 		default:
-			// wait to close the auth method until the ctx is canceled.
+			// Keep the method open until the execution context is canceled.
 			<-ctx.Done()
 			return nil
 		}
 	}
+
+	// Remove the method from the publication channel before returning.
 	select {
 	case <-c.methodCh:
 	default:
@@ -131,12 +138,15 @@ func (c *Controller) GetAuthMethod(ctx context.Context) (auth_method.Method, err
 // Any unexpected errors are returned for logging.
 // It is safe to add a reference to the directive during this call.
 func (c *Controller) HandleDirective(ctx context.Context, di directive.Instance) ([]directive.Resolver, error) {
+	// Inspect the directive type requested by the bus.
 	dir := di.GetDirective()
 	switch d := dir.(type) {
 	case auth_method.AuthLookupMethod:
+		// Return a resolver for authentication method lookups.
 		return directive.R(c.resolveAuthLookupMethod(di, d))
 	}
 
+	// Leave unsupported directives unresolved.
 	return nil, nil
 }
 

--- a/auth/method/directive-lookup-method.go
+++ b/auth/method/directive-lookup-method.go
@@ -30,16 +30,23 @@ func ExAuthLookupMethod(
 	methodID string,
 	returnIfIdle bool,
 ) (AuthLookupMethodValue, error) {
+	// Execute the lookup directive with the requested idle behavior.
 	val, _, valRef, err := bus.ExecOneOff(ctx, b, NewAuthLookupMethod(methodID), bus.ReturnIfIdle(returnIfIdle), nil)
 	if err != nil {
 		return nil, err
 	}
+
+	// Release the lookup reference before inspecting the returned value.
 	if valRef != nil {
 		valRef.Release()
 	}
+
+	// Return an empty result when the lookup found no value.
 	if val == nil {
 		return nil, nil
 	}
+
+	// Validate and return the resolved authentication method.
 	v, vOk := val.GetValue().(AuthLookupMethodValue)
 	if !vOk {
 		return nil, errors.New("lookup auth method returned invalid type")
@@ -127,7 +134,10 @@ func (d *lookupMethod) GetName() string {
 // This should be something like param1="test", param2="test".
 // This is not necessarily unique, and is primarily intended for display.
 func (d *lookupMethod) GetDebugVals() directive.DebugValues {
+	// Create the debug-value collection for this directive.
 	vals := directive.NewDebugValues()
+
+	// Record the requested authentication method ID.
 	vals["id"] = []string{d.AuthLookupMethodID()}
 	return vals
 }

--- a/auth/method/password/params.go
+++ b/auth/method/password/params.go
@@ -45,9 +45,11 @@ func BuildParametersWithUsernamePassword(username string, password []byte) (*Par
 // buildParametersWithUsernamePassword builds Parameters with explicit scrypt
 // settings and derives an Ed25519 private key from a username and password.
 func buildParametersWithUsernamePassword(username string, password []byte, n, r, p uint32) (*Parameters, crypto.PrivKey, error) {
+	// Derive the deterministic salt from the username.
 	var salt [saltLen]byte
 	blake3.DeriveKey(saltContext, []byte(username), salt[:])
 
+	// Assemble the persisted password KDF parameters.
 	params := &Parameters{
 		Salt:    salt[:],
 		ScryptN: n,
@@ -55,6 +57,7 @@ func buildParametersWithUsernamePassword(username string, password []byte, n, r,
 		ScryptP: p,
 	}
 
+	// Derive the private key from the assembled parameters.
 	privKey, err := deriveKey(params, password)
 	if err != nil {
 		return nil, nil, err
@@ -64,6 +67,7 @@ func buildParametersWithUsernamePassword(username string, password []byte, n, r,
 
 // deriveKey derives an Ed25519 private key from parameters and password.
 func deriveKey(params *Parameters, password []byte) (crypto.PrivKey, error) {
+	// Resolve default KDF parameters when the record omits them.
 	n := params.GetScryptN()
 	if n == 0 {
 		n = DefaultScryptN
@@ -77,15 +81,17 @@ func deriveKey(params *Parameters, password []byte) (crypto.PrivKey, error) {
 		p = DefaultScryptP
 	}
 
-	// Derive password key via blake3 before passing to scrypt.
+	// Derive the password key before passing it to scrypt.
 	var passKey [32]byte
 	blake3.DeriveKey("aperture/auth 2026-03-16 password-kdf passphrase v2", password, passKey[:])
 
+	// Run scrypt with the persisted salt and resolved parameters.
 	seed, err := scrypt.Key(passKey[:], params.GetSalt(), 1<<n, r, p, 32)
 	if err != nil {
 		return nil, errors.Wrap(err, "scrypt key derivation")
 	}
 
+	// Turn the derived seed into the Ed25519 private key.
 	privKey, _, err := crypto.GenerateEd25519Key(bytes.NewReader(seed))
 	if err != nil {
 		return nil, errors.Wrap(err, "generate ed25519 key from seed")

--- a/auth/method/password/password.go
+++ b/auth/method/password/password.go
@@ -59,13 +59,17 @@ func (p *PasswordMethod) UnmarshalParameters(data []byte) (auth_method.Parameter
 // Authenticate authenticates with existing auth parameters.
 // authSecretData is the password bytes.
 func (p *PasswordMethod) Authenticate(paramsi auth_method.Parameters, authSecretData []byte) (crypto.PrivKey, error) {
+	// Require the password parameter type used by this method.
 	params, ok := paramsi.(*Parameters)
 	if !ok {
 		return nil, errors.New("params object not recognized")
 	}
+
+	// Require secret data before deriving the private key.
 	if len(authSecretData) == 0 {
 		return nil, errors.New("auth secret data must be set")
 	}
+
 	return deriveKey(params, authSecretData)
 }
 

--- a/auth/method/pem/pem.go
+++ b/auth/method/pem/pem.go
@@ -61,12 +61,17 @@ func (p *PemMethod) UnmarshalParameters(data []byte) (auth_method.Parameters, er
 // Authenticate authenticates with existing auth parameters.
 // authSecretData is the full PEM private key file bytes.
 func (p *PemMethod) Authenticate(paramsi auth_method.Parameters, authSecretData []byte) (crypto.PrivKey, error) {
+	// Require PEM parameters before parsing the private key.
 	if _, ok := paramsi.(*PemParameters); !ok {
 		return nil, errors.New("params object not recognized")
 	}
+
+	// Require private-key data for authentication.
 	if len(authSecretData) == 0 {
 		return nil, errors.New("auth secret data must be set")
 	}
+
+	// Parse and validate the supplied private key.
 	privKey, err := keypem.ParsePrivKeyPem(authSecretData)
 	if err != nil {
 		return nil, errors.Wrap(err, "parse pem private key")
@@ -90,9 +95,12 @@ func (p *PemParameters) MarshalBlock() ([]byte, error) {
 
 // Validate validates the parameters by parsing the PEM public key.
 func (p *PemParameters) Validate() error {
+	// Require PEM public-key data before parsing.
 	if len(p.PubKeyPem) == 0 {
 		return errors.New("pub key pem must be set")
 	}
+
+	// Parse and validate the public key.
 	pub, err := keypem.ParsePubKeyPem(p.PubKeyPem)
 	if err != nil {
 		return errors.Wrap(err, "parse pub key pem")
@@ -109,14 +117,19 @@ var _ auth_method.Parameters = ((*PemParameters)(nil))
 // GenerateBackupKey creates a new Ed25519 keypair for PEM backup.
 // Returns the private key PEM and public key PEM bytes.
 func GenerateBackupKey() (privPem []byte, pubPem []byte, err error) {
+	// Generate the Ed25519 private key used for the backup.
 	priv, _, err := crypto.GenerateEd25519Key(rand.Reader)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "generate ed25519 key")
 	}
+
+	// Encode the private key as PEM.
 	privPem, err = keypem.MarshalPrivKeyPem(priv)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "marshal private key pem")
 	}
+
+	// Encode the corresponding public key as PEM.
 	pubPem, err = keypem.MarshalPubKeyPem(priv.GetPublic())
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "marshal public key pem")

--- a/bldr/dist.go
+++ b/bldr/dist.go
@@ -63,8 +63,9 @@ var DistSources embed.FS
 
 // BuildDistSourcesFSCursor builds a *fs.Cursor for the DistSources.
 func BuildDistSourcesFSCursor() *unixfs_iofs.FSCursor {
-	// NOTE: we assert there is no error in src-web_test.go
 	ifs := util_iofs.NewWritableFS(DistSources)
+
+	// NOTE: we assert there is no error in src-web_test.go
 	fs, _ := unixfs_iofs.NewFSCursor(ifs)
 	return fs
 }

--- a/bldr/web/entrypoint/browser/build/build.go
+++ b/bldr/web/entrypoint/browser/build/build.go
@@ -38,12 +38,13 @@ func BuildWasmRuntimeEntrypoint(
 ) error {
 	le.Info("building runtime-wasm.mjs")
 
+	// Resolve the wasm execution shim for the selected compiler.
 	wasmExecFile, err := gocompiler.GetWasmExecPath(ctx, le, useTinygo)
 	if err != nil {
 		return err
 	}
 
-	// Build runtime wasm entrypoint
+	// Configure the browser runtime entrypoint and output path.
 	entrypointJsDir := filepath.Join(bldrDistRoot, webEntrypointBrowserDir)
 	runtimeJsOut := filepath.Join(buildDir, "runtime-wasm.mjs")
 
@@ -52,6 +53,7 @@ func BuildWasmRuntimeEntrypoint(
 	opts.Outfile = runtimeJsOut
 	opts.Write = true
 
+	// Apply TinyGo fallbacks when requested.
 	if useTinygo {
 		nodeStubsLoc := filepath.Join(bldrDistRoot, nodeStubsPath)
 		nodeStubsLoc, err = filepath.Rel(entrypointJsDir, nodeStubsLoc)
@@ -62,18 +64,19 @@ func BuildWasmRuntimeEntrypoint(
 		entrypoint_browser_bundle.ApplyTinyGoNodeFallbacks(&opts)
 		entrypoint_browser_bundle.ApplyTinyGoWasmExecPatches(&opts, wasmExecFile)
 	}
+
+	// Add the wasm execution shim and optional runtime path define.
 	opts.Inject = append(opts.Inject, wasmExecFile)
 
 	if runtimeWasmPath != "" {
 		opts.Define["BLDR_RUNTIME_WASM"] = strconv.Quote(runtimeWasmPath)
 	}
 
+	// Build the configured browser runtime bundle.
 	res := esbuild_api.Build(opts)
 	if err := bldr_esbuild_build.BuildResultToErr(res); err != nil {
 		return err
 	}
-
-	// build complete
 	return nil
 }
 
@@ -82,6 +85,8 @@ func BuildWasmRuntimeEntrypoint(
 // builds to buildDir/runtime-ws.mjs
 func BuildWsRuntime(ctx context.Context, le *logrus.Entry, bldrDistRoot, buildDir string, minify, sourcemaps bool) error {
 	le.Info("building runtime-ws.mjs")
+
+	// Configure the WebSocket runtime entrypoint and output path.
 	entrypointJsDir := filepath.Join(bldrDistRoot, webEntrypointBrowserDir)
 	runtimeJsOut := filepath.Join(buildDir, "runtime-ws.mjs")
 
@@ -90,11 +95,10 @@ func BuildWsRuntime(ctx context.Context, le *logrus.Entry, bldrDistRoot, buildDi
 	opts.Outfile = runtimeJsOut
 	opts.Write = true
 
+	// Build the configured WebSocket runtime bundle.
 	res := esbuild_api.Build(opts)
 	if err := bldr_esbuild_build.BuildResultToErr(res); err != nil {
 		return err
 	}
-
-	// build complete
 	return nil
 }

--- a/bldr/web/entrypoint/browser/bundle/bundle-cache.go
+++ b/bldr/web/entrypoint/browser/bundle/bundle-cache.go
@@ -103,6 +103,7 @@ func (bc *bundleCache) build(
 	extraDigest []byte,
 	doBuild func() (*bundleBuildOutput, error),
 ) (*bundleBuildOutput, error) {
+	// Compute cache provenance and fall back to a direct build when unavailable.
 	configDigest, cacheable := bc.configDigest(opts, extraDigest)
 	if !cacheable {
 		out, err := doBuild()
@@ -112,18 +113,21 @@ func (bc *bundleCache) build(
 		return out, err
 	}
 
+	// Serialize builds for the same bundle name.
 	lock, err := acquireBundleCacheLock(filepath.Join(bc.dir, name+".lock"))
 	if err != nil {
 		return nil, err
 	}
 	defer func() { _ = lock.Close() }()
 
+	// Reuse a valid cached bundle when provenance still matches.
 	if cached := bc.load(name, configDigest); cached != nil {
 		bc.reuses.Add(1)
 		bc.le.WithField("bundle", name).Debug("reusing cached browser bundle")
 		return cached, nil
 	}
 
+	// Build the bundle and count the fresh output.
 	out, err := doBuild()
 	if err != nil {
 		return nil, err

--- a/bldr/web/pkg/routine-group.go
+++ b/bldr/web/pkg/routine-group.go
@@ -15,6 +15,7 @@ type RoutineGroup struct {
 // Wrap registers a routine until it returns, refusing work after shutdown begins.
 func (g *RoutineGroup) Wrap(r func(context.Context) error) func(context.Context) error {
 	return func(ctx context.Context) error {
+		// Reserve a routine slot before starting work.
 		if !g.Begin() {
 			return context.Canceled
 		}

--- a/bldr/web/runtime/controller/controller.go
+++ b/bldr/web/runtime/controller/controller.go
@@ -94,8 +94,10 @@ func (c *Controller) GetControllerInfo() *controller.Info {
 // Returning nil ends execution.
 // Returning an error triggers a retry with backoff.
 func (c *Controller) Execute(rctx context.Context) error {
+	// Derive a cancellable context for the runtime lifecycle.
 	ctx, ctxCancel := context.WithCancel(rctx)
 	defer ctxCancel()
+
 	// Construct the web runtime.
 	rt, err := c.ctor(
 		ctx,
@@ -112,17 +114,20 @@ func (c *Controller) Execute(rctx context.Context) error {
 		}
 	})
 
+	// Publish the runtime before starting its execution loop.
 	c.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
 		c.rt = rt
 		broadcast()
 	})
 
+	// Start runtime execution and retain its error channel.
 	c.le.Debug("executing bldr web runtime")
 	errCh := make(chan error, 1)
 	go func() {
 		errCh <- rt.Execute(ctx)
 	}()
 
+	// Wait for runtime cancellation or execution failure.
 	for {
 		// note: will add case to re-sync when needed
 		select {
@@ -141,6 +146,8 @@ func (c *Controller) GetWebRuntime(ctx context.Context) (web_runtime.WebRuntime,
 	for {
 		var trig <-chan struct{}
 		var rt web_runtime.WebRuntime
+
+		// Read the runtime and wait channel under one broadcast lock.
 		c.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
 			rt = c.rt
 			if rt == nil {
@@ -150,6 +157,8 @@ func (c *Controller) GetWebRuntime(ctx context.Context) (web_runtime.WebRuntime,
 		if rt != nil {
 			return rt, nil
 		}
+
+		// Wait for publication or caller cancellation.
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
@@ -163,12 +172,16 @@ func (c *Controller) GetWebRuntime(ctx context.Context) (web_runtime.WebRuntime,
 // Any unexpected errors are returned for logging.
 // It is safe to add a reference to the directive during this call.
 func (c *Controller) HandleDirective(ctx context.Context, di directive.Instance) ([]directive.Resolver, error) {
+	// Inspect the requested web runtime directive.
 	switch dir := di.GetDirective().(type) {
 	case web_runtime.LookupWebRuntime:
+		// Resolve the runtime when the requested ID matches this controller.
 		if dir.LookupWebRuntimeID() == c.runtimeID {
 			return directive.R(directive.NewGetterResolver(c.GetWebRuntime), nil)
 		}
 	}
+
+	// Leave unrelated runtime directives unresolved.
 	return nil, nil
 }
 
@@ -298,6 +311,7 @@ func (c *Controller) ServePluginDistFsHTTP(pluginID string, rw http.ResponseWrit
 		WithField("plugin-id", pluginID).
 		WithField("path", req.URL.Path).
 		Debug("accessing plugin dist filesystem")
+
 	// see: plugin/host/controller/plugin-tracker.go distFsID
 	unixFsID := bldr_plugin.PluginDistFsId(pluginID)
 	handler := unixfs_access_http.NewHTTPHandler(req.Context(), c.bus, unixFsID, "", "", true)
@@ -313,6 +327,7 @@ func (c *Controller) ServePluginAssetsFsHTTP(pluginID string, rw http.ResponseWr
 		WithField("plugin-id", pluginID).
 		WithField("path", req.URL.Path).
 		Debug("accessing plugin assets filesystem")
+
 	// see: plugin/host/controller/plugin-tracker.go assetsFsID
 	unixFsID := bldr_plugin.PluginAssetsFsId(pluginID)
 	handler := unixfs_access_http.NewHTTPHandler(req.Context(), c.bus, unixFsID, "", "", true)

--- a/cmd/spacewave/cli/auth.go
+++ b/cmd/spacewave/cli/auth.go
@@ -148,6 +148,7 @@ func runAuthBackupGenerate(c *cli.Context, statePath string, sessionIdx uint32, 
 // the PEM to outFile, and print a confirmation line. Used by both the
 // auth backup generate and auth method add backup subcommands.
 func generateAndSaveBackupKey(c *cli.Context, statePath string, sessionIdx uint32, authPemFile, outFile string) error {
+	// Resolve the state path and collect the account credential.
 	ctx := c.Context
 	resolved, err := authResolveStatePath(c, statePath)
 	if err != nil {
@@ -159,6 +160,7 @@ func generateAndSaveBackupKey(c *cli.Context, statePath string, sessionIdx uint3
 		return err
 	}
 
+	// Connect to the daemon and mount the requested session.
 	client, err := connectDaemonWithResolvedFallback(ctx, c, resolved)
 	if err != nil {
 		return err
@@ -171,6 +173,7 @@ func generateAndSaveBackupKey(c *cli.Context, statePath string, sessionIdx uint3
 	}
 	defer sess.Release()
 
+	// Resolve the account service for the mounted session.
 	info, err := sess.GetSessionInfo(ctx)
 	if err != nil {
 		return errors.Wrap(err, "get session info")
@@ -184,6 +187,7 @@ func generateAndSaveBackupKey(c *cli.Context, statePath string, sessionIdx uint3
 	}
 	defer acctCleanup()
 
+	// Generate and persist the backup key through the account service.
 	resp, err := acctSvc.GenerateBackupKey(ctx, &s4wave_account.GenerateBackupKeyRequest{
 		Credential: cred,
 	})
@@ -195,6 +199,7 @@ func generateAndSaveBackupKey(c *cli.Context, statePath string, sessionIdx uint3
 		return errors.Wrap(err, "write PEM file")
 	}
 
+	// Report the saved file and abbreviated peer identifier.
 	pidStr := resp.GetPeerId()
 	if len(pidStr) > 16 {
 		pidStr = pidStr[:16] + "..."
@@ -207,6 +212,7 @@ func generateAndSaveBackupKey(c *cli.Context, statePath string, sessionIdx uint3
 // If pemFile is non-empty, reads the PEM file. Otherwise prompts for password.
 func promptCredential(pemFile string) (*session_pb.EntityCredential, error) {
 	if pemFile != "" {
+		// Read and wrap the supplied PEM credential.
 		data, err := os.ReadFile(pemFile)
 		if err != nil {
 			return nil, errors.Wrap(err, "read PEM file")
@@ -215,6 +221,8 @@ func promptCredential(pemFile string) (*session_pb.EntityCredential, error) {
 			Credential: &session_pb.EntityCredential_PemPrivateKey{PemPrivateKey: data},
 		}, nil
 	}
+
+	// Prompt for and validate the account password.
 	os.Stderr.WriteString("Account password: ")
 	pw, err := term.ReadPassword(int(os.Stdin.Fd()))
 	os.Stderr.WriteString("\n")

--- a/cmd/spacewave/cli/status.go
+++ b/cmd/spacewave/cli/status.go
@@ -37,10 +37,13 @@ func getStatusMountSessionTimeout() (time.Duration, error) {
 }
 
 func (s *nativeSession) WatchRecoveryStatus(ctx context.Context) (*s4wave_status.RecoveryStatus, error) {
+	// Resolve the status resource client for the mounted session.
 	client, err := s.GetResourceRef().GetClient()
 	if err != nil {
 		return nil, err
 	}
+
+	// Open the recovery status stream and release it after the first update.
 	strm, err := s4wave_status.NewSRPCSystemStatusServiceClient(client).WatchRecoveryStatus(
 		ctx,
 		&s4wave_status.WatchRecoveryStatusRequest{},
@@ -49,6 +52,8 @@ func (s *nativeSession) WatchRecoveryStatus(ctx context.Context) (*s4wave_status
 		return nil, err
 	}
 	defer strm.Close()
+
+	// Return the first recovery status update.
 	resp, err := strm.Recv()
 	if err != nil {
 		return nil, err

--- a/core/account/settings/processor.go
+++ b/core/account/settings/processor.go
@@ -18,15 +18,21 @@ func ProcessAccountSettingsOps(
 	currentStateData []byte,
 	ops []*sobject.SOOperationInner,
 ) (*[]byte, []*sobject.SOOperationResult, error) {
+	// Decode the current AccountSettings snapshot.
 	state := &AccountSettings{}
 	if len(currentStateData) > 0 {
 		if err := state.UnmarshalVT(currentStateData); err != nil {
 			return nil, nil, errors.Wrap(err, "unmarshal account settings state")
 		}
 	}
+
+	// Preserve the initial state for no-op detection.
 	initState := state.CloneVT()
 
+	// Initialize operation results.
 	results := make([]*sobject.SOOperationResult, 0, len(ops))
+
+	// Decode and apply each submitted operation.
 	for _, opInner := range ops {
 		peerID, err := opInner.ParsePeerID()
 		if err != nil {
@@ -34,6 +40,7 @@ func ProcessAccountSettingsOps(
 		}
 		peerIDStr := peerID.String()
 
+		// Decode the operation payload before dispatch.
 		op := &AccountSettingsOp{}
 		if err := op.UnmarshalVT(opInner.GetOpData()); err != nil {
 			results = append(results, sobject.BuildSOOperationResult(
@@ -47,6 +54,7 @@ func ProcessAccountSettingsOps(
 			continue
 		}
 
+		// Dispatch the operation body by its concrete variant.
 		switch body := op.GetOp().(type) {
 		case *AccountSettingsOp_UpdateDisplayName:
 			state.DisplayName = body.UpdateDisplayName.GetDisplayName()
@@ -61,7 +69,8 @@ func ProcessAccountSettingsOps(
 				))
 				continue
 			}
-			// Remove existing entry with same peer_id to avoid duplicates.
+
+			// Replace any paired-device entry with the same peer ID.
 			state.PairedDevices = slices.DeleteFunc(state.PairedDevices, func(d *PairedDevice) bool {
 				return d.GetPeerId() == dev.GetPeerId()
 			})
@@ -91,7 +100,8 @@ func ProcessAccountSettingsOps(
 				))
 				continue
 			}
-			// Remove existing entry with same peer_id to avoid duplicates.
+
+			// Replace any entity-keypair entry with the same peer ID.
 			state.EntityKeypairs = slices.DeleteFunc(state.EntityKeypairs, func(k *session.EntityKeypair) bool {
 				return k.GetPeerId() == kp.GetPeerId()
 			})
@@ -212,11 +222,12 @@ func ProcessAccountSettingsOps(
 		}
 	}
 
-	// If no state changes, return nil to signal no-op.
+	// Return without state data when no operation changed the snapshot.
 	if state.EqualVT(initState) {
 		return nil, results, nil
 	}
 
+	// Marshal the changed AccountSettings snapshot.
 	nextData, err := state.MarshalVT()
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "marshal account settings state")

--- a/core/cdn/bstore/block-store.go
+++ b/core/cdn/bstore/block-store.go
@@ -63,6 +63,7 @@ type CdnBlockStore struct {
 // lazily on the first read; pass a pre-populated pointer via SetPointer if
 // the caller already has one.
 func NewCdnBlockStore(opts Options) (*CdnBlockStore, error) {
+	// Validate CDN configuration and select dependencies.
 	if opts.CdnBaseURL == "" {
 		return nil, errors.New("cdn bstore: CdnBaseURL required")
 	}
@@ -73,6 +74,8 @@ func NewCdnBlockStore(opts Options) (*CdnBlockStore, error) {
 	if cli == nil {
 		cli = http.DefaultClient
 	}
+
+	// Configure index caching and the anonymous packfile opener.
 	cache := opts.IndexCache
 	var memCache *memIndexCache
 	if cache == nil {
@@ -81,10 +84,14 @@ func NewCdnBlockStore(opts Options) (*CdnBlockStore, error) {
 	}
 	opener := NewAnonymousOpener(cli, opts.CdnBaseURL, opts.SpaceID)
 	pfs := packfile_store.NewPackfileStore(opener, cache)
+
+	// Allocate the decoded-block cache.
 	decodedBlocks, err := block.NewDecodedBlockCacheWithOptions(block.DefaultDecodedBlockCacheOptions())
 	if err != nil {
 		return nil, err
 	}
+
+	// Assemble the CDN block store.
 	return &CdnBlockStore{
 		opts:          opts,
 		cli:           cli,
@@ -133,6 +140,7 @@ func (s *CdnBlockStore) Close() {
 // SetWriteback enables local co-block persistence through the underlying
 // packfile store.
 func (s *CdnBlockStore) SetWriteback(ctx context.Context, target block.StoreOps, windowBytes int64) {
+	// Publish writeback configuration and update packfile verification.
 	s.bcast.HoldLock(func(broadcastFn func(), _ func() <-chan struct{}) {
 		s.writebackTarget = target
 		broadcastFn()
@@ -148,9 +156,12 @@ func (s *CdnBlockStore) SetRangeCacheMaxBytes(maxBytes int64) {
 
 // GetBlock reads a block by reference, refreshing the pointer if needed.
 func (s *CdnBlockStore) GetBlock(ctx context.Context, ref *block.BlockRef) ([]byte, bool, error) {
+	// Serve a current decoded-cache hit when available.
 	if data, ok, err := s.getCurrentCachedBlock(ctx, ref); err != nil || ok {
 		return data, ok, err
 	}
+
+	// Read the block through the current CDN manifest.
 	var data []byte
 	var found bool
 	err := s.withCurrentManifest(ctx, func() error {
@@ -230,6 +241,7 @@ func (s *CdnBlockStore) Pointer() *cdn.CdnRootPointer {
 // Refresh forces a re-fetch of the root pointer and updates the manifest.
 // Returns the new pointer (nil if the CDN Space is empty).
 func (s *CdnBlockStore) Refresh(ctx context.Context) (*cdn.CdnRootPointer, error) {
+	// Fetch and publish the current CDN root pointer.
 	ptr, err := FetchRootPointer(ctx, s.cli, s.opts.CdnBaseURL, s.opts.SpaceID)
 	if err != nil {
 		return nil, err
@@ -274,6 +286,7 @@ func (s *CdnBlockStore) setPointer(ctx context.Context, ptr *cdn.CdnRootPointer)
 		if s.memCache != nil {
 			s.memCache.reset()
 		}
+
 		// Pointer, manifest, and decoded-cache epoch publish under one bcast lock.
 		// Reads take the same lock while snapshotting the manifest so they cannot
 		// pair an old pointer decision with a new manifest view.
@@ -368,6 +381,7 @@ func (s *CdnBlockStore) invalidateDecodedBlocks(ctx context.Context) {
 	if s.decodedBlocks == nil {
 		return
 	}
+
 	// A CDN pointer swap replaces the manifest under the store. Decoded hits
 	// must be equivalent to reading through the current manifest, not an older
 	// CDN root that happened to decode the same ref earlier.

--- a/core/cdn/copy.go
+++ b/core/cdn/copy.go
@@ -64,6 +64,7 @@ func CopyV86ImageFromCdnWithProgress(
 	dstObjectKey string,
 	progress V86ImageCopyProgressFunc,
 ) error {
+	// Validate source and destination object keys.
 	if srcObjectKey == "" {
 		return errors.New("source object key is required")
 	}
@@ -71,21 +72,25 @@ func CopyV86ImageFromCdnWithProgress(
 		return errors.New("destination object key is required")
 	}
 
+	// Read the source image metadata.
 	img, err := readCdnV86Image(ctx, src, srcObjectKey)
 	if err != nil {
 		return errors.Wrapf(err, "read v86 image %q from cdn", srcObjectKey)
 	}
 
+	// Read the source image's asset edges.
 	edges, err := readV86ImageEdges(ctx, src, srcObjectKey)
 	if err != nil {
 		return errors.Wrapf(err, "read v86 image edges for %q", srcObjectKey)
 	}
 
+	// Check whether the destination image can be created.
 	dstImageExists, err := checkDstV86Image(ctx, dst, dstObjectKey, img)
 	if err != nil {
 		return errors.Wrap(err, "destination write check")
 	}
 
+	// Create the destination image when it is absent.
 	if !dstImageExists {
 		createdAt := img.GetCreatedAt().AsTime()
 		if createdAt.IsZero() {
@@ -97,6 +102,7 @@ func CopyV86ImageFromCdnWithProgress(
 		}
 	}
 
+	// Copy each asset object and link its graph edge.
 	var copiedStats bucket_lookup.ObjectCopyStats
 	for pred, targetKey := range edges {
 		if targetKey == "" {
@@ -119,6 +125,7 @@ func CopyV86ImageFromCdnWithProgress(
 		}
 	}
 
+	// Report completion after all asset edges are durable.
 	return nil
 }
 

--- a/core/cdn/copy_test.go
+++ b/core/cdn/copy_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 func TestCopyV86ImageFromCdnCopiesAssetObjectsBeforeEdges(t *testing.T) {
+	// Initialize source and destination World testbeds.
 	ctx := context.Background()
 	srcTB, err := world_testbed.Default(ctx, world_testbed.WithWorldVerbose(false))
 	if err != nil {
@@ -38,6 +39,7 @@ func TestCopyV86ImageFromCdnCopiesAssetObjectsBeforeEdges(t *testing.T) {
 		assetKey    = "assets/rootfs"
 	)
 
+	// Create the source asset object and V86 image graph.
 	content := bytes.Repeat([]byte("copied rootfs payload\n"), 64*1024)
 	createFSNodeObjectWithFile(t, ctx, srcTB.WorldState, assetKey, "hello.txt", content)
 	createdAt := time.Unix(123, 0)
@@ -54,6 +56,7 @@ func TestCopyV86ImageFromCdnCopiesAssetObjectsBeforeEdges(t *testing.T) {
 		t.Fatalf("set source rootfs edge: %v", err)
 	}
 
+	// Copy the image while collecting progress.
 	var progress []bucket_lookup.ObjectCopyStats
 	if err := CopyV86ImageFromCdnWithProgress(
 		ctx,
@@ -82,6 +85,7 @@ func TestCopyV86ImageFromCdnCopiesAssetObjectsBeforeEdges(t *testing.T) {
 		t.Fatalf("retry completed v86 image copy: %v", err)
 	}
 
+	// Verify destination object, type, and graph edge state.
 	if _, found, err := dstTB.WorldState.GetObject(ctx, assetKey); err != nil {
 		t.Fatalf("get copied asset: %v", err)
 	} else if !found {
@@ -102,6 +106,7 @@ func TestCopyV86ImageFromCdnCopiesAssetObjectsBeforeEdges(t *testing.T) {
 		t.Fatalf("expected copied rootfs edge target %q, got %q", assetKey, target)
 	}
 
+	// Verify copied asset content.
 	got := readFSNodeFile(t, ctx, dstTB.WorldState, assetKey, "hello.txt")
 	if !bytes.Equal(got, content) {
 		t.Fatalf("copied asset file content mismatch: got %q want %q", string(got), string(content))
@@ -117,6 +122,8 @@ func createFSNodeObjectWithFile(
 	content []byte,
 ) {
 	t.Helper()
+
+	// Create the source filesystem object and file.
 	op := unixfs_world.NewFsInitOp(objKey, unixfs_world.FSType_FSType_FS_NODE, nil, false, time.Unix(1, 0))
 	if _, _, err := ws.ApplyWorldOp(ctx, op, ""); err != nil {
 		t.Fatalf("create fs-node object %q: %v", objKey, err)
@@ -144,6 +151,7 @@ func createFSNodeObjectWithFile(
 	}
 }
 
+// Open and read the copied filesystem file.
 func readFSNodeFile(t *testing.T, ctx context.Context, ws world.WorldState, objKey, name string) []byte {
 	t.Helper()
 	fsc := unixfs_world.NewFSCursor(logrus.NewEntry(logrus.New()), ws, objKey, unixfs_world.FSType_FSType_FS_NODE, nil, false)
@@ -167,6 +175,7 @@ func readFSNodeFile(t *testing.T, ctx context.Context, ws world.WorldState, objK
 	return got
 }
 
+// Build diagnostic information for a filesystem object.
 func describeFSNodeObject(t *testing.T, ctx context.Context, ws world.WorldState, objKey string) string {
 	t.Helper()
 	obj, found, err := ws.GetObject(ctx, objKey)

--- a/core/device/policy/policy-store.go
+++ b/core/device/policy/policy-store.go
@@ -1,4 +1,4 @@
-// Package device_policy owns daemon-local Device policy persistence and watches.
+// Package device_policy stores and watches daemon-local Device policy.
 package device_policy
 
 import (

--- a/core/provider/local/account.go
+++ b/core/provider/local/account.go
@@ -138,14 +138,15 @@ func (p *Provider) buildProviderAccountTracker(accountID string) (keyed.Routine,
 
 // executeProviderAccountTracker executes the provider account tracker routine.
 func (t *providerAccountTracker) executeProviderAccountTracker(rctx context.Context) error {
+	// Initialize the account tracker context.
 	ctx, ctxCancel := context.WithCancel(rctx)
 	defer ctxCancel()
 
-	// Look up or create the ProviderAccount in the world.
+	// Resolve provider and account identity.
 	providerID := t.p.info.GetProviderId()
 	accountID := t.accountInfo.GetProviderAccountId()
 
-	// Mount the storage volume for this space.
+	// Select the storage volume identity.
 	storageID := t.p.storageID
 	if storageID == "" {
 		storageID = "default"
@@ -173,13 +174,13 @@ func (t *providerAccountTracker) executeProviderAccountTracker(rctx context.Cont
 	}
 	defer volCtrlRef.Release()
 
-	// wait for the volume
+	// Acquire the mounted volume.
 	vol, err := volCtrl.GetVolume(ctx)
 	if err != nil {
 		return err
 	}
 
-	// Construct the ProviderAccount handle
+	// Construct the ProviderAccount and keyed trackers.
 	le := t.p.le.WithField("account-id", t.accountInfo.GetProviderAccountId())
 	providerAcc := &ProviderAccount{
 		t:   t,

--- a/core/provider/local/bstore.go
+++ b/core/provider/local/bstore.go
@@ -24,7 +24,7 @@ const blockStoreBucketConfigRev = 2
 
 // BlockStore implements the bstore interface.
 type BlockStore struct {
-	// store owns local writes and durability.
+	// store provides local writes and durability.
 	store block_store.Store
 	// readStore optionally routes uncached reads through the active Session DEX.
 	readStore block_store.Store
@@ -95,23 +95,24 @@ func (b *BlockStore) PutBlockBatch(ctx context.Context, entries []*block.PutBatc
 	if err := b.store.PutBlockBatch(ctx, entries); err != nil {
 		return err
 	}
+
 	// Batch tombstones bypass RmBlock, so the provider wrapper must invalidate
 	// decoded entries here before any future read can reuse stale content.
 	b.invalidateBatchTombstones(ctx, entries)
 	return nil
 }
 
-// GetBlock forwards to the active Session read owner when configured.
+// GetBlock forwards to the configured Session read store.
 func (b *BlockStore) GetBlock(ctx context.Context, ref *block.BlockRef) ([]byte, bool, error) {
 	return b.readOwner().GetBlock(ctx, ref)
 }
 
-// GetBlockExists forwards to the active Session read owner when configured.
+// GetBlockExists forwards to the configured Session read store.
 func (b *BlockStore) GetBlockExists(ctx context.Context, ref *block.BlockRef) (bool, error) {
 	return b.readOwner().GetBlockExists(ctx, ref)
 }
 
-// GetBlockExistsBatch forwards batched existence probes to the active read owner.
+// GetBlockExistsBatch forwards batched existence probes to the configured read store.
 func (b *BlockStore) GetBlockExistsBatch(ctx context.Context, refs []*block.BlockRef) ([]bool, error) {
 	return b.readOwner().GetBlockExistsBatch(ctx, refs)
 }
@@ -133,7 +134,7 @@ func (b *BlockStore) invalidateBatchTombstones(ctx context.Context, entries []*b
 	}
 }
 
-// StatBlock forwards to the active Session read owner when configured.
+// StatBlock forwards to the configured Session read store.
 func (b *BlockStore) StatBlock(ctx context.Context, ref *block.BlockRef) (*block.BlockStat, error) {
 	return b.readOwner().StatBlock(ctx, ref)
 }

--- a/core/provider/local/confirm-pairing.go
+++ b/core/provider/local/confirm-pairing.go
@@ -38,9 +38,12 @@ func (a *ProviderAccount) ConfirmPairing(
 	remotePeerID peer.ID,
 	displayName string,
 ) error {
+	// Consume the verified pairing exchange.
 	if err := a.consumePairingExchange(remotePeerID); err != nil {
 		return err
 	}
+
+	// Resolve the remote peer identity and public key.
 	remotePeerIDStr := remotePeerID.String()
 
 	remotePub, err := remotePeerID.ExtractPublicKey()
@@ -48,7 +51,7 @@ func (a *ProviderAccount) ConfirmPairing(
 		return errors.Wrap(err, "extract remote public key")
 	}
 
-	// Get the volume's peer identity (used for SO participant/grant operations).
+	// Resolve the volume signer used for shared-object grants.
 	volPeer, err := a.vol.GetPeer(ctx, true)
 	if err != nil {
 		return errors.Wrap(err, "get volume peer")
@@ -59,14 +62,14 @@ func (a *ProviderAccount) ConfirmPairing(
 		return errors.Wrap(err, "get volume private key")
 	}
 
+	// Resolve the account-settings shared object.
 	accountSettingsRef, err := a.GetAccountSettingsRef(ctx)
 	if err != nil {
 		return errors.Wrap(err, "get account settings ref")
 	}
 	accountSettingsID := accountSettingsRef.GetProviderResourceRef().GetId()
 
-	// Add remote peer as OWNER on all SOs. For the account settings SO,
-	// also queue the AddPairedDevice operation in the same mount.
+	// Add the remote peer across mounted shared objects.
 	soList := a.soListCtr.GetValue()
 	for _, entry := range soList.GetSharedObjects() {
 		ref := entry.GetRef()
@@ -83,7 +86,7 @@ func (a *ProviderAccount) ConfirmPairing(
 			a.le.WithError(err).WithField("so-id", soID).Warn("failed to add participant to SO")
 		}
 
-		// Persist paired device while the account settings SO is still mounted.
+		// Persist the paired device while account settings remain mounted.
 		if isAccountSettings {
 			if err := a.queueAddPairedDevice(ctx, so, remotePeerIDStr, displayName); err != nil {
 				relSO()
@@ -94,7 +97,7 @@ func (a *ProviderAccount) ConfirmPairing(
 		relSO()
 	}
 
-	// Start P2P sync if the session transport is running.
+	// Start P2P sync when a session transport is already running.
 	if st := a.GetSessionTransport(); st != nil {
 		if err := a.StartP2PSync(ctx, st); err != nil {
 			a.le.WithError(err).Warn("failed to start P2P sync after pairing confirmation")
@@ -131,10 +134,12 @@ func (a *ProviderAccount) queueAddPairedDevice(
 	remotePeerIDStr string,
 	displayName string,
 ) error {
+	// Normalize the paired-device display name.
 	if displayName == "" {
 		displayName = "Device"
 	}
 
+	// Build and marshal the paired-device operation.
 	addOp := &account_settings.AccountSettingsOp{
 		Op: &account_settings.AccountSettingsOp_AddPairedDevice{
 			AddPairedDevice: &account_settings.PairedDevice{
@@ -149,10 +154,12 @@ func (a *ProviderAccount) queueAddPairedDevice(
 		return errors.Wrap(err, "marshal add paired device op")
 	}
 
+	// Queue the paired-device operation.
 	if _, err := so.QueueOperation(ctx, opData); err != nil {
 		return errors.Wrap(err, "queue add paired device operation")
 	}
 
+	// Build and queue the session-presentation operation.
 	presOp := &account_settings.AccountSettingsOp{
 		Op: &account_settings.AccountSettingsOp_UpsertSessionPresentation{
 			UpsertSessionPresentation: &account_settings.SessionPresentation{

--- a/core/provider/local/p2p-sync.go
+++ b/core/provider/local/p2p-sync.go
@@ -77,10 +77,14 @@ func (a *ProviderAccount) retainP2PSyncLowerSourceLocked(state *p2pSyncState) bo
 }
 
 func (a *ProviderAccount) watchP2PSyncOwner(ctx context.Context, state *p2pSyncState) {
+	// Ignore contexts that cannot signal cancellation.
 	if ctx.Done() == nil {
 		return
 	}
+
+	// Watch ownership until the state stops or the caller cancels.
 	go func() {
+		// Reconcile state ownership on each lifecycle transition.
 		for {
 			var waitCh <-chan struct{}
 			var stopped bool
@@ -93,6 +97,8 @@ func (a *ProviderAccount) watchP2PSyncOwner(ctx context.Context, state *p2pSyncS
 			if stopped {
 				return
 			}
+
+			// Release the state when the caller exits.
 			select {
 			case <-ctx.Done():
 				a.releaseP2PSyncState(state)
@@ -104,6 +110,7 @@ func (a *ProviderAccount) watchP2PSyncOwner(ctx context.Context, state *p2pSyncS
 }
 
 func (a *ProviderAccount) releaseP2PSyncState(state *p2pSyncState) {
+	// Decrement ownership and mark the state for retirement.
 	retire := false
 	state.bcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
 		if state.owners == 0 {
@@ -124,6 +131,7 @@ func (a *ProviderAccount) releaseP2PSyncState(state *p2pSyncState) {
 		retire = true
 	})
 
+	// Retire the state after the final owner releases it.
 	if retire {
 		a.retireP2PSyncState(state)
 	}

--- a/core/provider/local/pairing.go
+++ b/core/provider/local/pairing.go
@@ -43,10 +43,12 @@ func (a *ProviderAccount) GeneratePairingCode(
 	sessionPriv crypto.PrivKey,
 	sessionPeerID peer.ID,
 ) (string, error) {
+	// Start the session transport required by the relay request.
 	if _, _, err := a.ensureSessionTransport(ctx, sessionPriv, relayURL, signingEnvPrefix); err != nil {
 		return "", errors.Wrap(err, "start session transport")
 	}
 
+	// Generate and serialize the pairing request.
 	code, err := generatePairingCode()
 	if err != nil {
 		return "", err
@@ -60,6 +62,7 @@ func (a *ProviderAccount) GeneratePairingCode(
 		return "", errors.Wrap(err, "marshal pairing request")
 	}
 
+	// Build and sign the relay HTTP request.
 	reqURL, err := url.JoinPath(relayURL, "/api/pair")
 	if err != nil {
 		return "", errors.Wrap(err, "build pairing URL")
@@ -75,6 +78,7 @@ func (a *ProviderAccount) GeneratePairingCode(
 		return "", errors.Wrap(err, "sign pairing request")
 	}
 
+	// Submit the pairing code and classify the relay response.
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return "", errors.Wrap(err, "post pairing code")
@@ -89,6 +93,7 @@ func (a *ProviderAccount) GeneratePairingCode(
 		return "", errors.Errorf("pairing relay returned %d: %s", resp.StatusCode, string(respBody))
 	}
 
+	// Cache the code for later local confirmation.
 	a.SetPairingCode(code, sessionPriv)
 	return code, nil
 }
@@ -104,10 +109,12 @@ func (a *ProviderAccount) CompletePairing(
 	sessionPriv crypto.PrivKey,
 	sessionPeerID peer.ID,
 ) (peer.ID, error) {
+	// Start the session transport required for the lookup.
 	if _, _, err := a.ensureSessionTransport(ctx, sessionPriv, relayURL, signingEnvPrefix); err != nil {
 		return "", errors.Wrap(err, "start session transport")
 	}
 
+	// Fetch and decode the remote pairing response.
 	reqURL, err := url.JoinPath(relayURL, "/api/pair", code)
 	if err != nil {
 		return "", errors.Wrap(err, "build pairing URL")
@@ -138,6 +145,7 @@ func (a *ProviderAccount) CompletePairing(
 		return "", errors.Wrap(err, "unmarshal pairing response")
 	}
 
+	// Decode the remote peer identity and watch for its transport link.
 	remotePeerID, err := peer.IDB58Decode(pr.GetPeerId())
 	if err != nil {
 		return "", errors.Errorf("decode remote peer ID: %v", err)

--- a/core/provider/spacewave/account-fetcher.go
+++ b/core/provider/spacewave/account-fetcher.go
@@ -18,7 +18,7 @@ import (
 // accountStateCacheKey is the ObjectStore key for the account state cache.
 const accountStateCacheKey = "account-state-cache"
 
-// accountFetcherRetryOwner holds the transient retry delay for accountFetcher.
+// accountFetcherRetryOwner tracks transient retry delay for accountFetcher.
 //
 // The wake channel is captured with the account snapshot that produced the
 // failed fetch. If account epoch or session-client readiness changes while a
@@ -67,10 +67,12 @@ func waitAccountFetcherRetryDelay(
 // epoch advances past the last fetched epoch. Single goroutine, triggered by
 // epoch changes via accountBcast.
 func (a *ProviderAccount) accountFetcher(ctx context.Context) error {
+	// Initialize account-fetcher logging and retry state.
 	le := a.le.WithField("component", "account-fetcher")
 	retry := newAccountFetcherRetryOwner()
 	var prevKeypairs []*session.EntityKeypair
 	for {
+		// Read the current account epoch, client, and wake channel.
 		var epoch, lastFetched uint64
 		var cli *SessionClient
 		var ch <-chan struct{}
@@ -81,6 +83,7 @@ func (a *ProviderAccount) accountFetcher(ctx context.Context) error {
 			ch = getWaitCh()
 		})
 
+		// Wait for a usable authenticated client when an epoch needs fetching.
 		if epoch > lastFetched {
 			if cli == nil || cli.priv == nil || cli.peerID == "" {
 				select {
@@ -91,6 +94,7 @@ func (a *ProviderAccount) accountFetcher(ctx context.Context) error {
 				}
 			}
 
+			// Fetch account state for the current epoch.
 			state, err := cli.GetAccountState(ctx)
 			if err != nil {
 				if isNonRetryableCloudError(err) {
@@ -110,7 +114,7 @@ func (a *ProviderAccount) accountFetcher(ctx context.Context) error {
 				continue
 			}
 
-			// Fetch emails alongside account state (same epoch invalidation).
+			// Fetch the account email snapshot for the same epoch.
 			emailResp, err := cli.ListEmails(ctx)
 			if err != nil {
 				if isNonRetryableCloudError(err) {
@@ -130,6 +134,7 @@ func (a *ProviderAccount) accountFetcher(ctx context.Context) error {
 				continue
 			}
 
+			// Fetch the account session snapshot for the same epoch.
 			sessionRows, err := cli.ListSessions(ctx)
 			if err != nil {
 				if isNonRetryableCloudError(err) {
@@ -148,6 +153,8 @@ func (a *ProviderAccount) accountFetcher(ctx context.Context) error {
 				}
 				continue
 			}
+
+			// Apply the fetched snapshots and reset transient retries.
 			retry.Reset()
 
 			le.WithFields(logrus.Fields{
@@ -158,17 +165,19 @@ func (a *ProviderAccount) accountFetcher(ctx context.Context) error {
 			keypairsChanged := !protobuf_go_lite.IsEqualVTSlice(prevKeypairs, state.GetKeypairs())
 			prevKeypairs = state.GetKeypairs()
 
+			// Publish fetched state and refresh dependent access state.
 			a.applyFetchedAccountState(epoch, state, emailResp.GetEmails(), sessionRows)
 			a.syncSharedObjectListAccess(state.GetSubscriptionStatus())
 			a.refreshSelfRejoinSweepState()
 
-			// Write cache to ObjectStore if epoch advanced.
+			// Persist the fetched state when the server epoch advanced.
 			if uint64(state.GetEpoch()) > lastFetched {
 				if err := a.writeAccountStateCache(ctx, state); err != nil {
 					le.WithError(err).Warn("failed to write account state cache")
 				}
 			}
 
+			// Rewrap the session envelope when account keypairs changed.
 			if keypairsChanged && len(state.GetKeypairs()) > 0 {
 				le.Debug("keypairs changed, rewrapping session envelope")
 				if err := a.RewrapSessionEnvelope(ctx); err != nil {
@@ -177,6 +186,7 @@ func (a *ProviderAccount) accountFetcher(ctx context.Context) error {
 			}
 		}
 
+		// Wait for the next epoch change or cancellation.
 		select {
 		case <-ctx.Done():
 			return ctx.Err()

--- a/core/provider/spacewave/account-org.go
+++ b/core/provider/spacewave/account-org.go
@@ -23,8 +23,8 @@ func isOrganizationMemberNotFound(err error) bool {
 	return errors.As(err, &target)
 }
 
-// reconcileOwnedOrganizationSpaces enrolls org members into spaces owned by
-// organizations this account owns.
+// reconcileOwnedOrganizationSpaces enrolls org members into spaces for which
+// this account holds the organization owner role.
 func (a *ProviderAccount) reconcileOwnedOrganizationSpaces(ctx context.Context, orgID string) error {
 	if !a.canMutateCloudObjects() {
 		return nil
@@ -51,7 +51,7 @@ func (a *ProviderAccount) reconcileOwnedOrganizationSpaces(ctx context.Context, 
 }
 
 // reconcilePendingParticipant enrolls a single account into a shared object
-// after the cloud worker notifies the owner session.
+// after the cloud worker notifies the authorized organization session.
 func (a *ProviderAccount) reconcilePendingParticipant(ctx context.Context, soID, accountID string) error {
 	if soID == "" {
 		return errors.New("shared object id is required")

--- a/core/provider/spacewave/account-transport.go
+++ b/core/provider/spacewave/account-transport.go
@@ -234,18 +234,22 @@ func (a *ProviderAccount) createSessionTransportForSession(
 	sessionKey crypto.PrivKey,
 	signalingURL string,
 ) error {
+	// Acquire replacement cleanup scope and serialize transport changes.
 	cleanupCtx, cleanupCancel := sessionTransportReplacementContext(ctx)
 	rel, err := a.transportReplaceMtx.Lock(cleanupCtx)
 	if err != nil {
 		cleanupCancel()
 		return err
 	}
+
+	// Stop the previous session transport before constructing its replacement.
 	if err := a.stopSessionTransportLocked(cleanupCtx, sessionID, nil); err != nil {
 		rel()
 		cleanupCancel()
 		return err
 	}
 
+	// Construct the replacement transport with its bridge policy.
 	st, err := transport.NewSessionTransport(
 		a.le,
 		a.p.b,
@@ -264,6 +268,7 @@ func (a *ProviderAccount) createSessionTransportForSession(
 		return errors.Wrap(err, "create session transport")
 	}
 
+	// Publish the replacement transport state.
 	sts := newSessionTransportState(a, sessionID, st)
 	a.transportBcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
 		if a.sessionTransports == nil {
@@ -272,10 +277,13 @@ func (a *ProviderAccount) createSessionTransportForSession(
 		a.sessionTransports[sessionID] = sts
 		broadcast()
 	})
+
+	// Start the transport and release replacement locks.
 	sts.Start(ctx)
 	rel()
 	cleanupCancel()
 
+	// Await readiness and clean up failed startup.
 	if err := sts.WaitStarted(ctx); err != nil {
 		err = classifySessionTransportError(err)
 		if stopErr := a.stopSessionTransportForSession(ctx, sessionID, sts); stopErr != nil {

--- a/core/provider/spacewave/account-transport_test.go
+++ b/core/provider/spacewave/account-transport_test.go
@@ -25,6 +25,7 @@ func (c *observedDoneContext) Done() <-chan struct{} {
 }
 
 func TestCreateSessionTransportPublishesReadyAndStops(t *testing.T) {
+	// Start the initial session transport.
 	acc := NewTestProviderAccount(t, "http://example.invalid")
 	priv, _ := generateTestKeypair(t)
 	ctx := t.Context()
@@ -35,6 +36,8 @@ func TestCreateSessionTransportPublishesReadyAndStops(t *testing.T) {
 	if st := acc.GetSessionTransport(); st == nil {
 		t.Fatal("expected ready session transport to be published")
 	}
+
+	// Verify publication and stop cleanup.
 	running, _ := acc.GetTransportSnapshotWithWait()
 	if !running {
 		t.Fatal("expected transport snapshot to report running")
@@ -51,6 +54,7 @@ func TestCreateSessionTransportPublishesReadyAndStops(t *testing.T) {
 }
 
 func TestCreateSessionTransportReplacesExisting(t *testing.T) {
+	// Start the first transport for replacement.
 	acc := NewTestProviderAccount(t, "http://example.invalid")
 	ctx := t.Context()
 
@@ -63,6 +67,7 @@ func TestCreateSessionTransportReplacesExisting(t *testing.T) {
 		t.Fatal("expected first session transport")
 	}
 
+	// Start a second transport and verify replacement state.
 	secondPriv, _ := generateTestKeypair(t)
 	if err := acc.CreateSessionTransport(ctx, secondPriv, ""); err != nil {
 		t.Fatalf("second CreateSessionTransport: %v", err)
@@ -93,6 +98,7 @@ func TestSessionTransportStateExitBeforeReadyFailsStartup(t *testing.T) {
 }
 
 func TestSessionTransportStateExitWakesPendingStartup(t *testing.T) {
+	// Start a transport with a pending readiness waiter.
 	acc := NewTestProviderAccount(t, "http://example.invalid")
 	priv, _ := generateTestKeypair(t)
 	st, err := transport.NewSessionTransport(acc.le, acc.p.b, priv, "", "")
@@ -108,6 +114,7 @@ func TestSessionTransportStateExitWakesPendingStartup(t *testing.T) {
 		observed: observed,
 	}
 
+	// Wait for the pending startup before publishing exit.
 	done := make(chan error, 1)
 	go func() {
 		done <- sts.WaitStarted(waitCtx)
@@ -119,6 +126,7 @@ func TestSessionTransportStateExitWakesPendingStartup(t *testing.T) {
 	}
 	sts.setExited(context.Canceled)
 
+	// Assert the waiter observes the terminal exit.
 	select {
 	case err := <-done:
 		if !errors.Is(err, context.Canceled) {

--- a/core/provider/spacewave/account.go
+++ b/core/provider/spacewave/account.go
@@ -88,7 +88,7 @@ type ProviderAccount struct {
 	wsTracker *wsTracker
 	// soListCtr is the persistent shared object list container.
 	soListCtr *ccontainer.CContainer[*sobject.SharedObjectList]
-	// soListRc owns SO list fetches so all callers share one invalidatable path.
+	// soListRc coordinates SO list fetches so all callers share one invalidatable path.
 	soListRc *refcount.RefCount[struct{}]
 	// soListBcast guards the SO list fields below.
 	soListBcast broadcast.Broadcast
@@ -105,7 +105,7 @@ type ProviderAccount struct {
 	// selfRejoinSweep opportunistically heals missing same-entity SO peers after
 	// a new session registers or reconnect invalidates sweep-side caches.
 	selfRejoinSweep *routine.StateRoutineContainer[*selfRejoinSweepState]
-	// selfEnrollmentRunRoutine owns explicit visible Session Self-Enrollment runs.
+	// selfEnrollmentRunRoutine schedules explicit visible Session Self-Enrollment runs.
 	selfEnrollmentRunRoutine *routine.StateRoutineContainer[*selfenrollmentrun.Request]
 	// sessionPresentationReconcile prunes orphaned mirrored session metadata.
 	sessionPresentationReconcile *routine.StateRoutineContainer[*sessionPresentationReconcileState]
@@ -113,16 +113,16 @@ type ProviderAccount struct {
 	gcCleanup *routine.RoutineContainer
 	// gcCleanupRunner serializes provider-account cleanup sweeps.
 	gcCleanupRunner *provider_gccleanup.Runner
-	// accountFetcherRoutine owns account-state refetches for this account.
+	// accountFetcherRoutine runs account-state refetches for this account.
 	accountFetcherRoutine *routine.RoutineContainer
 	// orgProcessors watches org SO membership and runs org processors.
 	orgProcessors *routine.RoutineContainer
-	// launcherRecheckJobs owns update_available launcher recheck work.
+	// launcherRecheckJobs schedules update_available launcher recheck work.
 	launcherRecheckJobs *asyncCallbackJobs
 	// entityKeyStore holds unlocked entity keypairs shared across account
 	// resources for this provider account.
 	entityKeyStore *EntityKeyStore
-	// selfEnrollmentRun owns visible Session Self-Enrollment progress.
+	// selfEnrollmentRun tracks visible Session Self-Enrollment progress.
 	selfEnrollmentRun *selfEnrollmentRunState
 	// entityKeypairStepUp retains unlocked entity keypairs until the last
 	// screen-scoped step-up reference is released.
@@ -491,6 +491,7 @@ func (t *providerAccountTracker) executeProviderAccountTracker(rctx context.Cont
 		acc.accountBcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
 			broadcast()
 		})
+
 		// Re-evaluate every mounted SO once on reconnect: the cold-start gate
 		// short-circuits warm SOs and the cache-aware classifier fetches only
 		// what is missing on the rest, so a long disconnect window cannot leave
@@ -551,6 +552,7 @@ func (t *providerAccountTracker) executeProviderAccountTracker(rctx context.Cont
 			)
 			return
 		}
+
 		// Exiting dormant means cloud access reopened; force a fresh account
 		// state fetch so onboarding reflects the restored subscription.
 		acc.BumpLocalEpoch()

--- a/core/provider/spacewave/cacheseedbuffer/buffer.go
+++ b/core/provider/spacewave/cacheseedbuffer/buffer.go
@@ -1,5 +1,4 @@
-// Package cacheseedbuffer owns bounded recording of seed-reason-tagged HTTP
-// requests.
+// Package cacheseedbuffer records bounded seed-reason-tagged HTTP requests.
 package cacheseedbuffer
 
 import (

--- a/core/provider/spacewave/client.go
+++ b/core/provider/spacewave/client.go
@@ -1707,6 +1707,7 @@ func (c *SessionClient) CreateSharedObject(
 	ownerID string,
 	accountPrivate bool,
 ) error {
+	// Marshal the shared-object creation request.
 	body, err := (&api.CreateSObjectRequest{
 		DisplayName:    displayName,
 		ObjectType:     objectType,
@@ -1717,10 +1718,14 @@ func (c *SessionClient) CreateSharedObject(
 	if err != nil {
 		return errors.Wrap(err, "marshal create request")
 	}
+
+	// Submit the creation mutation to the cloud.
 	data, err := c.doPostBinary(ctx, path.Join("/api/sobject", soID, "create"), body, nil, SeedReasonMutation)
 	if err != nil {
 		return errors.Wrap(err, "create shared object")
 	}
+
+	// Decode the cloud response before returning.
 	var resp api.CreateSObjectResponse
 	if err := resp.UnmarshalVT(data); err != nil {
 		return errors.Wrap(err, "unmarshal create shared object response")

--- a/core/provider/spacewave/cloud-sohost.go
+++ b/core/provider/spacewave/cloud-sohost.go
@@ -553,7 +553,7 @@ func (h *cloudSOHost) handleSONotifyWithContext(ctx context.Context, payload *ap
 	case "configChanged":
 		h.triggerConfigChanged()
 	case "metadata":
-		// Account-level notification handling owns metadata cache updates.
+		// Metadata updates are handled by account-level notification routing.
 	case "delete":
 		// SO is being deleted; no inline state to apply.
 	default:
@@ -885,6 +885,7 @@ func (h *cloudSOHost) writeStateWithRetry(ctx context.Context, state *sobject.SO
 				WithField("duration", time.Since(started)).
 				WithField("so-seqno", state.GetRoot().GetInnerSeqno()).
 				Debug("posted root state")
+
 			// Update cached state on successful write.
 			h.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
 				h.stateCtr.SetValue(state)
@@ -1256,6 +1257,7 @@ func (h *cloudSOHost) syncConfigChainResponse(
 			if revInfo == nil {
 				continue
 			}
+
 			// Determine which peer was removed by diffing this entry's config
 			// against the previous entry's config.
 			if entry.GetConfigSeqno() == 0 {

--- a/core/provider/spacewave/cloud-sohost_test.go
+++ b/core/provider/spacewave/cloud-sohost_test.go
@@ -21,6 +21,7 @@ import (
 const testSharedObjectID = "test-shared-object"
 
 func TestCoalescedTriggerRoutineQueuesSinglePendingRun(t *testing.T) {
+	// Initialize a coalescing trigger routine.
 	started := make(chan struct{}, 3)
 	release := make(chan struct{})
 	routine := newCoalescedTriggerRoutine(
@@ -35,6 +36,7 @@ func TestCoalescedTriggerRoutineQueuesSinglePendingRun(t *testing.T) {
 		},
 	)
 
+	// Start the routine and observe its first run.
 	ctx := t.Context()
 	routine.SetContext(ctx)
 	defer routine.ClearContext()
@@ -42,11 +44,13 @@ func TestCoalescedTriggerRoutineQueuesSinglePendingRun(t *testing.T) {
 	routine.Trigger()
 	waitCoalescedTriggerRun(t, started)
 
+	// Queue duplicate triggers while the first run is active.
 	routine.Trigger()
 	routine.Trigger()
 	release <- struct{}{}
 	waitCoalescedTriggerRun(t, started)
 
+	// Confirm duplicates do not create an extra pending run.
 	release <- struct{}{}
 	select {
 	case <-started:
@@ -65,6 +69,7 @@ func waitCoalescedTriggerRun(t *testing.T, started <-chan struct{}) {
 }
 
 func TestAsyncCallbackJobsStartsOneOwnedJobPerTrigger(t *testing.T) {
+	// Initialize callback jobs and their lifecycle context.
 	started := make(chan struct{}, 2)
 	release := make(chan struct{})
 	jobs := newAsyncCallbackJobs(func(ctx context.Context) {
@@ -78,6 +83,7 @@ func TestAsyncCallbackJobsStartsOneOwnedJobPerTrigger(t *testing.T) {
 	jobs.SetContext(t.Context())
 	defer jobs.ClearContext()
 
+	// Trigger jobs and observe each admitted run.
 	jobs.Trigger()
 	waitAsyncCallbackJob(t, started)
 	jobs.Trigger()
@@ -88,6 +94,7 @@ func TestAsyncCallbackJobsStartsOneOwnedJobPerTrigger(t *testing.T) {
 }
 
 func TestAsyncCallbackJobsClearContextWaitsForOwnedJobs(t *testing.T) {
+	// Initialize a job blocked on cancellation.
 	started := make(chan struct{})
 	canceled := make(chan struct{})
 	allowReturn := make(chan struct{})
@@ -99,6 +106,7 @@ func TestAsyncCallbackJobsClearContextWaitsForOwnedJobs(t *testing.T) {
 		<-allowReturn
 	})
 
+	// Cancel the job context and start cleanup.
 	ctx, cancel := context.WithCancel(context.Background())
 	jobs.SetContext(ctx)
 	jobs.Trigger()
@@ -109,6 +117,8 @@ func TestAsyncCallbackJobsClearContextWaitsForOwnedJobs(t *testing.T) {
 		jobs.ClearContext()
 		close(clearReturned)
 	}()
+
+	// Verify cleanup waits for the callback to return.
 	select {
 	case <-canceled:
 	case <-time.After(time.Second):

--- a/core/provider/spacewave/friend-dm-owner.go
+++ b/core/provider/spacewave/friend-dm-owner.go
@@ -40,16 +40,20 @@ func (a *ProviderAccount) OpenFriendDM(
 	ctx context.Context,
 	targetAccountID string,
 ) (*FriendDmOpenResult, error) {
+	// Resolve the authenticated cloud client.
 	cli := a.GetSessionClient()
 	if cli == nil {
 		return nil, errors.New("session client not available")
 	}
 
+	// Load and validate the friend-DM bootstrap record.
 	targetAccountID = strings.TrimSpace(targetAccountID)
 	bootstrap, err := cli.GetFriendDM(ctx, targetAccountID)
 	if err != nil {
 		return nil, err
 	}
+
+	// Resolve local account and session identity.
 	localAccountID := a.GetAccountID()
 	localPeerID := a.GetCurrentSessionPeerID().String()
 	if err := validateFriendDmBootstrap(
@@ -61,6 +65,7 @@ func (a *ProviderAccount) OpenFriendDM(
 		return nil, err
 	}
 
+	// Create the canonical Space when bootstrap is not ready.
 	if !bootstrap.Ready {
 		if bootstrap.OwnerAccountID != localAccountID {
 			return nil, errors.New("friend dm is not ready and caller is not owner")
@@ -130,6 +135,7 @@ func (a *ProviderAccount) OpenFriendDM(
 		return nil, errors.New("friend dm is not ready")
 	}
 
+	// Mount the canonical shared object.
 	ref := a.buildSharedObjectRef(bootstrap.SharedObjectID)
 	swSO, relSO, err := a.mountSpaceSO(ctx, bootstrap.SharedObjectID)
 	if err != nil {
@@ -137,10 +143,13 @@ func (a *ProviderAccount) OpenFriendDM(
 	}
 	defer relSO()
 
+	// Read participant state before applying owner-authorized actions.
 	state, err := swSO.GetSOHost().GetHostState(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "read friend dm state")
 	}
+
+	// Reconcile grants and the deterministic channel for writable participants.
 	localParticipant := participantConfigForPeer(state.GetConfig(), localPeerID)
 	if localParticipant != nil && sobject.CanWriteOps(localParticipant.GetRole()) {
 		if bootstrap.OwnerAccountID == localAccountID &&
@@ -166,10 +175,13 @@ func (a *ProviderAccount) OpenFriendDM(
 		}
 	}
 
+	// Build the shared-object metadata response.
 	meta, err := space.NewSharedObjectMeta("Friend DM")
 	if err != nil {
 		return nil, errors.Wrap(err, "build friend dm metadata")
 	}
+
+	// Return the mounted Space identity.
 	return &FriendDmOpenResult{
 		SharedObjectRef:  ref,
 		SharedObjectMeta: meta,

--- a/core/provider/spacewave/mailbox-process.go
+++ b/core/provider/spacewave/mailbox-process.go
@@ -39,6 +39,7 @@ func (a *ProviderAccount) ProcessMailboxEntry(
 	entryID int64,
 	accept bool,
 ) error {
+	// Validate the mailbox target and authenticated client.
 	if soID == "" {
 		return errors.New("shared object id is required")
 	}
@@ -51,11 +52,13 @@ func (a *ProviderAccount) ProcessMailboxEntry(
 		return errors.New("session client not available")
 	}
 
+	// Load the pending mailbox snapshot.
 	resp, err := a.getPendingMailboxResponseCached(ctx, soID)
 	if err != nil {
 		return err
 	}
 
+	// Resolve the requested mailbox entry.
 	var entry *api.MailboxEntry
 	for _, candidate := range resp.GetEntries() {
 		if candidate.GetId() == entryID {
@@ -67,6 +70,7 @@ func (a *ProviderAccount) ProcessMailboxEntry(
 		return errors.New("mailbox entry not found")
 	}
 
+	// Apply the requested accept or reject action.
 	return a.processMailboxEntry(ctx, cli, soID, entry, accept)
 }
 
@@ -76,6 +80,7 @@ func (a *ProviderAccount) processPendingMailboxEntries(
 	ctx context.Context,
 	soID string,
 ) error {
+	// Validate mailbox processing authority.
 	if soID == "" {
 		return errors.New("shared object id is required")
 	}
@@ -88,11 +93,13 @@ func (a *ProviderAccount) processPendingMailboxEntries(
 		return errors.New("session client not available")
 	}
 
+	// Load pending entries and process them in order.
 	resp, err := a.getPendingMailboxResponseCached(ctx, soID)
 	if err != nil {
 		return err
 	}
 
+	// Reject or accept each pending entry.
 	for _, entry := range resp.GetEntries() {
 		if err := a.processMailboxEntryWithReject(ctx, cli, soID, entry); err != nil {
 			return err
@@ -132,12 +139,15 @@ func (a *ProviderAccount) clearMailboxAutoProcessEntry(key mailboxAutoProcessKey
 // buildMailboxAutoProcessRoutine builds the keyed owner-side mailbox processor.
 func (a *ProviderAccount) buildMailboxAutoProcessRoutine(key mailboxAutoProcessKey) (keyed.Routine, struct{}) {
 	return func(ctx context.Context) error {
+		// Validate the keyed auto-process request.
 		if key.soID == "" || key.entryID == 0 {
 			return nil
 		}
 		if !a.canAccessOwnerMailbox() {
 			return nil
 		}
+
+		// Load the queued mailbox entry and authenticated client.
 		entry := a.getMailboxAutoProcessEntry(key)
 		if entry == nil {
 			return nil
@@ -146,6 +156,8 @@ func (a *ProviderAccount) buildMailboxAutoProcessRoutine(key mailboxAutoProcessK
 		if cli == nil {
 			return errors.New("session client not available")
 		}
+
+		// Process the queued entry and preserve cancellation errors.
 		if err := a.processMailboxEntryWithReject(ctx, cli, key.soID, entry); err != nil {
 			if errors.Is(err, context.Canceled) {
 				return err
@@ -190,6 +202,7 @@ func (a *ProviderAccount) processMailboxEntryWithReject(
 	soID string,
 	entry *api.MailboxEntry,
 ) error {
+	// Attempt the accept path before rejecting invalid entries.
 	err := a.processMailboxEntry(ctx, cli, soID, entry, true)
 	if err == nil {
 		return nil
@@ -198,6 +211,8 @@ func (a *ProviderAccount) processMailboxEntryWithReject(
 	if !errors.As(err, &invalidErr) {
 		return err
 	}
+
+	// Reject invalid entries and remove them from the local queue.
 	if _, rejectErr := cli.ProcessMailboxEntry(ctx, soID, &api.ProcessMailboxEntryRequest{
 		Id:     entry.GetId(),
 		Accept: false,
@@ -215,10 +230,12 @@ func (a *ProviderAccount) processMailboxEntry(
 	entry *api.MailboxEntry,
 	accept bool,
 ) error {
+	// Validate the mailbox entry before applying the requested action.
 	if entry == nil {
 		return errors.New("mailbox entry is required")
 	}
 
+	// Reject immediately when acceptance was not requested.
 	if !accept {
 		if _, err := cli.ProcessMailboxEntry(ctx, soID, &api.ProcessMailboxEntryRequest{
 			Id:     entry.GetId(),
@@ -230,12 +247,14 @@ func (a *ProviderAccount) processMailboxEntry(
 		return nil
 	}
 
+	// Mount the shared object for accepted-entry validation.
 	swSO, rel, err := a.mountSpaceSO(ctx, soID)
 	if err != nil {
 		return err
 	}
 	defer rel()
 
+	// Resolve the owner account for targeted invitations.
 	ownerAccountID := ""
 	if entry.GetTargetedEnvelope() != nil {
 		account, err := cli.GetAccountInfo(ctx)
@@ -244,11 +263,14 @@ func (a *ProviderAccount) processMailboxEntry(
 		}
 		ownerAccountID = account.GetAccountId()
 	}
+
+	// Validate the invitation and responder proof.
 	invite, responderPeerID, responderPub, err := validateMailboxEntryForAccept(ctx, swSO, soID, entry, ownerAccountID)
 	if err != nil {
 		return err
 	}
 
+	// Add the responder participant and consume invite uses.
 	grant, err := swSO.AddParticipant(
 		ctx,
 		responderPeerID.String(),
@@ -265,6 +287,7 @@ func (a *ProviderAccount) processMailboxEntry(
 		}
 	}
 
+	// Commit the accepted mailbox decision to the cloud.
 	if _, err := cli.ProcessMailboxEntry(ctx, soID, &api.ProcessMailboxEntryRequest{
 		Id:     entry.GetId(),
 		Accept: true,

--- a/core/provider/spacewave/org-processor.go
+++ b/core/provider/spacewave/org-processor.go
@@ -24,6 +24,7 @@ type orgProcessorHooks struct {
 // buildOrgProcessorRoutine returns the keyed routine for an org processor.
 func (a *ProviderAccount) buildOrgProcessorRoutine(orgID string) (keyed.Routine, struct{}) {
 	return func(ctx context.Context) error {
+		// Mount the organization shared object for processing.
 		ref := sobject.NewSharedObjectRef(a.GetProviderID(), a.accountID, orgID, SobjectBlockStoreID(orgID))
 
 		so, soRef, err := sobject.ExMountSharedObject(ctx, a.p.b, ref, false, nil)
@@ -38,6 +39,7 @@ func (a *ProviderAccount) buildOrgProcessorRoutine(orgID string) (keyed.Routine,
 		}
 		defer soRef.Release()
 
+		// Process organization operations until cancellation.
 		return so.ProcessOperations(ctx, true, s4wave_org.ProcessOrgOps)
 	}, struct{}{}
 }
@@ -45,6 +47,7 @@ func (a *ProviderAccount) buildOrgProcessorRoutine(orgID string) (keyed.Routine,
 // watchOrgProcessors watches the SO list and starts/stops org processors
 // as org-typed SOs appear or disappear. Blocks until ctx is canceled.
 func (a *ProviderAccount) watchOrgProcessors(ctx context.Context) error {
+	// Configure keyed retries for organization processors.
 	processors := keyed.NewKeyedWithLogger[string, struct{}](
 		a.buildOrgProcessorRoutine,
 		a.le.WithField("subsystem", "org-processors"),
@@ -55,11 +58,13 @@ func (a *ProviderAccount) watchOrgProcessors(ctx context.Context) error {
 	processors.SetContext(ctx, true)
 	defer processors.SetContext(nil, false)
 
+	// Wait for the shared-object list before selecting processors.
 	soList, err := a.soListCtr.WaitValue(ctx, nil)
 	if err != nil {
 		return err
 	}
 
+	// Start processors for the initial organization set.
 	desired := newOrgProcessorDesiredKeys(a, processors, soList)
 	if err := a.runOrgProcessorDesiredKeys(ctx, desired); err != nil {
 		return err
@@ -79,21 +84,25 @@ func (a *ProviderAccount) runOrgProcessorDesiredKeysWithHooks(
 	desired *orgProcessorDesiredKeys,
 	hooks orgProcessorHooks,
 ) error {
+	// Apply the initial desired processor set.
 	desired.sync()
 	if hooks.afterInitialSync != nil {
 		hooks.afterInitialSync()
 	}
 
+	// Watch shared-object changes and reconcile processor keys.
 	soListWatcher := newNamedRoutineContainer(a.le, "org-processor-so-list")
 	soListWatcher.SetRoutine(desired.watchSOList)
 	soListWatcher.SetContext(ctx, true)
 	defer soListWatcher.ClearContext()
 
+	// Watch organization changes and reconcile processor keys.
 	orgListWatcher := newNamedRoutineContainer(a.le, "org-processor-org-list")
 	orgListWatcher.SetRoutine(desired.watchOrgList)
 	orgListWatcher.SetContext(ctx, true)
 	defer orgListWatcher.ClearContext()
 
+	// Wait for a watcher to exit or context cancellation.
 	return soListWatcher.WaitExited(ctx, false, nil)
 }
 

--- a/core/provider/spacewave/session.go
+++ b/core/provider/spacewave/session.go
@@ -124,28 +124,35 @@ func (s *Session) GetDirectP2PEnabled() bool {
 
 // SetDirectP2PEnabled persists and reconciles the Session-local transport policy.
 func (s *Session) SetDirectP2PEnabled(ctx context.Context, enabled bool) error {
+	// Acquire the session controller and read mounted metadata.
 	sessionCtrl, sessionCtrlRef, err := session.ExLookupSessionController(ctx, s.GetBus(), "", false, nil)
 	if err != nil {
 		return err
 	}
 	defer sessionCtrlRef.Release()
 
+	// Resolve the session metadata record.
 	ref := s.GetSessionRef()
 	meta, err := lookupSessionMetadata(ctx, sessionCtrl, ref)
 	if err != nil {
 		return err
 	}
+
+	// Fill metadata defaults for a first update.
 	if meta == nil {
 		meta = &session.SessionMetadata{
 			ProviderDisplayName: "Cloud",
 			ProviderId:          "spacewave",
 		}
 	}
+
+	// Persist the direct-transport policy in session metadata.
 	meta.DirectP2PDisabled = !enabled
 	if err := sessionCtrl.UpdateSessionMetadata(ctx, ref, meta); err != nil {
 		return err
 	}
 
+	// Publish the local policy and persist the account setting.
 	s.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
 		s.directP2PEnabled = enabled
 		broadcast()
@@ -163,6 +170,7 @@ func (s *Session) UnlockSession(ctx context.Context, pin []byte) error {
 		return errors.New("session is not PIN-locked")
 	}
 
+	// Read the encrypted PIN-lock material.
 	encPriv, encSymKey, config, err := session_lock.ReadPINLockFiles(ctx, s.objStore, s.tkr.id)
 	if err != nil {
 		return errors.Wrap(err, "read PIN lock files")
@@ -171,6 +179,7 @@ func (s *Session) UnlockSession(ctx context.Context, pin []byte) error {
 		return errors.New("PIN lock files not found")
 	}
 
+	// Decrypt and parse the session private key.
 	privPEM, err := session_lock.UnlockPIN(encPriv, encSymKey, config, pin)
 	if err != nil {
 		return err
@@ -182,6 +191,7 @@ func (s *Session) UnlockSession(ctx context.Context, pin []byte) error {
 		return errors.Wrap(err, "parse unlocked key")
 	}
 
+	// Install the key and reconcile authenticated transport state.
 	s.sessionPriv = privKey
 	s.tkr.a.maybeSetSessionClient(s.tkr.id, NewSessionClient(
 
@@ -204,7 +214,7 @@ func (s *Session) UnlockSession(ctx context.Context, pin []byte) error {
 		s.tkr.a.le.WithError(err).Warn("failed to reconcile session transport after unlock")
 	}
 
-	// Broadcast unlocked state.
+	// Publish the unlocked session state.
 	s.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
 		broadcast()
 	})
@@ -230,14 +240,14 @@ func (s *Session) LockSession(ctx context.Context) error {
 	}
 	s.sessionPriv = nil
 
-	// Invalidate the published session so future mounts do not reuse it.
+	// Invalidate the published session and stop its transport.
 	s.tkr.sessionProm.SetPromise(nil)
 	s.tkr.unlockProm = promise.NewPromiseContainer[[]byte]()
 	s.tkr.releasePinnedRef()
 	s.tkr.a.dropSessionClientForSession(s.tkr.id)
 	s.tkr.a.StopSessionTransportComposition(s.tkr.id)
 
-	// Broadcast locked=true so WatchLockState emits.
+	// Publish the locked session state.
 	s.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
 		broadcast()
 	})

--- a/core/provider/spacewave/standalone-space-init.go
+++ b/core/provider/spacewave/standalone-space-init.go
@@ -35,6 +35,7 @@ func (c *SessionClient) InitEmptyStandaloneSpace(
 	accountID string,
 	spaceID string,
 ) (bool, error) {
+	// Validate the authenticated client and initialization inputs.
 	if c == nil {
 		return false, errors.New("session client is required")
 	}
@@ -54,11 +55,13 @@ func (c *SessionClient) InitEmptyStandaloneSpace(
 		le = logrus.New().WithField("component", "standalone-space-init")
 	}
 
+	// Load the current shared-object state and config chain.
 	state, chain, err := c.loadStandaloneInitState(ctx, spaceID)
 	if err != nil {
 		return false, err
 	}
 
+	// Verify local owner participation and grant state.
 	localPeerID := c.peerID.String()
 	localParticipant := participantConfigForPeer(state.GetConfig(), localPeerID)
 	if localParticipant == nil {
@@ -73,6 +76,7 @@ func (c *SessionClient) InitEmptyStandaloneSpace(
 		return false, nil
 	}
 
+	// Initialize an unrooted shared object when needed.
 	root := state.GetRoot()
 	if root == nil || root.GetInnerSeqno() == 0 {
 		if err := initializeCloudSharedObjectState(
@@ -90,6 +94,7 @@ func (c *SessionClient) InitEmptyStandaloneSpace(
 		return true, nil
 	}
 
+	// Reject inconsistent config history before repair.
 	if len(chain.GetConfigChanges()) != 0 {
 		return false, errors.New("local grant missing on initialized space with config history")
 	}
@@ -98,6 +103,8 @@ func (c *SessionClient) InitEmptyStandaloneSpace(
 			return false, errors.New("local grant missing on initialized space with existing key grants")
 		}
 	}
+
+	// Repair an initialized shared object missing the local grant.
 	if err := repairGrantlessStandaloneSpace(
 		ctx,
 		c,
@@ -118,6 +125,7 @@ func (c *SessionClient) loadStandaloneInitState(
 	ctx context.Context,
 	spaceID string,
 ) (*sobject.SOState, *sobject.SOConfigChainResponse, error) {
+	// Fetch and decode the cloud state snapshot.
 	stateData, err := c.GetSOState(ctx, spaceID, 0, SeedReasonColdSeed)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "get so state")
@@ -129,6 +137,8 @@ func (c *SessionClient) loadStandaloneInitState(
 	if state == nil {
 		return nil, nil, errors.New("missing so state snapshot")
 	}
+
+	// Load the config chain when the state response omitted it.
 	if chain == nil {
 		chainData, err := c.GetConfigChain(ctx, spaceID)
 		if err != nil {
@@ -174,6 +184,7 @@ func initializeCloudSharedObjectState(
 	sfs *block_transform.StepFactorySet,
 	seedWorldHead bool,
 ) error {
+	// Build the signed standalone initialization state.
 	state, err := buildStandaloneSpaceInitState(
 		ctx,
 		cli,
@@ -188,6 +199,8 @@ func initializeCloudSharedObjectState(
 	if err != nil {
 		return err
 	}
+
+	// Publish the signed config state.
 	if err := cli.PostConfigState(
 		ctx,
 		sharedObjectID,
@@ -198,6 +211,8 @@ func initializeCloudSharedObjectState(
 	); err != nil {
 		return errors.Wrap(err, "post signed genesis config")
 	}
+
+	// Marshal and publish the initial root state.
 	rootData, err := state.root.MarshalVT()
 	if err != nil {
 		return errors.Wrap(err, "marshal root")

--- a/core/resource/listener/execute.go
+++ b/core/resource/listener/execute.go
@@ -37,6 +37,7 @@ const RequesterNameDefault = "spacewave serve"
 
 // Execute executes the controller.
 func (c *Controller) Execute(ctx context.Context) error {
+	// Resolve the configured socket and stop cleanly when it is disabled.
 	le := c.GetLogger()
 	b := c.GetBus()
 
@@ -49,15 +50,18 @@ func (c *Controller) Execute(ctx context.Context) error {
 		return nil
 	}
 
+	// Resolve the socket to an absolute path.
 	absPath, err := resolveSocketPath(le, sockPath)
 	if err != nil {
 		return errors.Wrap(err, "resolve socket path")
 	}
 
+	// Publish listener status while the resource service is acquired.
 	status := GetProcessStatusBroker()
 	status.SetSocketPath(absPath)
 	defer status.SetListening(false)
 
+	// Acquire the resource service invoker.
 	le.Info("waiting for resource service")
 	serviceID := resource.SRPCResourceServiceServiceID
 	invokers, _, invokerRef, err := bifrost_rpc.ExLookupRpcService(ctx, b, serviceID, "", true, nil)
@@ -70,6 +74,7 @@ func (c *Controller) Execute(ctx context.Context) error {
 	}
 	defer invokerRef.Release()
 
+	// Enter the handoff-aware serve and reclaim loop.
 	broker := GetProcessYieldBroker()
 
 	// allowTakeover is false on first entry so a live daemon on the
@@ -89,6 +94,8 @@ func (c *Controller) Execute(ctx context.Context) error {
 				continue
 			}
 		}
+
+		// Serve until shutdown, takeover, or context cancellation.
 		yielded, err := c.serveOnce(ctx, le, invokers[0], absPath, broker, status, allowTakeover)
 		if err != nil {
 			if listener_control.IsSocketInUse(err) {
@@ -107,6 +114,8 @@ func (c *Controller) Execute(ctx context.Context) error {
 		if !yielded || ctx.Err() != nil {
 			return nil
 		}
+
+		// Wait for a reclaim signal before binding again.
 		reclaimCh := broker.BeginHandoff(RequesterNameDefault, absPath)
 		le.Info("runtime handed off, waiting for reclaim signal")
 		select {
@@ -139,6 +148,7 @@ func (c *Controller) serveOnce(
 	status *StatusBroker,
 	allowTakeover bool,
 ) (bool, error) {
+	// Choose the socket preparation policy for this serve attempt.
 	prepare := listener_control.EnsureSocketAvailable
 	if allowTakeover {
 		prepare = listener_control.TakeoverSocket
@@ -150,6 +160,7 @@ func (c *Controller) serveOnce(
 		return false, err
 	}
 
+	// Bind the Unix socket and classify bind races.
 	lis, err := net.ListenUnix("unix", &net.UnixAddr{Name: absPath, Net: "unix"})
 	if err != nil {
 		if stderrors.Is(err, syscall.EADDRINUSE) {
@@ -167,6 +178,7 @@ func (c *Controller) serveOnce(
 		le.WithError(err).Warn("failed to chmod socket")
 	}
 
+	// Publish listening status and register RPC handlers.
 	le.Infof("resource listener listening on %s", absPath)
 	status.SetListening(true)
 	defer status.SetListening(false)
@@ -197,6 +209,7 @@ func (c *Controller) serveOnce(
 		lis.Close()
 	}()
 
+	// Serve clients and drain them after the listener stops.
 	srv := srpc.NewServer(mux)
 	drainClients, err := acceptCountingListener(serveCtx, lis, srv, status)
 	yielded := false
@@ -231,9 +244,12 @@ func acceptCountingListener(
 	srv *srpc.Server,
 	status *StatusBroker,
 ) (func(), error) {
+	// Initialize connection tracking and the client wait group.
 	var clients sync.WaitGroup
 	var connectionsMtx sync.Mutex
 	connections := make(map[*countingConn]struct{})
+
+	// Close a snapshot of active client connections.
 	closeConnections := func() {
 		connectionsMtx.Lock()
 		active := make([]*countingConn, 0, len(connections))
@@ -246,6 +262,7 @@ func acceptCountingListener(
 		}
 	}
 
+	// Build an idempotent drain operation for shutdown.
 	drainOnce := sync.Once{}
 	drainClients := func() {
 		drainOnce.Do(func() {
@@ -254,11 +271,14 @@ func acceptCountingListener(
 		})
 	}
 
+	// Accept connections until the listener closes.
 	for {
 		nc, err := lis.Accept()
 		if err != nil {
 			return drainClients, err
 		}
+
+		// Register each accepted client before serving it.
 		status.AddClient()
 		tracked := &countingConn{Conn: nc, status: status}
 		mc, err := srpc.NewMuxedConn(tracked, false, nil)

--- a/core/resource/listener/execute_test.go
+++ b/core/resource/listener/execute_test.go
@@ -68,12 +68,15 @@ func TestHandoffBlocksActiveListener(t *testing.T) {
 }
 
 func TestServeOnceRefusesConnectableSocket(t *testing.T) {
+	// Initialize a cancelable listener test context.
 	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 	defer cancel()
 
 	if err := os.MkdirAll(".tmp", 0o755); err != nil {
 		t.Fatal(err)
 	}
+
+	// Create the temporary socket directory.
 	dir, err := os.MkdirTemp(".tmp", "refuse-")
 	if err != nil {
 		t.Fatal(err)
@@ -82,6 +85,8 @@ func TestServeOnceRefusesConnectableSocket(t *testing.T) {
 		_ = os.RemoveAll(dir)
 	})
 	sock := filepath.Join(dir, "spacewave.sock")
+
+	// Bind the connectable Unix listener.
 	lis, err := net.ListenUnix("unix", &net.UnixAddr{Name: sock, Net: "unix"})
 	if err != nil {
 		t.Fatal(err)
@@ -145,6 +150,8 @@ func TestAcceptCountingListenerKeepsExistingClientAfterPeerDeparts(t *testing.T)
 			return false, nil
 		}
 	}))
+
+	// Start the accept loop with a drainable server.
 	serverErr := make(chan error, 1)
 	go func() {
 		drainClients, err := acceptCountingListener(ctx, listener, srpc.NewServer(mux), status)
@@ -161,6 +168,7 @@ func TestAcceptCountingListenerKeepsExistingClientAfterPeerDeparts(t *testing.T)
 		}
 	}()
 
+	// Connect clients and verify active-stream behavior.
 	clientA, closeA := dialListenerTestClient(t, listener.Addr().String())
 	defer closeA()
 	watchCtx, cancelWatch := context.WithCancel(t.Context())
@@ -177,6 +185,7 @@ func TestAcceptCountingListenerKeepsExistingClientAfterPeerDeparts(t *testing.T)
 	defer watchA.Close()
 	recvListenerTestWatch(t, watchA)
 
+	// Exercise a second client while the first watch remains active.
 	clientB, closeB := dialListenerTestClient(t, listener.Addr().String())
 	pingListenerTestClient(t, clientB)
 	waitListenerClientCount(t, status, 2)

--- a/core/resource/root/server.go
+++ b/core/resource/root/server.go
@@ -62,7 +62,7 @@ func NewCoreRootServer(le *logrus.Entry, b bus.Bus) *CoreRootServer {
 	return s
 }
 
-// SetHostPluginID records the plugin id that owns this resource root.
+// SetHostPluginID records the plugin id serving this resource root.
 func (s *CoreRootServer) SetHostPluginID(pluginID string) {
 	s.hostPluginID = pluginID
 }
@@ -88,17 +88,20 @@ func (s *CoreRootServer) GetDebugDb(
 	ctx context.Context,
 	_ *s4wave_root.GetDebugDbRequest,
 ) (*s4wave_root.GetDebugDbResponse, error) {
+	// Acquire the caller resource context.
 	resourceCtx, err := resource_server.MustGetResourceClientContext(ctx)
 	if err != nil {
 		return nil, err
 	}
 
+	// Construct and register the debug database resource.
 	debugResource := resource_debugdb.NewDebugDbResource(s.le, s.b)
 	id, err := resourceCtx.AddResource(debugResource.GetMux(), func() {})
 	if err != nil {
 		return nil, err
 	}
 
+	// Return the registered resource identifier.
 	return &s4wave_root.GetDebugDbResponse{ResourceId: id}, nil
 }
 

--- a/core/resource/root/server_close_test.go
+++ b/core/resource/root/server_close_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestRootServerCloseBeforeStateAtomUse(t *testing.T) {
+	// Configure a server and close it before any state-atom access.
 	var builds atomic.Int32
 	server := newCloseTestServer(t)
 	server.stateAtomStoreIndexBuilder = func(context.Context) (*session.StateAtomStoreIndex, func(), error) {
@@ -20,6 +21,7 @@ func TestRootServerCloseBeforeStateAtomUse(t *testing.T) {
 		return session.NewStateAtomStoreIndex(nil), func() {}, nil
 	}
 
+	// Verify closed servers reject lazy state-atom use.
 	server.Close()
 	if builds.Load() != 0 {
 		t.Fatalf("state atom store built after close: %d builds", builds.Load())
@@ -30,6 +32,7 @@ func TestRootServerCloseBeforeStateAtomUse(t *testing.T) {
 }
 
 func TestRootServerCloseReleasesStateAtomAndCDN(t *testing.T) {
+	// Configure state-atom and CDN resources for release tracking.
 	var releases atomic.Int32
 	server := newCloseTestServer(t)
 	server.stateAtomStoreIndexBuilder = func(context.Context) (*session.StateAtomStoreIndex, func(), error) {
@@ -37,6 +40,8 @@ func TestRootServerCloseReleasesStateAtomAndCDN(t *testing.T) {
 			releases.Add(1)
 		}, nil
 	}
+
+	// Materialize both resources before closing.
 	if _, err := server.getStateAtomStoreIndex(context.Background()); err != nil {
 		t.Fatal(err)
 	}
@@ -44,6 +49,7 @@ func TestRootServerCloseReleasesStateAtomAndCDN(t *testing.T) {
 		t.Fatalf("create CDN instance: %v", err)
 	}
 
+	// Close twice and verify each lifecycle release occurs once.
 	server.Close()
 	server.Close()
 
@@ -59,6 +65,7 @@ func TestRootServerCloseReleasesStateAtomAndCDN(t *testing.T) {
 }
 
 func TestRootServerCloseWaitsForConcurrentStateAtomUse(t *testing.T) {
+	// Block state-atom acquisition while close waits for the lock.
 	started := make(chan struct{})
 	allow := make(chan struct{})
 	var releases atomic.Int32
@@ -71,6 +78,7 @@ func TestRootServerCloseWaitsForConcurrentStateAtomUse(t *testing.T) {
 		}, nil
 	}
 
+	// Start acquisition and concurrent close operations.
 	useDone := make(chan error, 1)
 	go func() {
 		_, err := server.getStateAtomStoreIndex(context.Background())
@@ -89,6 +97,7 @@ func TestRootServerCloseWaitsForConcurrentStateAtomUse(t *testing.T) {
 	case <-time.After(25 * time.Millisecond):
 	}
 
+	// Release acquisition and await close completion.
 	close(allow)
 	if err := <-useDone; err != nil {
 		t.Fatalf("state atom use: %v", err)

--- a/core/resource/root/state-watch.go
+++ b/core/resource/root/state-watch.go
@@ -13,12 +13,14 @@ import (
 func (s *CoreRootServer) getStateAtomStoreIndex(
 	ctx context.Context,
 ) (*session.StateAtomStoreIndex, error) {
+	// Serialize lazy index creation and reject closed servers.
 	s.stateAtomStoreIndexMtx.Lock()
 	defer s.stateAtomStoreIndexMtx.Unlock()
 	if s.stateAtomStoreClosed {
 		return nil, errors.New("root resource server is closed")
 	}
 
+	// Reuse the existing state-atom index when available.
 	if s.stateAtomStoreIndex != nil {
 		return s.stateAtomStoreIndex, nil
 	}
@@ -28,6 +30,8 @@ func (s *CoreRootServer) getStateAtomStoreIndex(
 		release             func()
 		err                 error
 	)
+
+	// Build the index through the test hook or plugin object store.
 	if builder := s.stateAtomStoreIndexBuilder; builder != nil {
 		stateAtomStoreIndex, release, err = builder(ctx)
 	} else {
@@ -45,6 +49,8 @@ func (s *CoreRootServer) getStateAtomStoreIndex(
 		stateAtomStoreIndex = session.NewStateAtomStoreIndex(objStoreHandle.GetObjectStore())
 		release = diRef.Release
 	}
+
+	// Publish the initialized index and release callback.
 	if err != nil {
 		return nil, err
 	}
@@ -62,6 +68,7 @@ func (s *CoreRootServer) closeStateAtomStoreIndex() {
 	s.releaseStateAtomStoreIndex = nil
 	s.stateAtomStoreIndexMtx.Unlock()
 
+	// Release the detached object-store index after unlocking.
 	if release != nil {
 		release()
 	}

--- a/core/resource/root/state.go
+++ b/core/resource/root/state.go
@@ -22,27 +22,32 @@ func (s *CoreRootServer) AccessStateAtom(
 	ctx context.Context,
 	req *s4wave_root.AccessStateAtomRequest,
 ) (*s4wave_root.AccessStateAtomResponse, error) {
+	// Acquire the caller resource context.
 	resourceCtx, err := resource_server.MustGetResourceClientContext(ctx)
 	if err != nil {
 		return nil, err
 	}
 
+	// Resolve the requested state-atom store.
 	storeID := req.GetStoreId()
 	if storeID == "" {
 		storeID = resource_state.DefaultStateAtomStoreID
 	}
 
+	// Open the store and publish its identifier.
 	store, err := s.stateAtomMgr.GetOrCreateStore(ctx, storeID)
 	if err != nil {
 		return nil, err
 	}
 	s.trackStateAtomStoreID(ctx, storeID)
 
+	// Register the state-atom resource.
 	stateResource := resource_state.NewStateAtomResource(store)
 	id, err := resourceCtx.AddResource(stateResource.GetMux(), func() {})
 	if err != nil {
 		return nil, err
 	}
 
+	// Return the registered resource identifier.
 	return &s4wave_root.AccessStateAtomResponse{ResourceId: id}, nil
 }

--- a/core/resource/session/pairing-status-rpc.go
+++ b/core/resource/session/pairing-status-rpc.go
@@ -10,9 +10,10 @@ func (r *SessionResource) WatchPairingStatus(
 	req *s4wave_session.WatchPairingStatusRequest,
 	strm s4wave_session.SRPCSessionResourceService_WatchPairingStatusStream,
 ) error {
+	// Initialize the pairing watch context.
 	ctx := strm.Context()
 
-	// Only the local provider supports pairing status.
+	// Return idle status for providers without pairing support.
 	localAcc, ok := r.session.GetProviderAccount().(*provider_local.ProviderAccount)
 	if !ok {
 		return strm.Send(&s4wave_session.WatchPairingStatusResponse{
@@ -20,6 +21,7 @@ func (r *SessionResource) WatchPairingStatus(
 		})
 	}
 
+	// Capture pairing state and its wake channel.
 	bcast := localAcc.GetPairingBroadcast()
 	var prev *s4wave_session.WatchPairingStatusResponse
 	for {
@@ -30,6 +32,7 @@ func (r *SessionResource) WatchPairingStatus(
 			snap = localAcc.GetPairingSnapshot()
 		})
 
+		// Emit only changed pairing snapshots.
 		resp := pairingSnapshotToProto(snap)
 		if prev == nil || !resp.EqualVT(prev) {
 			if err := strm.Send(resp); err != nil {
@@ -38,6 +41,7 @@ func (r *SessionResource) WatchPairingStatus(
 			prev = resp
 		}
 
+		// Wait for pairing changes or cancellation.
 		select {
 		case <-ctx.Done():
 			return ctx.Err()

--- a/core/resource/session/session.go
+++ b/core/resource/session/session.go
@@ -95,7 +95,7 @@ func NewSessionResource(le *logrus.Entry, b bus.Bus, sess session.Session) *Sess
 }
 
 // NewSessionResourceWithHostPluginID creates a new SessionResource with the
-// plugin id that owns the resource root.
+// plugin id serving the resource root.
 func NewSessionResourceWithHostPluginID(
 	le *logrus.Entry,
 	b bus.Bus,
@@ -323,21 +323,21 @@ func (r *SessionResource) addSharedObjectResource(
 
 // CreateSpace creates a new space within the ProviderAccount with the Session.
 func (r *SessionResource) CreateSpace(ctx context.Context, req *s4wave_session.CreateSpaceRequest) (*s4wave_session.CreateSpaceResponse, error) {
-	// Create the new shared object metadata
+	// Build the requested Space metadata.
 	soId := ulid.NewULID()
 	soMeta, err := space.NewSharedObjectMeta(req.GetSpaceName())
 	if err != nil {
 		return nil, err
 	}
 
-	// Get the provider account feature for shared objects.
+	// Resolve the shared-object provider feature.
 	providerAcc := r.session.GetProviderAccount()
 	soFeature, err := sobject.GetSharedObjectProviderAccountFeature(ctx, providerAcc)
 	if err != nil {
 		return nil, err
 	}
 
-	// Default owner = caller's account when unspecified.
+	// Resolve the principal receiving ownership.
 	ownerType := req.GetOwnerType()
 	ownerID := req.GetOwnerId()
 	if ownerType == "" && ownerID == "" {
@@ -345,7 +345,7 @@ func (r *SessionResource) CreateSpace(ctx context.Context, req *s4wave_session.C
 		ownerID = r.session.GetSessionRef().GetProviderResourceRef().GetProviderAccountId()
 	}
 
-	// Create the new shared object.
+	// Create and mount the shared object.
 	soRef, err := soFeature.CreateSharedObject(ctx, soId, soMeta, ownerType, ownerID)
 	if err != nil {
 		return nil, err
@@ -647,6 +647,7 @@ func (r *SessionResource) watchSpaceIndexObjectType(
 		}
 		return
 	}
+
 	// A returnIfIdle miss is generic in the prompt batch; the blocking mount
 	// below reports the durable type as a later live update.
 	initialPending := true
@@ -1098,6 +1099,7 @@ func (r *SessionResource) DeleteAccount(ctx context.Context, req *s4wave_session
 			if ref.GetProviderId() != "spacewave" || ref.GetProviderAccountId() != cloudAccountID {
 				continue
 			}
+
 			// Look up the spacewave provider via the bus.
 			swProv, swProvRef, aerr := provider.ExLookupProvider(ctx, r.b, "spacewave", false, nil)
 			if aerr != nil {

--- a/core/resource/session/spacewave-session.go
+++ b/core/resource/session/spacewave-session.go
@@ -78,12 +78,15 @@ func (r *SpacewaveSessionResource) WatchOnboardingStatus(
 	req *s4wave_provider_spacewave.WatchOnboardingStatusRequest,
 	strm s4wave_session.SRPCSpacewaveSessionResourceService_WatchOnboardingStatusStream,
 ) error {
+	// Initialize the session projection watch state.
 	ctx := strm.Context()
 	sessionID := r.getSessionID()
 	sessRef := r.getSessionRef()
 	accountBcast := r.swAcc.GetAccountBroadcast()
 
 	var prev *s4wave_provider_spacewave.WatchOnboardingStatusResponse
+
+	// Read account status and wait channel for each update.
 	for {
 		var ch <-chan struct{}
 		var accountStatus provider.ProviderAccountStatus
@@ -110,12 +113,14 @@ func (r *SpacewaveSessionResource) WatchOnboardingStatus(
 			continue
 		}
 
+		// Build the current onboarding projection.
 		projCtx := r.buildOnboardingStatusProjectionContext(ctx, sessionID, sessRef)
 		resp, err := r.swAcc.BuildOnboardingStatusProjection(ctx, projCtx)
 		if err != nil {
 			r.le.WithError(err).Warn("failed to fetch managed billing account list")
 		}
 
+		// Emit only a changed projection.
 		if prev == nil || !resp.EqualVT(prev) {
 			if err := strm.Send(resp); err != nil {
 				return err
@@ -123,6 +128,7 @@ func (r *SpacewaveSessionResource) WatchOnboardingStatus(
 			prev = resp
 		}
 
+		// Wait for account changes or cancellation.
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
@@ -137,16 +143,18 @@ func (r *SpacewaveSessionResource) buildOnboardingStatusProjectionContext(
 	sessRef *session.SessionRef,
 ) provider_spacewave.OnboardingStatusProjectionContext {
 	var projCtx provider_spacewave.OnboardingStatusProjectionContext
+
+	// Resolve linked local-session state.
 	found, localIdx, _ := r.swAcc.GetLinkedLocalSession(ctx, sessionID)
 	if found {
 		projCtx.HasLinkedLocal = true
 		projCtx.LinkedLocalSessionIndex = localIdx
+
+		// Resolve the linked cloud session for local sessions.
 		projCtx.LinkedLocalHasContent = r.checkLocalHasContent(ctx, localIdx)
 	}
 
-	// Populate the cloud session index for local sessions that need to redirect
-	// to the migration wizard on the cloud session. Skip for cloud sessions:
-	// they would find themselves.
+	// Resolve the linked cloud session for local sessions that need migration.
 	if sessRef.GetProviderResourceRef().GetProviderId() != "spacewave" {
 		cloudIdx := r.findCloudSessionIndex(ctx, r.swAcc.GetAccountID())
 		if cloudIdx != 0 {
@@ -952,6 +960,7 @@ func (r *SpacewaveSessionResource) CreateOrgInvite(
 	if err := inv.UnmarshalVT(data); err != nil {
 		return nil, errors.Wrap(err, "unmarshal invite")
 	}
+
 	// Mirror to local org SO.
 	var inviteType s4wave_org.OrgInviteType
 	switch req.GetType() {
@@ -2491,6 +2500,7 @@ func (r *SpacewaveSessionResource) VerifyEmailCode(
 	if err := cli.VerifyEmailCode(ctx, req.GetEmail(), req.GetCode()); err != nil {
 		return nil, err
 	}
+
 	// Bump local epoch to trigger account state re-fetch (picks up emailVerified).
 	r.swAcc.BumpLocalEpoch()
 	return &s4wave_provider_spacewave.VerifyEmailCodeResponse{Verified: true}, nil

--- a/core/resource/space/space.go
+++ b/core/resource/space/space.go
@@ -52,7 +52,7 @@ func NewSpaceResourceWithSessionPeerID(
 }
 
 // NewSpaceResourceWithSessionPeerIDAndHostPluginID creates a SpaceResource
-// with the mounted local session peer ID and owning host plugin ID.
+// with the mounted local session peer ID and host plugin ID.
 func NewSpaceResourceWithSessionPeerIDAndHostPluginID(
 	le *logrus.Entry,
 	b bus.Bus,
@@ -108,12 +108,15 @@ func (r *SpaceResource) WatchSpaceState(
 	req *s4wave_space.WatchSpaceStateRequest,
 	strm s4wave_space.SRPCSpaceResourceService_WatchSpaceStateStream,
 ) error {
+	// Initialize the world snapshot watch.
 	ctx, worldEng := strm.Context(), r.space.GetWorldEngine()
 
-	// Watch the world contents.
+	// Read and publish the current world contents.
 	var prevWorldSeqno uint64
 	for {
 		r.le.Debugf("checking world state: seqno(%v)", prevWorldSeqno+1)
+
+		// Build one SpaceState snapshot from a read transaction.
 		var state *s4wave_space.SpaceState
 		if err := func() error {
 			wtx, err := worldEng.NewTransaction(ctx, false)
@@ -127,30 +130,31 @@ func (r *SpaceResource) WatchSpaceState(
 				return err
 			}
 
+			// Start a ready SpaceState response.
 			state = &s4wave_space.SpaceState{Ready: true}
 
-			// build the object list
+			// Build the world object list.
 			state.WorldContents, err = space_world.BuildWorldContents(ctx, wtx)
 			if err != nil {
 				return err
 			}
 
-			// Load SpaceSettings from the world (ignore not found error)
+			// Load SpaceSettings when present.
 			state.Settings, _, err = space_world.LookupSpaceSettings(ctx, wtx)
 			if err != nil {
 				return err
 			}
 
-			// Build transform info from the shared object state.
+			// Attach shared-object transform information.
 			state.TransformInfo = r.buildTransformInfo(ctx)
 
-			// send ready
+			// Publish the snapshot.
 			return strm.Send(state)
 		}(); err != nil {
 			return err
 		}
 
-		// wait til seqno changes
+		// Wait for the next world sequence.
 		if _, err := worldEng.WaitSeqno(ctx, prevWorldSeqno+1); err != nil {
 			return err
 		}

--- a/core/resource/space/space_test.go
+++ b/core/resource/space/space_test.go
@@ -38,6 +38,7 @@ func spaceResourceClient(t *testing.T, mux srpc.Invoker) srpc.Client {
 }
 
 func TestSpaceResourceChatSenderUsesMountedSessionPeer(t *testing.T) {
+	// Initialize the testbed and channel object.
 	ctx := t.Context()
 	tb, err := testbed.Default(ctx)
 	if err != nil {
@@ -48,6 +49,7 @@ func TestSpaceResourceChatSenderUsesMountedSessionPeer(t *testing.T) {
 	const channelKey = "chat/channel/space-resource"
 	createSpaceResourceChatChannel(t, ctx, tb.WorldState, channelKey)
 
+	// Install a recording object-type factory.
 	factory := &recordingChatFactory{
 		base:      spacewave_chat_world.ChatChannelType.GetFactory(),
 		cleanupCh: make(chan int, 4),
@@ -71,6 +73,8 @@ func TestSpaceResourceChatSenderUsesMountedSessionPeer(t *testing.T) {
 		engineID: tb.EngineID,
 		bucketID: tb.EngineBucketID,
 	}
+
+	// Exercise anonymous access and cleanup.
 	resources := newSpaceRecordingResourceClient(ctx)
 	ctx = resource_server.WithResourceClientContext(ctx, resources)
 
@@ -112,6 +116,8 @@ func TestSpaceResourceChatSenderUsesMountedSessionPeer(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for anonymous factory cleanup")
 	}
+
+	// Create peer-bound resources and resolve typed channels.
 	spaceA := NewSpaceResourceWithSessionPeerID(tb.Logger, tb.Bus, body, peerA.String())
 	spaceB := NewSpaceResourceWithSessionPeerID(tb.Logger, tb.Bus, body, peerB.String())
 
@@ -130,7 +136,7 @@ func TestSpaceResourceChatSenderUsesMountedSessionPeer(t *testing.T) {
 	engineA := s4wave_world.NewSRPCTypedObjectResourceServiceClient(resources.client(t, worldA.GetResourceId()))
 	engineB := s4wave_world.NewSRPCTypedObjectResourceServiceClient(resources.client(t, worldB.GetResourceId()))
 
-	// A downstream request carrying B's peer cannot override A's mounted identity.
+	// Verify mounted peer identity overrides request context.
 	ctxWithPeerB := objecttype.WithSessionPeerID(ctx, peerB)
 	typedA, err := engineA.AccessTypedObject(ctxWithPeerB, &s4wave_world.AccessTypedObjectRequest{ObjectKey: channelKey})
 	if err != nil {
@@ -143,6 +149,7 @@ func TestSpaceResourceChatSenderUsesMountedSessionPeer(t *testing.T) {
 	}
 	assertSpaceChatSender(t, ctx, tb.BusEngine, sendA.GetMessageKey(), peerA.String())
 
+	// Verify the second mounted peer identity.
 	ctxWithPeerA := objecttype.WithSessionPeerID(ctx, peerA)
 	typedB, err := engineB.AccessTypedObject(ctxWithPeerA, &s4wave_world.AccessTypedObjectRequest{ObjectKey: channelKey})
 	if err != nil {

--- a/core/resource/world/engine.go
+++ b/core/resource/world/engine.go
@@ -35,6 +35,7 @@ func NewEngineResource(
 	engineInfo *s4wave_world.EngineInfo,
 	opts ...WorldStateResourceOption,
 ) *EngineResource {
+	// Capture trusted access options and initialize the resource wrapper.
 	sessionPeerID, sessionPeerIDBound := worldStateResourceSessionPeerID(opts...)
 	engineResource := &EngineResource{
 		le:                le,
@@ -44,6 +45,8 @@ func NewEngineResource(
 		engineInfo:        engineInfo,
 		worldStateOptions: opts,
 	}
+
+	// Attach typed-object access to the world engine.
 	engineResource.typedResource = newTypedObjectResourceWithSessionPeerID(
 		le,
 		b,
@@ -52,6 +55,8 @@ func NewEngineResource(
 		sessionPeerID,
 		sessionPeerIDBound,
 	)
+
+	// Register world, watch, and typed-object RPC services.
 	engineResource.mux = resource_server.NewResourceMux(
 		func(mux srpc.Mux) error { return s4wave_world.SRPCRegisterEngineResourceService(mux, engineResource) },
 		func(mux srpc.Mux) error {
@@ -84,14 +89,18 @@ func (r *EngineResource) WatchWorldRootSnapshots(
 	req *s4wave_world.WatchWorldRootSnapshotsRequest,
 	stream s4wave_world.SRPCEngineResourceService_WatchWorldRootSnapshotsStream,
 ) error {
+	// Load and emit each changed root snapshot.
 	ctx := stream.Context()
 	var sentSeqno uint64
 	var sent bool
 	for {
+		// Read the current committed root.
 		snapshot, err := r.loadWorldRootSnapshot(ctx)
 		if err != nil {
 			return err
 		}
+
+		// Send a changed snapshot to the client.
 		if !sent || snapshot.GetSeqno() != sentSeqno {
 			if err := stream.Send(snapshot); err != nil {
 				return err
@@ -99,6 +108,8 @@ func (r *EngineResource) WatchWorldRootSnapshots(
 			sentSeqno = snapshot.GetSeqno()
 			sent = true
 		}
+
+		// Wait for the next committed sequence.
 		_, err = r.engine.WaitSeqno(ctx, sentSeqno+1)
 		if err != nil {
 			return err
@@ -108,12 +119,14 @@ func (r *EngineResource) WatchWorldRootSnapshots(
 
 // GetSeqno returns the current seqno of the world state.
 func (r *EngineResource) GetSeqno(ctx context.Context, req *s4wave_world.GetSeqnoRequest) (*s4wave_world.GetSeqnoResponse, error) {
+	// Open a read transaction for the current sequence.
 	wtx, err := r.engine.NewTransaction(ctx, false)
 	if err != nil {
 		return nil, err
 	}
 	defer wtx.Discard()
 
+	// Read the transaction sequence.
 	seqno, err := wtx.GetSeqno(ctx)
 	if err != nil {
 		return nil, err
@@ -124,6 +137,7 @@ func (r *EngineResource) GetSeqno(ctx context.Context, req *s4wave_world.GetSeqn
 
 // Sync fences durable storage and advances the durable head via the engine.
 func (r *EngineResource) Sync(ctx context.Context, req *s4wave_world.SyncRequest) (*s4wave_world.SyncResponse, error) {
+	// Flush durable state and notify browser observers.
 	fenced, err := r.engine.Sync(ctx)
 	if err != nil {
 		return nil, err
@@ -145,6 +159,7 @@ func (r *EngineResource) WaitSeqno(ctx context.Context, req *s4wave_world.WaitSe
 
 // NewTransaction creates a new transaction against the world state.
 func (r *EngineResource) NewTransaction(ctx context.Context, req *s4wave_world.NewTransactionRequest) (*s4wave_world.NewTransactionResponse, error) {
+	// Acquire the resource client and open a transaction.
 	resourceCtx, err := resource_server.MustGetResourceClientContext(ctx)
 	if err != nil {
 		return nil, err
@@ -155,6 +170,7 @@ func (r *EngineResource) NewTransaction(ctx context.Context, req *s4wave_world.N
 		return nil, err
 	}
 
+	// Register the transaction resource with its release hook.
 	txResource := NewTxResource(r.le, r.b, wtx, r.lookupOp, r.engine, r.worldStateOptions...)
 	id, err := resourceCtx.AddResource(txResource.GetMux(), func() {
 		txResource.Release()
@@ -169,6 +185,7 @@ func (r *EngineResource) NewTransaction(ctx context.Context, req *s4wave_world.N
 
 // BuildStorageCursor builds a cursor to the world storage with an empty ref.
 func (r *EngineResource) BuildStorageCursor(ctx context.Context, req *s4wave_world.BuildStorageCursorRequest) (*s4wave_world.BuildStorageCursorResponse, error) {
+	// Acquire the resource client and build a storage cursor.
 	resourceCtx, err := resource_server.MustGetResourceClientContext(ctx)
 	if err != nil {
 		return nil, err
@@ -179,6 +196,7 @@ func (r *EngineResource) BuildStorageCursor(ctx context.Context, req *s4wave_wor
 		return nil, err
 	}
 
+	// Register the cursor resource with its release hook.
 	cursorResource := resource_bucket_lookup.NewBucketLookupCursorResource(r.le, r.b, cursor)
 	id, err := resourceCtx.AddResource(cursorResource.GetMux(), func() {
 		cursor.Release()
@@ -193,6 +211,7 @@ func (r *EngineResource) BuildStorageCursor(ctx context.Context, req *s4wave_wor
 
 // AccessWorldState builds a bucket lookup cursor with an optional ref.
 func (r *EngineResource) AccessWorldState(ctx context.Context, req *s4wave_world.AccessWorldStateRequest) (*s4wave_world.AccessWorldStateResponse, error) {
+	// Acquire the resource client and build a world-state cursor.
 	resourceCtx, err := resource_server.MustGetResourceClientContext(ctx)
 	if err != nil {
 		return nil, err
@@ -207,6 +226,7 @@ func (r *EngineResource) AccessWorldState(ctx context.Context, req *s4wave_world
 		return nil, err
 	}
 
+	// Register the world-state cursor resource.
 	id, err := resourceCtx.AddResource(cursorResource.GetMux(), func() {})
 	if err != nil {
 		return nil, err
@@ -216,18 +236,22 @@ func (r *EngineResource) AccessWorldState(ctx context.Context, req *s4wave_world
 }
 
 func (r *EngineResource) loadWorldRootSnapshot(ctx context.Context) (*s4wave_world.WorldRootSnapshot, error) {
+	// Read the root sequence and storage reference.
 	wtx, err := r.engine.NewTransaction(ctx, false)
 	if err != nil {
 		return nil, err
 	}
 	defer wtx.Discard()
 
+	// Capture the current world sequence.
 	seqno, err := wtx.GetSeqno(ctx)
 	if err != nil {
 		return nil, err
 	}
 	var rootRef *bucket.ObjectRef
 	var storageVolumeID string
+
+	// Read the current root reference and storage volume.
 	err = wtx.AccessWorldState(ctx, nil, func(c *bucket_lookup.Cursor) error {
 		rootRef = c.GetRefWithOpArgs()
 		storageVolumeID = c.GetOpArgs().GetVolumeId()
@@ -236,6 +260,8 @@ func (r *EngineResource) loadWorldRootSnapshot(ctx context.Context) (*s4wave_wor
 	if err != nil {
 		return nil, err
 	}
+
+	// Assemble the root snapshot response.
 	return &s4wave_world.WorldRootSnapshot{
 		RootRef:         rootRef,
 		Seqno:           seqno,
@@ -257,25 +283,23 @@ func (r *EngineResource) WatchWorldState(
 	}
 
 	for {
-		// Create a read transaction to get current world state
+		// Begin a tracked snapshot transaction.
 		wtx, err := r.engine.NewTransaction(ctx, false)
 		if err != nil {
 			return err
 		}
 
-		// Get current world seqno
+		// Capture the current sequence.
 		seqno, err := wtx.GetSeqno(ctx)
 		if err != nil {
 			wtx.Discard()
 			return err
 		}
 
-		// Create new tracked WorldState (empty - no tracking yet).
-		// Client reads use the initial snapshot, while the watcher checks the
-		// current engine state so committed updates can invalidate the snapshot.
+		// Build a tracked WorldState for client reads.
 		trackedWs := NewTrackedWorldState(wtx, world.NewEngineWorldState(r.engine, false), seqno, ctx)
 
-		// Register as a resource
+		// Register the tracked resource.
 		trackedResource := NewEngineWorldStateResource(r.le, r.b, trackedWs, r.lookupOp, r.engine, r.worldStateOptions...)
 		resourceId, err := resourceCtx.AddResource(trackedResource.GetMux(), func() {
 			trackedWs.Close()
@@ -285,7 +309,7 @@ func (r *EngineResource) WatchWorldState(
 			return err
 		}
 
-		// Send resource_id to client
+		// Publish its resource ID.
 		err = stream.Send(&s4wave_world.WatchWorldStateResponse{
 			ResourceId: resourceId,
 		})
@@ -294,27 +318,18 @@ func (r *EngineResource) WatchWorldState(
 			return err
 		}
 
-		// Wait for tracked resources to change
-		// As client calls methods on TrackedWorldState:
-		//   1. Access recorded (e.g., GetObject called)
-		//   2. Snapshot cloned and updated
-		//   3. SetState() called on StateRoutineContainer
-		//   4. StateRoutineContainer compares snapshots (EqualVT)
-		//   5. If different, restarts watchTrackedChanges with new snapshot
-		//   6. watchTrackedChanges checks resources, waits on world seqno
-		//   7. When change detected, returns nil, writes to changeResultCh
-		// WaitForChanges blocks on changeResultCh until change or error
+		// Wait for an observed world change.
 		err = trackedWs.WaitForChanges(ctx)
 
-		// Release the tracked resource
+		// Release the previous tracked resource.
 		_ = resourceCtx.ReleaseResource(resourceId)
 
+		// Return terminal watch errors.
 		if err != nil {
-			// Context canceled or other error
 			return err
 		}
 
-		// Changes detected - loop will create new tracked WorldState (empty)
+		// Continue with a fresh tracked WorldState after a change.
 	}
 }
 

--- a/core/resource/world/tracked-world-state.go
+++ b/core/resource/world/tracked-world-state.go
@@ -41,17 +41,17 @@ func NewTrackedWorldState(ws world.WorldState, watchWs world.WorldState, initial
 		changeResultCh: make(chan error, 1),
 	}
 
-	// Create StateRoutineContainer with protobuf EqualVT comparison
+	// Initialize change detection with snapshot equality.
 	t.stateRoutine = routine.NewStateRoutineContainerVT[*s4wave_world.TrackedWorldStateSnapshot]()
 
-	// Set the state routine function that watches for changes
+	// Publish each watch result to the wait channel.
 	t.stateRoutine.SetStateRoutine(func(ctx context.Context, snapshot *s4wave_world.TrackedWorldStateSnapshot) error {
 		err := watchTrackedChanges(ctx, snapshot, watchWs)
 		if errors.Is(err, context.Canceled) {
 			return err
 		}
 
-		// Write result to channel (nil = changes detected, error = watch failed)
+		// Deliver the watch result without blocking the routine.
 		select {
 		case t.changeResultCh <- err:
 		default:
@@ -59,7 +59,7 @@ func NewTrackedWorldState(ws world.WorldState, watchWs world.WorldState, initial
 		return err
 	})
 
-	// Set context to start the routine
+	// Start change detection under the caller context.
 	t.stateRoutine.SetContext(ctx, false)
 
 	return t
@@ -78,7 +78,7 @@ func (t *TrackedWorldState) WaitForChanges(ctx context.Context) error {
 
 // cloneAndUpdateSnapshot creates a new snapshot with updated tracking data.
 func (t *TrackedWorldState) cloneAndUpdateSnapshot(updateFn func(*s4wave_world.TrackedWorldStateSnapshot)) *s4wave_world.TrackedWorldStateSnapshot {
-	// Clone the current snapshot
+	// Clone the current tracking state.
 	newSnapshot := &s4wave_world.TrackedWorldStateSnapshot{
 		ObjectAccesses: make([]*s4wave_world.TrackedWorldStateSnapshot_ObjectAccess, len(t.currentSnapshot.ObjectAccesses)),
 		HasQuadAccess:  t.currentSnapshot.HasQuadAccess,
@@ -86,7 +86,7 @@ func (t *TrackedWorldState) cloneAndUpdateSnapshot(updateFn func(*s4wave_world.T
 	}
 	copy(newSnapshot.ObjectAccesses, t.currentSnapshot.ObjectAccesses)
 
-	// Apply update
+	// Apply the requested tracking update.
 	updateFn(newSnapshot)
 
 	return newSnapshot
@@ -94,20 +94,18 @@ func (t *TrackedWorldState) cloneAndUpdateSnapshot(updateFn func(*s4wave_world.T
 
 // trackObjectAccess records an object access.
 func (t *TrackedWorldState) trackObjectAccess(key string, rev uint64) {
-	// Clone snapshot and add new access
+	// Clone the current tracking state.
 	newSnapshot := t.cloneAndUpdateSnapshot(func(snap *s4wave_world.TrackedWorldStateSnapshot) {
-		// Check if this key already exists
+		// Update an existing access or append a new entry.
 		found := false
 		for _, objAccess := range snap.ObjectAccesses {
 			if objAccess.Key == key {
-				// Update existing entry
 				objAccess.Rev = rev
 				found = true
 				break
 			}
 		}
 		if !found {
-			// Add new entry
 			snap.ObjectAccesses = append(snap.ObjectAccesses, &s4wave_world.TrackedWorldStateSnapshot_ObjectAccess{
 				Key: key,
 				Rev: rev,
@@ -115,7 +113,7 @@ func (t *TrackedWorldState) trackObjectAccess(key string, rev uint64) {
 		}
 	})
 
-	// Update current snapshot and notify StateRoutine
+	// Publish the updated snapshot.
 	t.currentSnapshot = newSnapshot
 	t.stateRoutine.SetState(newSnapshot)
 }
@@ -128,6 +126,7 @@ func (t *TrackedWorldState) trackObjectBodyAccesses(bodies []*world.ObjectBody) 
 		return
 	}
 
+	// Merge batched body accesses into one tracking snapshot.
 	newSnapshot := t.cloneAndUpdateSnapshot(func(snap *s4wave_world.TrackedWorldStateSnapshot) {
 		existing := make(map[string]*s4wave_world.TrackedWorldStateSnapshot_ObjectAccess, len(snap.ObjectAccesses))
 		for _, objAccess := range snap.ObjectAccesses {
@@ -147,18 +146,19 @@ func (t *TrackedWorldState) trackObjectBodyAccesses(bodies []*world.ObjectBody) 
 		}
 	})
 
+	// Publish the batched snapshot.
 	t.currentSnapshot = newSnapshot
 	t.stateRoutine.SetState(newSnapshot)
 }
 
 // trackQuadQuery records a quad query access.
 func (t *TrackedWorldState) trackQuadQuery() {
-	// Clone snapshot and set quad flag
+	// Mark quad access in a cloned snapshot.
 	newSnapshot := t.cloneAndUpdateSnapshot(func(snap *s4wave_world.TrackedWorldStateSnapshot) {
 		snap.HasQuadAccess = true
 	})
 
-	// Update current snapshot and notify StateRoutine
+	// Publish the updated quad-access snapshot.
 	t.currentSnapshot = newSnapshot
 	t.stateRoutine.SetState(newSnapshot)
 }
@@ -240,7 +240,7 @@ func (t *TrackedWorldState) AccessWorldState(ctx context.Context, ref *bucket.Ob
 func (t *TrackedWorldState) CreateObject(ctx context.Context, key string, rootRef *bucket.ObjectRef) (world.ObjectState, error) {
 	obj, err := t.ws.CreateObject(ctx, key, rootRef)
 	if err == nil {
-		// Track this access
+		// Record the created object's revision.
 		_, rev, _ := obj.GetRootRef(ctx)
 		t.trackObjectAccess(key, rev)
 	}
@@ -250,7 +250,7 @@ func (t *TrackedWorldState) CreateObject(ctx context.Context, key string, rootRe
 func (t *TrackedWorldState) GetObject(ctx context.Context, key string) (world.ObjectState, bool, error) {
 	obj, found, err := t.ws.GetObject(ctx, key)
 	if err == nil {
-		// Track this access even if not found (rev=0 means non-existent)
+		// Record the requested object's revision, including a missing object.
 		rev := uint64(0)
 		if found {
 			_, rev, _ = obj.GetRootRef(ctx)
@@ -392,6 +392,7 @@ func checkTrackedChanges(ctx context.Context, snapshot *s4wave_world.TrackedWorl
 		if refs[i].Exists {
 			currentRev = refs[i].Rev
 		}
+
 		// Detect changes:
 		// - Tracked as non-existent (rev=0) but now exists (currentRev>0)
 		// - Tracked as existing (rev>0) but now deleted (currentRev=0)

--- a/core/resource/world/typed-object.go
+++ b/core/resource/world/typed-object.go
@@ -79,9 +79,12 @@ func newTypedObjectResourceWithContextAndSessionPeerID(
 	sessionPeerID peer.ID,
 	sessionPeerIDBound bool,
 ) *TypedObjectResource {
+	// Normalize the parent context and create resource lifecycle state.
 	if ctx == nil {
 		ctx = context.Background()
 	}
+
+	// Construct the typed-object resource.
 	lifecycleCtx, lifecycleCancel := context.WithCancel(ctx)
 	r := &TypedObjectResource{
 		le:                 le,
@@ -93,10 +96,14 @@ func newTypedObjectResourceWithContextAndSessionPeerID(
 		sessionPeerID:      sessionPeerID,
 		sessionPeerIDBound: sessionPeerIDBound,
 	}
+
+	// Initialize keyed typed-object handles.
 	r.objects = keyed.NewKeyedRefCount(
 		r.buildTypedObjectHandle,
 		keyed.WithExitLoggerWithNameFn[typedObjectResourceKey, *typedObjectHandle](le, typedObjectResourceKey.String),
 	)
+
+	// Start handle tracking under the lifecycle context.
 	r.objects.SetContext(lifecycleCtx, false)
 	return r
 }
@@ -125,28 +132,31 @@ func (r *TypedObjectResource) Close() {
 //   - plugin-dist/{plugin-id}: accesses the plugin's distribution filesystem
 //   - plugin-assets/{plugin-id}: accesses the plugin's assets filesystem
 func (r *TypedObjectResource) AccessTypedObject(ctx context.Context, req *s4wave_world.AccessTypedObjectRequest) (*s4wave_world.AccessTypedObjectResponse, error) {
+	// Acquire the caller resource context.
 	resourceCtx, err := resource_server.MustGetResourceClientContext(ctx)
 	if err != nil {
 		return nil, err
 	}
 
+	// Validate the requested object key.
 	objectKey := req.GetObjectKey()
 	if objectKey == "" {
 		return nil, world.ErrEmptyObjectKey
 	}
 
-	// Check for plugin filesystem prefixes (plugin-dist/*, plugin-assets/*)
+	// Route plugin filesystem prefixes to their specialized resource.
 	_, matchedPrefix := bldr_plugin.ParsePluginUnixfsID(objectKey)
 	if matchedPrefix != "" {
 		return r.accessPluginUnixFS(ctx, resourceCtx, objectKey)
 	}
 
+	// Select the world state used for this access.
 	ws := r.ws
 	if r.engine != nil && r.ws.GetReadOnly() {
 		ws = world.NewEngineWorldState(r.engine, true)
 	}
 
-	// Look up the object to verify it exists
+	// Verify that the object exists.
 	_, found, err := ws.GetObject(ctx, objectKey)
 	if err != nil {
 		return nil, err
@@ -155,7 +165,7 @@ func (r *TypedObjectResource) AccessTypedObject(ctx context.Context, req *s4wave
 		return nil, world.ErrObjectNotFound
 	}
 
-	// Get the object type from graph quads
+	// Resolve the object's graph type.
 	typeID, err := world_types.GetObjectType(ctx, ws, objectKey)
 	if err != nil {
 		return nil, err
@@ -164,6 +174,7 @@ func (r *TypedObjectResource) AccessTypedObject(ctx context.Context, req *s4wave
 		return nil, world_types.ErrUnknownObjectType
 	}
 
+	// Bind trusted session and engine context to the handle key.
 	sessionPeerID := objecttype.SessionPeerIDFromContext(ctx)
 	if r.sessionPeerIDBound {
 		sessionPeerID = r.sessionPeerID
@@ -175,6 +186,8 @@ func (r *TypedObjectResource) AccessTypedObject(ctx context.Context, req *s4wave
 		sessionPeerID: sessionPeerID,
 		engineID:      objecttype.EngineIDFromContext(ctx),
 	}
+
+	// Acquire a shared typed-object handle.
 	ref, handle, _ := r.objects.AddKeyRef(key)
 	if handle == nil {
 		ref.Release()
@@ -185,6 +198,7 @@ func (r *TypedObjectResource) AccessTypedObject(ctx context.Context, req *s4wave
 		return nil, handle.err
 	}
 
+	// Register the typed-object resource and its release callback.
 	id, err := resourceCtx.AddResource(handle.invoker, ref.Release)
 	if err != nil {
 		ref.Release()

--- a/core/resource/world/world-state_test.go
+++ b/core/resource/world/world-state_test.go
@@ -27,6 +27,7 @@ import (
 
 // setupWorldTestbed creates a hydra world testbed and returns it.
 func setupWorldTestbed(ctx context.Context, t *testing.T) (*world_testbed.Testbed, func()) {
+	// Create the World testbed and release callback.
 	tb, err := world_testbed.Default(ctx)
 	if err != nil {
 		t.Fatal(err.Error())
@@ -41,6 +42,7 @@ func setupWorldTestbed(ctx context.Context, t *testing.T) (*world_testbed.Testbe
 
 // setupWorldResourceClient sets up resource client and returns Engine SDK wrapper.
 func setupWorldResourceClient(ctx context.Context, t *testing.T, tb *world_testbed.Testbed) (*resource_client.Client, *s4wave_world.Engine, func()) {
+	// Acquire the resource client and create a World engine.
 	resClient, clientCleanup := resource_testbed.SetupResourceClient(ctx, t, tb)
 
 	rootRef := resClient.AccessRootResource()
@@ -60,6 +62,7 @@ func setupWorldResourceClient(ctx context.Context, t *testing.T, tb *world_testb
 		t.Fatal(err.Error())
 	}
 
+	// Build the engine wrapper and cleanup closure.
 	engineRef := resClient.CreateResourceReference(createWorldResp.ResourceId)
 	engine, err := s4wave_world.NewEngine(resClient, engineRef)
 	if err != nil {
@@ -87,6 +90,7 @@ func TestGraphPathQueryResourceClose(t *testing.T) {
 	resClient, engine, cleanup := setupWorldResourceClient(ctx, t, tb)
 	defer cleanup()
 
+	// Create graph objects and commit their edges.
 	tx, err := engine.NewTransaction(ctx, true)
 	if err != nil {
 		t.Fatal(err.Error())
@@ -110,6 +114,7 @@ func TestGraphPathQueryResourceClose(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
+	// Open a read transaction and execute the graph-path query.
 	readTx, err := engine.NewTransaction(ctx, false)
 	if err != nil {
 		t.Fatal(err.Error())
@@ -137,6 +142,7 @@ func TestGraphPathQueryResourceClose(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
+	// Page and close the query resource.
 	queryRef := resClient.CreateResourceReference(resp.GetResourceId())
 	defer queryRef.Release()
 	queryClient, err := queryRef.GetClient()
@@ -162,6 +168,7 @@ func TestGraphPathQueryResourceClose(t *testing.T) {
 		t.Fatalf("expected closed query to return done, got keys=%#v done=%v", page.GetObjectKeys(), page.GetDone())
 	}
 
+	// Verify canceled and closed resource behavior.
 	resource := resource_world.NewGraphPathQueryResource(nil, nil, &world.GraphPathQueryResult{
 		ObjectKeys: []string{"query/direct"},
 	}, 1)

--- a/core/sobject/journal-crypto.go
+++ b/core/sobject/journal-crypto.go
@@ -81,6 +81,7 @@ func (c *JournalCrypto) SealWithIdentity(kind SOJournalRecordKind, sequence uint
 }
 
 func (c *JournalCrypto) seal(kind SOJournalRecordKind, sequence uint64, key *SOMutationKey, identity, plaintext []byte) (*SOJournalEncryptedPayload, error) {
+	// Validate the journal scope and cipher input.
 	if err := validateJournalScopeKey(c, key); err != nil {
 		return nil, err
 	}
@@ -90,6 +91,8 @@ func (c *JournalCrypto) seal(kind SOJournalRecordKind, sequence uint64, key *SOM
 	if err := validateJournalCipherInput(kind, key, plaintext); err != nil {
 		return nil, err
 	}
+
+	// Construct the authenticated block cipher.
 	block, err := c.newBlock(kind)
 	if err != nil {
 		return nil, err
@@ -98,6 +101,8 @@ func (c *JournalCrypto) seal(kind SOJournalRecordKind, sequence uint64, key *SOM
 	if err != nil {
 		return nil, errors.Wrap(ErrJournalKeyAuthority, "construct journal cipher")
 	}
+
+	// Allocate a unique nonce and authenticated metadata.
 	nonce, err := c.nextNonce()
 	if err != nil {
 		return nil, err
@@ -106,6 +111,8 @@ func (c *JournalCrypto) seal(kind SOJournalRecordKind, sequence uint64, key *SOM
 	if err != nil {
 		return nil, err
 	}
+
+	// Encrypt a scrubbed copy of the plaintext.
 	staged := slices.Clone(plaintext)
 	defer scrub.Scrub(staged)
 	ciphertext := gcm.Seal(nil, nonce[:], staged, aad)
@@ -118,9 +125,12 @@ func (c *JournalCrypto) seal(kind SOJournalRecordKind, sequence uint64, key *SOM
 // SealCheckpointGeneration encrypts a compact snapshot with generation-bound
 // authenticated metadata. The active marker supplies the same tuple on reopen.
 func (c *JournalCrypto) SealCheckpointGeneration(identity []byte, generation, nextSequence uint64, plaintext []byte) ([]byte, error) {
+	// Validate checkpoint generation inputs.
 	if c == nil || len(identity) != sha256.Size || len(plaintext) == 0 {
 		return nil, errors.Wrap(ErrJournalCheckpointCorrupt, "invalid checkpoint generation input")
 	}
+
+	// Construct the checkpoint cipher.
 	block, err := c.newDomainBlock(journalCheckpointDomain)
 	if err != nil {
 		return nil, err
@@ -129,16 +139,22 @@ func (c *JournalCrypto) SealCheckpointGeneration(identity []byte, generation, ne
 	if err != nil {
 		return nil, errors.Wrap(ErrJournalKeyAuthority, "construct checkpoint cipher")
 	}
+
+	// Allocate the nonce and bind the plaintext digest.
 	nonce, err := c.nextNonce()
 	if err != nil {
 		return nil, err
 	}
 	digest := sha256.Sum256(plaintext)
 	aad := journalCheckpointGenerationAAD(c.scopeID, identity, generation, nextSequence, len(plaintext), digest[:])
+
+	// Encrypt a scrubbed checkpoint copy.
 	staged := slices.Clone(plaintext)
 	defer scrub.Scrub(staged)
 	ciphertext := gcm.Seal(nil, nonce[:], staged, aad)
 	payload := &SOJournalEncryptedPayload{Nonce: slices.Clone(nonce[:]), Ciphertext: ciphertext}
+
+	// Marshal the encrypted checkpoint payload.
 	data, err := payload.MarshalVT()
 	if err != nil {
 		return nil, errors.Wrap(ErrJournalCheckpointCorrupt, "marshal encrypted checkpoint")
@@ -149,6 +165,7 @@ func (c *JournalCrypto) SealCheckpointGeneration(identity []byte, generation, ne
 // OpenCheckpointGeneration authenticates a checkpoint against the published
 // identity, generation, sequence, length, and digest tuple.
 func (c *JournalCrypto) OpenCheckpointGeneration(data, identity []byte, generation, nextSequence uint64, snapshotLength int, snapshotDigest []byte) ([]byte, error) {
+	// Validate checkpoint metadata and decode the payload.
 	if c == nil || len(identity) != sha256.Size || snapshotLength <= 0 || len(snapshotDigest) != sha256.Size {
 		return nil, errors.Wrap(ErrJournalCheckpointCorrupt, "invalid checkpoint generation metadata")
 	}
@@ -159,6 +176,8 @@ func (c *JournalCrypto) OpenCheckpointGeneration(data, identity []byte, generati
 	if len(payload.GetNonce()) != journalNonceSize || len(payload.GetCiphertext()) == 0 {
 		return nil, errors.Wrap(ErrJournalCheckpointCorrupt, "invalid encrypted checkpoint")
 	}
+
+	// Construct the checkpoint cipher for decryption.
 	block, err := c.newDomainBlock(journalCheckpointDomain)
 	if err != nil {
 		return nil, err
@@ -167,6 +186,8 @@ func (c *JournalCrypto) OpenCheckpointGeneration(data, identity []byte, generati
 	if err != nil {
 		return nil, errors.Wrap(ErrJournalKeyAuthority, "construct checkpoint cipher")
 	}
+
+	// Authenticate ciphertext length and associated metadata.
 	if len(payload.GetCiphertext())-gcm.Overhead() != snapshotLength {
 		return nil, errors.Wrap(ErrJournalCheckpointCorrupt, "checkpoint length mismatch")
 	}
@@ -175,6 +196,8 @@ func (c *JournalCrypto) OpenCheckpointGeneration(data, identity []byte, generati
 	if err != nil {
 		return nil, errors.Wrap(ErrJournalCheckpointCorrupt, "checkpoint ciphertext authentication failed")
 	}
+
+	// Verify the recovered snapshot digest.
 	digest := sha256.Sum256(plaintext)
 	if !bytes.Equal(digest[:], snapshotDigest) {
 		clear(plaintext)

--- a/core/sobject/journal-frame.go
+++ b/core/sobject/journal-frame.go
@@ -83,11 +83,14 @@ type FileJournalStorage struct {
 
 // OpenFileJournalStorage opens or creates a journal storage file.
 func OpenFileJournalStorage(path string) (*FileJournalStorage, error) {
+	// Inspect the journal path and persisted identity metadata.
 	_, pathErr := os.Stat(path)
 	pathExists := pathErr == nil
 	if pathErr != nil && !os.IsNotExist(pathErr) {
 		return nil, errors.Wrap(ErrJournalCheckpointCorrupt, pathErr.Error())
 	}
+
+	// Load or create the journal identity.
 	identity, initialized, identityExists, err := readJournalIdentityMetadata(path)
 	if err != nil {
 		return nil, err
@@ -116,6 +119,8 @@ func OpenFileJournalStorage(path string) (*FileJournalStorage, error) {
 			return nil, errors.Wrap(ErrJournalCheckpointCorrupt, "initializing journal is nonempty")
 		}
 	}
+
+	// Validate the active generation marker.
 	markerData, markerErr := os.ReadFile(path + ".generation")
 	if markerErr != nil && !os.IsNotExist(markerErr) {
 		return nil, errors.Wrap(ErrJournalCheckpointCorrupt, markerErr.Error())
@@ -123,6 +128,8 @@ func OpenFileJournalStorage(path string) (*FileJournalStorage, error) {
 	if !initialized && len(markerData) > 0 {
 		return nil, errors.Wrap(ErrJournalCheckpointCorrupt, "initializing journal has an active generation")
 	}
+
+	// Open the journal file with restricted permissions.
 	file, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o600)
 	if err != nil {
 		return nil, errors.Wrap(err, "open shared object journal")
@@ -131,6 +138,8 @@ func OpenFileJournalStorage(path string) (*FileJournalStorage, error) {
 		_ = file.Close()
 		return nil, openErr
 	}
+
+	// Verify file metadata before initialization.
 	stat, err := file.Stat()
 	if err != nil {
 		return closeWithError(errors.Wrap(err, "stat shared object journal"))
@@ -138,6 +147,8 @@ func OpenFileJournalStorage(path string) (*FileJournalStorage, error) {
 	if stat.Mode().Perm()&0o077 != 0 {
 		return closeWithError(ErrJournalInsecureFileMode)
 	}
+
+	// Initialize generation metadata for a new journal.
 	if !initialized {
 		if err := ensureJournalGenerationFloor(path, identity, true); err != nil {
 			return closeWithError(err)
@@ -169,6 +180,8 @@ func OpenFileJournalStorage(path string) (*FileJournalStorage, error) {
 	if !initialized {
 		return closeWithError(errors.Wrap(ErrJournalCheckpointCorrupt, "journal identity was not initialized"))
 	}
+
+	// Return the initialized file-backed journal storage.
 	return &FileJournalStorage{file: file, path: path, identity: identity}, nil
 }
 

--- a/core/sobject/journal-phase1_test.go
+++ b/core/sobject/journal-phase1_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestPhase1MutationKeyAndTransitionCorpus(t *testing.T) {
+	// Build mutation keys, lineages, and version fixtures.
 	scope := testScope("scope")
 	keyA := testMutationKey(scope, "peer-a", "same-local")
 	keyB := testMutationKey(scope, "peer-b", "same-local")
@@ -26,6 +27,7 @@ func TestPhase1MutationKeyAndTransitionCorpus(t *testing.T) {
 		t.Fatalf("short origin scope accepted: %v", err)
 	}
 
+	// Append valid intents and verify participant separation.
 	crypto := testJournalCrypto(t, scope)
 	intentA := testIntent(t, crypto, keyA, lineageA, version, 1, "world-neutral-op")
 	intentB := testIntent(t, crypto, keyB, testLineage(keyB, nil), version, 2, "non-world-op")
@@ -40,6 +42,7 @@ func TestPhase1MutationKeyAndTransitionCorpus(t *testing.T) {
 		t.Fatalf("participant-separated attempts = %d, want 2", got)
 	}
 
+	// Reject an envelope with a changed version tuple.
 	badVersion := JournalVersion(4, 2, 3, testDigest("config"))
 	badEnvelope, err := NewJournalEnvelopeRecord(crypto, 3, &SOJournalIntent{Key: keyA, Lineage: lineageA, Version: badVersion, CanonicalOperation: []byte("changed")}, []byte("signed-envelope"), journalDefaultIdentity())
 	if err != nil {
@@ -48,6 +51,8 @@ func TestPhase1MutationKeyAndTransitionCorpus(t *testing.T) {
 	if err := pipeline.appendRecord(badEnvelope); !errors.Is(err, ErrJournalSupersessionImmutable) {
 		t.Fatalf("changed tuple accepted: %v", err)
 	}
+
+	// Append valid terminal evidence and verify checkpoint readiness.
 	validEnvelope, err := NewJournalEnvelopeRecord(crypto, 3, testDecodedIntent(t, crypto, intentA, keyA, lineageA, version, 1), []byte("signed-envelope"), journalDefaultIdentity())
 	if err != nil {
 		t.Fatal(err)
@@ -97,6 +102,7 @@ func TestPhase1MutationKeyAndTransitionCorpus(t *testing.T) {
 		t.Fatal("checkpoint dropped staged or terminal evidence")
 	}
 
+	// Reject transitions with missing or unknown terminal state.
 	illegal := NewJournalReceiptRecord(keyB, testLineage(keyB, nil), version, testReceipt(keyB, []byte("e"), []byte("r"), 1, []byte("root")))
 	illegal.Sequence = uint64(len(pipeline.Replay()) + 1)
 	if err := NewJournalReducer().Apply(illegal); !errors.Is(err, ErrJournalInvalidTransition) {

--- a/core/sobject/recovery.go
+++ b/core/sobject/recovery.go
@@ -23,6 +23,7 @@ func BuildSOEntityRecoveryEnvelope(
 	material *SOEntityRecoveryMaterial,
 	recipientPubs []bifrost_crypto.PubKey,
 ) (*SOEntityRecoveryEnvelope, error) {
+	// Validate recovery inputs and recipients.
 	if entityID == "" {
 		return nil, errors.New("entity id is required")
 	}
@@ -36,12 +37,14 @@ func BuildSOEntityRecoveryEnvelope(
 		return nil, errors.New("at least one recipient pubkey is required")
 	}
 
+	// Marshal and scrub the recovery material.
 	materialData, err := material.MarshalVT()
 	if err != nil {
 		return nil, errors.Wrap(err, "marshal recovery material")
 	}
 	defer scrub.Scrub(materialData)
 
+	// Build one envelope grant for each recipient.
 	grantConfigs := make([]*envelope.EnvelopeGrantConfig, len(recipientPubs))
 	for i := range recipientPubs {
 		grantConfigs[i] = &envelope.EnvelopeGrantConfig{
@@ -54,6 +57,7 @@ func BuildSOEntityRecoveryEnvelope(
 		GrantConfigs: grantConfigs,
 	}
 
+	// Encrypt the recovery payload for all recipients.
 	env, err := envelope.BuildEnvelope(
 		rand.Reader,
 		soEntityRecoveryEnvelopeContext,
@@ -65,11 +69,13 @@ func BuildSOEntityRecoveryEnvelope(
 		return nil, errors.Wrap(err, "build recovery envelope")
 	}
 
+	// Marshal the encrypted envelope.
 	envData, err := env.MarshalVT()
 	if err != nil {
 		return nil, errors.Wrap(err, "marshal recovery envelope")
 	}
 
+	// Return the envelope with config-chain identity.
 	return &SOEntityRecoveryEnvelope{
 		EntityId:         entityID,
 		KeyEpoch:         keyEpoch,
@@ -81,6 +87,7 @@ func BuildSOEntityRecoveryEnvelope(
 
 // UnlockSOEntityRecoveryEnvelope decrypts a recovery envelope into recovery material.
 func UnlockSOEntityRecoveryEnvelope(entityPrivKeys []bifrost_crypto.PrivKey, env *SOEntityRecoveryEnvelope) (*SOEntityRecoveryMaterial, error) {
+	// Validate and decode the recovery envelope.
 	if env == nil {
 		return nil, errors.New("recovery envelope is required")
 	}
@@ -88,16 +95,19 @@ func UnlockSOEntityRecoveryEnvelope(entityPrivKeys []bifrost_crypto.PrivKey, env
 		return nil, ErrSharedObjectRecoveryCredentialRequired
 	}
 
+	// Read and authenticate the envelope payload.
 	data := env.GetEnvelopeData()
 	if len(data) == 0 {
 		return nil, errors.New("recovery envelope data is required")
 	}
 
+	// Decode the recovery envelope message.
 	envMsg := &envelope.Envelope{}
 	if err := envMsg.UnmarshalVT(data); err != nil {
 		return nil, errors.Wrap(err, "unmarshal recovery envelope")
 	}
 
+	// Unlock the envelope with entity keys.
 	payload, result, err := envelope.UnlockEnvelope(
 		soEntityRecoveryEnvelopeContext,
 		envMsg,
@@ -111,6 +121,7 @@ func UnlockSOEntityRecoveryEnvelope(entityPrivKeys []bifrost_crypto.PrivKey, env
 	}
 	defer scrub.Scrub(payload)
 
+	// Decode the recovered material.
 	material := &SOEntityRecoveryMaterial{}
 	if err := material.UnmarshalVT(payload); err != nil {
 		return nil, errors.Wrap(err, "unmarshal recovery material")
@@ -127,6 +138,7 @@ func BuildSelfEnrollPeerConfigChange(
 	entityID string,
 	role SOParticipantRole,
 ) (*SOConfigChange, error) {
+	// Validate self-enrollment inputs.
 	if currentCfg == nil {
 		return nil, errors.New("current config is required")
 	}
@@ -143,12 +155,15 @@ func BuildSelfEnrollPeerConfigChange(
 		return nil, err
 	}
 
+	// Append the enrolling peer to the next configuration.
 	nextCfg := currentCfg.CloneVT()
 	nextCfg.Participants = append(nextCfg.Participants, &SOParticipantConfig{
 		PeerId:   signerPeerID,
 		Role:     role,
 		EntityId: entityID,
 	})
+
+	// Sign the self-enrollment configuration change.
 	return BuildSOConfigChange(
 		currentCfg,
 		nextCfg,
@@ -196,11 +211,13 @@ func ResolveSharedObjectRecoveryMaterial(
 	provAcc provider.ProviderAccount,
 	ref *SharedObjectRef,
 ) (*SOEntityRecoveryMaterial, error) {
+	// Resolve the recovery provider feature.
 	recoveryProv, err := GetSharedObjectRecoveryProviderAccountFeature(ctx, provAcc)
 	if err != nil {
 		return nil, err
 	}
 
+	// Resolve the current entity identity.
 	entityID, err := recoveryProv.GetSelfEntityID(ctx)
 	if err != nil {
 		return nil, err
@@ -209,6 +226,7 @@ func ResolveSharedObjectRecoveryMaterial(
 		return nil, errors.New("self entity id is required")
 	}
 
+	// Read and validate the recovery envelope.
 	env, err := recoveryProv.ReadSharedObjectRecoveryEnvelope(ctx, ref)
 	if err != nil {
 		return nil, err
@@ -217,11 +235,13 @@ func ResolveSharedObjectRecoveryMaterial(
 		return nil, ErrSharedObjectRecoveryEntityMismatch
 	}
 
+	// Acquire the recovery decoder.
 	dec, err := recoveryProv.GetSharedObjectRecoveryDecoder(ctx)
 	if err != nil {
 		return nil, err
 	}
 
+	// Decrypt and validate recovered material.
 	material, err := dec.DecryptSharedObjectRecoveryEnvelope(ctx, env)
 	if err != nil {
 		return nil, err

--- a/core/sobject/recovery_test.go
+++ b/core/sobject/recovery_test.go
@@ -49,6 +49,7 @@ func (a *fakeProviderAccount) GetProviderAccountFeature(ctx context.Context, fea
 }
 
 func TestResolveSharedObjectRecoveryMaterial(t *testing.T) {
+	// Build a provider-backed recovery fixture.
 	ctx := context.Background()
 	entityID := "entity-1"
 	expected := &SOEntityRecoveryMaterial{
@@ -67,10 +68,13 @@ func TestResolveSharedObjectRecoveryMaterial(t *testing.T) {
 		},
 	}
 
+	// Resolve recovery material through the provider feature.
 	got, err := ResolveSharedObjectRecoveryMaterial(ctx, provAcc, &SharedObjectRef{})
 	if err != nil {
 		t.Fatalf("ResolveSharedObjectRecoveryMaterial: %v", err)
 	}
+
+	// Verify the recovered entity identity.
 	if got.GetEntityId() != expected.GetEntityId() {
 		t.Fatalf("expected entity id %q, got %q", expected.GetEntityId(), got.GetEntityId())
 	}

--- a/core/space/migration/planner.go
+++ b/core/space/migration/planner.go
@@ -45,6 +45,7 @@ func NewPlanner(registry *Registry) *Planner {
 
 // Plan scans both Worlds and returns a deterministic preview.
 func (p *Planner) Plan(ctx context.Context, input *PlannerInput) (*MigrationPreview, error) {
+	// Validate planner inputs and normalize the requested migration operation.
 	if p == nil || p.registry == nil {
 		return nil, errors.New("migration registry is required")
 	}
@@ -62,6 +63,7 @@ func (p *Planner) Plan(ctx context.Context, input *PlannerInput) (*MigrationPrev
 		return nil, errors.Wrapf(ErrUnknownOperation, "%d", input.Operation)
 	}
 
+	// Read source and destination revisions for the preview.
 	sourceRevision, err := input.Source.GetSeqno(ctx)
 	if err != nil {
 		return nil, err
@@ -70,6 +72,8 @@ func (p *Planner) Plan(ctx context.Context, input *PlannerInput) (*MigrationPrev
 	if err != nil {
 		return nil, err
 	}
+
+	// Scan both Worlds into object descriptors.
 	source, err := scanWorld(ctx, input.Source)
 	if err != nil {
 		return nil, err
@@ -78,6 +82,8 @@ func (p *Planner) Plan(ctx context.Context, input *PlannerInput) (*MigrationPrev
 	if err != nil {
 		return nil, err
 	}
+
+	// Resolve the block-store identities used by each World.
 	sourceBlockStoreID, err := owningBlockStoreID(ctx, input.Source, source, "source")
 	if err != nil {
 		return nil, err
@@ -86,6 +92,8 @@ func (p *Planner) Plan(ctx context.Context, input *PlannerInput) (*MigrationPrev
 	if err != nil {
 		return nil, err
 	}
+
+	// Index source objects and initialize closure diagnostics.
 	objects := make(map[string]*ObjectDescriptor, len(source))
 	for _, object := range source {
 		objects[object.ObjectKey] = object
@@ -95,6 +103,8 @@ func (p *Planner) Plan(ctx context.Context, input *PlannerInput) (*MigrationPrev
 	conflicts := make([]*MigrationConflict, 0)
 	closure := make(map[string]struct{}, len(selected))
 	queue := append([]string(nil), selected...)
+
+	// Traverse selected objects and collect dependency closure diagnostics.
 	for len(queue) > 0 {
 		key := queue[0]
 		queue = queue[1:]
@@ -168,6 +178,7 @@ func (p *Planner) Plan(ctx context.Context, input *PlannerInput) (*MigrationPrev
 		}
 	}
 
+	// Sort the closure and initialize identity mappings.
 	closureKeys := make([]string, 0, len(closure))
 	for key := range closure {
 		closureKeys = append(closureKeys, key)
@@ -177,6 +188,8 @@ func (p *Planner) Plan(ctx context.Context, input *PlannerInput) (*MigrationPrev
 	mapping.SpaceIDs[input.SourceSpaceID] = input.DestinationSpaceID
 	mapping.BlockStoreIDs[sourceBlockStoreID] = destinationBlockStoreID
 	canvasCombineKeys := make(map[string]bool)
+
+	// Detect Canvas collisions that support identity combination.
 	for _, key := range closureKeys {
 		object := objects[key]
 		destinationObject := destination[key]
@@ -188,6 +201,8 @@ func (p *Planner) Plan(ctx context.Context, input *PlannerInput) (*MigrationPrev
 			canvasCombineKeys[key] = true
 		}
 	}
+
+	// Translate each object's typed references into destination identities.
 	for _, key := range closureKeys {
 		mapping.ObjectKeys[key] = key
 		object := objects[key]
@@ -207,7 +222,7 @@ func (p *Planner) Plan(ctx context.Context, input *PlannerInput) (*MigrationPrev
 						Code:       "block-store-mismatch",
 						ObjectType: object.ObjectType,
 						ObjectKeys: []string{key},
-						Detail:     "typed block-store reference does not belong to the source World owner",
+						Detail:     "typed block-store reference does not belong to the source World",
 					})
 					continue
 				}
@@ -216,6 +231,7 @@ func (p *Planner) Plan(ctx context.Context, input *PlannerInput) (*MigrationPrev
 		}
 	}
 
+	// Resolve destination-key collisions and record blockers.
 	for _, key := range closureKeys {
 		object := objects[key]
 		destinationObject := destination[key]
@@ -280,6 +296,7 @@ func (p *Planner) Plan(ctx context.Context, input *PlannerInput) (*MigrationPrev
 		}
 	}
 
+	// Expand renamed parent keys to their dependent child keys.
 	for _, key := range closureKeys {
 		if mapping.ObjectKeys[key] != key {
 			continue
@@ -296,6 +313,8 @@ func (p *Planner) Plan(ctx context.Context, input *PlannerInput) (*MigrationPrev
 			mapping.ObjectKeys[key] = bestDestination + key[len(bestSource):]
 		}
 	}
+
+	// Detect duplicate destination keys and populate graph IRIs.
 	seenDestinationKeys := make(map[string]string, len(closureKeys))
 	for _, key := range closureKeys {
 		destinationKey := mapping.ObjectKeys[key]
@@ -320,6 +339,7 @@ func (p *Planner) Plan(ctx context.Context, input *PlannerInput) (*MigrationPrev
 		mapping.GraphIRIs["<"+source+">"] = "<" + destinationKey + ">"
 	}
 
+	// Assemble deterministic identity-mapping records.
 	identityMappings := make([]*MigrationIdentityMapping, 0)
 	for _, key := range closureKeys {
 		identityMappings = append(identityMappings, &MigrationIdentityMapping{
@@ -334,6 +354,7 @@ func (p *Planner) Plan(ctx context.Context, input *PlannerInput) (*MigrationPrev
 	appendIdentityMappings(&identityMappings, MigrationReferenceKind_MIGRATION_REFERENCE_KIND_GRAPH_IRI, mapping.GraphIRIs)
 	slices.SortStableFunc(identityMappings, compareIdentityMappings)
 
+	// Assemble planned object metadata.
 	planObjects := make([]*MigrationObject, 0, len(closureKeys))
 	for _, key := range closureKeys {
 		object := objects[key]
@@ -345,6 +366,8 @@ func (p *Planner) Plan(ctx context.Context, input *PlannerInput) (*MigrationPrev
 			LogicalBytes: object.LogicalBytes,
 		})
 	}
+
+	// Rewrite migratable objects against the destination identity map.
 	for _, key := range closureKeys {
 		object := objects[key]
 		handler := p.registry.Lookup(object.ObjectType)
@@ -360,12 +383,14 @@ func (p *Planner) Plan(ctx context.Context, input *PlannerInput) (*MigrationPrev
 			})
 		}
 	}
+
+	// Sum logical bytes and apply capacity blockers.
 	logicalBytes := uint64(0)
 	logicalOverflow := false
 	for _, key := range closureKeys {
 		object := objects[key]
 		if !object.LogicalBytesKnown {
-			blockers = append(blockers, &MigrationBlocker{Code: "logical-size-unavailable", ObjectKeys: []string{key}, Detail: "the immutable block-store DAG size owner could not provide a logical byte total"})
+			blockers = append(blockers, &MigrationBlocker{Code: "logical-size-unavailable", ObjectKeys: []string{key}, Detail: "the immutable block-store DAG size provider could not provide a logical byte total"})
 			continue
 		}
 		size := object.LogicalBytes
@@ -381,6 +406,8 @@ func (p *Planner) Plan(ctx context.Context, input *PlannerInput) (*MigrationPrev
 	if input.CapacityKnown && input.DestinationCapacity < logicalBytes {
 		blockers = append(blockers, &MigrationBlocker{Code: "destination-capacity", Detail: "available destination capacity is below the estimated logical bytes"})
 	}
+
+	// Sort diagnostics and choose the terminal preview state.
 	slices.SortStableFunc(blockers, compareBlockers)
 	slices.SortStableFunc(conflicts, compareConflicts)
 	result := &MigrationTerminalResult{State: MigrationTerminalState_MIGRATION_TERMINAL_STATE_PREVIEW_READY}
@@ -389,6 +416,8 @@ func (p *Planner) Plan(ctx context.Context, input *PlannerInput) (*MigrationPrev
 		result.Code = "preview-blocked"
 		result.Detail = blockerDetail(blockers[0])
 	}
+
+	// Assemble the preview and compute its digest.
 	preview := &MigrationPreview{
 		Operation:           operation,
 		SourceSpaceId:       input.SourceSpaceID,
@@ -405,6 +434,8 @@ func (p *Planner) Plan(ctx context.Context, input *PlannerInput) (*MigrationPrev
 		CapacityKnown:       input.CapacityKnown,
 	}
 	preview.Digest = digestPreview(preview)
+
+	// Return a blocked preview or the ready preview.
 	if len(blockers) > 0 {
 		if input.CapacityKnown && input.DestinationCapacity < logicalBytes {
 			return preview, errors.Wrap(ErrCapacityInsufficient, result.Detail)

--- a/core/space/migration/planner_test.go
+++ b/core/space/migration/planner_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 func TestPlannerDeterminismClosureAndTypedMappings(t *testing.T) {
+	// Initialize source and destination World testbeds.
 	ctx := context.Background()
 	source, err := world_testbed.Default(ctx)
 	if err != nil {
@@ -32,6 +33,7 @@ func TestPlannerDeterminismClosureAndTypedMappings(t *testing.T) {
 	}
 	defer destination.Release()
 
+	// Populate the source closure and construct the planner.
 	setObject(t, ctx, source.WorldState, "root", s4wave_kv_world.KvStoreTypeID)
 	setObject(t, ctx, source.WorldState, "child", s4wave_kv_world.KvStoreTypeID)
 	setObject(t, ctx, source.WorldState, "secret", s4wave_kv_world.KvStoreTypeID)
@@ -47,6 +49,8 @@ func TestPlannerDeterminismClosureAndTypedMappings(t *testing.T) {
 		Destination:        destination.WorldState,
 		SelectedObjectKeys: []string{"root"},
 	}
+
+	// Plan twice and compare deterministic output.
 	first, err := planner.Plan(ctx, input)
 	if err != nil {
 		t.Fatal(err)
@@ -55,6 +59,8 @@ func TestPlannerDeterminismClosureAndTypedMappings(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// Verify closure totals and identity mappings.
 	if first.Digest != second.Digest {
 		t.Fatalf("digest changed between identical plans: %s != %s", first.Digest, second.Digest)
 	}
@@ -67,6 +73,7 @@ func TestPlannerDeterminismClosureAndTypedMappings(t *testing.T) {
 }
 
 func TestPlannerRefusesUnknownAndInsufficientCapacity(t *testing.T) {
+	// Initialize testbeds for blocker and capacity cases.
 	ctx := context.Background()
 	source, err := world_testbed.Default(ctx)
 	if err != nil {
@@ -78,6 +85,8 @@ func TestPlannerRefusesUnknownAndInsufficientCapacity(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer destination.Release()
+
+	// Plan an unknown object and verify its blocker.
 	setObject(t, ctx, source.WorldState, "unknown", "plugin/unknown")
 	registry, err := space_migration.BuiltInRegistry()
 	if err != nil {
@@ -103,6 +112,7 @@ func TestPlannerRefusesUnknownAndInsufficientCapacity(t *testing.T) {
 		t.Fatalf("unknown type blocker = %#v", preview.GetBlockers())
 	}
 
+	// Plan a known object against insufficient destination capacity.
 	setObject(t, ctx, source.WorldState, "known", s4wave_kv_world.KvStoreTypeID)
 	preview, err = planner.Plan(ctx, &space_migration.PlannerInput{
 		SourceSpaceID:       "source-space",
@@ -122,6 +132,7 @@ func TestPlannerRefusesUnknownAndInsufficientCapacity(t *testing.T) {
 }
 
 func TestPlannerRejectsStaleWorld(t *testing.T) {
+	// Initialize worlds and a baseline preview.
 	ctx := context.Background()
 	source, err := world_testbed.Default(ctx)
 	if err != nil {
@@ -147,6 +158,8 @@ func TestPlannerRejectsStaleWorld(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// Mutate the source after planning and reject the stale preview.
 	setObject(t, ctx, source.WorldState, "later", s4wave_kv_world.KvStoreTypeID)
 	if err := planner.VerifyFresh(ctx, input, preview); !errors.Is(err, space_migration.ErrStalePlan) {
 		t.Fatalf("stale verification error = %v, want ErrStalePlan", err)

--- a/core/transport/transport.go
+++ b/core/transport/transport.go
@@ -395,6 +395,7 @@ func (t *SessionTransport) publishStartupReady() {
 // Execute creates the child bus with bifrost transport controllers and
 // blocks until ctx is canceled.
 func (t *SessionTransport) Execute(ctx context.Context) (err error) {
+	// Initialize cancellation and publish startup state.
 	ctx, cancel := context.WithCancel(ctx)
 	t.ensureStartupDeadline(ctx)
 	var startupStopped bool
@@ -431,8 +432,8 @@ func (t *SessionTransport) Execute(ctx context.Context) (err error) {
 		}()
 	}
 
+	// Create the child bus and its controller infrastructure.
 	t.setStartupStage("child-bus")
-	// Create child bus with loader and resolver infrastructure.
 	b, sr, err := cbc.NewCoreBus(ctx, le)
 	if err != nil {
 		return err
@@ -450,6 +451,7 @@ func (t *SessionTransport) Execute(ctx context.Context) (err error) {
 	}()
 
 	t.setStartupStage("bridge")
+
 	// Bridge directives from child to parent.
 	bridge := bus_bridge.NewBusBridge(t.parentBus, func(di directive.Instance) (bool, error) {
 		if t.bridgeFilter != nil {
@@ -469,6 +471,7 @@ func (t *SessionTransport) Execute(ctx context.Context) (err error) {
 	}
 
 	t.setStartupStage("peer-controller")
+
 	// Register peer controller with the session's private key.
 	sessionPeer, err := peer.NewPeer(t.sessionKey)
 	if err != nil {
@@ -480,6 +483,7 @@ func (t *SessionTransport) Execute(ctx context.Context) (err error) {
 	}
 
 	t.setStartupStage("factories")
+
 	// Register bifrost transport factories on the child bus.
 	for _, factory := range sessionTransportFactories(b) {
 		sr.AddFactory(factory)
@@ -488,6 +492,7 @@ func (t *SessionTransport) Execute(ctx context.Context) (err error) {
 	sr.AddFactory(dex_solicit.NewFactory(b))
 
 	t.setStartupStage("solicit-controller")
+
 	// Start solicit controller for bilateral stream matching.
 	_, _, solicitRef, err := loader.WaitExecControllerRunning(
 		ctx, b,

--- a/core/transport/transport_startup_test.go
+++ b/core/transport/transport_startup_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestSessionTransportStartupTimeoutCannotBeOverwrittenByReady(t *testing.T) {
+	// Initialize startup state and admit the timeout.
 	st := &SessionTransport{startupTimeout: time.Second}
 	st.setStartupStage("ready")
 
@@ -18,6 +19,7 @@ func TestSessionTransportStartupTimeoutCannotBeOverwrittenByReady(t *testing.T) 
 		t.Fatal("expected startup timeout admission")
 	}
 
+	// Attempt readiness publication after terminal timeout.
 	st.publishStartupReady()
 
 	if st.startupReady {
@@ -30,6 +32,7 @@ func TestSessionTransportStartupTimeoutCannotBeOverwrittenByReady(t *testing.T) 
 }
 
 func TestSessionTransportPublicationWinsInternalDeadlineCancellation(t *testing.T) {
+	// Define terminal publication cases.
 	terminalErr := errors.New("terminal startup")
 	tests := []struct {
 		name      string
@@ -67,6 +70,8 @@ func TestSessionTransportPublicationWinsInternalDeadlineCancellation(t *testing.
 			wantError: errSignalTicketUnauthorized.Error(),
 		},
 	}
+
+	// Run each publication case behind a captured wait epoch.
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx, cancel := context.WithTimeout(t.Context(), time.Second)
@@ -88,6 +93,7 @@ func TestSessionTransportPublicationWinsInternalDeadlineCancellation(t *testing.
 				})
 			}()
 
+			// Wait for the readiness snapshot before publishing the result.
 			select {
 			case <-snapshot:
 			case <-ctx.Done():
@@ -96,6 +102,7 @@ func TestSessionTransportPublicationWinsInternalDeadlineCancellation(t *testing.
 			tt.publish(st)
 			close(release)
 
+			// Assert the admitted terminal outcome.
 			select {
 			case err := <-done:
 				if !tt.check(err) {
@@ -109,6 +116,7 @@ func TestSessionTransportPublicationWinsInternalDeadlineCancellation(t *testing.
 }
 
 func TestSessionTransportCancellationDoesNotAdmitStartupTimeout(t *testing.T) {
+	// Initialize cancellation and the transport deadline.
 	callerCtx, callerCancel := context.WithCancel(t.Context())
 	defer callerCancel()
 	st := &SessionTransport{startupTimeout: time.Second}
@@ -117,6 +125,7 @@ func TestSessionTransportCancellationDoesNotAdmitStartupTimeout(t *testing.T) {
 	st.ensureStartupDeadline(startupCtx)
 	st.cancelStartupDeadline()
 
+	// Await readiness after caller cancellation.
 	err := st.awaitReady(callerCtx, callerCancel)
 	if !errors.Is(err, context.Canceled) {
 		t.Fatalf("AwaitReady returned %v after owner cancellation, want context canceled", err)

--- a/db/block/blob/blob.go
+++ b/db/block/blob/blob.go
@@ -53,6 +53,7 @@ func (b BlobType) Validate() error {
 // FetchToBuffer fetches a full blob to a buffer.
 // Note: the block cursor context is also used.
 func FetchToBuffer(ctx context.Context, bcs *block.Cursor, buf *bytes.Buffer) error {
+	// Decode and validate the root before selecting its storage representation.
 	root, err := UnmarshalBlob(ctx, bcs)
 	if err != nil {
 		return err
@@ -61,15 +62,18 @@ func FetchToBuffer(ctx context.Context, bcs *block.Cursor, buf *bytes.Buffer) er
 		return err
 	}
 
+	// Skip storage reads for an empty blob.
 	if root.GetTotalSize() == 0 {
 		return nil
 	}
 
+	// Copy raw bytes directly or stream chunk data through a blob reader.
 	switch root.GetBlobType() {
 	case BlobType_BlobType_RAW:
 		if root.GetTotalSize() > math.MaxInt {
 			return errors.New("total size exceeds maximum")
 		}
+
 		if len(root.GetRawData()) != int(root.GetTotalSize()) { //nolint:gosec
 			return errors.Errorf(
 				"raw blob size mismatch: %d != actual %d",
@@ -96,6 +100,7 @@ func FetchToBuffer(ctx context.Context, bcs *block.Cursor, buf *bytes.Buffer) er
 
 // FetchToBytes fetches to a bytes slice.
 func FetchToBytes(ctx context.Context, bcs *block.Cursor) ([]byte, error) {
+	// Fetch the complete blob into a temporary buffer before returning bytes.
 	var buf bytes.Buffer
 	if err := FetchToBuffer(ctx, bcs, &buf); err != nil {
 		return nil, err
@@ -115,6 +120,7 @@ func (b *Blob) IsNil() bool {
 
 // Validate performs cursory validation of the Blob object.
 func (b *Blob) Validate() error {
+	// Validate empty-state fields before checking representation-specific data.
 	blobType := b.GetBlobType()
 	if b.GetTotalSize() == 0 {
 		if blobType != 0 {
@@ -125,10 +131,13 @@ func (b *Blob) Validate() error {
 			return errors.Wrap(err, "blob_type")
 		}
 	}
+
+	// Validate raw payload size and reject raw bytes on chunked blobs.
 	if blobType == BlobType_BlobType_RAW {
 		if b.GetTotalSize() > math.MaxInt {
 			return errors.New("total size exceeds maximum")
 		}
+
 		if len(b.GetRawData()) != int(b.GetTotalSize()) { //nolint:gosec
 			return ErrRawBlobSizeMismatch
 		}
@@ -136,6 +145,7 @@ func (b *Blob) Validate() error {
 		return errors.New("raw_data field must be empty for non-raw blob")
 	}
 
+	// Require an empty chunk index for non-chunked values.
 	if blobType != BlobType_BlobType_CHUNKED {
 		if len(b.GetChunkIndex().GetChunks()) != 0 {
 			return errors.New("expected empty chunks field for non-chunked blob type")
@@ -158,19 +168,19 @@ func (b *Blob) ComputeStorageSize(
 ) (uint64, uint64, error) {
 	var storageSize uint64
 
-	// add the size of the root block
+	// Fetch the root block so its encoded bytes contribute to storage size.
 	rootData, _, err := bcs.Fetch(ctx)
 	if err != nil {
 		return 0, 0, err
 	}
 	storageSize += uint64(len(rootData))
 
+	// Return root-only size for raw blobs and deduplicate chunk storage sizes.
 	if b.GetBlobType() != BlobType_BlobType_CHUNKED {
 		return storageSize, storageSize, nil
 	}
 
-	// if chunked, add the size of each chunk
-	// assume raw chunks (avoid fetching them)
+	// Add chunk payload sizes without fetching chunk bodies.
 	totalSize := storageSize
 	seenBlocks := make(map[string]struct{})
 	for _, chunk := range b.GetChunkIndex().GetChunks() {
@@ -182,10 +192,13 @@ func (b *Blob) ComputeStorageSize(
 		if dataRefStr == "" {
 			continue
 		}
+
+		// Count each content-addressed chunk block once for physical storage.
 		if _, ok := seenBlocks[dataRefStr]; ok {
 			continue
 		}
 		seenBlocks[dataRefStr] = struct{}{}
+
 		// assume storage block size == chunk size
 		storageSize += blobSize
 	}
@@ -196,6 +209,7 @@ func (b *Blob) ComputeStorageSize(
 // Depending on the blob implementation this will fetch data.
 // The block cursor should be located at the blob root.
 func (b *Blob) ValidateFull(ctx context.Context, bcs *block.Cursor) error {
+	// Validate root metadata before deciding whether chunk data can be read.
 	if err := b.GetBlobType().Validate(); err != nil {
 		return err
 	}
@@ -204,6 +218,7 @@ func (b *Blob) ValidateFull(ctx context.Context, bcs *block.Cursor) error {
 	if b.GetTotalSize() > math.MaxInt64 {
 		return errors.New("total size exceeds maximum")
 	}
+
 	totalSize := int64(b.GetTotalSize()) //nolint:gosec
 	if totalSize == 0 {
 		if blobType != BlobType_BlobType_RAW {
@@ -212,6 +227,7 @@ func (b *Blob) ValidateFull(ctx context.Context, bcs *block.Cursor) error {
 		return nil
 	}
 
+	// Validate raw payloads directly before requiring a cursor for chunks.
 	rdLen := len(b.GetRawData())
 	if blobType == BlobType_BlobType_RAW {
 		if len(b.GetRawData()) != int(totalSize) {
@@ -227,11 +243,12 @@ func (b *Blob) ValidateFull(ctx context.Context, bcs *block.Cursor) error {
 		return errors.New("non-raw blob type: raw data field should be empty")
 	}
 
-	// if we have no block cursor, skip remaining checks.
+	// Without a cursor, validate the root fields but skip chunk reads.
 	if bcs == nil {
 		return nil
 	}
 
+	// Stream every chunk and enforce the declared total size.
 	// fetch all of the chunked data w/o errors
 	rdr, err := NewReader(ctx, bcs)
 	if err != nil {
@@ -246,6 +263,7 @@ func (b *Blob) ValidateFull(ctx context.Context, bcs *block.Cursor) error {
 		if err != nil && err != io.EOF {
 			return err
 		}
+
 		// expect to read exactly totalSize
 		if rn == 0 {
 			return errors.Errorf("blob: eof before end of blob: %d < expected %d", readn, totalSize)
@@ -261,6 +279,7 @@ func (b *Blob) ValidateFull(ctx context.Context, bcs *block.Cursor) error {
 // WriteChunkIndex builds and writes the chunk index to the blob.
 // bcs must be located at the blob.
 func (b *Blob) WriteChunkIndex(ctx context.Context, bcs *block.Cursor, opts *BuildBlobOpts, rdr io.Reader) error {
+	// Build the chunk index and update the blob's chunked metadata.
 	chkIdxBcs := bcs.FollowSubBlock(4)
 	nChunkIndex, nTotalSize, err := BuildChunkIndex(
 		ctx,
@@ -284,16 +303,19 @@ func (b *Blob) AppendData(
 	bcs *block.Cursor,
 	opts *BuildBlobOpts,
 ) error {
+	// Resolve append mode from the high-water mark and existing blob type.
 	hwm := opts.GetRawHighWaterMark()
 	if hwm == 0 {
 		hwm = DefRawHighWaterMark
 	}
 
+	// Extend raw data in place when the next size stays below the high-water mark.
 	oldLen := b.GetTotalSize()
+
 	nextLen := oldLen + uint64(dataLen) //nolint:gosec
 	if b.GetBlobType() == BlobType_BlobType_RAW {
 		if nextLen <= hwm {
-			// append to existing raw data blob
+			// Extend the raw buffer while it remains below the high-water mark.
 			ndata := make([]byte, nextLen)
 			_, err := io.ReadAtLeast(rdr, ndata[oldLen:], int(dataLen))
 			if err != nil {
@@ -303,7 +325,7 @@ func (b *Blob) AppendData(
 			b.RawData = ndata
 			b.TotalSize = nextLen
 		} else {
-			// create a new chunked blob
+			// Rechunk the existing raw bytes together with the appended reader.
 			mrdr := io.MultiReader(
 				bytes.NewReader(b.GetRawData()),
 				io.LimitReader(rdr, dataLen),
@@ -318,6 +340,7 @@ func (b *Blob) AppendData(
 		return nil
 	}
 
+	// Reject unsupported types before preparing the existing chunk index.
 	if b.GetBlobType() != BlobType_BlobType_CHUNKED {
 		return errors.Errorf("cannot extend blob type: %s", b.GetBlobType().String())
 	}
@@ -335,23 +358,26 @@ func (b *Blob) AppendData(
 		return b.WriteChunkIndex(ctx, bcs, opts, io.LimitReader(rdr, dataLen))
 	}
 
+	// Remove the final chunk so its data can be combined with appended input.
 	chunksSet := NewChunkSet(&chunks, chkIdxBcs.FollowSubBlock(1))
 
-	// remove the last chunk
+	// Remove the last chunk so its bytes can be combined with new input.
 	lastChunkIdx := len(chunks) - 1
 	lastChunk := chunks[lastChunkIdx]
 	_, lastChunkBcs := chunksSet.Get(lastChunkIdx)
+
 	chunksSet.GetCursor().ClearRef(uint32(lastChunkIdx)) //nolint:gosec
 	chunks = chunks[:lastChunkIdx]
 	b.ChunkIndex.Chunks = chunks
 
-	// fetch last chunk data
+	// Fetch the removed tail and rebuild the chunk index with new input.
+	// Fetch the removed chunk before rebuilding the tail index.
 	lastChunkData, err := lastChunk.FetchData(ctx, lastChunkBcs, false)
 	if err != nil {
 		return err
 	}
 
-	// build new chunk index with last chunk + new data
+	// Rebuild the chunk index from the old tail and appended data.
 	chkIdx, totalSize, err := BuildChunkIndex(
 		ctx,
 		io.MultiReader(bytes.NewReader(lastChunkData), io.LimitReader(rdr, dataLen)),
@@ -368,15 +394,18 @@ func (b *Blob) AppendData(
 
 // Truncate changes the length of the blob.
 func (b *Blob) Truncate(ctx context.Context, bcs *block.Cursor, blobOpts *BuildBlobOpts, nsize int64) error {
+	// Validate size bounds before selecting clear, raw, or chunked truncation.
 	if b.GetTotalSize() > math.MaxInt64 {
 		return errors.New("total size exceeds maximum")
 	}
+
+	// Clear all references and metadata when truncating to an empty blob.
 	oldSize := int64(b.GetTotalSize()) //nolint:gosec
 	if oldSize == nsize {
 		return nil
 	}
 	if nsize == 0 {
-		// clear file
+		// Clear all root data and references for an empty blob.
 		b.RawData = nil
 		b.ChunkIndex = nil
 		b.BlobType = 0
@@ -391,12 +420,17 @@ func (b *Blob) Truncate(ctx context.Context, bcs *block.Cursor, blobOpts *BuildB
 		hwm = DefRawHighWaterMark
 	}
 
+	// Resize raw storage in place or promote it when the new size is large.
+	// Resize raw data in place or promote it to a chunk index.
 	if b.GetBlobType() == BlobType_BlobType_RAW {
 		oldSize = int64(len(b.RawData))
+
 		b.TotalSize = uint64(nsize) //nolint:gosec
 		if oldSize < nsize {
 			b.RawData = b.RawData[:nsize]
+
 		} else if nsize > int64(hwm) { //nolint:gosec
+
 			// create a chunk index with the raw data
 			// the TotalSize will be used as a limit for reading RawData.
 			if err := b.TransformToChunked(ctx, bcs, blobOpts); err != nil {
@@ -406,6 +440,7 @@ func (b *Blob) Truncate(ctx context.Context, bcs *block.Cursor, blobOpts *BuildB
 			// extend buffer if possible
 			if cap(b.RawData) >= int(nsize) {
 				b.RawData = b.RawData[:nsize]
+
 				// note: optimized to memset by compiler
 				for i := int(oldSize); i < len(b.RawData); i++ {
 					b.RawData[i] = 0
@@ -416,6 +451,7 @@ func (b *Blob) Truncate(ctx context.Context, bcs *block.Cursor, blobOpts *BuildB
 				b.RawData = nraw
 			}
 		}
+
 		// done
 		return nil
 	}
@@ -425,8 +461,11 @@ func (b *Blob) Truncate(ctx context.Context, bcs *block.Cursor, blobOpts *BuildB
 		return errors.Wrap(ErrUnknownBlobType, b.GetBlobType().String())
 	}
 
+	// Convert small chunked blobs to raw storage when the high-water mark permits.
+	// Convert small chunked blobs to raw storage when the high-water mark permits.
 	// if new size is below high water mark, move to raw blob.
 	if hwm >= uint64(nsize) { //nolint:gosec
+
 		return b.TransformToRaw(ctx, bcs, uint64(nsize)) //nolint:gosec
 	}
 
@@ -436,7 +475,8 @@ func (b *Blob) Truncate(ctx context.Context, bcs *block.Cursor, blobOpts *BuildB
 		ci = &ChunkIndex{}
 	}
 
-	// truncate chunked blob
+	// Remove chunks beyond the new end and shorten the retained tail.
+	// Remove chunks outside the new end and shorten the final retained chunk.
 	ciBcs := bcs.FollowSubBlock(4)
 	ciChunks := ci.GetChunks()
 	ciChunksBcs := ciBcs.FollowSubBlock(1)
@@ -444,10 +484,12 @@ func (b *Blob) Truncate(ctx context.Context, bcs *block.Cursor, blobOpts *BuildB
 	// delete any chunks that start outside the new size
 	for i, v := range slices.Backward(ciChunks) {
 		chk := v
+
 		if chk.GetStart() < uint64(nsize) { //nolint:gosec
 			break
 		}
 		ciChunks = ciChunks[:i]
+
 		ciChunksBcs.ClearRef(uint32(i)) //nolint:gosec
 	}
 	if len(ciChunks) != len(ci.Chunks) {
@@ -458,35 +500,42 @@ func (b *Blob) Truncate(ctx context.Context, bcs *block.Cursor, blobOpts *BuildB
 		ciBcs.MarkDirty()
 	}
 
+	// Fetch and rewrite the final chunk when it extends beyond the new size.
 	// shrink the last chunk
 	if len(ciChunks) != 0 {
 		lastChunkIdx := len(ciChunks) - 1
 		lastChunk := ciChunks[lastChunkIdx]
 		lastChunkStart, lastChunkSize := lastChunk.GetStart(), lastChunk.GetSize()
 		lastChunkEnd := lastChunkStart + lastChunkSize
+
 		if lastChunkEnd > uint64(nsize) { //nolint:gosec
 			if lastChunkStart > math.MaxInt64 {
 				return errors.New("chunk start exceeds maximum")
 			}
 			nlastChkLen := nsize - int64(lastChunkStart)
+
 			lastChkBcs := ciChunksBcs.FollowSubBlock(uint32(lastChunkIdx)) //nolint:gosec
+
 			// fetch last chunk data
 			lastChkData, err := lastChunk.FetchData(ctx, lastChkBcs, false)
 			if err != nil {
 				return err
 			}
+
 			// if necessary, shrink the data field.
 			if len(lastChkData) > int(nlastChkLen) {
 				lastChkDataBcs := lastChkBcs.FollowRef(1, nil)
 				lastChkData = lastChkData[:nlastChkLen]
 				lastChkDataBcs.SetBlock(byteslice.NewByteSlice(&lastChkData), true)
 			}
+
 			// update the length
 			lastChunk.Size = uint64(nlastChkLen) //nolint:gosec
 			lastChkBcs.MarkDirty()
 		}
 	}
 
+	// Record the final truncated size after chunk references are reconciled.
 	// update total size
 	b.TotalSize = uint64(nsize) //nolint:gosec
 	return nil
@@ -494,6 +543,7 @@ func (b *Blob) Truncate(ctx context.Context, bcs *block.Cursor, blobOpts *BuildB
 
 // TransformToChunked transforms a raw blob to a chunked blob.
 func (b *Blob) TransformToChunked(ctx context.Context, bcs *block.Cursor, blobOpts *BuildBlobOpts) error {
+	// Convert raw data into a chunk index while preserving the declared size.
 	if b.GetBlobType() == 0 || b.GetBlobType() == BlobType_BlobType_CHUNKED {
 		return nil
 	}
@@ -520,11 +570,13 @@ func (b *Blob) TransformToRaw(ctx context.Context, bcs *block.Cursor, nsize uint
 		return errors.Wrap(ErrUnknownBlobType, b.GetBlobType().String())
 	}
 
+	// Read chunk data into contiguous raw storage and clear the chunk index.
 	// chunk index
 	ci := b.GetChunkIndex()
 	ciBcs := bcs.FollowSubBlock(4)
 	ciChunkSet := ci.GetChunkSet(ciBcs)
 
+	// Read chunk data into a contiguous raw buffer up to the requested size.
 	nraw := make([]byte, nsize)
 	pos := 0
 	var rn, chkIdx int

--- a/db/block/copy/copy.go
+++ b/db/block/copy/copy.go
@@ -24,6 +24,7 @@ func CopyBlockDAG(
 	src block.StoreOps,
 	dest block.StoreOps,
 ) error {
+	// Start tracing and return immediately for an empty root.
 	ctx, task := trace.NewTask(ctx, "hydra/block/copy/dag")
 	defer task.End()
 
@@ -31,6 +32,8 @@ func CopyBlockDAG(
 		trace.Log(ctx, "result", "empty-root")
 		return nil
 	}
+
+	// Record the root and recurse through the destination graph.
 	trace.Log(ctx, "root-ref", rootRef.MarshalString())
 	visited := make(map[string]bool)
 	return copyBlock(ctx, rootRef, rootCtor, src, dest, visited)
@@ -45,22 +48,25 @@ func copyBlock(
 	dest block.StoreOps,
 	visited map[string]bool,
 ) error {
+	// Skip empty or previously visited references before reading storage.
 	if ref.GetEmpty() {
 		return nil
 	}
 
+	// Start tracing this block copy and skip references already visited.
 	refStr := ref.MarshalString()
 	ctx, task := trace.NewTask(ctx, "hydra/block/copy/block")
 	defer task.End()
 	trace.Log(ctx, "block-ref", refStr)
 
+	// Avoid traversing a reference more than once.
 	if visited[refStr] {
 		trace.Log(ctx, "result", "already-visited")
 		return nil
 	}
 	visited[refStr] = true
 
-	// Check if already in dest.
+	// Check whether the destination already contains this block.
 	exists, err := dest.GetBlockExists(ctx, ref)
 	if err != nil {
 		return errors.Wrapf(err, "check block exists: %s", refStr)
@@ -86,6 +92,8 @@ func copyBlock(
 			return errors.Wrapf(block.ErrNotFound, "existing block: %s", refStr)
 		}
 	}
+
+	// Fetch missing blocks from the source and persist them in the destination.
 	if !exists {
 		// Read from source.
 		taskCtx, subtask := trace.NewTask(ctx, "hydra/block/copy/source-get")
@@ -111,7 +119,7 @@ func copyBlock(
 		}
 	}
 
-	// Decode to find child refs (only if we have a constructor).
+	// Decode copied data and recurse through known child references.
 	if ctor == nil {
 		trace.Log(ctx, "result", "leaf-copied")
 		return nil
@@ -143,6 +151,7 @@ func followBlockGraph(
 	dest block.StoreOps,
 	visited map[string]bool,
 ) error {
+	// Copy direct block references before descending into nested sub-blocks.
 	withRefs, ok := blk.(block.BlockWithRefs)
 	if ok {
 		refs, err := withRefs.GetBlockRefs()
@@ -157,6 +166,7 @@ func followBlockGraph(
 		}
 	}
 
+	// Recurse through each non-empty nested sub-block.
 	if withSubBlocks, ok := blk.(block.BlockWithSubBlocks); ok {
 		for _, sub := range withSubBlocks.GetSubBlocks() {
 			if sub == nil || sub.IsNil() {

--- a/db/block/file/create.go
+++ b/db/block/file/create.go
@@ -25,11 +25,13 @@ func BuildFileWithBytes(
 	data []byte,
 	buildBlobOpts *blob.BuildBlobOpts,
 ) (*File, error) {
+	// Initialize the file root and clear any previous cursor references.
 	totalSize := uint64(len(data))
 	fn := &File{TotalSize: totalSize}
 	bcs.ClearAllRefs()
 	bcs.SetBlock(fn, true)
 
+	// Build and attach the root blob beneath the initialized file.
 	rootBlobCs := bcs.FollowSubBlock(2)
 	rootBlob, err := blob.BuildBlob(
 		ctx,
@@ -50,11 +52,12 @@ func BuildFileWithReader(
 	rdr io.Reader,
 	buildBlobOpts *blob.BuildBlobOpts,
 ) (*File, error) {
-	// Create initial file with TotalSize blank
+	// Initialize an empty file root before streaming reader data.
 	fn := &File{}
 	bcs.ClearAllRefs()
 	bcs.SetBlock(fn, true)
 
+	// Build and attach the streamed root blob, then record its size.
 	rootBlobCs := bcs.FollowSubBlock(2)
 	rootBlob, err := blob.BuildBlobWithReader(
 		ctx,

--- a/db/block/file/writer.go
+++ b/db/block/file/writer.go
@@ -71,15 +71,18 @@ func (w *Writer) Write(p []byte) (n int, err error) {
 
 // WriteFrom writes data from a reader to a blob and then an index.
 func (w *Writer) WriteFrom(index uint64, dataLen int64, dataRdr io.Reader) error {
+	// Reject empty writes before preparing blob or range state.
 	if dataLen <= 0 {
 		return nil
 	}
 
+	// Reuse the append operation for an existing root or range blob.
 	// appendToBlob appends to an existing blob
 	appendToBlob := func(rcsBlob *blob.Blob, rblobCs *block.Cursor) error {
 		return rcsBlob.AppendData(w.ctx, dataLen, dataRdr, rblobCs, w.buildBlobOpts)
 	}
 
+	// Replace the file root when this write covers the existing contents.
 	// optimization: if start=0 and len >= size, fully overwrite the entire file
 	rootTotalSize := w.root.GetTotalSize()
 	if rootTotalSize > math.MaxInt64 {
@@ -88,6 +91,7 @@ func (w *Writer) WriteFrom(index uint64, dataLen int64, dataRdr io.Reader) error
 	if index == 0 && dataLen >= int64(rootTotalSize) {
 		// clear file contents
 		w.Reset()
+
 		// set root blob to the new contents
 		rootBlobCs := w.bcs.FollowSubBlock(2)
 		b1, err := blob.BuildBlob(w.ctx, dataLen, dataRdr, rootBlobCs, w.buildBlobOpts)
@@ -95,12 +99,14 @@ func (w *Writer) WriteFrom(index uint64, dataLen int64, dataRdr io.Reader) error
 			return err
 		}
 		w.root.RootBlob = b1
+
 		// set total size to new size
 		w.root.TotalSize = uint64(dataLen)
 		w.bcs.MarkDirty()
 		return nil
 	}
 
+	// Append directly to an un-ranged root blob when the write is contiguous.
 	// optimization: if root blob is set and len == index, append to it
 	rlen := len(w.root.Ranges)
 	rootBlobSize := w.root.GetRootBlob().GetTotalSize()
@@ -117,15 +123,18 @@ func (w *Writer) WriteFrom(index uint64, dataLen int64, dataRdr io.Reader) error
 		return nil
 	}
 
+	// Move the root blob into a range before handling partial writes.
 	// XXX: optimization: if index==0, check root blob has same len and contents
 	if err := w.moveRootBlobToRange(); err != nil {
 		return err
 	}
 
+	// Extend a contiguous range when no higher-nonce range would overlap.
 	// optimization: extend the range at the location
 	// to do this properly, need to assert that:
 	// - the range is the highest nonce for that position
 	// - there is no range following the range w/ a higher nonce within the write len
+	// Locate a candidate range and inspect its overlap boundary.
 	ranges := w.root.Ranges
 	rlen = len(ranges)
 	if rlen != 0 && index != 0 {
@@ -135,6 +144,7 @@ func (w *Writer) WriteFrom(index uint64, dataLen int64, dataRdr io.Reader) error
 		rangeSlice := RangeSlice(ranges)
 		rng, rngIdx, rngFound := rangeSlice.LocatePosition(int(index) - 1)
 		writeEnd := index + uint64(dataLen)
+
 		// if the range covers index-1 and ends at the write index...
 		if rngFound && rng.GetStart()+rng.GetLength() == index {
 			// scan forward
@@ -151,12 +161,14 @@ func (w *Writer) WriteFrom(index uint64, dataLen int64, dataRdr io.Reader) error
 				if rrngEnd < index {
 					continue
 				}
+
 				// ignore nonce < rng.Nonce
 				if rrng.GetNonce() > rng.GetNonce() {
 					found = true
 					break
 				}
 			}
+
 			// if found = true, we can't extend this range, it will collide with another.
 			if !found {
 				// append to the range
@@ -166,6 +178,7 @@ func (w *Writer) WriteFrom(index uint64, dataLen int64, dataRdr io.Reader) error
 				if err != nil {
 					return err
 				}
+
 				// only append to blob with length filling entire range
 				rcsBlobSize := rcsBlob.GetTotalSize()
 				if rcsBlobSize != 0 && rcsBlobSize == rng.GetLength() {
@@ -191,6 +204,7 @@ func (w *Writer) WriteFrom(index uint64, dataLen int64, dataRdr io.Reader) error
 		}
 	}
 
+	// Create a new range for data that cannot extend an existing range.
 	nonce := w.root.GetRangeNonce()
 	w.root.RangeNonce += 1
 	w.root.Ranges = append(w.root.Ranges, &Range{
@@ -200,9 +214,11 @@ func (w *Writer) WriteFrom(index uint64, dataLen int64, dataRdr io.Reader) error
 		Ref:    nil, // will be filled by writer
 	})
 
+	// Replace the range's blob reference with the newly built blob.
 	_, rangeCs := w.rangeSet.Get(rlen)
 	rangeCs.ClearRef(4)
 	rcs := rangeCs.FollowRef(4, nil)
+
 	// rcs.SetBlock() and MarkDirty() will be called
 	bblob, err := blob.BuildBlob(
 		w.ctx,
@@ -218,6 +234,7 @@ func (w *Writer) WriteFrom(index uint64, dataLen int64, dataRdr io.Reader) error
 		return err
 	}
 
+	// Sort and compact ranges, then grow the file size when necessary.
 	size := bblob.GetTotalSize()
 	w.sortRanges()
 	w.compactOccludedRanges()
@@ -230,6 +247,7 @@ func (w *Writer) WriteFrom(index uint64, dataLen int64, dataRdr io.Reader) error
 		w.bcs.MarkDirty()
 	}
 
+	// Move the new range back into the root blob when it can be folded.
 	// move range to root blob if possible
 	if err := w.moveRangeToRootBlob(); err != nil {
 		return err
@@ -261,6 +279,7 @@ func (w *Writer) WriteBlob(index, size uint64, ref *block.BlockRef) error {
 	})
 	_, rcs := w.rangeSet.Get(rlen)
 	rcs.ClearRef(4)
+
 	w.sortRanges() // TODO: faster sorted insert
 	w.compactOccludedRanges()
 
@@ -315,6 +334,7 @@ func (w *Writer) Truncate(size uint64) error {
 			irangeStart := irange.GetStart()
 			if irangeStart >= size {
 				removeFrom = i
+
 				rangesBcs.ClearRef(uint32(i)) //nolint:gosec
 				continue
 			}
@@ -324,6 +344,7 @@ func (w *Writer) Truncate(size uint64) error {
 			if irangeEnd <= size {
 				continue
 			}
+
 			// shorten range to end of file
 			irangeBcs := rangesBcs.FollowSubBlock(uint32(i)) //nolint:gosec
 			if irangeEnd > size {
@@ -447,6 +468,7 @@ func (w *Writer) moveRootBlobToRange() error {
 // with start == 0 or containing zeros only. otherwise does nothing.
 func (w *Writer) moveRangeToRootBlob() error {
 	ranges := w.root.GetRanges()
+
 	// note: can probably remove the ranges[0].getstart check here.
 	if len(ranges) != 1 || ranges[0].GetStart() != 0 {
 		return nil
@@ -510,6 +532,7 @@ func (w *Writer) deleteRange(idx int) {
 	}
 	w.root.Ranges[lastIdx] = nil
 	w.root.Ranges = w.root.Ranges[:lastIdx]
+
 	w.rangeSet.GetCursor().ClearRef(uint32(lastIdx)) //nolint:gosec
 	w.bcs.MarkDirty()
 }

--- a/db/block/gc/gc.go
+++ b/db/block/gc/gc.go
@@ -89,14 +89,17 @@ func (c *Collector) CollectGraphOnly(ctx context.Context) (*Stats, error) {
 // collect loops until no unreferenced nodes remain, since removing a node may
 // orphan its children.
 func (c *Collector) collect(ctx context.Context, removeBlocks bool) (*Stats, error) {
+	// Start timing and accumulate cycle statistics across cascaded sweeps.
 	start := time.Now()
 	stats := &Stats{}
 
+	// Scan unreferenced nodes until an iteration makes no progress.
 	for {
 		if err := ctx.Err(); err != nil {
 			return stats, context.Canceled
 		}
 
+		// Read the current unreferenced set and account for scan time.
 		phaseStart := time.Now()
 		nodes, err := c.refGraph.GetUnreferencedNodes(ctx)
 		stats.UnreferencedScanDuration += time.Since(phaseStart)
@@ -111,6 +114,7 @@ func (c *Collector) collect(ctx context.Context, removeBlocks bool) (*Stats, err
 			break
 		}
 
+		// Remove each eligible node's graph edges, callback, and physical block.
 		var swept int
 		for _, node := range nodes {
 			if err := ctx.Err(); err != nil {
@@ -182,6 +186,7 @@ func (c *Collector) collect(ctx context.Context, removeBlocks bool) (*Stats, err
 			stats.NodesSwept++
 		}
 
+		// Stop when only permanent roots or otherwise unsweepable nodes remain.
 		// If no nodes were swept this iteration (e.g., all were
 		// permanent roots), stop to avoid infinite loop.
 		if swept == 0 {

--- a/db/block/gc/refgraph.go
+++ b/db/block/gc/refgraph.go
@@ -147,6 +147,7 @@ func (rg *RefGraph) applyRefBatch(
 	markOrphaned bool,
 	lockPerSlice bool,
 ) error {
+	// Disable nested store tracking before tracing the bounded batch.
 	ctx = disableStoreTracking(ctx)
 	ctx, task := trace.NewTask(ctx, "hydra/block-gc/refgraph/apply-ref-batch")
 	defer task.End()
@@ -160,6 +161,7 @@ func (rg *RefGraph) applyRefBatch(
 		refGraphApplyBatchLimit,
 	)
 
+	// Return early when the batch carries no ownership transition.
 	if len(adds) == 0 && len(removes) == 0 {
 		return nil
 	}
@@ -173,6 +175,7 @@ func (rg *RefGraph) applyRefBatch(
 			}
 		}
 
+		// Slice the transition and acquire the write lock for each slice.
 		addCount, removeCount := refBatchSliceCounts(adds, removes)
 		slice++
 		trace.Logf(
@@ -191,6 +194,8 @@ func (rg *RefGraph) applyRefBatch(
 		if lockPerSlice {
 			rg.writeMu.Lock()
 		}
+
+		// Prepare durable additions and removals before applying the slice.
 		preparedAdds, preparedRemoves, err := rg.prepareRefBatch(
 			ctx,
 			sliceAdds,
@@ -225,6 +230,8 @@ func (rg *RefGraph) applyRefBatch(
 				removes: appendRefEdges(sliceRemoves, removes[removeCount:]),
 			}
 		}
+
+		// Advance to the next slice after recording its successful application.
 		trace.Logf(
 			ctx,
 			"hydra/block-gc/refgraph/apply-ref-batch/slice-complete",
@@ -273,6 +280,7 @@ func (rg *RefGraph) applyRefBatchSliceLocked(
 	ctx context.Context,
 	adds, removes []RefEdge,
 ) ([]RefEdge, []RefEdge, error) {
+	// Commit additions in bounded chunks before committing removals.
 	chunks := 0
 	for len(adds) != 0 {
 		count := min(len(adds), refGraphApplyBatchLimit)
@@ -299,6 +307,7 @@ func (rg *RefGraph) applyRefBatchChunk(ctx context.Context, adds, removes []RefE
 	defer task.End()
 	trace.Logf(ctx, "hydra/block-gc/refgraph/apply-ref-batch/apply-transaction/shape", "adds=%d removes=%d", len(adds), len(removes))
 
+	// Materialize one transaction preserving additions-before-removals order.
 	n := len(adds) + len(removes)
 	tx := graph.NewTransactionN(n)
 	for _, e := range adds {
@@ -315,6 +324,7 @@ func (rg *RefGraph) prepareRefBatch(
 	adds, removes []RefEdge,
 	markOrphaned bool,
 ) ([]RefEdge, []RefEdge, error) {
+	// Filter missing removals before deriving orphan markers.
 	removes, err := rg.filterExistingRemoves(ctx, adds, removes)
 	if err != nil {
 		return nil, nil, err
@@ -331,6 +341,7 @@ func (rg *RefGraph) prepareOrphanMarks(
 		return adds, removes, nil
 	}
 
+	// Collect current owners for each removed edge before applying the transition.
 	owners := make(map[string]map[string]struct{})
 	stagingRemoves := make(map[string]struct{})
 	for _, edge := range removes {
@@ -356,14 +367,18 @@ func (rg *RefGraph) prepareOrphanMarks(
 		}
 		owners[edge.Object] = set
 	}
+
 	// Additions land before removals, so an object whose only owner this batch
 	// both adds and removes ends the batch with no owner at all. Deleting first
 	// would leave that owner in the set and hide the orphan.
+	// Apply additions to the owner sets before removing edges.
 	for _, edge := range adds {
 		if set, ok := owners[edge.Object]; ok && edge.Subject != NodeUnreferenced {
 			set[edge.Subject] = struct{}{}
 		}
 	}
+
+	// Remove outgoing owners and mark objects with no remaining owners.
 	for _, edge := range removes {
 		if set, ok := owners[edge.Object]; ok {
 			delete(set, edge.Subject)

--- a/db/block/rpc/client/block-store.go
+++ b/db/block/rpc/client/block-store.go
@@ -49,6 +49,7 @@ func (v *BlockStore) GetHashType() hash.HashType {
 // The result is cached after the first call: the remote feature set is static
 // for the lifetime of the store, and this method is on the hot path.
 func (v *BlockStore) GetSupportedFeatures() block.StoreFeature {
+	// Fetch and cache the remote feature set once for this store lifetime.
 	v.featuresOnce.Do(func() {
 		resp, err := v.client.GetSupportedFeatures(context.Background(), &block_rpc.GetSupportedFeaturesRequest{})
 		if err != nil {
@@ -73,6 +74,7 @@ func (v *BlockStore) BeginReadOperation(context.Context) (block.StoreOps, func()
 // The ref should not be modified after return.
 // The second return value can optionally indicate if the block already existed.
 func (v *BlockStore) PutBlock(ctx context.Context, data []byte, opts *block.PutOpts) (*block.BlockRef, bool, error) {
+	// Reject writes from a read-only client before issuing the RPC.
 	if v.readOnly {
 		return nil, false, block_store.ErrReadOnly
 	}
@@ -95,6 +97,7 @@ func (v *BlockStore) PutBlock(ctx context.Context, data []byte, opts *block.PutO
 
 // PutBlockBatch requests a remote batch write.
 func (v *BlockStore) PutBlockBatch(ctx context.Context, entries []*block.PutBatchEntry) error {
+	// Reject read-only clients before building the remote batch request.
 	if v.readOnly {
 		return block_store.ErrReadOnly
 	}

--- a/db/block/transform/transformer.go
+++ b/db/block/transform/transformer.go
@@ -24,6 +24,7 @@ func NewTransformer(
 	fs *StepFactorySet,
 	c *Config,
 ) (*Transformer, error) {
+	// Construct each configured transform step in order.
 	steps := make([]Step, len(c.GetSteps()))
 	for i, s := range c.GetSteps() {
 		if fs == nil {
@@ -43,6 +44,8 @@ func NewTransformer(
 		}
 		steps[i] = s
 	}
+
+	// Derive the cache identity after all steps are constructed.
 	key, err := decodedBlockCacheTransformKeyForConfig(c)
 	if err != nil {
 		return nil, err
@@ -76,6 +79,7 @@ func (t *Transformer) DecodedBlockCacheTransformKey() string {
 // EncodeBlock encodes the block according to the config.
 // May reuse the same byte slice if possible.
 func (t *Transformer) EncodeBlock(data []byte) ([]byte, error) {
+	// Apply transforms in declaration order for encoding.
 	var err error
 	for _, s := range t.steps {
 		data, err = s.EncodeBlock(data)
@@ -90,10 +94,12 @@ func (t *Transformer) EncodeBlock(data []byte) ([]byte, error) {
 // DecodeBlock decodes the block according to the config.
 // May reuse the same byte slice if possible.
 func (t *Transformer) DecodeBlock(data []byte) ([]byte, error) {
+	// Leave untransformed data untouched when no decode steps exist.
 	if len(t.steps) == 0 {
 		return data, nil
 	}
 
+	// Reverse the configured steps to restore the original block.
 	var err error
 	for _, s := range slices.Backward(t.steps) {
 		data, err = s.DecodeBlock(data)

--- a/db/bucket/lookup/lookup-handle.go
+++ b/db/bucket/lookup/lookup-handle.go
@@ -49,6 +49,7 @@ func (l *lookupBucket) BeginReadOperation(context.Context) (block.StoreOps, func
 // PutBlock puts a block into the store.
 // The ref should not be modified after return.
 func (l *lookupBucket) PutBlock(ctx context.Context, data []byte, opts *block.PutOpts) (*block.BlockRef, bool, error) {
+	// Resolve the lookup handle before writing the block.
 	lb, err := l.h.GetLookup(ctx)
 	if err != nil {
 		return nil, false, err
@@ -58,6 +59,8 @@ func (l *lookupBucket) PutBlock(ctx context.Context, data []byte, opts *block.Pu
 	}
 
 	var blockRef *block.BlockRef
+
+	// Select the first non-empty root reference returned by the lookup write.
 	objRefs, existed, err := lb.PutBlock(ctx, data, opts)
 	for _, objRef := range objRefs {
 		rootRef := objRef.GetRootRef()
@@ -71,6 +74,7 @@ func (l *lookupBucket) PutBlock(ctx context.Context, data []byte, opts *block.Pu
 
 // PutBlockBatch loops calling PutBlock or RmBlock per entry.
 func (l *lookupBucket) PutBlockBatch(ctx context.Context, entries []*block.PutBatchEntry) error {
+	// Apply each batch entry as either a tombstone removal or a block write.
 	for _, entry := range entries {
 		if entry.Tombstone {
 			if err := l.RmBlock(ctx, entry.Ref); err != nil {

--- a/db/bucket/lookup/lookup-op-rw.go
+++ b/db/bucket/lookup/lookup-op-rw.go
@@ -18,11 +18,13 @@ func StartBucketRWOperation(
 	b bus.Bus,
 	args *bucket.BucketOpArgs,
 ) (bucket.Bucket, func(), error) {
+	// Validate the bucket operation before acquiring any handles.
 	if err := args.Validate(); err != nil {
 		return nil, nil, err
 	}
 
 	// 1. acquire the lookup handle
+	// Acquire the lookup handle used for reads.
 	blv, _, blvRel, err := ExBuildBucketLookup(ctx, b, false, args.GetBucketId(), nil)
 	if err != nil {
 		return nil, nil, err
@@ -30,6 +32,7 @@ func StartBucketRWOperation(
 	readHandle := NewBucketFromHandle(blv)
 
 	// 2. acquire the write handle
+	// Acquire the optional volume handle used for writes and retain releases.
 	var writeHandle bucket.Bucket
 	rels := []func(){blvRel.Release}
 	rel := func() {

--- a/db/bucket/setup/controller.go
+++ b/db/bucket/setup/controller.go
@@ -60,11 +60,14 @@ func (c *Controller) GetControllerInfo() *controller.Info {
 // Returning nil ends execution.
 // Returning an error triggers a retry with backoff.
 func (c *Controller) Execute(ctx context.Context) error {
+	// Snapshot configured bucket applications and track their completion.
 	bucketConfs := c.conf.GetApplyBucketConfigs()
 	refs := make([]func(), 0, len(bucketConfs)*2)
 	var running atomic.Int32
+
 	running.Store(int32(len(bucketConfs))) //nolint:gosec
 
+	// Report the first application failure without blocking other buckets.
 	errCh := make(chan error, 1)
 	handleErr := func(err error) {
 		select {
@@ -73,6 +76,7 @@ func (c *Controller) Execute(ctx context.Context) error {
 		}
 	}
 
+	// Build and submit each valid bucket configuration directive.
 	for i, conf := range bucketConfs {
 		if conf.GetConfig() == nil {
 			continue
@@ -94,6 +98,8 @@ func (c *Controller) Execute(ctx context.Context) error {
 			le.WithError(err).Warn("apply bucket config failed")
 			continue
 		}
+
+		// Release each directive when idle and publish completion or failure.
 		var markedNotRunning atomic.Bool
 		refs = append(refs,
 			di.AddIdleCallback(func(isIdle bool, errs []error) {
@@ -114,6 +120,8 @@ func (c *Controller) Execute(ctx context.Context) error {
 			ref.Release,
 		)
 	}
+
+	// Retain directive references until the controller closes or is already closed.
 	if len(refs) != 0 {
 		c.le.Infof("applied %d bucket configs", len(refs)/2)
 	}
@@ -129,6 +137,7 @@ func (c *Controller) Execute(ctx context.Context) error {
 		}
 	}
 
+	// Wait for cancellation or the first application error.
 	// wait
 	select {
 	case <-ctx.Done():
@@ -153,6 +162,7 @@ func (c *Controller) Close() error {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 
+	// Release every retained directive reference during controller close.
 	// release all refs
 	for _, r := range c.refs {
 		r()

--- a/db/cdc/jc/jc.go
+++ b/db/cdc/jc/jc.go
@@ -61,6 +61,7 @@ func embedMask(maskC uint64) uint64 {
 	if maskC == 0 {
 		return 0
 	}
+
 	// Unset the least significant 1-bit in maskC
 	return maskC & (maskC - 1)
 }
@@ -139,6 +140,7 @@ func NewJC() (*JC, error) {
 // NewWithOptions constructs the JC with the given options.
 func NewWithOptions(minSize, maxSize, targetSize uint64, key []byte) (*JC, error) {
 	// validate parameters
+	// Validate chunk size bounds before deriving masks and jump parameters.
 	if targetSize == 0 || targetSize < 64 || targetSize > 1024*1024*1024 {
 		return nil, ErrTargetSize
 	}
@@ -149,6 +151,7 @@ func NewWithOptions(minSize, maxSize, targetSize uint64, key []byte) (*JC, error
 		return nil, ErrMaxSize
 	}
 
+	// Derive the jump and boundary masks from the target size.
 	c := &JC{minSize: int(minSize), maxSize: int(maxSize), targetSize: int(targetSize)} //nolint:gosec
 	bits := uint64(math.Log2(float64(targetSize)))
 
@@ -161,6 +164,7 @@ func NewWithOptions(minSize, maxSize, targetSize uint64, key []byte) (*JC, error
 	c.maskC = generateSpacedMask(int(cOnes), 64) //nolint:gosec
 	c.maskJ = embedMask(c.maskC)
 
+	// Populate the hash table from the caller key or deterministic defaults.
 	// the key can be len(0) here and this will still be acceptable.
 	if len(key) == 0 {
 		copy(c.G[:], defaultG())
@@ -247,11 +251,13 @@ func (c *Chunker) Reset() {
 // current chunk is undefined. When the last chunk has been returned, all
 // subsequent calls yield an io.EOF error.
 func (c *Chunker) Next(data []byte) (Chunk, error) {
+	// Return EOF only after buffered data has been exhausted.
 	availableData := c.bufLen - c.bufPos
 	if c.eof && availableData == 0 {
 		return Chunk{}, io.EOF
 	}
 
+	// Fill the sliding buffer until a boundary is available or the reader ends.
 	// Keep reading until we have enough data for chunk boundary detection or reach EOF
 	for !c.eof {
 		// If we have enough data to potentially find a boundary, try that first
@@ -297,11 +303,13 @@ func (c *Chunker) Next(data []byte) (Chunk, error) {
 		}
 	}
 
+	// Return EOF when filling produced no remaining data.
 	// If no data left, return EOF
 	if availableData == 0 {
 		return Chunk{}, io.EOF
 	}
 
+	// Choose the next boundary and copy or expose its bytes.
 	// Find chunk boundary using JC algorithm
 	chunkSize := c.jc.Algorithm(c.buf[c.bufPos:c.bufLen], availableData)
 
@@ -316,6 +324,7 @@ func (c *Chunker) Next(data []byte) (Chunk, error) {
 		chunkData = c.buf[c.bufPos : c.bufPos+chunkSize]
 	}
 
+	// Record the chunk position and advance the streaming cursor.
 	// Create chunk
 	chunk := Chunk{
 		Start:  c.pos,
@@ -325,6 +334,7 @@ func (c *Chunker) Next(data []byte) (Chunk, error) {
 
 	// Update state
 	c.bufPos += chunkSize
+
 	c.pos += uint64(chunkSize) //nolint:gosec
 
 	return chunk, nil

--- a/db/cli/block.go
+++ b/db/cli/block.go
@@ -13,12 +13,15 @@ import (
 
 // RunPutBlock runs putting a block into a bucket.
 func (a *ClientArgs) RunPutBlock(_ *cli.Context) error {
+	// Resolve the client and request context.
 	le := a.GetLogger()
 	ctx := a.GetContext()
 	c, err := a.BuildClient()
 	if err != nil {
 		return err
 	}
+
+	// Read block data from stdin or the configured file.
 	var dat []byte
 	if a.BlockDataFile == "" || a.BlockDataFile == "-" {
 		le.Debug("reading from stdin")
@@ -31,6 +34,7 @@ func (a *ClientArgs) RunPutBlock(_ *cli.Context) error {
 		return err
 	}
 
+	// Submit the block operation to the daemon.
 	resp, err := c.BucketOp(ctx, &api.BucketOpRequest{
 		Op:           api.BucketOp_BucketOp_BLOCK_PUT,
 		BucketOpArgs: &a.BucketOpArgs,
@@ -40,6 +44,7 @@ func (a *ClientArgs) RunPutBlock(_ *cli.Context) error {
 		return err
 	}
 
+	// Log the response and print the resulting block reference.
 	d, err := resp.MarshalJSON()
 	if err != nil {
 		le.WithError(err).Warn("unable to marshal put block result")
@@ -54,19 +59,19 @@ func (a *ClientArgs) RunPutBlock(_ *cli.Context) error {
 
 // RunGetBlock runs getting a block from a bucket.
 func (a *ClientArgs) RunGetBlock(_ *cli.Context) error {
+	// Resolve the request context and block reference.
 	le := a.GetLogger()
 	ctx := a.GetContext()
-
 	br, err := block.UnmarshalBlockRefB58(a.GetBlockRef)
 	if err != nil {
 		return err
 	}
 
+	// Open the daemon client and fetch the block.
 	c, err := a.BuildClient()
 	if err != nil {
 		return err
 	}
-
 	resp, err := c.BucketOp(ctx, &api.BucketOpRequest{
 		Op:           api.BucketOp_BucketOp_BLOCK_GET,
 		BucketOpArgs: &a.BucketOpArgs,
@@ -76,10 +81,10 @@ func (a *ClientArgs) RunGetBlock(_ *cli.Context) error {
 		return err
 	}
 
+	// Reject missing blocks and log the response before writing data.
 	if !resp.GetFound() {
 		return block.ErrNotFound
 	}
-
 	data := resp.GetData()
 	resp.Data = nil
 	d, err := resp.MarshalJSON()
@@ -93,18 +98,18 @@ func (a *ClientArgs) RunGetBlock(_ *cli.Context) error {
 
 // RunRmBlock runs removing a block from a bucket.
 func (a *ClientArgs) RunRmBlock(_ *cli.Context) error {
+	// Resolve and validate the block reference.
 	ctx := a.GetContext()
-
 	br, err := block.UnmarshalBlockRefB58(a.GetBlockRef)
 	if err != nil {
 		return err
 	}
 
+	// Submit the block removal operation.
 	c, err := a.BuildClient()
 	if err != nil {
 		return err
 	}
-
 	_, err = c.BucketOp(ctx, &api.BucketOpRequest{
 		Op:           api.BucketOp_BucketOp_BLOCK_RM,
 		BucketOpArgs: &a.BucketOpArgs,
@@ -113,6 +118,8 @@ func (a *ClientArgs) RunRmBlock(_ *cli.Context) error {
 	if err != nil {
 		return err
 	}
+
+	// Print the removed block reference.
 	os.Stdout.WriteString(br.MarshalString())
 	os.Stdout.WriteString("\n")
 	return nil

--- a/db/cli/bucket.go
+++ b/db/cli/bucket.go
@@ -13,35 +13,33 @@ import (
 
 // RunApplyBucketConf runs applying a bucket configuration.
 func (a *ClientArgs) RunApplyBucketConf(_ *cli.Context) error {
+	// Resolve the request context and read the bucket configuration file.
 	le := a.GetLogger()
 	ctx := a.GetContext()
-
-	// parse json to bucket configuration.
 	dat, err := os.ReadFile(a.ApplyBucketConfigFile)
 	if err != nil {
 		return err
 	}
 
+	// Build the resolver bus and parse the JSON configuration.
 	b, _, err := core.NewCoreBus(ctx, le)
 	if err != nil {
 		return err
 	}
-
 	jconf, err := bucket_json.ParseConfig(dat)
 	if err != nil {
 		return err
 	}
-
 	bconf, err := jconf.ResolveToProto(ctx, b)
 	if err != nil {
 		return err
 	}
 
+	// Submit the resolved bucket configuration to the daemon.
 	c, err := a.BuildClient()
 	if err != nil {
 		return err
 	}
-
 	req := &a.ApplyBucketConfigReq
 	req.Config = bconf
 	req.VolumeIdList = a.ApplyBucketConfigReqVolumeIDs.Value()
@@ -50,6 +48,7 @@ func (a *ClientArgs) RunApplyBucketConf(_ *cli.Context) error {
 		return err
 	}
 
+	// Stream each applied configuration result to standard output.
 	for {
 		msg, err := resp.Recv()
 		if err != nil {
@@ -82,12 +81,14 @@ func (a *ClientArgs) RunApplyBucketConf(_ *cli.Context) error {
 
 // RunListBuckets runs listing buckets.
 func (a *ClientArgs) RunListBuckets(_ *cli.Context) error {
+	// Resolve the client and request context.
 	ctx := a.GetContext()
 	c, err := a.BuildClient()
 	if err != nil {
 		return err
 	}
 
+	// Configure and execute the bucket listing.
 	req := a.ListBucketsReq.CloneVT()
 	req.VolumeIdList = a.ListBucketsReqVolumeIDs.Value()
 	ni, err := c.ListBuckets(ctx, req)
@@ -95,10 +96,10 @@ func (a *ClientArgs) RunListBuckets(_ *cli.Context) error {
 		return err
 	}
 
+	// Marshal the response and write formatted JSON.
 	dat, err := ni.MarshalJSON()
 	if err != nil {
 		return err
 	}
-
 	return writeIndentedJSON(os.Stdout, dat)
 }

--- a/db/cli/client.go
+++ b/db/cli/client.go
@@ -67,6 +67,7 @@ type ClientArgs struct {
 
 // ParseRemotePeerIdsCsv parses the RemotePeerIdsCsv field.
 func (a *ClientArgs) ParseRemotePeerIdsCsv() []string {
+	// Split and normalize the configured peer IDs.
 	pts := strings.Split(a.RemotePeerIdsCsv, ",")
 	var peerIds []string
 	for _, pt := range pts {
@@ -95,18 +96,21 @@ func (a *ClientArgs) SetClient(client api.HydraDaemonClient) {
 
 // BuildClient builds the client or returns it if it has been set.
 func (a *ClientArgs) BuildClient() (api.HydraDaemonClient, error) {
+	// Reuse an injected client when available.
 	if a.client != nil {
 		return a.client, nil
 	}
 
+	// Validate the configured dial address and open the connection.
 	if a.DialAddr == "" {
 		return nil, errors.New("dial address is not set")
 	}
-
 	nconn, err := net.Dial("tcp", a.DialAddr)
 	if err != nil {
 		return nil, err
 	}
+
+	// Wrap the connection in an SRPC client and cache it.
 	muxedConn, err := srpc.NewMuxedConn(nconn, true, nil)
 	if err != nil {
 		return nil, err

--- a/db/cli/daemonflags.go
+++ b/db/cli/daemonflags.go
@@ -88,11 +88,13 @@ func (a *DaemonArgs) BuildFlags() []cli.Flag {
 //
 // If baseVolCtrlConf is nil, a default volume controller config is used.
 func (a *DaemonArgs) ApplyToConfigSet(confSet configset.ConfigSet, overwrite bool, baseVolCtrlConf *volume_controller.Config) error {
+	// Prepare the shared volume configuration and CLI alias.
 	if baseVolCtrlConf == nil {
 		baseVolCtrlConf = &volume_controller.Config{}
 	}
 	baseVolCtrlConf.VolumeIdAlias = append(baseVolCtrlConf.VolumeIdAlias, CLIVolumeIDAlias)
 
+	// Register the optional in-memory volume.
 	if a.InmemDB || a.InmemDBVerbose {
 		id := "cli-inmem-volume-0"
 		conf := &volume_kvtxinmem.Config{
@@ -104,13 +106,13 @@ func (a *DaemonArgs) ApplyToConfigSet(confSet configset.ConfigSet, overwrite boo
 		}
 	}
 
+	// Register each configured Badger volume.
 	for i, bdbi := range a.BadgerDBs.Value() {
 		id := "cli-badger-volume-" + strconv.Itoa(i)
 		bdb := strings.TrimSpace(bdbi)
 		if bdb == "" {
 			continue
 		}
-
 		if _, ok := confSet[id]; !ok || overwrite {
 			confSet[id] = configset.NewControllerConfig(1, &volume_badger.Config{
 				Dir:          bdb,
@@ -119,13 +121,13 @@ func (a *DaemonArgs) ApplyToConfigSet(confSet configset.ConfigSet, overwrite boo
 		}
 	}
 
+	// Register each configured Bolt volume.
 	for i, bdbi := range a.BoltDBs.Value() {
 		id := "cli-bolt-volume-" + strconv.Itoa(i)
 		bdb := strings.TrimSpace(bdbi)
 		if bdb == "" {
 			continue
 		}
-
 		if _, ok := confSet[id]; !ok || overwrite {
 			confSet[id] = configset.NewControllerConfig(1, &volume_bolt.Config{
 				Path:         bdb,
@@ -135,6 +137,7 @@ func (a *DaemonArgs) ApplyToConfigSet(confSet configset.ConfigSet, overwrite boo
 		}
 	}
 
+	// Register the optional Redis volume.
 	if a.RedisURL != "" {
 		id := "cli-redis-volume-0"
 		if _, ok := confSet[id]; !ok || overwrite {
@@ -154,36 +157,35 @@ func (a *DaemonArgs) ApplyToConfigSet(confSet configset.ConfigSet, overwrite boo
 // id is optional and specifies a prefix to use for the volume. If
 // baseVolCtrlConf is nil, a default volume controller config is used.
 func (a *DaemonArgs) BuildSingleVolume(id string, baseVolCtrlConf *volume_controller.Config) config.Config {
+	// Prepare the shared volume configuration and normalize the volume ID.
 	if baseVolCtrlConf == nil {
 		baseVolCtrlConf = &volume_controller.Config{}
 	}
 	baseVolCtrlConf.VolumeIdAlias = append(baseVolCtrlConf.VolumeIdAlias, CLIVolumeIDAlias)
-
 	id = strings.TrimSpace(id)
 
+	// Build a Badger volume when a database directory is configured.
 	for _, bdbi := range a.BadgerDBs.Value() {
 		bdb := strings.TrimSpace(bdbi)
 		if bdb == "" {
 			continue
 		}
-
 		dir := bdb
 		if id != "" {
 			dir = filepath.Join(dir, id)
 		}
-
 		return &volume_badger.Config{
 			Dir:          dir,
 			VolumeConfig: baseVolCtrlConf,
 		}
 	}
 
+	// Build a Bolt volume when a database file is configured.
 	for _, bdbi := range a.BoltDBs.Value() {
 		bdb := strings.TrimSpace(bdbi)
 		if bdb == "" {
 			continue
 		}
-
 		if id != "" {
 			dir := filepath.Dir(bdb)
 			fileName := filepath.Base(bdb)
@@ -191,7 +193,6 @@ func (a *DaemonArgs) BuildSingleVolume(id string, baseVolCtrlConf *volume_contro
 			nameWithoutExt := strings.TrimSuffix(fileName, ext)
 			bdb = filepath.Join(dir, nameWithoutExt+"-"+id+ext)
 		}
-
 		return &volume_bolt.Config{
 			Path:         bdb,
 			Verbose:      a.BoltDBVerbose,
@@ -199,6 +200,7 @@ func (a *DaemonArgs) BuildSingleVolume(id string, baseVolCtrlConf *volume_contro
 		}
 	}
 
+	// Build a Redis volume when a Redis URL is configured.
 	if a.RedisURL != "" {
 		// Redis volume construction has no id-scoped path component.
 		return &volume_redis.Config{
@@ -209,5 +211,6 @@ func (a *DaemonArgs) BuildSingleVolume(id string, baseVolCtrlConf *volume_contro
 		}
 	}
 
+	// Fall back to the in-memory volume configuration.
 	return &volume_kvtxinmem.Config{Verbose: a.InmemDBVerbose, VolumeConfig: baseVolCtrlConf}
 }

--- a/db/cli/json.go
+++ b/db/cli/json.go
@@ -10,10 +10,13 @@ import (
 )
 
 func writeIndentedJSON(out io.Writer, dat []byte) error {
+	// Indent the JSON response into a reusable buffer.
 	var buf bytes.Buffer
 	if err := json.Indent(&buf, dat, "", "\t"); err != nil {
 		return err
 	}
+
+	// Write the indented response and its trailing newline.
 	if _, err := out.Write(buf.Bytes()); err != nil {
 		return err
 	}

--- a/db/cli/object.go
+++ b/db/cli/object.go
@@ -13,6 +13,7 @@ import (
 
 // RunGetObject returns an object from the store.
 func (a *ClientArgs) RunGetObject(_ *cli.Context) error {
+	// Resolve the client and request context.
 	le := a.GetLogger()
 	ctx := a.GetContext()
 	c, err := a.BuildClient()
@@ -20,12 +21,12 @@ func (a *ClientArgs) RunGetObject(_ *cli.Context) error {
 		return err
 	}
 
+	// Validate and execute the object lookup.
 	req := &a.ObjectStoreOpReq
 	req.Op = api.ObjectStoreOp_ObjectStoreOp_GET_KEY
 	if err := req.Validate(); err != nil {
 		return err
 	}
-
 	resp, err := c.ObjectStoreOp(ctx, req)
 	if err != nil {
 		return err
@@ -34,6 +35,7 @@ func (a *ClientArgs) RunGetObject(_ *cli.Context) error {
 		return errors.New("object not found")
 	}
 
+	// Log the response metadata and write the object data.
 	data := resp.GetData()
 	resp.Data = nil
 	d, err := resp.MarshalJSON()
@@ -47,6 +49,7 @@ func (a *ClientArgs) RunGetObject(_ *cli.Context) error {
 
 // RunRmObject removes an object from the store.
 func (a *ClientArgs) RunRmObject(_ *cli.Context) error {
+	// Resolve the client and request context.
 	le := a.GetLogger()
 	ctx := a.GetContext()
 	c, err := a.BuildClient()
@@ -54,12 +57,12 @@ func (a *ClientArgs) RunRmObject(_ *cli.Context) error {
 		return err
 	}
 
+	// Validate and execute the object removal.
 	req := &a.ObjectStoreOpReq
 	req.Op = api.ObjectStoreOp_ObjectStoreOp_DELETE_KEY
 	if err := req.Validate(); err != nil {
 		return err
 	}
-
 	resp, err := c.ObjectStoreOp(ctx, req)
 	if err != nil {
 		return err
@@ -68,6 +71,7 @@ func (a *ClientArgs) RunRmObject(_ *cli.Context) error {
 		return errors.New("object not found")
 	}
 
+	// Log the response metadata and write the removed object data.
 	data := resp.GetData()
 	resp.Data = nil
 	d, err := resp.MarshalJSON()
@@ -81,6 +85,7 @@ func (a *ClientArgs) RunRmObject(_ *cli.Context) error {
 
 // RunPutObject puts an object to the store.
 func (a *ClientArgs) RunPutObject(_ *cli.Context) error {
+	// Resolve the client and request context.
 	le := a.GetLogger()
 	ctx := a.GetContext()
 	c, err := a.BuildClient()
@@ -88,6 +93,7 @@ func (a *ClientArgs) RunPutObject(_ *cli.Context) error {
 		return err
 	}
 
+	// Read object data from stdin or the configured file.
 	var dat []byte
 	if a.ObjectStoreFile == "" || a.ObjectStoreFile == "-" {
 		le.Debug("reading from stdin")
@@ -100,6 +106,7 @@ func (a *ClientArgs) RunPutObject(_ *cli.Context) error {
 		return err
 	}
 
+	// Configure and submit the object write.
 	req := &a.ObjectStoreOpReq
 	req.Data = dat
 	req.Op = api.ObjectStoreOp_ObjectStoreOp_PUT_KEY
@@ -111,6 +118,7 @@ func (a *ClientArgs) RunPutObject(_ *cli.Context) error {
 
 // RunListObjectKeys lists object keys in a store.
 func (a *ClientArgs) RunListObjectKeys(_ *cli.Context) error {
+	// Resolve the client and request context.
 	le := a.GetLogger()
 	ctx := a.GetContext()
 	c, err := a.BuildClient()
@@ -118,16 +126,18 @@ func (a *ClientArgs) RunListObjectKeys(_ *cli.Context) error {
 		return err
 	}
 
+	// Validate and execute the key listing.
 	req := &a.ObjectStoreOpReq
 	req.Op = api.ObjectStoreOp_ObjectStoreOp_LIST_KEYS
 	if err := req.Validate(); err != nil {
 		return err
 	}
-
 	resp, err := c.ObjectStoreOp(ctx, req)
 	if err != nil {
 		return err
 	}
+
+	// Log the key count and print each returned key.
 	le.WithField("key-count", len(resp.GetKeys())).Debug("returned keys")
 	for _, key := range resp.GetKeys() {
 		os.Stdout.WriteString(string(key))

--- a/db/cli/util/object-ref.go
+++ b/db/cli/util/object-ref.go
@@ -10,15 +10,16 @@ import (
 
 // RunParseObjectRef parses the object ref provided.
 func (a *UtilArgs) RunParseObjectRef(cctx *ucli.Context) error {
+	// Require and parse the object reference argument.
 	if a.ObjectRef == "" {
 		return errors.New("object ref must be specified")
 	}
-
 	oref, err := bucket.ParseObjectRef(a.ObjectRef)
 	if err != nil {
 		return err
 	}
 
+	// Print the bucket identity.
 	os.Stdout.WriteString("Bucket ID: ")
 	if obid := oref.GetBucketId(); obid != "" {
 		os.Stdout.WriteString(obid)
@@ -27,6 +28,7 @@ func (a *UtilArgs) RunParseObjectRef(cctx *ucli.Context) error {
 	}
 	os.Stdout.WriteString("\n")
 
+	// Print the inline transform configuration.
 	os.Stdout.WriteString("Transform Config: ")
 	if tc := oref.GetTransformConf(); !tc.GetEmpty() {
 		os.Stdout.WriteString(tc.String())
@@ -35,6 +37,7 @@ func (a *UtilArgs) RunParseObjectRef(cctx *ucli.Context) error {
 	}
 	os.Stdout.WriteString("\n")
 
+	// Print the transform configuration reference.
 	os.Stdout.WriteString("Transform Config Ref: ")
 	if tcr := oref.GetTransformConfRef(); !tcr.GetEmpty() {
 		os.Stdout.WriteString(tcr.MarshalString())
@@ -43,6 +46,7 @@ func (a *UtilArgs) RunParseObjectRef(cctx *ucli.Context) error {
 	}
 	os.Stdout.WriteString("\n")
 
+	// Print the root reference.
 	os.Stdout.WriteString("Root Ref: ")
 	if tcr := oref.GetRootRef(); !tcr.GetEmpty() {
 		os.Stdout.WriteString(tcr.MarshalString())

--- a/db/coord/bolt/coordinator.go
+++ b/db/coord/bolt/coordinator.go
@@ -38,6 +38,7 @@ func NewCoordinator(db *bdb.DB, inner *coord_inmem.Coordinator) *Coordinator {
 
 // Capability reports bbolt coordination support.
 func (c *Coordinator) Capability(ctx context.Context, scope coord.Scope) (*coord.Capability, error) {
+	// Reject canceled requests before reading coordinator state.
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -53,6 +54,7 @@ func (c *Coordinator) Capability(ctx context.Context, scope coord.Scope) (*coord
 
 // Snapshot returns the latest bbolt commit generation and coordinator root.
 func (c *Coordinator) Snapshot(ctx context.Context, scope coord.Scope) (*coord.Snapshot, error) {
+	// Read the inner snapshot before overlaying the bbolt generation.
 	snapshot, err := c.inner.Snapshot(ctx, scope)
 	if err != nil {
 		return nil, err
@@ -65,11 +67,13 @@ func (c *Coordinator) Snapshot(ctx context.Context, scope coord.Scope) (*coord.S
 
 // Watch streams root/prefix lease events and bbolt commit-generation changes.
 func (c *Coordinator) Watch(ctx context.Context, scope coord.Scope, afterGeneration uint64) (coord.Watch, error) {
+	// Start the inner watch before creating the bbolt event stream.
 	inner, err := c.inner.Watch(ctx, scope, afterGeneration)
 	if err != nil {
 		return nil, err
 	}
 
+	// Create and start the combined watch lifecycle.
 	ctx, cancel := context.WithCancel(ctx)
 	w := &watch{
 		ctx:    ctx,
@@ -86,6 +90,7 @@ func (c *Coordinator) Watch(ctx context.Context, scope coord.Scope, afterGenerat
 
 // TryAcquireWriteLease attempts to acquire the logical bbolt write lease.
 func (c *Coordinator) TryAcquireWriteLease(ctx context.Context, scope coord.Scope) (coord.WriteLease, bool, error) {
+	// Reject canceled requests before reserving the write lease.
 	if err := ctx.Err(); err != nil {
 		return nil, false, err
 	}
@@ -95,10 +100,13 @@ func (c *Coordinator) TryAcquireWriteLease(ctx context.Context, scope coord.Scop
 		// exclusion namespace.
 		return c.inner.TryAcquireWriteLease(ctx, scope)
 	}
+
+	// Reserve the local write turn before acquiring the inner lease.
 	if reserved, _ := c.reserveWriteLease(); !reserved {
 		return nil, false, nil
 	}
 
+	// Roll back local reservation when inner or cross-process acquisition fails.
 	inner, ok, err := c.inner.TryAcquireWriteLease(ctx, scope)
 	if err != nil || !ok {
 		c.releaseWriteLease()
@@ -124,6 +132,7 @@ func (c *Coordinator) WaitAcquireWriteLease(ctx context.Context, scope coord.Sco
 			return nil, err
 		}
 
+		// Reserve the local write turn or await its release notification.
 		reserved, waitCh := c.reserveWriteLease()
 		if !reserved {
 			select {
@@ -134,12 +143,14 @@ func (c *Coordinator) WaitAcquireWriteLease(ctx context.Context, scope coord.Sco
 			continue
 		}
 
+		// Acquire the inner lease after reserving this process's write turn.
 		inner, err := c.inner.WaitAcquireWriteLease(ctx, scope)
 		if err != nil {
 			c.releaseWriteLease()
 			return nil, err
 		}
 
+		// Acquire the cross-process bbolt lock and return the combined lease.
 		releaseCoordinationLock, acquired, err := c.tryAcquireCoordinationLock()
 		if err != nil {
 			_ = inner.Release(context.Background())
@@ -150,6 +161,7 @@ func (c *Coordinator) WaitAcquireWriteLease(ctx context.Context, scope coord.Sco
 			return &lease{c: c, scope: scope, inner: inner, releaseCoordinationLock: releaseCoordinationLock}, nil
 		}
 
+		// Release local state before waiting for another process's lock turn.
 		_ = inner.Release(context.Background())
 		c.releaseWriteLease()
 

--- a/db/coord/filelock/coordinator.go
+++ b/db/coord/filelock/coordinator.go
@@ -37,6 +37,7 @@ type Coordinator struct {
 // sibling volumes sharing dir do not contend. On platforms without advisory
 // file locks the keyed scopes fall back to in-memory exclusion.
 func NewCoordinator(dir, storeID string, inner coord.Coordinator) *Coordinator {
+	// Canonicalize the store identity before constructing keyed state.
 	canonicalStoreID := canonicalLockStoreID(storeID)
 	return &Coordinator{
 		inner:   inner,
@@ -48,6 +49,7 @@ func NewCoordinator(dir, storeID string, inner coord.Coordinator) *Coordinator {
 
 // Capability reports keyed file lock support, delegating ObjectStore scopes.
 func (c *Coordinator) Capability(ctx context.Context, scope coord.Scope) (*coord.Capability, error) {
+	// Delegate root scopes and validate keyed capability requests.
 	if scope.Key == "" {
 		return c.inner.Capability(ctx, scope)
 	}
@@ -64,6 +66,7 @@ func (c *Coordinator) Capability(ctx context.Context, scope coord.Scope) (*coord
 
 // Snapshot delegates ObjectStore scopes; keyed scopes carry no generations.
 func (c *Coordinator) Snapshot(ctx context.Context, scope coord.Scope) (*coord.Snapshot, error) {
+	// Delegate snapshots to the coordinator selected by scope kind.
 	if scope.Key == "" {
 		return c.inner.Snapshot(ctx, scope)
 	}
@@ -72,6 +75,7 @@ func (c *Coordinator) Snapshot(ctx context.Context, scope coord.Scope) (*coord.S
 
 // Watch delegates ObjectStore scopes; keyed scopes carry no event stream.
 func (c *Coordinator) Watch(ctx context.Context, scope coord.Scope, afterGeneration uint64) (coord.Watch, error) {
+	// Delegate watches to the coordinator selected by scope kind.
 	if scope.Key == "" {
 		return c.inner.Watch(ctx, scope, afterGeneration)
 	}
@@ -80,10 +84,12 @@ func (c *Coordinator) Watch(ctx context.Context, scope coord.Scope, afterGenerat
 
 // TryAcquireWriteLease attempts to acquire the keyed file lock without blocking.
 func (c *Coordinator) TryAcquireWriteLease(ctx context.Context, scope coord.Scope) (coord.WriteLease, bool, error) {
+	// Delegate root scopes before acquiring the keyed lease.
 	if scope.Key == "" {
 		return c.inner.TryAcquireWriteLease(ctx, scope)
 	}
 
+	// Claim the in-memory keyed lease before probing the cross-process lock.
 	inner, ok, err := c.keyed.TryAcquireWriteLease(ctx, scope)
 	if err != nil || !ok {
 		return nil, ok, err
@@ -92,6 +98,7 @@ func (c *Coordinator) TryAcquireWriteLease(ctx context.Context, scope coord.Scop
 		return &lease{inner: inner}, true, nil
 	}
 
+	// Probe the lock file and release the keyed lease if acquisition fails.
 	file, locked, err := c.openLockedFile(ctx, scope)
 	if err != nil || !locked {
 		_ = inner.Release(context.Background())
@@ -102,10 +109,12 @@ func (c *Coordinator) TryAcquireWriteLease(ctx context.Context, scope coord.Scop
 
 // WaitAcquireWriteLease waits until the keyed file lock is available.
 func (c *Coordinator) WaitAcquireWriteLease(ctx context.Context, scope coord.Scope) (coord.WriteLease, error) {
+	// Delegate root scopes before waiting for the keyed lease.
 	if scope.Key == "" {
 		return c.inner.WaitAcquireWriteLease(ctx, scope)
 	}
 
+	// Retry keyed acquisition until both in-memory and file locks are held.
 	for {
 		inner, err := c.keyed.WaitAcquireWriteLease(ctx, scope)
 		if err != nil {
@@ -115,6 +124,7 @@ func (c *Coordinator) WaitAcquireWriteLease(ctx context.Context, scope coord.Sco
 			return &lease{inner: inner}, nil
 		}
 
+		// Probe the lock file after the keyed lease is available.
 		file, locked, err := c.openLockedFile(ctx, scope)
 		if err != nil {
 			_ = inner.Release(context.Background())
@@ -125,6 +135,7 @@ func (c *Coordinator) WaitAcquireWriteLease(ctx context.Context, scope coord.Sco
 		}
 		_ = inner.Release(context.Background())
 
+		// Release the keyed lease before pacing the next cross-process probe.
 		timer := time.NewTimer(crossProcessLockRetryDelay)
 		select {
 		case <-ctx.Done():
@@ -143,6 +154,7 @@ func (c *Coordinator) WaitAcquireWriteLease(ctx context.Context, scope coord.Sco
 // openLockedFile opens and try-locks the lock file for scope, returning the
 // locked file, whether the lock was acquired, and any error.
 func (c *Coordinator) openLockedFile(ctx context.Context, scope coord.Scope) (*os.File, bool, error) {
+	// Validate context and lock identity before creating the lock directory.
 	if err := ctx.Err(); err != nil {
 		return nil, false, err
 	}
@@ -153,6 +165,7 @@ func (c *Coordinator) openLockedFile(ctx context.Context, scope coord.Scope) (*o
 		return nil, false, errors.New("filelock: backing store identity cannot be empty")
 	}
 
+	// Create the private lock directory before opening this scope's file.
 	lockDir := filepath.Join(c.dir, lockDirName)
 	if err := os.MkdirAll(lockDir, 0o700); err != nil {
 		return nil, false, pkgerrors.Wrap(err, "create lock directory")
@@ -161,6 +174,7 @@ func (c *Coordinator) openLockedFile(ctx context.Context, scope coord.Scope) (*o
 		return nil, false, err
 	}
 
+	// Open and validate the lock file, then acquire its advisory lock.
 	path := filepath.Join(lockDir, lockDigest(c.storeID, scope)+".lock")
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {

--- a/db/coord/inmem/coordinator.go
+++ b/db/coord/inmem/coordinator.go
@@ -26,10 +26,12 @@ func NewCoordinator() *Coordinator {
 
 // Capability reports in-memory coordination support.
 func (c *Coordinator) Capability(ctx context.Context, scope coord.Scope) (*coord.Capability, error) {
+	// Reject canceled capability requests before reading shared state.
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
 
+	// Snapshot the current scope generation under the coordinator lock.
 	c.mu.Lock()
 	state := c.getScopeLocked(scope)
 	generation := state.generation
@@ -47,6 +49,7 @@ func (c *Coordinator) Capability(ctx context.Context, scope coord.Scope) (*coord
 
 // Snapshot returns the latest in-memory generation and root.
 func (c *Coordinator) Snapshot(ctx context.Context, scope coord.Scope) (*coord.Snapshot, error) {
+	// Reject canceled or keyed snapshot requests before reading state.
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -54,6 +57,7 @@ func (c *Coordinator) Snapshot(ctx context.Context, scope coord.Scope) (*coord.S
 		return nil, coord.ErrUnsupported
 	}
 
+	// Copy the scope snapshot while holding the state lock.
 	c.mu.Lock()
 	snapshot := c.getScopeLocked(scope).snapshot(scope)
 	c.mu.Unlock()
@@ -62,6 +66,7 @@ func (c *Coordinator) Snapshot(ctx context.Context, scope coord.Scope) (*coord.S
 
 // Watch returns coordination events after afterGeneration.
 func (c *Coordinator) Watch(ctx context.Context, scope coord.Scope, afterGeneration uint64) (coord.Watch, error) {
+	// Reject canceled or keyed watch requests before registering a watcher.
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -69,6 +74,7 @@ func (c *Coordinator) Watch(ctx context.Context, scope coord.Scope, afterGenerat
 		return nil, coord.ErrUnsupported
 	}
 
+	// Register the watcher and replay a missed generation while locked.
 	watch := &watch{
 		c:     c,
 		scope: scope,
@@ -86,6 +92,7 @@ func (c *Coordinator) Watch(ctx context.Context, scope coord.Scope, afterGenerat
 	}
 	c.mu.Unlock()
 
+	// Close the watcher when its request context ends.
 	go func() {
 		select {
 		case <-ctx.Done():
@@ -99,6 +106,7 @@ func (c *Coordinator) Watch(ctx context.Context, scope coord.Scope, afterGenerat
 
 // TryAcquireWriteLease attempts to acquire the logical write lease.
 func (c *Coordinator) TryAcquireWriteLease(ctx context.Context, scope coord.Scope) (coord.WriteLease, bool, error) {
+	// Validate the lease request before checking lock ownership.
 	if err := ctx.Err(); err != nil {
 		return nil, false, err
 	}
@@ -106,6 +114,7 @@ func (c *Coordinator) TryAcquireWriteLease(ctx context.Context, scope coord.Scop
 		return nil, false, coord.ErrScopeEmpty
 	}
 
+	// Publish contention or claim the scope lock atomically.
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -127,6 +136,7 @@ func (c *Coordinator) TryAcquireWriteLease(ctx context.Context, scope coord.Scop
 
 // WaitAcquireWriteLease waits until the logical write lease is available.
 func (c *Coordinator) WaitAcquireWriteLease(ctx context.Context, scope coord.Scope) (coord.WriteLease, error) {
+	// Validate the wait request before installing cancellation wakeups.
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -134,6 +144,7 @@ func (c *Coordinator) WaitAcquireWriteLease(ctx context.Context, scope coord.Sco
 		return nil, coord.ErrScopeEmpty
 	}
 
+	// Wake the condition wait when the context is canceled.
 	cancelWake := context.AfterFunc(ctx, func() {
 		c.mu.Lock()
 		c.cond.Broadcast()
@@ -141,6 +152,7 @@ func (c *Coordinator) WaitAcquireWriteLease(ctx context.Context, scope coord.Sco
 	})
 	defer cancelWake()
 
+	// Wait for the scope lock and recheck context after each wakeup.
 	c.mu.Lock()
 	defer c.mu.Unlock()
 

--- a/db/coord/opfs/coordinator.go
+++ b/db/coord/opfs/coordinator.go
@@ -38,9 +38,12 @@ func NewCoordinator(meta *metashard.MetaShard, lockPrefix string, inner *coord_i
 
 // Capability reports OPFS coordination support.
 func (c *Coordinator) Capability(ctx context.Context, scope coord.Scope) (*coord.Capability, error) {
+	// Reject canceled capability requests before reading generation state.
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
+
+	// Build the capability record and mark keyed scopes as generation-free.
 	capability := &coord.Capability{
 		Supported:     true,
 		Backend:       coord.BackendKindOPFS,
@@ -51,6 +54,8 @@ func (c *Coordinator) Capability(ctx context.Context, scope coord.Scope) (*coord
 	if !capability.Generations {
 		return capability, nil
 	}
+
+	// Read the metashard generation for root scopes.
 	generation, err := c.generation(ctx, scope)
 	if err != nil {
 		return nil, err
@@ -61,6 +66,7 @@ func (c *Coordinator) Capability(ctx context.Context, scope coord.Scope) (*coord
 
 // Snapshot returns the latest metashard generation and coordinator root.
 func (c *Coordinator) Snapshot(ctx context.Context, scope coord.Scope) (*coord.Snapshot, error) {
+	// Read the inner snapshot before overlaying metashard generation.
 	snapshot, err := c.inner.Snapshot(ctx, scope)
 	if err != nil {
 		return nil, err
@@ -68,6 +74,8 @@ func (c *Coordinator) Snapshot(ctx context.Context, scope coord.Scope) (*coord.S
 	if c.meta == nil {
 		return snapshot, nil
 	}
+
+	// Refresh the generation only when this coordinator has a metashard.
 	snapshot.Generation, err = c.generation(ctx, scope)
 	if err != nil {
 		return nil, err
@@ -77,11 +85,13 @@ func (c *Coordinator) Snapshot(ctx context.Context, scope coord.Scope) (*coord.S
 
 // Watch streams root/prefix lease events and OPFS BroadcastChannel wakeups.
 func (c *Coordinator) Watch(ctx context.Context, scope coord.Scope, afterGeneration uint64) (coord.Watch, error) {
+	// Start the inner watch before attaching OPFS invalidation events.
 	inner, err := c.inner.Watch(ctx, scope, afterGeneration)
 	if err != nil {
 		return nil, err
 	}
 
+	// Create and start the combined watch lifecycle.
 	ctx, cancel := context.WithCancel(ctx)
 	w := &watch{
 		ctx:      ctx,
@@ -99,15 +109,18 @@ func (c *Coordinator) Watch(ctx context.Context, scope coord.Scope, afterGenerat
 
 // TryAcquireWriteLease attempts to acquire the OPFS logical write lease.
 func (c *Coordinator) TryAcquireWriteLease(ctx context.Context, scope coord.Scope) (coord.WriteLease, bool, error) {
+	// Reject canceled requests before acquiring the Web Lock and inner lease.
 	if err := ctx.Err(); err != nil {
 		return nil, false, err
 	}
 
+	// Acquire the Web Lock before claiming the inner logical lease.
 	releaseWebLock, acquired, err := filelock.AcquireWebLockIfAvailable(writeLockName(c.lockPrefix, scope), true)
 	if err != nil || !acquired {
 		return nil, acquired, err
 	}
 
+	// Claim the inner lease and release Web Lock state on failure.
 	inner, ok, err := c.inner.TryAcquireWriteLease(ctx, scope)
 	if err != nil || !ok {
 		releaseWebLock()
@@ -118,11 +131,13 @@ func (c *Coordinator) TryAcquireWriteLease(ctx context.Context, scope coord.Scop
 
 // WaitAcquireWriteLease waits until the OPFS logical write lease is available.
 func (c *Coordinator) WaitAcquireWriteLease(ctx context.Context, scope coord.Scope) (coord.WriteLease, error) {
+	// Acquire the inner lease before waiting for the Web Lock.
 	inner, err := c.inner.WaitAcquireWriteLease(ctx, scope)
 	if err != nil {
 		return nil, err
 	}
 
+	// Acquire the Web Lock and roll back the inner lease on failure.
 	releaseWebLock, err := filelock.AcquireWebLockContext(ctx, writeLockName(c.lockPrefix, scope), true)
 	if err != nil {
 		_ = inner.Release(context.Background())
@@ -132,6 +147,7 @@ func (c *Coordinator) WaitAcquireWriteLease(ctx context.Context, scope coord.Sco
 }
 
 func (c *Coordinator) generation(ctx context.Context, scope coord.Scope) (uint64, error) {
+	// Reject canceled generation reads before consulting metashard state.
 	if err := ctx.Err(); err != nil {
 		return 0, err
 	}

--- a/db/core/core.go
+++ b/db/core/core.go
@@ -24,30 +24,34 @@ func NewCoreBus(
 	le *logrus.Entry,
 	opts ...cbc.Option,
 ) (bus.Bus, *static.Resolver, error) {
+	// Construct the controller bus and static resolver.
 	b, sr, err := cbc.NewCoreBus(ctx, le, opts...)
 	if err != nil {
 		return nil, nil, err
 	}
 
+	// Register the standard controller factories.
 	AddFactories(b, sr)
 	return b, sr, nil
 }
 
 // AddFactories adds factories to an existing static resolver.
 func AddFactories(b bus.Bus, sr *static.Resolver) {
+	// Register platform and network factories.
 	addNativeFactories(b, sr)
 	bifrostcore.AddFactories(b, sr)
 
+	// Register node, bucket, and lookup factories.
 	sr.AddFactory(nctr.NewFactory(b))
 	sr.AddFactory(bucket_setup.NewFactory(b))
-
 	sr.AddFactory(node_controller.NewFactory(b))
 	sr.AddFactory(lookup_concurrent.NewFactory(b))
 
+	// Register the in-memory volume and block stores.
 	sr.AddFactory(volume_kvtxinmem.NewFactory(b))
-
 	sr.AddFactory(block_store_inmem.NewFactory(b))
 	sr.AddFactory(block_store_overlay.NewFactory(b))
 
+	// Register the pub-sub exchange factory.
 	sr.AddFactory(psecho.NewFactory(b))
 }

--- a/db/core/test/core.go
+++ b/db/core/test/core.go
@@ -16,11 +16,13 @@ func NewTestingBus(
 	le *logrus.Entry,
 	opts ...cbc.Option,
 ) (bus.Bus, *static.Resolver, error) {
+	// Construct the minimal controller bus.
 	b, sr, err := cbc.NewCoreBus(ctx, le, opts...)
 	if err != nil {
 		return nil, nil, err
 	}
 
+	// Register the network peer factory used by tests.
 	sr.AddFactory(nctr.NewFactory(b))
 	return b, sr, nil
 }

--- a/db/daemon/api/api-bucket-op.go
+++ b/db/daemon/api/api-bucket-op.go
@@ -14,15 +14,20 @@ func (a *API) BucketOp(
 	ctx context.Context,
 	req *BucketOpRequest,
 ) (*BucketOpResponse, error) {
+	// Validate the requested bucket operation.
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
+
+	// Open the bucket operation and ensure its release callback runs.
 	bk, rel, err := a.startBucketOp(ctx, req.GetBucketOpArgs())
 	if err != nil {
 		return nil, err
 	}
 	defer rel()
 	resp := &BucketOpResponse{}
+
+	// Apply the requested block mutation or lookup.
 	switch req.GetOp() {
 	case BucketOp_BucketOp_BLOCK_PUT:
 		ref, existed, err := bk.PutBlock(ctx, req.GetData(), req.GetPutOpts())

--- a/db/daemon/api/api-bucket.go
+++ b/db/daemon/api/api-bucket.go
@@ -15,11 +15,11 @@ func (a *API) ApplyBucketConfig(
 	req *ApplyBucketConfigRequest,
 	serv SRPCHydraDaemonService_ApplyBucketConfigStream,
 ) error {
+	// Validate and resolve the requested bucket configuration.
 	ctx := serv.Context()
 	if err := req.Validate(); err != nil {
 		return err
 	}
-
 	errCh := make(chan error, 1)
 	handleErr := func(err error) {
 		select {
@@ -27,12 +27,12 @@ func (a *API) ApplyBucketConfig(
 		default:
 		}
 	}
-
 	applyBucketConf, err := req.ToApplyBucketConfig()
 	if err != nil {
 		return err
 	}
 
+	// Watch the configuration and stream each result.
 	var emittedAny atomic.Bool
 	di, diRef, err := bus.ExecWatchEffect(
 		func(val directive.TypedAttachedValue[*bucket.ApplyBucketConfigResult]) func() {
@@ -52,24 +52,23 @@ func (a *API) ApplyBucketConfig(
 	}
 	defer diRef.Release()
 
+	// Complete the stream when the resolver becomes idle.
 	defer di.AddIdleCallback(func(isIdle bool, resolverErrs []error) {
 		if !isIdle {
 			return
 		}
-
 		for _, err := range resolverErrs {
 			if err != nil && err != context.Canceled {
 				handleErr(err)
 				return
 			}
 		}
-
-		// handle idle with success if at least one value emitted
 		if emittedAny.Load() {
 			handleErr(nil)
 		}
 	})()
 
+	// Wait for cancellation or the resolver result.
 	select {
 	case <-ctx.Done():
 		return nil
@@ -83,11 +82,13 @@ func (a *API) ListBuckets(
 	ctx context.Context,
 	req *volume.ListBucketsRequest,
 ) (*ListBucketsResponse, error) {
+	// Collect bucket values from the controller bus.
 	bucketInfos, _, ref, err := bus.ExecCollectValues[*volume.ListBucketsValue](ctx, a.bus, req, false, nil)
 	if err != nil {
 		return nil, err
 	}
 	ref.Release()
 
+	// Return the collected bucket information.
 	return &ListBucketsResponse{Buckets: bucketInfos}, nil
 }

--- a/db/daemon/api/api-objstore-op.go
+++ b/db/daemon/api/api-objstore-op.go
@@ -13,10 +13,12 @@ func (a *API) ObjectStoreOp(
 	ctx context.Context,
 	req *ObjectStoreOpRequest,
 ) (*ObjectStoreOpResponse, error) {
+	// Validate the requested object operation.
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
 
+	// Resolve the object store and retain its directive release.
 	av, _, diRef, err := bus.ExecOneOffTyped[volume.BuildObjectStoreAPIValue](
 		ctx,
 		a.bus,
@@ -32,11 +34,11 @@ func (a *API) ObjectStoreOp(
 	}
 	defer diRef.Release()
 
+	// Open the resolved object store and choose transaction write access.
 	objStore := av.GetValue().GetObjectStore()
 	if objStore == nil {
 		return nil, errors.New("object store value was empty")
 	}
-
 	var write bool
 	switch req.GetOp() {
 	case ObjectStoreOp_ObjectStoreOp_DELETE_KEY:
@@ -44,13 +46,13 @@ func (a *API) ObjectStoreOp(
 	case ObjectStoreOp_ObjectStoreOp_PUT_KEY:
 		write = true
 	}
-
 	tx, err := objStore.NewTransaction(ctx, write)
 	if err != nil {
 		return nil, err
 	}
 	defer tx.Discard()
 
+	// Execute the object operation against the transaction.
 	err = nil
 	resp := &ObjectStoreOpResponse{}
 	reqKey := []byte(req.GetKey())
@@ -72,6 +74,8 @@ func (a *API) ObjectStoreOp(
 		})
 		resp.Keys = keys
 	}
+
+	// Commit successful write operations.
 	if err == nil && write {
 		err = tx.Commit(ctx)
 	}

--- a/db/daemon/api/api-volume.go
+++ b/db/daemon/api/api-volume.go
@@ -12,6 +12,7 @@ func (a *API) ListVolumes(
 	ctx context.Context,
 	req *ListVolumesRequest,
 ) (*ListVolumesResponse, error) {
+	// Inspect each registered volume controller.
 	var volumeInfos []*volume.VolumeInfo
 	controllers := a.bus.GetControllers()
 	for _, controller := range controllers {
@@ -32,6 +33,7 @@ func (a *API) ListVolumes(
 		}
 	}
 
+	// Return the collected volume information.
 	return &ListVolumesResponse{
 		Volumes: volumeInfos,
 	}, nil

--- a/db/daemon/api/controller/controller.go
+++ b/db/daemon/api/controller/controller.go
@@ -58,17 +58,15 @@ func (c *Controller) GetControllerInfo() *controller.Info {
 // Returning nil ends execution.
 // Returning an error triggers a retry with backoff.
 func (c *Controller) Execute(ctx context.Context) error {
-	// Construct the API
+	// Construct and register the Hydra API.
 	api, err := hydra_api.NewAPI(c.bus, c.conf.GetHydraApiConfig())
 	if err != nil {
 		return err
 	}
-
-	// hydra api
 	mux := srpc.NewMux()
 	api.RegisterAsSRPCServer(mux)
 
-	// bifrost api
+	// Register optional Bifrost and controller-bus APIs.
 	if !c.conf.GetDisableBifrostApi() {
 		bapi, err := bapi.NewAPI(c.bus, c.conf.GetBifrostApiConfig())
 		if err != nil {
@@ -76,19 +74,17 @@ func (c *Controller) Execute(ctx context.Context) error {
 		}
 		bapi.RegisterAsSRPCServer(mux)
 	}
-
-	// controllerbus api
 	if !c.conf.GetDisableBusApi() {
 		bapi := cbapi.NewAPI(c.bus, c.conf.GetBusApiConfig())
 		_ = bapi.RegisterAsSRPCServer(mux)
 	}
 
+	// Listen for API connections and serve until cancellation or failure.
 	c.le.WithField("local-addr", c.listenAddr).Info("starting to listen for api connections")
 	lis, err := net.Listen("tcp", c.listenAddr)
 	if err != nil {
 		return err
 	}
-
 	srv := srpc.NewServer(mux)
 	errCh := make(chan error, 1)
 	go func() {
@@ -96,6 +92,7 @@ func (c *Controller) Execute(ctx context.Context) error {
 		_ = lis.Close()
 	}()
 
+	// Close the listener when the context ends.
 	select {
 	case <-ctx.Done():
 		_ = lis.Close()

--- a/db/daemon/daemon.go
+++ b/db/daemon/daemon.go
@@ -47,6 +47,7 @@ func NewDaemon(
 	nodePriv crypto.PrivKey,
 	opts ConstructOpts,
 ) (*Daemon, error) {
+	// Resolve the daemon logger.
 	le := opts.LogEntry
 	if le == nil {
 		log := logrus.New()
@@ -54,6 +55,7 @@ func NewDaemon(
 		le = logrus.NewEntry(log)
 	}
 
+	// Create the daemon context and local peer identity.
 	ctx, subCtxCancel := context.WithCancel(ctx)
 	nodePeer, err := peer.NewPeer(nodePriv)
 	if err != nil {
@@ -61,7 +63,7 @@ func NewDaemon(
 		return nil, err
 	}
 
-	// Construct the controller bus.
+	// Construct the controller bus and register all factories.
 	b, sr, err := core.NewCoreBus(ctx, le)
 	if err != nil {
 		subCtxCancel()
@@ -69,7 +71,7 @@ func NewDaemon(
 	}
 	core_all.AddFactories(b, sr)
 
-	// Construct the node controller.
+	// Resolve the node controller.
 	dir := resolver.NewLoadControllerWithConfig(&node_controller.Config{})
 	_, _, valRef, err := bus.ExecOneOff(ctx, b, dir, nil, nil)
 	if err != nil {
@@ -78,7 +80,7 @@ func NewDaemon(
 	}
 	le.Info("node controller resolved")
 
-	// Construct the peer controller
+	// Add and retain the peer controller.
 	peerCtrl := peer_controller.NewController(le, nodePeer)
 	peerCtrlRel, err := b.AddController(ctx, peerCtrl, nil)
 	if err != nil {
@@ -87,6 +89,7 @@ func NewDaemon(
 	}
 	le.Info("node peer controller resolved")
 
+	// Return the daemon with all release callbacks.
 	return &Daemon{
 		Peer: nodePeer,
 
@@ -109,8 +112,11 @@ func (d *Daemon) GetControllerBus() bus.Bus {
 
 // Close calls all close callbacks.
 func (d *Daemon) Close() {
+	// Detach the release callbacks before invoking them.
 	closeCbs := d.closeCbs
 	d.closeCbs = nil
+
+	// Invoke each detached release callback.
 	for _, cb := range closeCbs {
 		cb()
 	}

--- a/db/dex/psecho/controller.go
+++ b/db/dex/psecho/controller.go
@@ -91,6 +91,7 @@ func NewController(le *logrus.Entry, b bus.Bus, cc *Config) (*Controller, error)
 
 // Execute executes the controller goroutine.
 func (c *Controller) Execute(ctx context.Context) error {
+	// Resolve the configured peer and private key.
 	c.le.Debug("psecho controller running")
 
 	peerID, err := c.cc.ParsePeerID()
@@ -114,6 +115,7 @@ func (c *Controller) Execute(ctx context.Context) error {
 	c.incomingKeyed.SetContext(ctx, true)
 	c.outgoingKeyed.SetContext(ctx, true)
 
+	// Subscribe to the configured pub-sub channel.
 	sub, _, subRef, err := pubsub.ExBuildChannelSubscription(
 		ctx, c.b, false, c.cc.GetPubsubChannelId(), privKey, nil,
 	)
@@ -122,6 +124,7 @@ func (c *Controller) Execute(ctx context.Context) error {
 	}
 	defer subRef.Release()
 
+	// Register message handling and start want-list publishing.
 	relHandler := sub.AddHandler(func(m pubsub.Message) {
 		c.handleIncomingMessage(ctx, m, privKey)
 	})
@@ -129,6 +132,7 @@ func (c *Controller) Execute(ctx context.Context) error {
 
 	go c.publishLoop(ctx, sub)
 
+	// Wait for controller cancellation.
 	<-ctx.Done()
 	return ctx.Err()
 }
@@ -148,6 +152,7 @@ func (c *Controller) publishLoop(ctx context.Context, sub pubsub.Subscription) {
 			maps.Copy(refs, c.wantRefs)
 		})
 
+		// Wait for a publish trigger or debounce interval.
 		immediate := c.publishNow.Swap(0) != 0
 		if !immediate {
 			if !timer.Stop() {
@@ -163,6 +168,7 @@ func (c *Controller) publishLoop(ctx context.Context, sub pubsub.Subscription) {
 			case <-ch:
 			case <-timer.C:
 			}
+
 			// Re-snapshot after waiting.
 			c.bcast.HoldLock(func(_ func(), getWaitCh func() <-chan struct{}) {
 				ch = getWaitCh()
@@ -171,6 +177,7 @@ func (c *Controller) publishLoop(ctx context.Context, sub pubsub.Subscription) {
 			})
 		}
 
+		// Wait for a directive when the want-list is empty.
 		if len(refs) == 0 {
 			// Empty wantlist: wait for a directive to add something.
 			select {
@@ -184,6 +191,7 @@ func (c *Controller) publishLoop(ctx context.Context, sub pubsub.Subscription) {
 		// Always re-publish non-empty wantlists on each tick.
 		// Pub-sub messages can be lost (e.g. subscription not yet
 		// established), so periodic re-announce ensures delivery.
+		// Re-publish the non-empty want-list for peer delivery.
 		if err := c.publishWantList(sub, refs); err != nil {
 			c.le.WithError(err).Warn("publish wantlist failed")
 		}
@@ -244,6 +252,7 @@ func (c *Controller) handleIncomingMessage(
 		return
 	}
 
+	// Decode the authenticated pub-sub message.
 	var msg PubSubMessage
 	if err := msg.UnmarshalVT(m.GetData()); err != nil {
 		c.le.WithError(err).Warn("cannot parse pubsub message")
@@ -253,6 +262,7 @@ func (c *Controller) handleIncomingMessage(
 	from := m.GetFrom()
 	ts := msg.GetTimestampUnixNano()
 
+	// Reconcile the remote peer want-list snapshot.
 	c.bcast.HoldLock(func(bcast func(), _ func() <-chan struct{}) {
 		rp, ok := c.remotePeers[from]
 		if msg.GetWantEmpty() {
@@ -290,7 +300,7 @@ func (c *Controller) handleIncomingMessage(
 		bcast()
 	})
 
-	// Check local bucket for blocks the remote peer wants.
+	// Check the local bucket and queue blocks for the remote peer.
 	c.checkAndQueueBlocks(ctx, from)
 }
 

--- a/db/dex/psecho/streams.go
+++ b/db/dex/psecho/streams.go
@@ -39,6 +39,7 @@ func filterLocalExistingBlocks(
 	lk bucket_lookup.Lookup,
 	refs []*block.BlockRef,
 ) ([]*block.BlockRef, error) {
+	// Prefer the batch existence lookup for the requested references.
 	found, err := lk.LookupBlockExistsBatch(ctx, refs, WithLocalOnly())
 	if err != nil {
 		return filterLocalExistingBlocksIndividually(ctx, lk, refs), nil
@@ -47,6 +48,7 @@ func filterLocalExistingBlocks(
 		return nil, errors.Errorf("lookup exists batch returned %d results for %d refs", len(found), len(refs))
 	}
 
+	// Queue references confirmed present in the local store.
 	queued := make([]*block.BlockRef, 0, len(refs))
 	for i, ok := range found {
 		if ok {

--- a/db/dex/session/session.go
+++ b/db/dex/session/session.go
@@ -41,6 +41,7 @@ func NewDexSession(stream io.ReadWriteCloser, chunkSize int, maxBlockSize uint64
 	if maxBlockSize <= 0 {
 		maxBlockSize = defaultMaxBlockSize
 	}
+
 	// maxMessageSize must accommodate a single chunk plus proto framing overhead.
 	// We always chunk, so the largest single message is chunkSize + BlockTransfer fields.
 	maxMsg := uint32(chunkSize) + 1024 //nolint:gosec
@@ -101,10 +102,12 @@ func (d *DexSession) ReadMessage() (*BlockTransfer, error) {
 // SendBlock sends a complete block as Init + chunked data messages.
 // The data is always chunked even if it fits in a single chunk.
 func (d *DexSession) SendBlock(requestID uint64, ref *block.BlockRef, data []byte) error {
+	// Send the block initialization message.
 	if err := d.SendInit(requestID, ref, uint64(len(data))); err != nil {
 		return errors.Wrap(err, "send init")
 	}
 
+	// Send each data chunk and mark the final chunk.
 	for i := 0; i < len(data); i += d.chunkSize {
 		end := min(i+d.chunkSize, len(data))
 		complete := end >= len(data)
@@ -113,7 +116,7 @@ func (d *DexSession) SendBlock(requestID uint64, ref *block.BlockRef, data []byt
 		}
 	}
 
-	// Handle empty data: send a single empty chunk with complete=true.
+	// Send an explicit complete chunk for empty data.
 	if len(data) == 0 {
 		if err := d.SendChunk(requestID, nil, true); err != nil {
 			return errors.Wrap(err, "send chunk")
@@ -127,11 +130,12 @@ func (d *DexSession) SendBlock(requestID uint64, ref *block.BlockRef, data []byt
 // If maxBlockSize is 0, uses the session default.
 // Returns the request ID, block reference, assembled data, and any error.
 func (d *DexSession) ReceiveBlock(maxBlockSize uint64) (uint64, *block.BlockRef, []byte, error) {
+	// Resolve the maximum accepted block size.
 	if maxBlockSize == 0 {
 		maxBlockSize = d.maxBlock
 	}
 
-	// Read the init message.
+	// Read and validate the initialization message.
 	init, err := d.ReadMessage()
 	if err != nil {
 		return 0, nil, nil, errors.Wrap(err, "read init")
@@ -145,7 +149,6 @@ func (d *DexSession) ReceiveBlock(maxBlockSize uint64) (uint64, *block.BlockRef,
 	if init.GetError() != "" {
 		return init.GetRequestId(), init.GetRef(), nil, errors.New(init.GetError())
 	}
-
 	totalSize := init.GetTotalSize()
 	if totalSize > maxBlockSize {
 		return init.GetRequestId(), init.GetRef(), nil, errors.Errorf(
@@ -154,12 +157,12 @@ func (d *DexSession) ReceiveBlock(maxBlockSize uint64) (uint64, *block.BlockRef,
 			strconv.FormatUint(maxBlockSize, 10),
 		)
 	}
-
 	requestID := init.GetRequestId()
 	ref := init.GetRef()
 
-	// Read chunks into a buffer.
+	// Accumulate chunks until the transfer is complete.
 	var buf bytes.Buffer
+
 	buf.Grow(int(totalSize)) //nolint:gosec
 	for {
 		msg, rerr := d.ReadMessage()
@@ -172,10 +175,10 @@ func (d *DexSession) ReceiveBlock(maxBlockSize uint64) (uint64, *block.BlockRef,
 		if msg.GetError() != "" {
 			return requestID, ref, nil, errors.New(msg.GetError())
 		}
-
 		chunk := msg.GetData()
 		if len(chunk) > 0 {
 			buf.Write(chunk)
+
 			if uint64(buf.Len()) > totalSize { //nolint:gosec
 				return requestID, ref, nil, errors.Errorf(
 					"accumulated data %s exceeds declared size %s",
@@ -184,19 +187,16 @@ func (d *DexSession) ReceiveBlock(maxBlockSize uint64) (uint64, *block.BlockRef,
 				)
 			}
 		}
-
 		if msg.GetComplete() {
 			break
 		}
 	}
-
 	data := buf.Bytes()
 
-	// Verify hash.
+	// Verify the assembled block hash before returning data.
 	if err := ref.VerifyData(data, true); err != nil {
 		return requestID, ref, nil, errors.Wrap(err, "block verification failed")
 	}
-
 	return requestID, ref, data, nil
 }
 

--- a/db/dex/solicit/controller.go
+++ b/db/dex/solicit/controller.go
@@ -61,6 +61,7 @@ func NewController(le *logrus.Entry, b bus.Bus, cc *Config) (*Controller, error)
 
 // Execute executes the controller goroutine.
 func (c *Controller) Execute(ctx context.Context) error {
+	// Resolve the local peer identity.
 	c.le.Debug("dex solicit controller running")
 
 	peerID, err := c.cc.ParsePeerID()
@@ -68,6 +69,7 @@ func (c *Controller) Execute(ctx context.Context) error {
 		return err
 	}
 
+	// Publish the solicitation protocol for the configured bucket.
 	// Emit SolicitProtocol directive with bucket ID as context.
 	solicitCtx := []byte(c.cc.GetBucketId())
 	dir := link_solicit.NewSolicitProtocol(
@@ -91,12 +93,14 @@ func (c *Controller) Execute(ctx context.Context) error {
 	}
 	defer solicitRef.Release()
 
+	// Wait for controller cancellation.
 	<-ctx.Done()
 	return ctx.Err()
 }
 
 // handleSolicitedStream processes a new solicited stream from a DEX peer.
 func (c *Controller) handleSolicitedStream(ctx context.Context, sms link_solicit.SolicitMountedStream) {
+	// Accept the solicited stream and identify the remote peer.
 	ms, taken, err := sms.AcceptMountedStream()
 	if err != nil || taken {
 		return
@@ -111,6 +115,7 @@ func (c *Controller) handleSolicitedStream(ctx context.Context, sms link_solicit
 		le.Debug("dex peer session ended")
 	})
 
+	// Replace any previous session for this peer.
 	c.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
 		// Replace existing session if any.
 		if old, ok := c.sessions[remotePeer]; ok {
@@ -120,6 +125,7 @@ func (c *Controller) handleSolicitedStream(ctx context.Context, sms link_solicit
 		broadcast()
 	})
 
+	// Start the peer session.
 	le.Debug("dex peer session started")
 	sess.start(ctx)
 }
@@ -195,6 +201,7 @@ type lookupResolver struct {
 
 // Resolve resolves the values, emitting them to the handler.
 func (r *lookupResolver) Resolve(ctx context.Context, handler directive.ResolverHandler) error {
+	// Snapshot connected peer sessions.
 	var sessions []*peerSession
 	r.c.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
 		for _, s := range r.c.sessions {
@@ -202,6 +209,7 @@ func (r *lookupResolver) Resolve(ctx context.Context, handler directive.Resolver
 		}
 	})
 
+	// Query peers and emit the first successful block.
 	data, found := r.queryPeers(ctx, sessions)
 	if !found {
 		handler.AddValue(dex.NewLookupBlockFromNetworkValue(nil, nil))
@@ -241,6 +249,7 @@ func (f peerBlockFanout) run(ctx context.Context) ([]byte, bool) {
 	reqCtx, reqCancel := context.WithTimeout(ctx, requestTimeout)
 	defer reqCancel()
 
+	// Fan out the request with a bounded timeout.
 	results := make(chan peerBlockFanoutResult, len(f.sessions))
 	for _, sess := range f.sessions {
 		go func(sess *peerSession) {
@@ -253,6 +262,7 @@ func (f peerBlockFanout) run(ctx context.Context) ([]byte, bool) {
 		}(sess)
 	}
 
+	// Return the first successful peer response.
 	for range f.sessions {
 		res := <-results
 		if res.found {

--- a/db/dex/solicit/session.go
+++ b/db/dex/solicit/session.go
@@ -69,12 +69,14 @@ func (s *peerSession) waitExited(ctx context.Context) error {
 // run starts the session, reading messages in a loop and dispatching
 // responses to pending requests or handling incoming requests.
 func (s *peerSession) run(ctx context.Context) {
+	// Mark the session closed and wake pending requests on exit.
 	defer func() {
 		s.closed.Store(true)
 		s.sess.Close()
 		s.wakePending()
 	}()
 
+	// Read and dispatch session messages.
 	for {
 		var msg DexMessage
 		if err := s.sess.RecvMsg(&msg); err != nil {
@@ -104,6 +106,7 @@ func (s *peerSession) run(ctx context.Context) {
 
 // handleRequest handles an incoming block request and sends a response.
 func (s *peerSession) handleRequest(ctx context.Context, req *DexMessage) {
+	// Prepare a response that is sent when request handling finishes.
 	ref := req.GetRef()
 	resp := &DexMessage{
 		RequestId:  req.GetRequestId(),
@@ -120,6 +123,7 @@ func (s *peerSession) handleRequest(ctx context.Context, req *DexMessage) {
 		return
 	}
 
+	// Check the local bucket before forwarding.
 	// Check local store first.
 	data, found, err := s.lookupLocalBlock(ctx, ref)
 	if err != nil {
@@ -132,6 +136,7 @@ func (s *peerSession) handleRequest(ctx context.Context, req *DexMessage) {
 		return
 	}
 
+	// Forward unresolved requests while hops remain.
 	// Forward to other peers if hops remain.
 	// Clamp to configured max so a malicious peer cannot amplify traffic.
 	maxHops := s.c.cc.GetMaxForwardHops()
@@ -170,6 +175,7 @@ func (s *peerSession) requestBlock(ctx context.Context, ref *block.BlockRef, hop
 		return nil, false, errors.New("session closed")
 	}
 
+	// Register the pending request before sending it.
 	id := s.nextID.Add(1)
 	ch := make(chan *DexMessage, 1)
 	s.mtx.Lock()
@@ -185,6 +191,7 @@ func (s *peerSession) requestBlock(ctx context.Context, ref *block.BlockRef, hop
 		s.mtx.Unlock()
 	}()
 
+	// Send the block request to the peer.
 	req := &DexMessage{
 		RequestId:     id,
 		Ref:           ref,
@@ -194,6 +201,7 @@ func (s *peerSession) requestBlock(ctx context.Context, ref *block.BlockRef, hop
 		return nil, false, err
 	}
 
+	// Await the response or request cancellation.
 	select {
 	case <-ctx.Done():
 		return nil, false, ctx.Err()
@@ -207,6 +215,8 @@ func (s *peerSession) requestBlock(ctx context.Context, ref *block.BlockRef, hop
 		if !resp.GetFound() {
 			return nil, false, nil
 		}
+
+		// Verify returned block data before reporting success.
 		data := resp.GetData()
 		if err := ref.VerifyData(data, true); err != nil {
 			return data, false, err

--- a/db/examples/common/demo-cayley.go
+++ b/db/examples/common/demo-cayley.go
@@ -26,12 +26,14 @@ func RunDemoCayley(
 	b bus.Bus,
 	volCtr volume.Controller,
 ) error {
+	// Resolve the example volume.
 	tStart := time.Now()
 	vol, err := volCtr.GetVolume(ctx)
 	if err != nil {
 		return err
 	}
 
+	// Build the lookup controller configuration.
 	lookupConf := &lc.Config{
 		// NotFoundBehavior: lc.NotFoundBehavior_NotFoundBehavior_LOOKUP_DIRECTIVE,
 		NotFoundBehavior: lc.NotFoundBehavior_NotFoundBehavior_NONE,
@@ -41,6 +43,8 @@ func RunDemoCayley(
 	if err != nil {
 		return err
 	}
+
+	// Create and apply the example bucket configuration.
 	bucketConf, err := bucket.NewConfig("example-bucket-1", 1, &bucket.LookupConfig{
 		Controller: cc,
 	})
@@ -57,6 +61,7 @@ func RunDemoCayley(
 		return err
 	}
 
+	// Open the bucket lookup and store a sample block.
 	// store something
 	lkr, _, lkRef, err := lookup.ExBuildBucketLookup(ctx, b, false, "example-bucket-1", nil)
 	if err != nil {
@@ -84,6 +89,7 @@ func RunDemoCayley(
 		le.Infof("placed block with ref: %v", refStr)
 	}
 
+	// Parse the stored block reference and read the block back.
 	le.WithField("ref", refStr).Info("attempting to lookup block")
 	br, err := bucket.ParseObjectRef(
 		refStr,
@@ -102,6 +108,7 @@ func RunDemoCayley(
 	}
 	le.Infof("fetched block with data length: %d", len(data))
 
+	// Open the example object store for transaction checks.
 	// build the key/value "object store" for the volume
 	objStoreAv, _, objStoreRef, err := bus.ExecOneOff(
 		ctx,
@@ -116,11 +123,13 @@ func RunDemoCayley(
 	defer objStoreRef.Release()
 	objStore := objStoreAv.GetValue().(volume.BuildObjectStoreAPIValue).GetObjectStore()
 
+	// Exercise concurrent object-store transactions.
 	// attempt concurrent transactions
 	t1, _ := objStore.NewTransaction(ctx, false)
 	t2, _ := objStore.NewTransaction(ctx, false)
 	_, _, _ = t2.Get(ctx, []byte("test"))
 	t2.Discard()
+
 	// expect that t1 is still live (not discarded)
 	_, _, err = t1.Get(ctx, []byte("test"))
 	if err != nil {
@@ -220,6 +229,7 @@ func RunDemoCayley(
 	le.Infof("demo completed in %v", tEnd.Sub(tStart).String())
 
 	le.Info("demo: starting follow recursive: expect to see <f> <b> <d> <c>")
+
 	// Test follow recursive
 	gt := graph.NewTransaction()
 	gt.AddQuad(quad.MakeIRI("a", "ref", "b", ""))
@@ -231,6 +241,7 @@ func RunDemoCayley(
 	if err := store.ApplyTransaction(ctx, gt); err != nil {
 		return err
 	}
+
 	// The third argument, "depthTags" is a set of tags that will return strings of
 	// numeric values relating to how many applications of the path were applied the
 	// first time the result node was seen.

--- a/db/examples/common/demo-git.go
+++ b/db/examples/common/demo-git.go
@@ -25,11 +25,13 @@ func RunDemoGit(
 	volCtr volume.Controller,
 	url string,
 ) error {
+	// Resolve the example volume.
 	vol, err := volCtr.GetVolume(ctx)
 	if err != nil {
 		return err
 	}
 
+	// Build the lookup controller configuration.
 	lookupConf := &lc.Config{
 		// NotFoundBehavior: lc.NotFoundBehavior_NotFoundBehavior_LOOKUP_DIRECTIVE,
 		NotFoundBehavior: lc.NotFoundBehavior_NotFoundBehavior_NONE,
@@ -39,6 +41,8 @@ func RunDemoGit(
 	if err != nil {
 		return err
 	}
+
+	// Create the example bucket configuration.
 	bucketConf, err := bucket.NewConfig(
 		"example-bucket-1",
 		1,
@@ -49,6 +53,7 @@ func RunDemoGit(
 	}
 	bucketID := bucketConf.GetId()
 
+	// Apply the bucket configuration to the volume.
 	// assert the volume
 	_, _, abcRef, err := bus.ExecOneOff(
 		ctx,
@@ -65,6 +70,7 @@ func RunDemoGit(
 	}
 	abcRef.Release()
 
+	// Build the empty graph cursor and Git store.
 	inMem := memory.NewStorage()
 	worktree := memfs.New()
 
@@ -79,6 +85,8 @@ func RunDemoGit(
 	if err != nil {
 		return err
 	}
+
+	// Run the clone example and commit the result.
 	err = git_examples.RunCloneExample(ctx, le, url, store, worktree)
 	if err != nil {
 		return err

--- a/db/examples/cross-platform/main.go
+++ b/db/examples/cross-platform/main.go
@@ -15,11 +15,13 @@ import (
 )
 
 func Run(ctx context.Context, le *logrus.Entry) error {
+	// Construct the core bus.
 	b, sr, err := core.NewCoreBus(ctx, le)
 	if err != nil {
 		return err
 	}
 
+	// Add the platform-specific storage volume.
 	// TODO: add storage depending on if we are in js or not.
 	verbose := false
 	av, _, ref, err := common.AddStorageVolume(ctx, le, b, sr, verbose)
@@ -28,6 +30,7 @@ func Run(ctx context.Context, le *logrus.Entry) error {
 	}
 	defer ref.Release()
 
+	// Resolve the node controller.
 	// Construct the node controller.
 	dir := resolver.NewLoadControllerWithConfig(&node_controller.Config{})
 	_, _, ncRef, err := loader.WaitExecControllerRunning(ctx, b, dir, nil)
@@ -37,6 +40,7 @@ func Run(ctx context.Context, le *logrus.Entry) error {
 	defer ncRef.Release()
 	le.Info("node controller resolved")
 
+	// Run the block and Git demos on the resolved volume.
 	le.Info("storage volume resolved")
 	volCtr := av.(volume.Controller)
 

--- a/db/git/block/store-encoded-object_test.go
+++ b/db/git/block/store-encoded-object_test.go
@@ -43,7 +43,7 @@ func TestStorage_EncodedObject(t *testing.T) {
 	}
 	defer store.Close()
 
-	// check not exists
+	// Confirm missing hashes return ErrObjectNotFound.
 	ohash, ok := plumbing.FromBytes([]byte("notfound000000000000"))
 	if !ok {
 		t.Fatal("FromBytes failed")
@@ -98,20 +98,20 @@ func TestStorage_EncodedObject(t *testing.T) {
 		return encObj
 	}
 
-	// put an object
+	// Write an encoded object into the bulk store.
 	ph := putObject(store, objData)
 
-	// read the object back
+	// Read the object before committing the bulk store.
 	encObj := getObject(store, ph)
 	_ = encObj
 
-	// commit via Store (builds IAVL trees from bulk-written objects)
+	// Commit the store so its IAVL trees become durable.
 	err = store.Commit()
 	if err != nil {
 		t.Fatal(err.Error())
 	}
 
-	// re-build the store from the committed ref
+	// Reopen the store from the committed root reference.
 	storeRef := store.GetRef()
 	oc.SetRootRef(storeRef)
 	btx, bcs = oc.BuildTransaction(nil)
@@ -121,7 +121,7 @@ func TestStorage_EncodedObject(t *testing.T) {
 	}
 	defer store.Close()
 
-	// read the object back
+	// Read the committed object and verify its size.
 	encObj = getObject(store, ph)
 
 	// check it exists
@@ -133,6 +133,6 @@ func TestStorage_EncodedObject(t *testing.T) {
 		t.Fatalf("size mismatch: got %d, want %d", size, len(objData))
 	}
 
-	// success
+	// Finish after validating the committed object.
 	_ = encObj
 }

--- a/db/git/block/store-refs_test.go
+++ b/db/git/block/store-refs_test.go
@@ -41,13 +41,13 @@ func TestStorage_References(t *testing.T) {
 	}
 	defer store.Close()
 
-	// check not exists
+	// Confirm missing references return ErrReferenceNotFound.
 	_, err = store.Reference("notfound")
 	if err != plumbing.ErrReferenceNotFound {
 		t.Fail()
 	}
 
-	// store a reference
+	// Store a symbolic reference in the repository.
 	testRef := plumbing.ReferenceName("main")
 	err = store.SetReference(plumbing.NewSymbolicReference(testRef, "master"))
 	if err != nil {
@@ -55,13 +55,13 @@ func TestStorage_References(t *testing.T) {
 	}
 	le.Info("set reference 'main'")
 
-	// check exists
+	// Read back the reference before persisting the transaction.
 	_, err = store.Reference(testRef)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
 
-	// write
+	// Persist the reference root and reopen the store.
 	rootRef, bcs, err := btx.Write(ctx, true)
 	if err != nil {
 		t.Fatal(err.Error())
@@ -74,7 +74,7 @@ func TestStorage_References(t *testing.T) {
 	}
 	defer store.Close()
 
-	// check exists
+	// Verify the reference remains after reopening the store.
 	ref, err := store.Reference(testRef)
 	if err != nil {
 		t.Fatal(err.Error())

--- a/db/git/block/store-submodule.go
+++ b/db/git/block/store-submodule.go
@@ -62,8 +62,7 @@ func (r *Store) Module(name string) (storage.Storer, error) {
 	}
 	var repoRootCs *block.Cursor
 	if subm == nil {
-		// create submodule
-		// use a somewhat round-about method to double-check our work
+		// Create the missing submodule reference and verify it can be reopened.
 		if err := r.SetModuleReference(name, nil); err != nil {
 			return nil, err
 		}
@@ -74,7 +73,8 @@ func (r *Store) Module(name string) (storage.Storer, error) {
 		if subm == nil || submCs == nil {
 			return nil, errors.New("failed to create submodule")
 		}
-		// initialize the submodule storer
+
+		// Initialize the new submodule repository root.
 		repoRootCs = submCs.FollowRef(2, nil)
 		subm.RepoRef = nil
 		nrepo := NewRepo()

--- a/db/git/unixfs/fs-cursor_test.go
+++ b/db/git/unixfs/fs-cursor_test.go
@@ -288,7 +288,7 @@ func TestReadAtFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// read entire file
+	// Read the full file and verify the end-of-file contract.
 	buf := make([]byte, 100)
 	n, err := childOps.ReadAt(ctx, 0, buf)
 	if err != io.EOF {
@@ -324,7 +324,7 @@ func TestReadAtOffset(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// read from offset 2 ("Hello World\n")
+	// Read from a non-zero offset and verify the returned suffix.
 	buf := make([]byte, 100)
 	n, err := childOps.ReadAt(ctx, 2, buf)
 	if err != io.EOF {
@@ -398,6 +398,7 @@ func TestFileSize(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	if size != 14 { // "# Hello World\n" = 14 bytes
 		t.Fatalf("expected size 14, got %d", size)
 	}
@@ -440,6 +441,7 @@ func TestFilePermissions(t *testing.T) {
 
 	tests := []struct {
 		name string
+
 		perm string // expected permission string representation
 	}{
 		{"README.md", "-rw-r--r--"},
@@ -483,6 +485,7 @@ func TestRootPermissions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	// root dir: 0755 | ModeDir
 	if perm.String() != "drwxr-xr-x" {
 		t.Fatalf("expected drwxr-xr-x, got %s", perm.String())
@@ -707,7 +710,7 @@ func TestReadlinkAbsolute(t *testing.T) {
 	ctx := context.Background()
 	s := memory.NewStorage()
 
-	// create a symlink with absolute target
+	// Build a symlink with an absolute target for readlink checks.
 	linkHash := storeBlob(t, s, "/usr/local/bin/foo")
 	rootHash := storeTree(t, s, []object.TreeEntry{
 		{Name: "abs-link", Mode: filemode.Symlink, Hash: linkHash},
@@ -811,7 +814,7 @@ func TestWriteOpsReturnReadOnly(t *testing.T) {
 		t.Fatalf("Symlink: expected ErrReadOnly, got %v", err)
 	}
 
-	// Remove
+	// Confirm immutable cursor operations reject removal.
 	if err := ops.Remove(ctx, []string{"x"}, time.Time{}); err != unixfs_errors.ErrReadOnly {
 		t.Fatalf("Remove: expected ErrReadOnly, got %v", err)
 	}

--- a/db/git/world/git-clone.go
+++ b/db/git/world/git-clone.go
@@ -35,6 +35,7 @@ func GitClone(
 	worktreeArgs *GitCreateWorktreeOp,
 	ts *timestamppb.Timestamp,
 ) (*bucket.ObjectRef, error) {
+	// Build clone options and defer checkout until the world operation completes.
 	cloneArgs := cloneOpts.BuildCloneOpts()
 	enableCheckout := !cloneOpts.GetDisableCheckout()
 
@@ -43,9 +44,9 @@ func GitClone(
 	// Cloning with checkout builds a git index in the Store that leaks
 	// into Phase 2 and confuses the MergeReset diff logic.
 	cloneArgs.NoCheckout = true
-	// write progress if necessary
+
+	// Pass progress output and optional SSH authentication to the clone client.
 	cloneArgs.Progress = progress
-	// override auth method
 	if authMethod != nil {
 		cloneArgs.ClientOptions = append(cloneArgs.ClientOptions, client.WithSSHAuth(authMethod))
 	}
@@ -58,6 +59,7 @@ func GitClone(
 		ws.AccessWorldState,
 		nil,
 		func(bcs *block.Cursor) error {
+			// Initialize the repository block and storage adapter.
 			root := git_block.NewRepo()
 			bcs.SetBlock(root, true)
 			store, err := git_block.NewStore(ctx, nil, bcs, &memory.IndexStorage{}, nil)
@@ -66,12 +68,14 @@ func GitClone(
 			}
 			defer store.Close()
 
+			// Clone objects into the world-backed store without creating a worktree.
 			worktree := memfs.New()
 			_, err = git.CloneContext(ctx, store, worktree, cloneArgs)
 			if err != nil {
 				return errors.Wrap(err, "clone")
 			}
 
+			// Commit the streamed objects into the repository root.
 			return store.Commit()
 		},
 	)
@@ -79,7 +83,7 @@ func GitClone(
 		return nil, err
 	}
 
-	// we cloned the repo to repoRef, now create repo and worktree
+	// Register the cloned repository and optionally create its worktree.
 	initOp := NewGitInitOp(objKey, repoRef, !enableCheckout, worktreeArgs, ts)
 	_, _, err = ws.ApplyWorldOp(ctx, initOp, sender)
 	if err != nil {

--- a/db/git/world/git-create-worktree.go
+++ b/db/git/world/git-create-worktree.go
@@ -107,7 +107,7 @@ func (o *GitCreateWorktreeOp) ApplyWorldOp(
 		}
 	}
 
-	// create worktree and checkout
+	// Create the worktree and perform checkout when configured.
 	err = CreateWorldObjectWorktree(
 		ctx,
 		le,
@@ -124,7 +124,7 @@ func (o *GitCreateWorktreeOp) ApplyWorldOp(
 		return false, err
 	}
 
-	// success
+	// Report successful worktree creation.
 	return false, nil
 }
 

--- a/db/git/world/git-fetch.go
+++ b/db/git/world/git-fetch.go
@@ -86,7 +86,7 @@ func (o *GitFetchOp) ApplyWorldOp(
 ) (sysErr bool, err error) {
 	objKey := o.GetObjectKey()
 
-	// check that the object exists
+	// Confirm that the target repository object exists before fetching.
 	_, exists, err := worldHandle.GetObject(ctx, objKey)
 	if err != nil {
 		return false, err
@@ -95,7 +95,7 @@ func (o *GitFetchOp) ApplyWorldOp(
 		return false, errors.Wrap(world.ErrObjectNotFound, objKey)
 	}
 
-	// perform the fetch
+	// Fetch remote objects into the existing repository.
 	err = GitFetch(ctx, worldHandle, objKey, o.GetFetchOpts(), nil, nil)
 	return false, err
 }

--- a/db/git/world/git-init.go
+++ b/db/git/world/git-init.go
@@ -76,24 +76,24 @@ func (o *GitInitOp) ApplyWorldOp(
 	objKey := o.GetObjectKey()
 	repoRef := o.GetRepoRef()
 
-	// create / validate the objectref for the repo
+	// Create or validate the repository root reference.
 	repoRef, err = ValidateOrCreateRepo(ctx, worldHandle.AccessWorldState, repoRef)
 	if err != nil {
 		return false, err
 	}
 
-	// create the repo object
+	// Register the repository object in world state.
 	_, err = worldHandle.CreateObject(ctx, objKey, repoRef)
 	if err != nil {
 		return false, err
 	}
 
-	// repo type -> types/git/repo
+	// Record the repository type metadata.
 	if err := world_types.SetObjectType(ctx, worldHandle, objKey, GitRepoTypeID); err != nil {
 		return false, err
 	}
 
-	// if configured perform the checkout
+	// Create the configured worktree and checkout when enabled.
 	if !o.GetDisableCheckout() {
 		op := o.GetCreateWorktree()
 		if op == nil {
@@ -127,13 +127,13 @@ func (o *GitInitOp) ApplyWorldObjectOp(
 	// Disable checkout, ignore object key.
 	repoRef := o.GetRepoRef()
 
-	// create / validate the objectref for the repo
+	// Create or validate the repository root for the existing object.
 	repoRef, err = ValidateOrCreateRepo(ctx, objectHandle.AccessWorldState, repoRef)
 	if err != nil {
 		return false, err
 	}
 
-	// update the object
+	// Publish the validated repository root on the object handle.
 	_, err = objectHandle.SetRootRef(ctx, repoRef)
 	return false, err
 }

--- a/db/git/world/git.go
+++ b/db/git/world/git.go
@@ -91,6 +91,7 @@ func AccessRepoWithCursor(
 	refStore git_block.ReferenceStore,
 	cb func(repo *git.Repository) error,
 ) error {
+	// Resolve default stores and validate the persisted repository block.
 	if indexStore == nil {
 		indexStore = &memory.IndexStorage{}
 	}
@@ -104,11 +105,15 @@ func AccessRepoWithCursor(
 	if err := repob.Validate(); err != nil {
 		return err
 	}
+
+	// Open the block-backed git store and release it after the callback.
 	store, err := git_block.NewStore(ctx, nil, bcs, indexStore, refStore)
 	if err != nil {
 		return err
 	}
 	defer store.Close()
+
+	// Open or initialize the git repository in the requested worktree.
 	repo, err := git.Open(store, workdir)
 	if errors.Is(err, git.ErrRepositoryNotExists) {
 		repo, err = git.Init(store, git.WithWorkTree(workdir))
@@ -116,11 +121,15 @@ func AccessRepoWithCursor(
 	if err != nil {
 		return err
 	}
+
+	// Run the repository callback before committing its block changes.
 	if cb != nil {
 		if err := cb(repo); err != nil {
 			return err
 		}
 	}
+
+	// Commit the repository mutation.
 	return store.Commit()
 }
 
@@ -131,6 +140,7 @@ func ValidateOrCreateRepo(
 	accessState world.AccessWorldStateFunc,
 	repoRef *bucket.ObjectRef,
 ) (*bucket.ObjectRef, error) {
+	// Create a repository block for an empty reference or validate the existing repository.
 	var err error
 	if repoRef.GetEmpty() {
 		repoRef, err = world.AccessObject(ctx, accessState, nil, func(bcs *block.Cursor) error {
@@ -138,6 +148,7 @@ func ValidateOrCreateRepo(
 			return nil
 		})
 	} else {
+		// Validate the supplied reference before opening its repository block.
 		if err := repoRef.Validate(); err != nil {
 			return nil, err
 		}
@@ -150,6 +161,8 @@ func ValidateOrCreateRepo(
 			return err
 		})
 	}
+
+	// Return any repository creation or validation failure.
 	if err != nil {
 		return nil, err
 	}
@@ -246,7 +259,7 @@ func AccessWorldObjectRepoWithWorktree(
 		return err
 	}
 
-	// open the workdir fs
+	// Open the referenced UnixFS workdir with write access when requested.
 	writeWorkdir := updateWorld && sender != ""
 	wdFsHandle, err := unixfs_world.BuildFSFromUnixfsRef(ctx, le, ws, sender, workdirRef, true, writeWorkdir, ts)
 	if err != nil {
@@ -254,19 +267,22 @@ func AccessWorldObjectRepoWithWorktree(
 	}
 	defer wdFsHandle.Release()
 
-	// construct billy fs
+	// Wrap the UnixFS handle as the billy worktree filesystem.
 	wdBfs := unixfs_billy.NewBillyFilesystem(ctx, wdFsHandle, "", ts)
 
-	// access worktree object
+	// Access the worktree object and persist its updated block when writable.
 	_, _, err = AccessWorldObjectWorktree(ctx, ws, worktreeObjKey, updateWorld, wdBfs, func(bcs *block.Cursor, wt *Worktree) error {
 		if updateWorld {
 			bcs.SetBlock(wt, true)
 		}
-		// access repo
+
+		// Resolve the repository's HEAD reference store before invoking the callback.
 		hrs, err := wt.FollowHeadRefStore(bcs)
 		if err != nil {
 			return err
 		}
+
+		// Access the repository object and run the caller callback against both handles.
 		_, _, err = AccessWorldObjectRepo(ctx, ws, repoObjKey, updateWorld, wt, wdBfs, hrs, func(repo *git.Repository) error {
 			if cb != nil {
 				return cb(repo, wdBfs)
@@ -296,7 +312,7 @@ func CreateWorldObjectWorktree(
 	sender peer.ID,
 	ts time.Time,
 ) error {
-	// ensure workdir exists
+	// Ensure the referenced workdir object exists before creating the worktree.
 	workdirObjKey := workdirRef.GetObjectKey()
 	_, wdObjExists, err := ws.GetObject(ctx, workdirObjKey)
 	if err != nil {
@@ -307,17 +323,17 @@ func CreateWorldObjectWorktree(
 			return errors.Wrap(world.ErrObjectNotFound, "workdir")
 		}
 
-		// init the workdir
+		// Initialize the missing workdir when creation was requested.
 		_, _, err = unixfs_world.FsInit(ctx, ws, sender, workdirObjKey, workdirRef.GetFsType(), nil, false, ts)
 		if err != nil {
 			return err
 		}
 	}
 
-	// create worktree
+	// Allocate the worktree block that will hold checkout metadata.
 	wtree := &Worktree{}
 
-	// checkout
+	// Configure checkout staging and cleanup for the optional checkout path.
 	disableCheckout := checkoutOpts == nil
 	var checkoutDir string
 	defer func() {
@@ -326,12 +342,12 @@ func CreateWorldObjectWorktree(
 		}
 	}()
 
-	// create worktree object
+	// Create or update the worktree object and materialize checkout files when enabled.
 	_, _, err = world.AccessWorldObject(ctx, ws, worktreeObjKey, true, func(bcs *block.Cursor) error {
 		bcs.SetBlock(wtree, true)
 
 		if !disableCheckout {
-			// call git to checkout to the worktree
+			// Materialize the repository, perform checkout, and capture its index.
 			hrs, err := wtree.FollowHeadRefStore(bcs)
 			if err != nil {
 				return err
@@ -371,6 +387,7 @@ func CreateWorldObjectWorktree(
 		return err
 	}
 	if checkoutDir != "" {
+		// Synchronize materialized checkout files into the UnixFS workdir.
 		if err := syncFSToUnixfsRefBatch(
 			ctx,
 			ws,
@@ -383,18 +400,18 @@ func CreateWorldObjectWorktree(
 		}
 	}
 
-	// worktree type -> types/git/worktree
+	// Record the worktree type in world metadata.
 	if err := world_types.SetObjectType(ctx, ws, worktreeObjKey, GitWorktreeTypeID); err != nil {
 		return err
 	}
 
-	// worktree parent -> repo
+	// Record the worktree's parent repository relationship.
 	err = world_parent.SetObjectParent(ctx, ws, worktreeObjKey, repoObjKey, false)
 	if err != nil {
 		return err
 	}
 
-	// worktree git/repo -> repo
+	// Record the worktree-to-repository graph edge.
 	err = ws.SetGraphQuad(
 		ctx,
 		world.NewGraphQuadWithKeys(worktreeObjKey, GitRepoPred, repoObjKey, ""),
@@ -403,7 +420,7 @@ func CreateWorldObjectWorktree(
 		return err
 	}
 
-	// worktree git/workdir -> workdir <ref-value>
+	// Encode the workdir reference and record its graph edge.
 	refValue := &unixfs_world.RefValue{
 		FsType: workdirRef.GetFsType(),
 		Path:   workdirRef.GetPath().Clone(),
@@ -421,7 +438,7 @@ func CreateWorldObjectWorktree(
 		return err
 	}
 
-	// repo git/worktree -> worktree
+	// Record the repository-to-worktree graph edge.
 	err = ws.SetGraphQuad(
 		ctx,
 		world.NewGraphQuadWithKeys(repoObjKey, GitRepoWorktreePred, worktreeObjKey, ""),
@@ -440,7 +457,7 @@ func WorktreeLookupWorkdirRef(
 	worldHandle world.WorldState,
 	objKey string,
 ) (*unixfs_world.UnixfsRef, error) {
-	// access the workdir
+	// Read the workdir graph edge and normalize a missing edge to ErrQuadNotFound.
 	gqs, err := worldHandle.LookupGraphQuads(ctx, world.NewGraphQuadWithKeys(objKey, GitWorktreeWorkdirPred, "", ""), 1)
 	if len(gqs) == 0 && err == nil {
 		err = world.ErrQuadNotFound
@@ -455,7 +472,7 @@ func WorktreeLookupWorkdirRef(
 		return nil, errors.Wrap(err, "workdir: graph quad object")
 	}
 
-	// get the ref opts
+	// Decode the optional ref-value label attached to the graph edge.
 	var workdirRefValue *unixfs_world.RefValue
 	if refValueKey := gq.GetLabel(); len(refValueKey) != 0 {
 		refValueGv, err := world.GraphValueToKey(refValueKey)
@@ -466,6 +483,8 @@ func WorktreeLookupWorkdirRef(
 			return nil, errors.Wrap(err, "workdir: graph quad label")
 		}
 	}
+
+	// Build and validate the UnixFS reference returned to the caller.
 	ref := &unixfs_world.UnixfsRef{
 		ObjectKey: workdirObjKey,
 		FsType:    workdirRefValue.GetFsType(),

--- a/db/kvtx/transaction.go
+++ b/db/kvtx/transaction.go
@@ -58,6 +58,7 @@ func RunTransactionWithRetry[T TransactionLifecycle](
 			return err
 		}
 
+		// Run one transaction attempt and classify its retryability.
 		err := runTransactionAttempt(ctx, write, open, body)
 		if err == nil {
 			return nil
@@ -86,13 +87,18 @@ func runTransactionAttempt[T TransactionLifecycle](
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+
+	// Execute the replayable transaction body.
 	if err := body(ctx, tx); err != nil {
 		return err
 	}
+
 	// Body cancellation must prevent a write from committing partial work.
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+
+	// Commit completed write work before the deferred discard.
 	if !write {
 		return nil
 	}

--- a/db/kvtx/transaction_test.go
+++ b/db/kvtx/transaction_test.go
@@ -25,6 +25,7 @@ func TestRunTransactionRetriesFreshAttemptsAndDiscards(t *testing.T) {
 	var events []string
 	var opened int
 
+	// Run a write transaction whose first body attempt requests a retry.
 	err := RunTransaction(
 		context.Background(),
 		true,
@@ -44,6 +45,7 @@ func TestRunTransactionRetriesFreshAttemptsAndDiscards(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Compare the retry, commit, and discard event sequence.
 	want := []string{
 		"body:1",
 		"discard:1",
@@ -51,6 +53,8 @@ func TestRunTransactionRetriesFreshAttemptsAndDiscards(t *testing.T) {
 		"commit:2",
 		"discard:2",
 	}
+
+	// Require exactly one successful commit after the retry.
 	if len(events) != len(want) {
 		t.Fatalf("events = %v, want %v", events, want)
 	}

--- a/db/kvtx/txcache/tx.go
+++ b/db/kvtx/txcache/tx.go
@@ -64,18 +64,22 @@ func NewTxWithCbs(
 // Commit commits the transaction to storage.
 // Can return an error to indicate tx failure.
 func (t *Tx) Commit(ctx context.Context) error {
+	// Reject commits for read-only or discarded transactions.
 	if !t.write {
 		return kvtx.ErrNotWrite
 	}
 	if t.readTx == nil || t.tc == nil {
 		return kvtx.ErrDiscarded
 	}
+
+	// Close the read transaction before opening its write replacement.
 	if t.closeReadTx != nil {
 		t.closeReadTx()
 		t.closeReadTx = nil
 	}
 	t.readTx = nil
 
+	// Open the write transaction that will receive cached operations.
 	writeTx, err := t.newWriteTx()
 	if err != nil {
 		return err
@@ -84,20 +88,27 @@ func (t *Tx) Commit(ctx context.Context) error {
 		defer writeTx.Discard()
 	}
 
+	// Build cached operations and release the cache before applying them.
 	ops, err := t.tc.BuildOps(ctx, false)
 	t.tc = nil
 	if err != nil {
 		return err
 	}
+
+	// Apply cached operations in order and release each operation after use.
 	for i, op := range ops {
 		if err := op(writeTx); err != nil {
 			return err
 		}
 		ops[i] = nil
 	}
+
+	// Leave externally managed write transactions uncommitted.
 	if !t.commitWriteTx {
 		return nil
 	}
+
+	// Commit the internally managed write transaction.
 	return writeTx.Commit(ctx)
 }
 

--- a/db/node/controller/controller.go
+++ b/db/node/controller/controller.go
@@ -56,7 +56,7 @@ func NewController(cc *Config, le *logrus.Entry, b bus.Bus) *Controller {
 // Returning nil ends execution.
 // Returning an error triggers a retry with backoff.
 func (c *Controller) Execute(ctx context.Context) error {
-	// execute block store monitoring.
+	// Watch block-store values for bucket tracking.
 	_, vRef, err := c.b.AddDirective(
 		block_store.NewLookupBlockStore(""),
 		newBlockStoreRefHandler(c),
@@ -65,6 +65,7 @@ func (c *Controller) Execute(ctx context.Context) error {
 		return err
 	}
 
+	// Start bucket routines and release the watcher on cancellation.
 	c.buckets.SetContext(ctx, true)
 	_ = context.AfterFunc(ctx, vRef.Release)
 	return nil

--- a/db/node/controller/loaded-bucket-block-store.go
+++ b/db/node/controller/loaded-bucket-block-store.go
@@ -34,7 +34,7 @@ func (b *loadedBucket) newLoadedBucketBlockStore(blockStoreID string) (keyed.Rou
 
 // execute executes the bucket block store tracker.
 func (l *loadedBucketBlockStore) execute(ctx context.Context) error {
-	// TODO: clean this function up and avoid the unnecessary goroutine
+	// Watch the bucket API for this block store.
 	_, diRef, err := l.b.c.b.AddDirective(
 		bucket.NewBuildBucketAPI(l.b.bucketID, l.blockStoreID),
 		l,
@@ -42,6 +42,8 @@ func (l *loadedBucketBlockStore) execute(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	// Release the directive when the tracker context ends.
 	<-ctx.Done()
 	diRef.Release()
 	return nil

--- a/db/node/controller/loaded-bucket.go
+++ b/db/node/controller/loaded-bucket.go
@@ -78,12 +78,14 @@ func (c *Controller) newLoadedBucket(bucketID string) (keyed.Routine, *loadedBuc
 
 // execute executes the loaded bucket routine.
 func (b *loadedBucket) execute(ctx context.Context) error {
+	// Start bucket tracking and defer routine shutdown.
 	b.le.Debug("starting bucket tracking")
 
 	// State management routines.
 	defer b.blockStores.SyncKeys(nil, false)
 	defer b.le.Debug("exited bucket tracking")
 
+	// Publish state changes through the state container.
 	var st loadedBucketState
 	emitState := func() {
 		if b.lastState.equal(&st) {
@@ -97,6 +99,7 @@ func (b *loadedBucket) execute(ctx context.Context) error {
 		emitState()
 	}()
 
+	// Start block-store tracking and wait for state changes.
 	// startup
 	var waitCh <-chan struct{}
 	b.blockStores.SetContext(ctx, true)
@@ -116,6 +119,7 @@ func (b *loadedBucket) execute(ctx context.Context) error {
 			}
 		}
 
+		// Reconcile bucket configuration and available block-store handles.
 		b.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
 			waitCh = getWaitCh()
 			if b.lastState == nil {
@@ -148,10 +152,12 @@ func (b *loadedBucket) execute(ctx context.Context) error {
 				b.bucketHandleSetDirty = false
 			}
 
+			// Publish the current bucket state when it changed.
 			if stDirty {
 				emitState()
 			}
 
+			// Start or retain the configured lookup controller.
 			// if necessary, start the lookup controller.
 			if bc := b.bucketConf; bc != nil &&
 				lookupCtrCancel == nil &&
@@ -216,6 +222,7 @@ func (b *loadedBucket) execLookupController(
 			le.WithError(err).Warn("lookup controller exited with error")
 		}
 	}()
+
 	// acquire controller conf
 	c := bc.GetLookup().GetController()
 	if c.GetId() == "" {

--- a/db/object/rpc/client/object-store.go
+++ b/db/object/rpc/client/object-store.go
@@ -27,6 +27,7 @@ func NewObjectStore(client object_rpc.SRPCObjectStoreClient) *ObjectStore {
 // AccessObjectStore opens a object store by ID.
 // The context is used for the API calls.
 func (s *ObjectStore) AccessObjectStore(ctx context.Context, id string, released func()) (object.ObjectStore, func(), error) {
+	// Build the RPC stream and object-store client adapters.
 	openStream := rpcstream.NewRpcStreamOpenStream(s.client.ObjectStoreRpc, id, false)
 	rpcClient := srpc.NewClient(openStream)
 	storeClient := rpc_kvtx.NewSRPCKvtxClient(rpcClient)
@@ -36,12 +37,15 @@ func (s *ObjectStore) AccessObjectStore(ctx context.Context, id string, released
 
 // DeleteObjectStore deletes a object store and all contents by ID.
 func (s *ObjectStore) DeleteObjectStore(ctx context.Context, id string) error {
+	// Send the deletion request to the remote object-store service.
 	resp, err := s.client.DeleteObjectStore(ctx, &object_rpc.DeleteObjectStoreRequest{
 		ObjectStoreId: id,
 	})
 	if err != nil {
 		return err
 	}
+
+	// Surface a service-level deletion error.
 	if errStr := resp.GetError(); errStr != "" {
 		return errors.New(errStr)
 	}

--- a/db/object/rpc/server/object-store.go
+++ b/db/object/rpc/server/object-store.go
@@ -44,30 +44,33 @@ func (s *ObjectStore) DeleteObjectStore(
 	ctx context.Context,
 	req *object_rpc.DeleteObjectStoreRequest,
 ) (*object_rpc.DeleteObjectStoreResponse, error) {
+	// Delete the requested object store.
 	err := s.store.DeleteObjectStore(ctx, req.GetObjectStoreId())
 	var errStr string
 	if err != nil {
 		errStr = err.Error()
 	}
+
+	// Return the deletion error as an RPC response field.
 	return &object_rpc.DeleteObjectStoreResponse{Error: errStr}, nil
 }
 
 // GetObjectStoreMux returns the srpc.Mux for an object store.
 func (s *ObjectStore) GetObjectStoreMux(ctx context.Context, objStoreID string, _ func()) (srpc.Invoker, func(), error) {
+	// Acquire the keyed object-store tracker.
 	ref, tracker, _ := s.kvtxStores.AddKeyRef(objStoreID)
-
 	st, err := tracker.waitStore(ctx)
 	if err != nil {
 		ref.Release()
 		return nil, nil, err
 	}
 
+	// Register the object-store RPC implementation.
 	mux := srpc.NewMux()
 	if err := rpc_kvtx.SRPCRegisterKvtx(mux, st); err != nil {
 		ref.Release()
 		return nil, nil, err
 	}
-
 	return mux, ref.Release, nil
 }
 

--- a/db/opfs/opfs.go
+++ b/db/opfs/opfs.go
@@ -205,11 +205,13 @@ func newJSErrorCode(code int) *JSError {
 // AwaitPromise blocks the calling goroutine until a JS Promise resolves or rejects.
 // Returns the resolved value or an error wrapping the rejection reason.
 func AwaitPromise(promise js.Value) (js.Value, error) {
+	// Allocate callback state for the promise result and rejection.
 	ch := make(chan struct{})
 	var closeOnce sync.Once
 	var result js.Value
 	var jsErr error
 
+	// Register the promise fulfillment callback.
 	thenCb := js.FuncOf(func(this js.Value, args []js.Value) any {
 		if len(args) > 0 {
 			result = args[0]
@@ -221,6 +223,7 @@ func AwaitPromise(promise js.Value) (js.Value, error) {
 	})
 	defer thenCb.Release()
 
+	// Register the promise rejection callback.
 	catchCb := js.FuncOf(func(this js.Value, args []js.Value) any {
 		if len(args) > 0 && !args[0].IsUndefined() && !args[0].IsNull() {
 			jsErr = newJSError(args[0])
@@ -232,6 +235,7 @@ func AwaitPromise(promise js.Value) (js.Value, error) {
 	})
 	defer catchCb.Release()
 
+	// Attach callbacks, wait for settlement, and return the captured result.
 	jsutil.AwaitPromise(promise, thenCb, catchCb)
 	<-ch
 
@@ -962,6 +966,7 @@ func (BrowserDriver) ListDirectory(dir js.Value) ([]string, error) {
 		if done {
 			break
 		}
+
 		// entry is [name, handle]
 		entry := nextResult.Get("value")
 		name := entry.Index(0).String()

--- a/db/opfs/remote-driver.go
+++ b/db/opfs/remote-driver.go
@@ -94,6 +94,7 @@ func (d *RemoteDriver) installPort(port js.Value) bool {
 		if remotePortUsable(d.port) && d.port.Equal(port) {
 			return
 		}
+
 		// Replacing an existing usable port is a swap: bump the generation and
 		// wake WaitSwap so the mounted volume remounts and rebuilds its handle
 		// tree from a fresh GetRoot. Every cached handle from the root down
@@ -119,16 +120,24 @@ func (d *RemoteDriver) WaitSwap(ctx context.Context) error {
 	d.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
 		startGen = d.swapGen
 	})
+
+	// Capture the generation that was current when the wait began.
 	for {
+		// Wait for a generation change or context cancellation.
 		var changed bool
 		var waitCh <-chan struct{}
+
+		// Compare the current generation and retain its wake channel atomically.
 		d.bcast.HoldLock(func(_ func(), getWaitCh func() <-chan struct{}) {
 			changed = d.swapGen != startGen
 			waitCh = getWaitCh()
 		})
 		if changed {
+			// Return after observing the bridge swap.
 			return nil
 		}
+
+		// Wait for a swap notification or cancellation.
 		select {
 		case <-ctx.Done():
 			return ctx.Err()

--- a/db/sql/mysql/controller/controller.go
+++ b/db/sql/mysql/controller/controller.go
@@ -75,16 +75,16 @@ func (c *Controller) executeDB(ctx context.Context, ctr *ccontainer.CContainer[*
 	rctx, rctxCancel := context.WithCancel(ctx)
 	defer rctxCancel()
 
-	// Determine the init ref to the HEAD
+	// Select the configured initial head reference.
 	var headRef *bucket.ObjectRef
 
-	// initialize headRef using the configured head ref
+	// Resolve the configured initial head reference.
 	initRef := c.conf.GetInitHeadRef()
 	if initRef != nil {
 		headRef = initRef.Clone()
 	}
 
-	// Lookup the state store
+	// Resolve the object store used for persisted SQL state.
 	stateStoreID := c.conf.GetObjectStoreId()
 	stateStoreVol := c.conf.GetVolumeId()
 	if stateStoreVol == "" {
@@ -103,11 +103,12 @@ func (c *Controller) executeDB(ctx context.Context, ctr *ccontainer.CContainer[*
 	}
 	var headState *HeadState
 	if stateStore != nil {
-		// apply object store prefix
+		// Apply the configured object-store key prefix.
 		if prefix := c.conf.GetObjectStorePrefix(); len(prefix) != 0 {
 			stateStore = object.NewPrefixer(stateStore, []byte(prefix))
 		}
-		// load initial head ref
+
+		// Load the persisted head state when available.
 		var headStateFound bool
 		var err error
 		headState, headStateFound, err = c.loadHeadState(ctx, stateStore)
@@ -126,7 +127,8 @@ func (c *Controller) executeDB(ctx context.Context, ctr *ccontainer.CContainer[*
 	if headRef == nil {
 		headRef = &bucket.ObjectRef{}
 	}
-	// override bucket id if configured
+
+	// Override the configured bucket and validate the selected head.
 	if confBucketID := c.conf.GetBucketId(); confBucketID != "" {
 		headRef.BucketId = confBucketID
 	}
@@ -134,6 +136,7 @@ func (c *Controller) executeDB(ctx context.Context, ctr *ccontainer.CContainer[*
 		return errors.New("head ref bucket id required but was unset")
 	}
 
+	// Build the SQL cursor from the selected head reference.
 	le.Debug("building sql database")
 	cursor, err := bucket_lookup.BuildCursor(
 		ctx,
@@ -149,14 +152,16 @@ func (c *Controller) executeDB(ctx context.Context, ctr *ccontainer.CContainer[*
 	}
 	defer cursor.Release()
 
+	// Connect commits to head-state persistence when a state store exists.
 	var commitFn sql_mysql.CommitFn
 	if stateStore != nil {
 		commitFn = func(nref *bucket.ObjectRef) error {
-			// write state back to state store
+			// Persist each committed head state in the configured object store.
 			return c.writeHeadState(ctx, stateStore, nref)
 		}
 	}
 
+	// Create configured databases before publishing the SQL store.
 	mysql := sql_mysql.NewMysql(cursor, commitFn)
 	createDBs := c.conf.GetCreateDbs()
 	if len(createDBs) != 0 {
@@ -176,11 +181,13 @@ func (c *Controller) executeDB(ctx context.Context, ctr *ccontainer.CContainer[*
 		}
 	}
 
+	// Publish the SQL store until controller shutdown.
 	le.Info("sql store ready")
 	var handle hydra_sql.SqlStore = mysql
 	ctr.SetValue(&handle)
 	<-rctx.Done()
 
+	// Clear the published SQL store after controller shutdown.
 	le.Debug("shutting down")
 	ctr.SetValue(nil)
 	return context.Canceled

--- a/db/store/kvtx/bolt/tx.go
+++ b/db/store/kvtx/bolt/tx.go
@@ -54,13 +54,13 @@ func (t *Tx) Get(ctx context.Context, key []byte) (out []byte, found bool, err e
 		return nil, false, err
 	}
 
-	// bolt uses nil vs. []byte{} to indicate existence.
+	// Read the value from Bolt's transaction-scoped bucket view.
 	value := bkt.Get(key)
 	if value == nil {
 		return nil, false, nil
 	}
 
-	// value is only valid for time of transaction, copy
+	// Clone the transaction-scoped value before returning it.
 	return slices.Clone(value), true, nil
 }
 
@@ -72,6 +72,7 @@ func (t *Tx) Size(ctx context.Context) (size uint64, err error) {
 		return 0, err
 	}
 	stats := bkt.Stats()
+
 	return uint64(stats.KeyN), nil //nolint:gosec
 }
 
@@ -102,6 +103,7 @@ func (t *Tx) ScanPrefix(ctx context.Context, prefix []byte, cb func(key, value [
 		return err
 	}
 
+	// Position the cursor at the requested prefix boundary.
 	cur := bkt.Cursor()
 	var key, value []byte
 	if len(prefix) == 0 {
@@ -109,6 +111,8 @@ func (t *Tx) ScanPrefix(ctx context.Context, prefix []byte, cb func(key, value [
 	} else {
 		key, value = cur.Seek(prefix)
 	}
+
+	// Deliver each matching key and value in sorted cursor order.
 	for ; key != nil && (len(prefix) == 0 || bytes.HasPrefix(key, prefix)); key, value = cur.Next() {
 		if err := cb(key, value); err != nil {
 			return err
@@ -188,7 +192,7 @@ func (t *Tx) Exists(ctx context.Context, key []byte) (exists bool, err error) {
 		return false, err
 	}
 
-	// bolt uses nil vs. []byte{} to indicate existence.
+	// Use Bolt's nil value to distinguish an absent key.
 	i := bkt.Get(key)
 	return i != nil, nil
 }

--- a/db/testbed/testbed.go
+++ b/db/testbed/testbed.go
@@ -70,6 +70,7 @@ func WithVerbose(verbose bool) Option {
 // NewTestbed constructs a new core bus with a attached kvtx in-memory volume,
 // logger, and other core controllers required for a test to function.
 func NewTestbed(ctx context.Context, le *logrus.Entry, opts ...Option) (tb *Testbed, tbErr error) {
+	// Release partially initialized controllers when setup fails.
 	var rels []func()
 	defer func() {
 		if tbErr != nil {
@@ -79,6 +80,7 @@ func NewTestbed(ctx context.Context, le *logrus.Entry, opts ...Option) (tb *Test
 		}
 	}()
 
+	// Construct the testing bus and register core factories.
 	b, sr, err := core_test.NewTestingBus(ctx, le)
 	if err != nil {
 		return nil, err
@@ -87,6 +89,7 @@ func NewTestbed(ctx context.Context, le *logrus.Entry, opts ...Option) (tb *Test
 	core.AddFactories(b, sr)
 
 	// ConfigSet controller
+	// Start the config-set controller.
 	_, _, csRef, err := loader.WaitExecControllerRunning(
 		ctx,
 		b,
@@ -98,6 +101,7 @@ func NewTestbed(ctx context.Context, le *logrus.Entry, opts ...Option) (tb *Test
 	}
 	rels = append(rels, csRef.Release)
 
+	// Resolve testbed volume options.
 	var volumeConfig config.Config
 	var volumeConfigEmpty bool
 	verbose := Verbose
@@ -119,6 +123,7 @@ func NewTestbed(ctx context.Context, le *logrus.Entry, opts ...Option) (tb *Test
 		}
 	}
 
+	// Start the node controller.
 	_, _, nref, err := loader.WaitExecControllerRunning(
 		ctx,
 		b,
@@ -132,6 +137,7 @@ func NewTestbed(ctx context.Context, le *logrus.Entry, opts ...Option) (tb *Test
 	}
 	rels = append(rels, nref.Release)
 
+	// Start the configured volume and apply the test bucket.
 	var vc volume.Controller
 	var v volume.Volume
 	var bucketID string
@@ -166,6 +172,7 @@ func NewTestbed(ctx context.Context, le *logrus.Entry, opts ...Option) (tb *Test
 		}
 	}
 
+	// Build the transform factory set and return the testbed.
 	sfs := transform_all.BuildFactorySet()
 
 	return &Testbed{

--- a/db/unixfs/fs-handle.go
+++ b/db/unixfs/fs-handle.go
@@ -47,15 +47,18 @@ func NewFSHandleWithPrefix(
 	mkdirPath bool,
 	ts time.Time,
 ) (*FSHandle, error) {
+	// Create the root handle.
 	rootHandle, err := NewFSHandle(cursor)
 	if err != nil {
 		return nil, err
 	}
 
+	// Return the root when no prefix traversal is needed.
 	if len(prefixPath) == 0 {
 		return rootHandle, nil
 	}
 
+	// Create the requested prefix directories.
 	// if we should mkdirPath, ensure the prefix exists first.
 	if mkdirPath {
 		err = rootHandle.MkdirAll(
@@ -70,10 +73,13 @@ func NewFSHandleWithPrefix(
 		}
 	}
 
+	// Traverse the prefix and release the temporary root handle.
 	// follow the new prefix path
 	handle, _, err := rootHandle.LookupPathPts(ctx, prefixPath)
+
 	// release the old root
 	rootHandle.Release()
+
 	// return the new handle
 	return handle, err
 }
@@ -91,22 +97,26 @@ func (h *FSHandle) CheckReleased() bool {
 // AddReleaseCallback adds a callback that will be called when the FSHandle is released.
 // May be called immediately (in the same call as AddReleaseCallback).
 func (h *FSHandle) AddReleaseCallback(rcb func()) {
+	// Ignore nil callbacks.
 	if rcb == nil {
 		return
 	}
 
+	// Wrap the callback so release invokes it once.
 	var once sync.Once
 	cb := func() {
 		once.Do(rcb)
 	}
 	h.relCbs.Push(rcb)
 
+	// Handle an already-released handle without locking.
 	// fast path
 	if h.CheckReleased() {
 		cb()
 		return
 	}
 
+	// Register the callback on the current inode, retrying replacement races.
 	// slow path
 	for {
 		inode := h.i()
@@ -115,6 +125,7 @@ func (h *FSHandle) AddReleaseCallback(rcb func()) {
 			return
 		}
 		inode.relCbs.Push(rcb)
+
 		// if the inode was released or changed on h, continue & retry
 		if inode.checkReleased() || h.i() != inode {
 			continue
@@ -153,6 +164,7 @@ func (h *FSHandle) GetOps(ctx context.Context) (FSCursor, FSCursorOps, error) {
 
 // GetFileInfo constructs a file info object and creation time for the inode at handle.
 func (h *FSHandle) GetFileInfo(ctx context.Context) (fs.FileInfo, error) {
+	// Read permissions, size, and timestamps from the cursor.
 	var fileInfo fs.FileInfo
 	err := h.i().accessInode(ctx, func(cursor FSCursor, ops FSCursorOps) error {
 		permissions, err := ops.GetPermissions(ctx)
@@ -168,6 +180,7 @@ func (h *FSHandle) GetFileInfo(ctx context.Context) (fs.FileInfo, error) {
 		if err != nil {
 			return err
 		}
+
 		fileInfo = NewFileInfo(ops.GetName(), int64(size), mode, modTime) //nolint:gosec
 		return nil
 	})
@@ -359,10 +372,13 @@ func (h *FSHandle) LookupPathHandles(ctx context.Context, filePath string) ([]*F
 //
 // Check if fsHandle is not nil and release it even if an error is returned.
 func (h *FSHandle) LookupPathPts(ctx context.Context, pathParts []string) (*FSHandle, []string, error) {
+	// Clone the starting handle for path traversal.
 	outHandle, err := h.Clone(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// Traverse each non-empty path component.
 	for i, pathPart := range pathParts {
 		// these should not be given but handle it anyway
 		if pathPart == "." || pathPart == "" {
@@ -373,6 +389,7 @@ func (h *FSHandle) LookupPathPts(ctx context.Context, pathParts []string) (*FSHa
 		if err != nil {
 			return outHandle, pathParts[:i], err
 		}
+
 		outHandle.Release() // release parent handle
 		outHandle = nh
 	}
@@ -457,14 +474,18 @@ func (h *FSHandle) MkdirAllPath(ctx context.Context, filepath string, perm fs.Fi
 // for all directories that MkdirAll creates. If path is/ already a directory,
 // MkdirAll does nothing and returns nil.
 func (h *FSHandle) MkdirAll(ctx context.Context, dirPath []string, perm fs.FileMode, ts time.Time) error {
+	// Clone the starting directory handle.
 	dirHandle, err := h.Clone(ctx)
 	if err != nil {
 		return err
 	}
+
+	// Resolve or create each directory component.
 	for _, pname := range dirPath {
 		if pname == "." {
 			continue
 		}
+
 		// check if exists
 		dh, err := dirHandle.Lookup(ctx, pname)
 		if err == unixfs_errors.ErrNotExist {
@@ -474,6 +495,7 @@ func (h *FSHandle) MkdirAll(ctx context.Context, dirPath []string, perm fs.FileM
 				dirHandle.Release()
 				return err
 			}
+
 			// lookup again
 			dh, err = dirHandle.Lookup(ctx, pname)
 		}
@@ -495,6 +517,7 @@ func (h *FSHandle) MkdirAll(ctx context.Context, dirPath []string, perm fs.FileM
 		}
 	}
 
+	// Release the final directory handle.
 	// done
 	dirHandle.Release()
 	return nil
@@ -510,6 +533,7 @@ func (h *FSHandle) MkdirLookup(ctx context.Context, name string, perm fs.FileMod
 		if err != nil {
 			return nil, err
 		}
+
 		// Lookup again
 		dir, err = h.Lookup(ctx, name)
 	}
@@ -671,10 +695,12 @@ func (h *FSHandle) Rename(ctx context.Context, dest *FSHandle, destName string, 
 		}
 
 		srcLoc, destParent = h.i(), dest.i()
+
 		// check if srcLoc is destParent
 		if srcLoc == destParent {
 			return unixfs_errors.ErrMoveToSelf
 		}
+
 		// check if srcLoc is a parent of destParent
 		for nn := destParent.parent; nn != nil; nn = nn.parent {
 			if nn == srcLoc {
@@ -762,9 +788,11 @@ func (h *FSHandle) Rename(ctx context.Context, dest *FSHandle, destName string, 
 		if fsOpsSrc == nil || fsOpsSrc.CheckReleased() {
 			// release the destination loc for now
 			relDestParent()
+
 			// we will perform the lookup
 			fsWait := make(chan struct{})
 			srcLoc.fsWait = fsWait
+
 			// expects mtx to be locked on entry & released on exit.
 			srcLoc.resolveOpsRoutineLocked(ctx, fsWait, relSrcLoc)
 			continue
@@ -774,9 +802,11 @@ func (h *FSHandle) Rename(ctx context.Context, dest *FSHandle, destName string, 
 		if fsOpsDest == nil || fsOpsSrc.CheckReleased() {
 			// release the src loc for now
 			relSrcLoc()
+
 			// we will perform the lookup
 			fsWait := make(chan struct{})
 			destParent.fsWait = fsWait
+
 			// expects mtx to be locked on entry & released on exit.
 			destParent.resolveOpsRoutineLocked(ctx, fsWait, relDestParent)
 			continue
@@ -859,6 +889,7 @@ func (h *FSHandle) Rename(ctx context.Context, dest *FSHandle, destName string, 
 		if oldChild != nil {
 			// remove the old child from the parent
 			parent.removeChildInodeAtIdx(oldChildIdx)
+
 			// release the old child if it's not srcLoc (unlikely)
 			if oldChild != srcLoc {
 				oldChild.releaseWithChildrenLocked(nil)

--- a/db/util/buffered-reader-at/buffered-reader-at.go
+++ b/db/util/buffered-reader-at/buffered-reader-at.go
@@ -57,8 +57,10 @@ func (br *BufferedReaderAt) alignOffset(offset int64) int64 {
 // ReadAt reads from the underlying io.ReaderAt into p, implementing caching, page alignment, and preventing overlapping cache pages.
 // Supports concurrent requests.
 func (br *BufferedReaderAt) ReadAt(p []byte, off int64) (n int, err error) {
+	// Track the unread portion of the caller's request.
 	remaining := len(p)
 
+	// Resolve and copy each aligned cache range.
 	for remaining > 0 {
 		currentOffset := off + int64(n)
 		startOffset := br.alignOffset(currentOffset)
@@ -68,6 +70,7 @@ func (br *BufferedReaderAt) ReadAt(p []byte, off int64) (n int, err error) {
 		}
 		desiredSize := endOffset - startOffset
 
+		// Find or create the cache range covering the current offset.
 		br.mtx.Lock()
 
 		// Using binary search to find the insertion index or existing range
@@ -158,12 +161,14 @@ func (br *BufferedReaderAt) ReadAt(p []byte, off int64) (n int, err error) {
 		}
 		br.mtx.Unlock()
 
+		// Wait for the cache range to finish loading.
 		<-matchedRange.done // Wait for the read to complete
 
 		if matchedRange.err != nil {
 			return n, matchedRange.err // Return the error if any
 		}
 
+		// Copy the requested bytes from the completed range.
 		copyStart := int(currentOffset - matchedRange.offset)
 		if copyStart < 0 {
 			// range returned was after the requested starting point

--- a/db/util/jsbuf/jsbuf.go
+++ b/db/util/jsbuf/jsbuf.go
@@ -50,10 +50,13 @@ func CastToUint8Array(value safejs.Value) (safejs.Value, error) {
 //
 // Returns an error if value is not a Uint8Array.
 func CopyBytesToGo(value safejs.Value) ([]byte, error) {
+	// Convert the JavaScript value to a Uint8Array.
 	arr, err := CastToUint8Array(value)
 	if err != nil {
 		return nil, err
 	}
+
+	// Allocate the Go buffer and copy the JavaScript bytes.
 	len, err := arr.Length()
 	if err != nil {
 		return nil, err

--- a/db/volume/controller/controller.go
+++ b/db/volume/controller/controller.go
@@ -109,6 +109,7 @@ func (c *Controller) Execute(ctx context.Context) error {
 	}
 	defer v.Close()
 
+	// Prepare readiness diagnostics and the volume execution error channel.
 	le := c.le.WithField("peer-id", v.GetPeerID().String())
 	le.Debug("volume constructed, initializing")
 	errCh := make(chan error, 1)
@@ -127,7 +128,7 @@ func (c *Controller) Execute(ctx context.Context) error {
 		}
 	}()
 
-	// check the cache mode & wrap the volume if necessary
+	// Wrap the volume with the configured block-store overlay.
 	if blockStoreID := c.config.GetBlockStoreId(); blockStoreID != "" {
 		blkStore, _, blkStoreRef, err := block_store.ExLookupFirstBlockStore(ctx, c.bus, blockStoreID, false, func() {
 			if ctx.Err() == nil {
@@ -167,7 +168,7 @@ func (c *Controller) Execute(ctx context.Context) error {
 		le.Debugf("wrapped volume with block store %s mode %s", blockStoreID, overlayMode.String())
 	}
 
-	// load the peer to the bus
+	// Register the volume peer with the controller bus.
 	if !c.config.GetDisablePeer() {
 		peerWithPriv, err := v.GetPeer(ctx, true)
 		if err != nil {
@@ -183,6 +184,7 @@ func (c *Controller) Execute(ctx context.Context) error {
 		}
 	}
 
+	// Publish the ready volume and enable bucket-handle activity.
 	le.WithField("volume-id", v.GetID()).Debug("volume ready")
 	c.volume.SetValue(&volumeCtxPair{
 		ctx: volCtx,
@@ -197,12 +199,14 @@ func (c *Controller) Execute(ctx context.Context) error {
 		}
 	}()
 
+	// Start garbage collection and wait for shutdown or execution failure.
 	select {
 	case <-ctx.Done():
 		err = ctx.Err()
 	case err = <-errCh:
 	}
 
+	// Disable bucket-handle activity before returning the terminal error.
 	c.bucketHandles.SetContext(nil, false)
 	return err
 }

--- a/db/volume/js/opfs/blockshard/engine.go
+++ b/db/volume/js/opfs/blockshard/engine.go
@@ -175,8 +175,11 @@ func NewEngineWithSettings(
 	lockPrefix string,
 	settings *Settings,
 ) (*Engine, error) {
+	// Normalize settings and derive the engine cancellation context.
 	settings = normalizeSettings(settings)
 	ctx, cancel := context.WithCancel(ctx)
+
+	// Allocate shard state, actors, pending buffers, and bridge listeners.
 	e := &Engine{
 		shards:      make([]*Shard, settings.ShardCount),
 		actors:      make([]*shardActor, settings.ShardCount),
@@ -189,6 +192,7 @@ func NewEngineWithSettings(
 		listener:    NewListener(lockPrefix),
 	}
 
+	// Open and recover every shard before starting its write actor.
 	for i := range e.shards {
 		name := "shard-" + zeroPad(uint64(i), 2)
 		shardDir, err := opfs.GetDirectory(dir, name, true)
@@ -225,7 +229,7 @@ func NewEngineWithSettings(
 		go e.runActor(ctx, e.actors[i])
 	}
 
-	// Start invalidation listener.
+	// Start the invalidation listener after all shard actors are running.
 	e.wg.Add(1)
 	go e.runInvalidationListener(ctx)
 
@@ -530,6 +534,7 @@ func (e *Engine) getFromShard(
 	// Scan segments newest-first (last in manifest = newest).
 	for i := len(m.Segments) - 1; i >= 0; i-- {
 		seg := &m.Segments[i]
+
 		// Range check.
 		if string(key) < string(seg.MinKey) || string(key) > string(seg.MaxKey) {
 			continue
@@ -826,6 +831,7 @@ func (e *Engine) getExistsBatchFromShard(
 
 	out := make([]bool, len(keys))
 	resolved := make([]bool, len(keys))
+
 	// Pending-then-published: resolve buffered keys before scanning segments so
 	// an in-flight write or tombstone wins over an older published value.
 	for i, key := range keys {
@@ -957,6 +963,7 @@ func (e *Engine) runActor(ctx context.Context, actor *shardActor) {
 	shard := actor.shard
 
 	var reqs []writeReq
+
 	var fgOnly int // consecutive foreground-only cycles
 	for {
 		// If no pending entries, block for the next request.

--- a/db/world/block/engine-tx-object-iterator.go
+++ b/db/world/block/engine-tx-object-iterator.go
@@ -69,7 +69,8 @@ func (e *engineTxObjectIterator) Next() bool {
 	var prevTx *Tx
 	err := e.e.performOp(e.ctx, func(tx *Tx) error {
 		var iter world.ObjectIterator
-		// fast path: same txn as before
+
+		// Reuse the prior iterator when the transaction snapshot is unchanged.
 		if prevTx == tx {
 			iter = prevIter
 			if !iter.Next() {
@@ -80,16 +81,16 @@ func (e *engineTxObjectIterator) Next() bool {
 			return nil
 		}
 
-		// slow path: rebuild iterator with new read txn (contents changed)
+		// Rebuild the iterator after the transaction snapshot changes.
 		iter = tx.IterateObjects(e.ctx, e.prefix, e.reversed)
 		defer iter.Close()
 
-		// check for error
+		// Reject an iterator that failed during initialization.
 		if err := iter.Err(); err != nil {
 			return err
 		}
 
-		// save txn and iter for later
+		// Retain the transaction and iterator for the next call.
 		prevTx, prevIter = tx, iter
 
 		if e.currKey != "" {
@@ -101,15 +102,15 @@ func (e *engineTxObjectIterator) Next() bool {
 				return iter.Err()
 			}
 
-			// Check if Seek already moved us past the current key
+			// Advance past the current key when Seek returns it again.
 			if iter.Key() == e.currKey {
-				// Still on same key, need to move past it
+				// Advance once more when Seek returned the previous key.
 				if !iter.Next() {
 					return iter.Err()
 				}
 			}
 		} else {
-			// Need to move to first valid entry
+			// Position the fresh iterator at its first valid entry.
 			if !iter.Next() {
 				return iter.Err()
 			}

--- a/db/world/block/engine-tx.go
+++ b/db/world/block/engine-tx.go
@@ -50,19 +50,23 @@ func (e *EngineTx) Commit(ctx context.Context) error {
 // Can return an error to indicate tx failure.
 // If not write, returns ErrNotWrite.
 func (e *EngineTx) CommitBlockTransaction(ctx context.Context) (*bucket.ObjectRef, error) {
+	// Start the commit trace.
 	ctx, task := trace.NewTask(ctx, "hydra/world-block/engine-tx/commit-block-transaction")
 	defer task.End()
 
+	// Require a writable transaction.
 	if e.writeTx == nil {
 		e.Discard()
 		return nil, tx.ErrNotWrite
 	}
+
 	// Set rel before moving the lease out of Engine state. A commit that finds
 	// rel already set returns ErrDiscarded.
 	if e.rel.Swap(true) {
 		return nil, tx.ErrDiscarded
 	}
-	// Keep the coordinator lease local so root publication still precedes release.
+
+	// Move the coordinator lease into commit-local state.
 	locked := e.engine.bcast.Lock()
 	if e.engine.writeTx != e {
 		locked.Unlock()
@@ -92,6 +96,7 @@ func (e *EngineTx) CommitBlockTransaction(ctx context.Context) (*bucket.ObjectRe
 	if commitErr == nil {
 		_, subtask = trace.NewTask(ctx, "hydra/world-block/engine-tx/commit-block-transaction/validate-root")
 		nroot = e.writeTx.state.GetRootRef()
+
 		// A successful block commit must return a root.
 		commitErr = nroot.Validate(false)
 		subtask.End()
@@ -102,6 +107,7 @@ func (e *EngineTx) CommitBlockTransaction(ctx context.Context) (*bucket.ObjectRe
 	var retirement engineRetirement
 	_, subtask = trace.NewTask(ctx, "hydra/world-block/engine-tx/commit-block-transaction/apply-root-update")
 	locked = e.engine.bcast.Lock()
+
 	// Another Engine lifecycle path discarded this writer.
 	if e.engine.writeTx != e {
 		if commitErr == nil {
@@ -111,9 +117,11 @@ func (e *EngineTx) CommitBlockTransaction(ctx context.Context) (*bucket.ObjectRe
 		// Apply the root only after commit and validation succeed.
 		if commitErr == nil {
 			nextRootRef = e.engine.head.root.GetRef().Clone()
+
 			// Publish only when the transaction changed root data.
 			if !nroot.EqualVT(nextRootRef.RootRef) {
 				nextRootRef.RootRef = nroot
+
 				// Durable-on-write modes validate that the committed root is
 				// followable from durable storage, then publish it through commitFn.
 				// Deferred single-writer mode postpones both steps until Sync makes
@@ -128,6 +136,8 @@ func (e *EngineTx) CommitBlockTransaction(ctx context.Context) (*bucket.ObjectRe
 					if errors.Is(commitErr, block.ErrNotFound) {
 						commitErr = errors.Wrap(coord.ErrStaleGeneration, "validate committed root")
 					}
+
+					// Publish the durable root through the configured callback.
 					if commitErr == nil && e.engine.commitFn != nil {
 						commitErr = e.engine.commitFn(ctx, e.baseHeadRef, nextRootRef.Clone())
 						if commitErr == nil {
@@ -135,37 +145,50 @@ func (e *EngineTx) CommitBlockTransaction(ctx context.Context) (*bucket.ObjectRe
 						}
 					}
 				}
+
+				// Publish the root into Engine state and capture retired resources.
 				if commitErr == nil {
 					retirement, commitErr = e.engine.setRootRefLocked(ctx, nextRootRef)
 				}
 			}
 		}
+
 		// Detach this writer even when commit or publication failed.
 		if e.engine.writeTx == e {
 			retirement = e.engine.beginRetirementLocked(e.detachLocked())
 		}
 	}
+
+	// Release the Engine lock and drain retired transaction users.
 	locked.Unlock()
 	subtask.End()
-	// Drain transaction users before releasing the serialized writer turn.
 	e.engine.drainRetirement(ctx, retirement)
 
 	// Publish the coordinator event only after local head publication succeeds.
 	if commitErr == nil && commitLease != nil {
+		// Select the root to publish. Fall back to the current head when this
+		// transaction did not produce a new root reference.
 		publishRoot := nextRootRef
 		if publishRoot == nil {
 			locked := e.engine.bcast.Lock()
 			publishRoot = e.engine.head.root.GetRef().Clone()
 			locked.Unlock()
 		}
+
+		// Build the coordinator event for the written key prefix.
 		event := coord.Event{
 			KeyPrefixChanged: append([]byte(nil), e.engine.writeCoordKeyPrefix...),
 		}
+
+		// Attach the selected root when one is available.
 		if publishRoot != nil {
 			event.RootChanged = publishRoot.Clone()
 		}
+
+		// Publish the event after local head publication succeeds.
 		_, commitErr = commitLease.Publish(ctx, event)
 	}
+
 	// Always release the coordinator lease after commit cleanup.
 	if commitLease != nil {
 		leaseErr := commitLease.Release(ctx)
@@ -174,9 +197,12 @@ func (e *EngineTx) CommitBlockTransaction(ctx context.Context) (*bucket.ObjectRe
 		}
 	}
 
+	// Return any commit or cleanup failure.
 	if commitErr != nil {
 		return nil, commitErr
 	}
+
+	// Return the committed root.
 	return nextRootRef, nil
 }
 
@@ -185,9 +211,11 @@ func (e *EngineTx) CommitBlockTransaction(ctx context.Context) (*bucket.ObjectRe
 // Cannot return an error.
 // Can be called unlimited times.
 func (e *EngineTx) Discard() {
+	// Stop when another lifecycle path already released this transaction.
 	if e.rel.Swap(true) {
 		return
 	}
+
 	// Detach under the Engine lock, then drain after unlocking.
 	locked := e.engine.bcast.Lock()
 	retirement := e.engine.beginRetirementLocked(e.detachLocked())
@@ -208,6 +236,7 @@ func (e *EngineTx) detachLocked() engineRetirement {
 		lease:   e.lease,
 	}
 	e.lease = nil
+
 	// Move Engine.writeTxRel into the retirement, which releases the serialized
 	// write turn after the Engine lock drops.
 	if e.engine.writeTx == e {
@@ -215,6 +244,8 @@ func (e *EngineTx) detachLocked() engineRetirement {
 		retirement.writeTxRel = e.engine.writeTxRel
 		e.engine.writeTxRel = nil
 	}
+
+	// Return the detached resources for retirement outside the Engine lock.
 	return retirement
 }
 

--- a/db/world/block/mock.go
+++ b/db/world/block/mock.go
@@ -28,7 +28,7 @@ func BuildMockWorldState(ctx context.Context, le *logrus.Entry, write bool, ocs 
 
 // BuildMockObject builds a mock object in a world.
 func BuildMockObject(ctx context.Context, ws world.WorldState, objKey string) (world.ObjectState, error) {
-	// construct a basic example object
+	// Choose a default key and build the example block transaction.
 	if objKey == "" {
 		objKey = "test-obj-1"
 	}
@@ -46,13 +46,13 @@ func BuildMockObject(ctx context.Context, ws world.WorldState, objKey string) (w
 		return nil, err
 	}
 
-	// create the object in the world
+	// Register the newly written root reference as a world object.
 	_, err = ws.CreateObject(ctx, objKey, oref)
 	if err != nil {
 		return nil, err
 	}
 
-	// lookup the object
+	// Read back the object to confirm registration succeeded.
 	objState, found, err := ws.GetObject(ctx, objKey)
 	if err != nil {
 		return nil, err

--- a/db/world/block/tx/tx-delete-object.go
+++ b/db/world/block/tx/tx-delete-object.go
@@ -70,7 +70,7 @@ func (t *TxDeleteObject) ExecuteTx(
 
 	objKey := t.GetObjectKey()
 
-	// check if it exists, if necessary
+	// Confirm the object exists when the operation requires it.
 	failNotFound := t.GetFailIfNotFound()
 	if failNotFound {
 		_, err := world.MustGetObject(ctx, worldInstance, objKey)
@@ -79,7 +79,7 @@ func (t *TxDeleteObject) ExecuteTx(
 		}
 	}
 
-	// delete the object
+	// Delete the object and normalize a missing-object result when required.
 	deleted, err := worldInstance.DeleteObject(ctx, t.GetObjectKey())
 	if err == nil && failNotFound && !deleted {
 		err = world.ErrObjectNotFound

--- a/db/world/block/tx/tx_test.go
+++ b/db/world/block/tx/tx_test.go
@@ -34,13 +34,13 @@ func TestWorldState(t *testing.T) {
 	}
 	defer ocs.Release()
 
-	// pass 1: build base mock world
+	// Build the base mock world state.
 	ws, err := world_block.BuildMockWorldState(ctx, le, true, ocs, false)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
 
-	// add the mock object
+	// Seed the base state with a mock object and commit it.
 	objKey := "tx-test-obj-1"
 	sender := tb.Volume.GetPeerID()
 	_, err = world_block.BuildMockObject(ctx, ws, objKey)
@@ -54,7 +54,7 @@ func TestWorldState(t *testing.T) {
 	}
 	ocs.SetRootRef(ws.GetRootRef())
 
-	// pass 2: test forking it + applying changes
+	// Reopen the base state before forking and applying changes.
 	ws, err = world_block.BuildMockWorldState(ctx, le, true, ocs, false)
 	if err == nil {
 		_, err = world.MustGetObject(ctx, ws, objKey)
@@ -63,14 +63,13 @@ func TestWorldState(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	// test forking the state using the tx wrapper
-	// create a new tx wrapper, forking the state.
+	// Fork the state through the transaction wrapper.
 	forkedTx, err := ForkWorldState(ctx, ws, true)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
 
-	// checkRev asserts a object is at a revision
+	// Define the revision assertion used for the fork.
 	checkRev := func(obj world.ObjectState, expected uint64) {
 		if err := world.AssertObjectRev(ctx, obj, expected); err != nil {
 			t.Fatal(err.Error())
@@ -87,14 +86,14 @@ func TestWorldState(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	// ensure the change was applied to the object
+	// Verify the forked operation changed the object revision.
 	obj, err := world.MustGetObject(ctx, forkedTx, objKey)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
 	checkRev(obj, 2)
 
-	// check the updated field on the object
+	// Verify the forked operation changed the object payload.
 	_, _, err = world.AccessObjectState(ctx, obj, false, func(bcs *block.Cursor) error {
 		e, err := block_mock.UnmarshalExample(ctx, bcs)
 		if err == nil && e.GetMsg() != secondMsg {
@@ -106,13 +105,13 @@ func TestWorldState(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	// check the transaction set
+	// Verify the fork recorded exactly one transaction.
 	txBatch := forkedTx.GetTxBatch()
 	if l := len(txBatch.GetTxs()); l != 1 {
 		t.Fatalf("expected 1 tx but got %d", l)
 	}
 
-	// check the tx
+	// Verify the recorded transaction type and sender.
 	tx := txBatch.GetTxs()[0]
 	if tt := tx.GetTxType(); tt != TxType_TxType_APPLY_WORLD_OP {
 		t.Fatalf("expected %s but got %s", TxType_TxType_APPLY_WORLD_OP.String(), tt.String())
@@ -121,7 +120,7 @@ func TestWorldState(t *testing.T) {
 		t.Fatalf("expected world op sender %q, got %q", sender.String(), got)
 	}
 
-	// pass 3: apply the tx to a fresh state and check result
+	// Apply the recorded transaction to a fresh state and verify its result.
 	ws, err = world_block.BuildMockWorldState(ctx, le, true, ocs, false)
 	if err == nil {
 		_, err = world.MustGetObject(ctx, ws, objKey)

--- a/db/world/block/world-object.go
+++ b/db/world/block/world-object.go
@@ -192,6 +192,7 @@ func (t *WorldState) renameObjectSingle(ctx context.Context, oldKey, newKey stri
 	if err := ot.Delete(ctx, oldTreeKey); err != nil {
 		return nil, err
 	}
+
 	// The old key no longer resolves; drop any stale object memo entry.
 	t.forgetObject(oldKey)
 
@@ -364,21 +365,22 @@ func (t *WorldState) DeleteObject(ctx context.Context, key string) (bool, error)
 		}
 	}
 
-	// delete any graph links with the object as subject or object
+	// Remove graph links that refer to the object.
 	err = t.DeleteGraphObject(ctx, key)
 	if err != nil {
 		return true, err
 	}
 
-	// delete the object
+	// Delete the object entry and clear its memoized state.
 	err = ot.Delete(ctx, k)
 	if err != nil {
 		return true, err
 	}
+
 	// A deleted object no longer exists; drop any stale object memo entry.
 	t.forgetObject(key)
 
-	// update the changelog
+	// Record the object deletion in the world changelog.
 	changeBcs, err := t.queueWorldChange(ctx, &WorldChange{
 		Key:        key,
 		ChangeType: WorldChangeType_WorldChange_OBJECT_DELETE,
@@ -390,7 +392,7 @@ func (t *WorldState) DeleteObject(ctx context.Context, key string) (bool, error)
 		changeBcs.SetRef(6, nbcs)
 	}
 
-	// success
+	// Report that the object was deleted.
 	return true, nil
 }
 

--- a/db/world/block/world_test.go
+++ b/db/world/block/world_test.go
@@ -644,7 +644,7 @@ func TestWorldState_DeleteObject(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	// Create a test object
+	// Create two objects for graph deletion checks.
 	objKey1 := "test-obj1"
 	oref := &bucket.ObjectRef{BucketId: "test-bucket"}
 	_, err = ws.CreateObject(ctx, objKey1, oref)
@@ -658,7 +658,7 @@ func TestWorldState_DeleteObject(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	// Add some graph quads related to the object
+	// Add graph edges between the objects.
 	err = ws.SetGraphQuad(ctx, world.NewGraphQuad(
 		world.KeyToGraphValue(objKey1).String(),
 		"<predicate1>",
@@ -679,13 +679,13 @@ func TestWorldState_DeleteObject(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	// Commit the changes
+	// Commit the initial objects and graph edges.
 	err = ws.Commit(ctx)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
 
-	// Delete the object
+	// Delete the first object and its graph edges.
 	deleted, err := ws.DeleteObject(ctx, objKey1)
 	if err != nil {
 		t.Fatal(err.Error())
@@ -694,13 +694,13 @@ func TestWorldState_DeleteObject(t *testing.T) {
 		t.FailNow()
 	}
 
-	// Commit the deletion
+	// Commit the deletion before verifying persisted absence.
 	err = ws.Commit(ctx)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
 
-	// Verify that the object no longer exists
+	// Verify the deleted object is no longer addressable.
 	_, err = world.MustGetObject(ctx, ws, objKey1)
 	if err == nil {
 		t.Fatal("Expected error when getting deleted object, but got nil")
@@ -709,16 +709,16 @@ func TestWorldState_DeleteObject(t *testing.T) {
 		t.Fatalf("Expected ErrObjectNotFound, but got: %v", err)
 	}
 
-	// Verify that the quads related to the object are deleted
+	// Verify graph edges involving the deleted object are gone.
 	valueStr := world.KeyToGraphValue(objKey1).String()
 
-	// find all matching quads where subject == value
+	// Query quads where the deleted object was the subject.
 	subjQuads, err := ws.LookupGraphQuads(ctx, world.NewGraphQuad(valueStr, "", "", ""), 0)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
 
-	// find all matching quads where object == value
+	// Query quads where the deleted object was the object.
 	objQuads, err := ws.LookupGraphQuads(ctx, world.NewGraphQuad("", "", valueStr, ""), 0)
 	if err != nil {
 		t.Fatal(err.Error())
@@ -1059,7 +1059,7 @@ func TestWorldEngine_Fork(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	// add the mock object
+	// Seed the original state with a mock object.
 	objKey := "tx-test-obj-1"
 	_, err = world_block.BuildMockObject(ctx, ws, objKey)
 	if err != nil {
@@ -1072,7 +1072,7 @@ func TestWorldEngine_Fork(t *testing.T) {
 	}
 	ocs.SetRootRef(ws.GetRootRef())
 
-	// test forking it + applying changes
+	// Fork the state and apply a revision-changing operation.
 	sender := tb.Volume.GetPeerID()
 	ws, err = world_block.BuildMockWorldState(ctx, le, true, ocs, false)
 	if err == nil {
@@ -1088,7 +1088,7 @@ func TestWorldEngine_Fork(t *testing.T) {
 	}
 	forked := forkedWs.(*world_block.WorldState)
 
-	// apply operation, after, rev=3
+	// Apply the operation to the fork.
 	_, _, err = forked.ApplyWorldOp(
 		ctx,
 		world_mock.NewMockWorldOp(objKey, "hello there #2"),
@@ -1098,14 +1098,14 @@ func TestWorldEngine_Fork(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	// checkRev asserts a object is at a revision
+	// Define the revision assertion used for both states.
 	checkRev := func(obj world.ObjectState, expected uint64) {
 		if err := world.AssertObjectRev(ctx, obj, expected); err != nil {
 			t.Fatal(err.Error())
 		}
 	}
 
-	// ensure original state was still at rev=1
+	// Verify the original state remains unchanged.
 	obj, err := world.MustGetObject(ctx, ws, objKey)
 	if err == nil {
 		checkRev(obj, 1)
@@ -1114,21 +1114,22 @@ func TestWorldEngine_Fork(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	// write the forked state
+	// Commit the forked state.
 	err = forked.Commit(ctx)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
 
-	// apply the updated ref to the original state.
+	// Publish the forked root and reopen the original state from it.
 	ocs.SetRootRef(forked.GetRootRef())
-	// note: we need a new block transaction to force a new cursor
+
+	// A new block transaction forces a fresh cursor for the reopened state.
 	ws, err = world_block.BuildMockWorldState(ctx, le, true, ocs, false)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
 
-	// check if it was applied
+	// Verify the forked revision was published.
 	obj, err = world.MustGetObject(ctx, ws, objKey)
 	if err == nil {
 		checkRev(obj, 2)
@@ -1137,7 +1138,7 @@ func TestWorldEngine_Fork(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	// success
+	// Report successful fork assertions.
 	t.Log("tests successful")
 }
 
@@ -1173,7 +1174,7 @@ func TestWorldEngine_UpdateRootRef(t *testing.T) {
 
 	objKey := "test-object"
 
-	// create the object in the world
+	// Create and commit the initial object state.
 	ws, err := eng.NewTransaction(ctx, true)
 	if err != nil {
 		t.Fatal(err.Error())
@@ -1187,10 +1188,10 @@ func TestWorldEngine_UpdateRootRef(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	// save the first state
+	// Capture the first published root reference.
 	state1 := eng.GetRootRef()
 
-	// change the object
+	// Increment the object revision and commit the updated state.
 	ws, err = eng.NewTransaction(ctx, true)
 	if err != nil {
 		t.Fatal(err.Error())
@@ -1207,16 +1208,16 @@ func TestWorldEngine_UpdateRootRef(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	// create a new read tx
+	// Open a read transaction for the updated revision.
 	rtx, err := eng.NewTransaction(ctx, false)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
 
-	// save the second state
+	// Capture the second published root reference.
 	state2 := eng.GetRootRef()
 
-	// ensure the rev is correct
+	// Verify the read transaction observes the committed revision.
 	obj1, err = world.MustGetObject(ctx, rtx, objKey)
 	if err == nil {
 		var rev uint64
@@ -1229,15 +1230,16 @@ func TestWorldEngine_UpdateRootRef(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	// create a write tx
+	// Open a write transaction that will be invalidated by root rollback.
 	wtx, err := eng.NewTransaction(ctx, true)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
 
-	// change back to the original state
+	// Roll back the engine root and verify the read transaction follows it.
 	err = eng.SetRootRef(ctx, state1)
-	// use the same read tx to get the current rev
+
+	// Re-read the current revision through the existing read transaction.
 	if err == nil {
 		var rev uint64
 		_, rev, err = obj1.GetRootRef(ctx)
@@ -1248,7 +1250,8 @@ func TestWorldEngine_UpdateRootRef(t *testing.T) {
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	// expect the write tx to have been discarded
+
+	// Confirm the prior write transaction was discarded by the rollback.
 	werr := wtx.Commit(ctx)
 	if werr != tx.ErrDiscarded {
 		t.Fatalf("expected discarded error, got %v", werr)
@@ -1258,7 +1261,7 @@ func TestWorldEngine_UpdateRootRef(t *testing.T) {
 	// could check state2 again as well
 	_ = state2
 
-	// success
+	// Report successful root update assertions.
 	t.Log("tests successful")
 }
 
@@ -1285,7 +1288,7 @@ func TestWorldState_Basic(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	// construct a basic example object
+	// Build a reusable example root reference for the object set.
 	objRefCs := ocs.Clone()
 	oref := objRefCs.GetRef()
 	oref.BucketId = ""
@@ -1309,13 +1312,13 @@ func TestWorldState_Basic(t *testing.T) {
 		}
 	}
 
-	// create the objects in the world
+	// Create all test objects in the world.
 	forEachObj(func(objKey string) error {
 		_, err = ws.CreateObject(ctx, objKey, oref)
 		return err
 	})
 
-	// lookup the objects
+	// Read all test objects into iterator test state.
 	var i int
 	objStates := make([]world.ObjectState, len(keys))
 	forEachObj(func(objKey string) error {
@@ -1325,7 +1328,7 @@ func TestWorldState_Basic(t *testing.T) {
 		return err
 	})
 
-	// adjust object ref
+	// Update the shared root reference used by each object.
 	obcs.SetBlock(&block_mock.SubBlock{ExamplePtr: oref.GetRootRef()}, true)
 	oref.RootRef, obcs, err = obtx.Write(ctx, true)
 	if err != nil {
@@ -1333,7 +1336,7 @@ func TestWorldState_Basic(t *testing.T) {
 	}
 	_ = obcs
 
-	// adjust ref in the state
+	// Publish the updated root reference on every object.
 	for _, objState := range objStates {
 		_, err = objState.SetRootRef(ctx, oref)
 		if err != nil {
@@ -1341,7 +1344,7 @@ func TestWorldState_Basic(t *testing.T) {
 		}
 	}
 
-	// increment rev
+	// Increment every object's revision after updating its root.
 	for _, objState := range objStates {
 		_, err = objState.IncrementRev(ctx)
 		if err != nil {
@@ -1405,6 +1408,7 @@ func TestWorldState_Basic(t *testing.T) {
 			}
 			return nil
 		})
+
 		if int(ent.GetSeqno()) != 3-i { //nolint:gosec
 			t.Fatalf("%d: seqno expected %d but got %d", i, 3-i, ent.GetSeqno())
 		}
@@ -2415,6 +2419,7 @@ func TestEngineDeferredDurabilityCrashRecovery(t *testing.T) {
 	if _, err := world.MustGetObject(ctx, recovered, "obj-a"); err != nil {
 		t.Fatalf("recovery must land on the last Sync'd head with its blocks present: %v", err.Error())
 	}
+
 	// ...and obj-b, committed after the last Sync, is rolled back.
 	if _, err := world.MustGetObject(ctx, recovered, "obj-b"); err == nil {
 		t.Fatal("post-Sync commit must not survive a crash before the next Sync")

--- a/db/world/graph-util.go
+++ b/db/world/graph-util.go
@@ -21,7 +21,7 @@ func QuadEqual(q1, q2 quad.Quad) bool {
 
 // CheckQuadExists checks if the quad exists on the graph handle.
 func CheckQuadExists(ctx context.Context, h CayleyHandle, gq quad.Quad) (bool, error) {
-	// there may be a faster way to lookup a quad
+	// Scan matching quads until the requested quad is found.
 	var found bool
 	err := FilterIterateQuads(ctx, h, gq, func(q quad.Quad) error {
 		if q.IsValid() && QuadEqual(q, gq) {
@@ -30,6 +30,8 @@ func CheckQuadExists(ctx context.Context, h CayleyHandle, gq quad.Quad) (bool, e
 		}
 		return nil
 	})
+
+	// Normalize the early-stop sentinel into a successful lookup.
 	if err == io.EOF {
 		err = nil
 	}
@@ -44,6 +46,7 @@ func FilterIterateQuads(ctx context.Context, h CayleyHandle, gq quad.Quad, cb fu
 
 // IterateFilteredFullQuads iterates over full quads matching a concrete quad filter.
 func IterateFilteredFullQuads(ctx context.Context, h CayleyHandle, filter quad.Quad, cb func(q quad.Quad) error) error {
+	// Leave empty callbacks and filters to the cheapest valid path.
 	if cb == nil {
 		return nil
 	}
@@ -53,11 +56,13 @@ func IterateFilteredFullQuads(ctx context.Context, h CayleyHandle, filter quad.Q
 		return iterateQuadResults(ctx, h, it, cb)
 	}
 
+	// Select the smallest indexed direction for the concrete filter.
 	dir, ref, ok, err := selectQuadFilterIterator(ctx, h, filter)
 	if err != nil || !ok {
 		return err
 	}
 
+	// Filter the selected iterator before forwarding each matching quad.
 	it := h.QuadIterator(ctx, dir, ref).Iterate(ctx)
 	defer it.Close()
 	return iterateQuadResults(ctx, h, it, func(q quad.Quad) error {
@@ -70,6 +75,7 @@ func IterateFilteredFullQuads(ctx context.Context, h CayleyHandle, filter quad.Q
 
 // CollectFilteredFullQuadsBatch collects full quads for a batch of concrete quad filters.
 func CollectFilteredFullQuadsBatch(ctx context.Context, h CayleyHandle, filters []quad.Quad, limitPerFilter uint32) ([][]quad.Quad, error) {
+	// Allocate result slots and group filters by their selected iterator.
 	results := make([][]quad.Quad, len(filters))
 	groupsByKey := make(map[quadFilterBatchKey]int)
 	var groups []quadFilterBatchGroup
@@ -103,6 +109,7 @@ func CollectFilteredFullQuadsBatch(ctx context.Context, h CayleyHandle, filters 
 		})
 	}
 
+	// Scan each shared iterator group and populate its result slots.
 	for _, group := range groups {
 		if err := collectQuadFilterBatchGroup(ctx, h, filters, results, group, limitPerFilter); err != nil {
 			return nil, err
@@ -123,14 +130,18 @@ type quadFilterBatchGroup struct {
 }
 
 func collectFilteredFullQuads(ctx context.Context, h CayleyHandle, filter quad.Quad, limit uint32) ([]quad.Quad, error) {
+	// Collect matching quads until the requested limit or iterator end.
 	var quads []quad.Quad
 	err := IterateFilteredFullQuads(ctx, h, filter, func(q quad.Quad) error {
 		quads = append(quads, q)
+
 		if limit != 0 && uint32(len(quads)) >= limit { //nolint:gosec
 			return io.EOF
 		}
 		return nil
 	})
+
+	// Normalize the early-stop sentinel into a successful collection.
 	if err == io.EOF {
 		err = nil
 	}
@@ -145,6 +156,7 @@ func collectQuadFilterBatchGroup(
 	group quadFilterBatchGroup,
 	limit uint32,
 ) error {
+	// Open the shared iterator and initialize each filter's limit state.
 	it := h.QuadIterator(ctx, group.dir, group.ref).Iterate(ctx)
 	defer it.Close()
 
@@ -153,12 +165,15 @@ func collectQuadFilterBatchGroup(
 	if limit != 0 {
 		remaining = len(group.filterIndexes)
 	}
+
+	// Route each scanned quad to every matching filter still below its limit.
 	err := iterateQuadResults(ctx, h, it, func(q quad.Quad) error {
 		for _, filterIdx := range group.filterIndexes {
 			if filled[filterIdx] || !quadMatchesFilter(q, filters[filterIdx]) {
 				continue
 			}
 			results[filterIdx] = append(results[filterIdx], q)
+
 			if limit != 0 && uint32(len(results[filterIdx])) >= limit { //nolint:gosec
 				filled[filterIdx] = true
 				remaining--
@@ -169,6 +184,8 @@ func collectQuadFilterBatchGroup(
 		}
 		return nil
 	})
+
+	// Normalize the early-stop sentinel after all requested filters are filled.
 	if err == io.EOF {
 		err = nil
 	}
@@ -190,6 +207,7 @@ func IterateFullQuads(ctx context.Context, h CayleyHandle, sh shape.Shape, cb fu
 }
 
 func iterateQuadResults(ctx context.Context, h CayleyHandle, it iterator.Scanner, cb func(q quad.Quad) error) error {
+	// Read quads from the scanner and forward each one to the callback.
 	rsc := graph.NewResultReader(ctx, h, it)
 	for {
 		q, err := rsc.ReadQuad(ctx)
@@ -197,6 +215,7 @@ func iterateQuadResults(ctx context.Context, h CayleyHandle, it iterator.Scanner
 			err = cb(q)
 		}
 		if err != nil {
+			// End-of-stream is a successful completion for this iterator.
 			if err == io.EOF {
 				err = nil
 			}

--- a/db/world/mock/testing.go
+++ b/db/world/mock/testing.go
@@ -38,7 +38,8 @@ func TestWorldEngine(ctx context.Context, le *logrus.Entry, eng world.Engine) er
 // TestWorldEngine_Basic performs basic sanity tests on a world engine.
 func TestWorldEngine_Basic(ctx context.Context, le *logrus.Entry, eng world.Engine) error {
 	objKey := "test-object"
-	// create the object in the world
+
+	// Create the initial object in a writable transaction.
 	ws, err := eng.NewTransaction(ctx, true)
 	if err != nil {
 		return err
@@ -48,7 +49,8 @@ func TestWorldEngine_Basic(ctx context.Context, le *logrus.Entry, eng world.Engi
 	if err != nil {
 		return errors.Wrapf(err, "create object: %s", objKey)
 	}
-	// lookup the object
+
+	// Read back the created object and verify its root reference.
 	objState, err := world.MustGetObject(ctx, ws, objKey)
 	if err != nil {
 		return errors.Wrapf(err, "get object: %s", objKey)
@@ -69,13 +71,13 @@ func TestWorldEngine_Basic(ctx context.Context, le *logrus.Entry, eng world.Engi
 		return errors.Wrap(err, "object state get root ref")
 	}
 
-	// commit
+	// Commit the initial object transaction.
 	err = ws.Commit(ctx)
 	if err != nil {
 		return err
 	}
 
-	// create read tx
+	// Open a read transaction for persisted-state assertions.
 	ws, err = eng.NewTransaction(ctx, false)
 	if err != nil {
 		return err
@@ -102,20 +104,19 @@ func TestWorldEngine_Basic(ctx context.Context, le *logrus.Entry, eng world.Engi
 
 	oref2 := &bucket.ObjectRef{}
 
-	// expect ErrNotWrite
+	// Confirm that read transactions reject root-reference writes.
 	_, err = objState.SetRootRef(ctx, oref2)
 	if err != tx.ErrNotWrite {
 		return errors.Errorf("expected error %v but got %v", tx.ErrNotWrite, err)
 	}
 
-	// check mechanics of writing while reading
-	// this should be possible with a world engine
+	// Open a writable transaction while retaining the original read snapshot.
 	ws2, err := eng.NewTransaction(ctx, true)
 	if err != nil {
 		return err
 	}
 
-	// update object reference & commit
+	// Update the object reference and commit the writable transaction.
 	objState2, err := world.MustGetObject(ctx, ws2, objKey)
 	if err != nil {
 		ws2.Discard()
@@ -135,9 +136,7 @@ func TestWorldEngine_Basic(ctx context.Context, le *logrus.Entry, eng world.Engi
 		return err
 	}
 
-	// check if original read tx was updated. Some engines keep read
-	// transactions live-updated, while coordinated storage engines provide a
-	// stable snapshot and expose the write through the next read transaction.
+	// Verify whether the original read snapshot observes the committed reference.
 	oref1b, _, err = objState.GetRootRef(ctx)
 	if err == nil {
 		err = assertEqual(oref1b, oref2)
@@ -161,13 +160,13 @@ func TestWorldEngine_Basic(ctx context.Context, le *logrus.Entry, eng world.Engi
 		}
 	}
 
-	// test some graph transactions
+	// Open a writable transaction for graph mutation checks.
 	ws2, err = eng.NewTransaction(ctx, true)
 	if err != nil {
 		return err
 	}
 
-	// add a second object
+	// Add a second object and connect it with a graph quad.
 	obj2Key := "test-object-2"
 	_, err = ws2.CreateObject(ctx, obj2Key, oref1)
 	if err != nil {
@@ -193,8 +192,7 @@ func TestWorldEngine_Basic(ctx context.Context, le *logrus.Entry, eng world.Engi
 		return err
 	}
 
-	// Continue read assertions from a fresh transaction so engines with
-	// snapshot-isolated reads observe the committed graph update.
+	// Reopen a read transaction so snapshot-isolated engines observe the graph update.
 	ws.Discard()
 	ws, err = eng.NewTransaction(ctx, false)
 	if err != nil {
@@ -202,7 +200,7 @@ func TestWorldEngine_Basic(ctx context.Context, le *logrus.Entry, eng world.Engi
 	}
 	defer ws.Discard()
 
-	// check quad exists
+	// Verify that the committed graph quad can be looked up.
 	quads, err := ws.LookupGraphQuads(ctx, testQuad1, 1)
 	found := len(quads) != 0
 	if err == nil && !found {
@@ -212,11 +210,12 @@ func TestWorldEngine_Basic(ctx context.Context, le *logrus.Entry, eng world.Engi
 		return err
 	}
 
-	// attempt a cayley graph query
+	// Exercise a Cayley path query and iterator result handling.
 	err = ws.AccessCayleyGraph(ctx, false, func(ctx context.Context, h world.CayleyHandle) error {
-		// check obj <parent> -> ?
+		// Build the parent path from the first object key.
 		p := cayley.StartPath(h, world.KeyToGraphValue(objKey)).Out(quad.IRI("parent"))
-		// quad stats + optimization basics
+
+		// Optimize the path and verify its iterator statistics.
 		sh, _, err := p.Shape().Optimize(ctx, nil)
 		if err != nil {
 			return err
@@ -229,7 +228,8 @@ func TestWorldEngine_Basic(ctx context.Context, le *logrus.Entry, eng world.Engi
 		if stats.Size.Exact && stats.Size.Value != 1 {
 			return errors.Errorf("expected size of %d but got %d", 1, stats.Size.Value)
 		}
-		// test iterator basics
+
+		// Iterate path results and verify the expected child key.
 		sc := it.Iterate(ctx)
 		defer sc.Close()
 		n := 0
@@ -261,7 +261,7 @@ func TestWorldEngine_Basic(ctx context.Context, le *logrus.Entry, eng world.Engi
 		return err
 	}
 
-	// attempt a parent graph system query using our existing <parent> quad
+	// Exercise the parent graph helper against the existing relationship.
 	ws2, err = eng.NewTransaction(ctx, true)
 	if err != nil {
 		return err
@@ -292,7 +292,7 @@ func TestWorldEngine_Basic(ctx context.Context, le *logrus.Entry, eng world.Engi
 		return errors.Errorf("expected parent to be empty but got: %s", parentStr)
 	}
 
-	// test a type set/lookup
+	// Verify the object type can be stored and read back.
 	objTypeID := "mock"
 	if err := world_types.SetObjectType(ctx, ws2, objKey, objTypeID); err != nil {
 		ws2.Discard()
@@ -326,7 +326,7 @@ func TestWorldEngine_Basic(ctx context.Context, le *logrus.Entry, eng world.Engi
 	}
 	defer ws.Discard()
 
-	// search for objects with the given type via path
+	// Query the graph for objects carrying the stored type.
 	err = ws.AccessCayleyGraph(ctx, false, func(ctx context.Context, h world.CayleyHandle) error {
 		p := path.StartPath(h)
 		p = world_types.LimitNodesToTypes(p, objTypeID)
@@ -344,7 +344,7 @@ func TestWorldEngine_Basic(ctx context.Context, le *logrus.Entry, eng world.Engi
 		return err
 	}
 
-	// search for types (iterate references to the type object)
+	// Enumerate objects linked to the stored type.
 	var objsWithTypeKey []string
 	err = world_types.IterateObjectsWithType(ctx, ws, objTypeID, func(objKey string) (bool, error) {
 		objsWithTypeKey = append(objsWithTypeKey, objKey)
@@ -360,13 +360,11 @@ func TestWorldEngine_Basic(ctx context.Context, le *logrus.Entry, eng world.Engi
 		return errors.Errorf("expected object %s w/ type %q but got %s", objKey, objTypeID, v)
 	}
 
-	// test a control loop by applying various operations to increase the
-	// revision of an object until the revision >= 20.
-	// if any one operation fails, the rev won't increase and the test will fail.
+	// Drive a control loop until repeated operations reach revision 20.
 	subCtx, subCtxCancel := context.WithCancel(ctx)
 	defer subCtxCancel()
 
-	// increment revision until revision >= 20
+	// Configure the control loop's target revision.
 	var targetRev uint64 = 20
 	loop := world_control.NewWatchLoop(le, objKey, func(
 		ctx context.Context,
@@ -403,12 +401,10 @@ func TestWorldEngine_Basic(ctx context.Context, le *logrus.Entry, eng world.Engi
 		nextMsg := "Hello from rev: " + strconv.Itoa(int(rev)) //nolint:gosec
 		if rev < targetRev {
 			if rev%2 != 0 || prevMsg == "" {
-				// odd numbers
+				// Build the next example block for odd revisions.
 				eb := block_mock.NewExample(nextMsg)
 
-				// write next root object into storage
-				// note: world.AccessObjectState is a utility for this
-				// var nroot *bucket.ObjectRef
+				// Write the next root block through the object-state access path.
 				var changed bool
 				_, changed, err = world.AccessObjectState(ctx, obj, true, func(bcs *block.Cursor) error {
 					bcs.SetBlock(eb, true)
@@ -418,11 +414,10 @@ func TestWorldEngine_Basic(ctx context.Context, le *logrus.Entry, eng world.Engi
 					err = errors.New("changed = false but expected true")
 				}
 			} else if rev%10 == 0 {
-				// even numbers divisible by 10, use world op method
+				// Apply a world operation at revisions divisible by ten.
 				_, _, err = ws.ApplyWorldOp(ctx, NewMockWorldOp(objKey, nextMsg), "")
 			} else if rev%5 == 0 {
-				// even numbers divisible by 5, use object op method
-				// note: passing empty peer id
+				// Apply an object operation at other selected revisions.
 				_, _, err = obj.ApplyObjectOp(ctx, NewMockObjectOp(nextMsg), "")
 			} else {
 				_, err = obj.IncrementRev(ctx)
@@ -435,17 +430,18 @@ func TestWorldEngine_Basic(ctx context.Context, le *logrus.Entry, eng world.Engi
 		if rev > targetRev {
 			return false, errors.Errorf("unexpected exceeded target rev: %v", rev)
 		}
-		// stop execution, success
+
+		// Stop the loop after the target revision is reached.
 		return false, nil
 	})
 
-	// test control loop
+	// Execute the control loop against the engine world state.
 	engWs := world.NewEngineWorldState(eng, true)
 	if err := loop.Execute(subCtx, engWs); err != nil {
 		return err
 	}
 
-	// delete the object
+	// Delete the object after the control-loop assertions complete.
 	ws2, err = eng.NewTransaction(ctx, true)
 	if err != nil {
 		return err
@@ -468,7 +464,8 @@ func TestWorldEngine_Basic(ctx context.Context, le *logrus.Entry, eng world.Engi
 	if err != nil {
 		return err
 	}
-	// test access object to create a blob
+
+	// Recreate the object with a blob payload.
 	_, bref, err := world.CreateWorldObject(ctx, ws2, objKey, func(bcs *block.Cursor) error {
 		_, berr := blob.BuildBlobWithBytes(ctx, blobTestData, bcs)
 		return berr
@@ -482,7 +479,7 @@ func TestWorldEngine_Basic(ctx context.Context, le *logrus.Entry, eng world.Engi
 		return err
 	}
 
-	// read the data out again
+	// Read the blob back and verify its content and unchanged reference.
 	le.Infof("stored blob length %d to object %s", len(blobTestData), bref.MarshalString())
 	engWs = world.NewEngineWorldState(eng, true)
 	var blobReadbackData []byte
@@ -510,13 +507,13 @@ func TestWorldEngine_Basic(ctx context.Context, le *logrus.Entry, eng world.Engi
 	}
 	le.Info("read back and verified blob contents from object")
 
-	// Test IterateObjects
+	// Create objects for prefix iteration checks.
 	ws2, err = eng.NewTransaction(ctx, true)
 	if err != nil {
 		return err
 	}
 
-	// Create a few test objects with different prefixes
+	// Seed objects under two prefixes.
 	testObjs := map[string]*bucket.ObjectRef{
 		"test/a":  {BucketId: "test-1"},
 		"test/b":  {BucketId: "test-2"},
@@ -536,13 +533,13 @@ func TestWorldEngine_Basic(ctx context.Context, le *logrus.Entry, eng world.Engi
 		return err
 	}
 
-	// Create new transaction for iteration tests
+	// Open a read transaction for forward iteration.
 	ws2, err = eng.NewTransaction(ctx, false)
 	if err != nil {
 		return err
 	}
 
-	// Test forward iteration with prefix
+	// Verify forward iteration order for the test prefix.
 	iter := ws2.IterateObjects(ctx, "test/", false)
 
 	var keys []string
@@ -573,13 +570,13 @@ func TestWorldEngine_Basic(ctx context.Context, le *logrus.Entry, eng world.Engi
 	iter.Close()
 	ws2.Discard()
 
-	// Create new transaction for reverse iteration
+	// Open a read transaction for reverse iteration.
 	ws2, err = eng.NewTransaction(ctx, false)
 	if err != nil {
 		return err
 	}
 
-	// Test reverse iteration with prefix
+	// Verify reverse iteration order for the test prefix.
 	iter = ws2.IterateObjects(ctx, "test/", true)
 
 	keys = nil
@@ -609,13 +606,13 @@ func TestWorldEngine_Basic(ctx context.Context, le *logrus.Entry, eng world.Engi
 
 	iter.Close()
 
-	// Create new transaction for seek test
+	// Open a read transaction for seek checks.
 	ws2, err = eng.NewTransaction(ctx, false)
 	if err != nil {
 		return err
 	}
 
-	// Test seek
+	// Verify seeking to a prefix key.
 	iter = ws2.IterateObjects(ctx, "", false)
 
 	if err := iter.Seek("test/b"); err != nil {

--- a/db/world/world-state.go
+++ b/db/world/world-state.go
@@ -309,25 +309,36 @@ func AccessObject(
 	defer task.End()
 
 	var outRef *bucket.ObjectRef
+
+	// Build the block transaction for the accessed object.
 	err := access(ctx, ref, func(bls *bucket_lookup.Cursor) error {
 		_, subtask := trace.NewTask(ctx, "hydra/world/access-object/build-transaction")
 		btx, bcs := bls.BuildTransaction(nil)
 		subtask.End()
+
+		// Initialize an empty object root before invoking the caller operation.
 		if ref.GetRootRef().GetEmpty() {
 			_, subtask = trace.NewTask(ctx, "hydra/world/access-object/init-empty-root")
+
 			// bcs.SetBlock(nil, false)
 			bcs.SetRefAtCursor(nil, true)
 			subtask.End()
 		}
+
+		// Apply the caller operation to the object cursor.
 		_, subtask = trace.NewTask(ctx, "hydra/world/access-object/callback")
 		berr := cb(bcs)
 		subtask.End()
 		if berr != nil {
 			return berr
 		}
+
+		// Capture the updated object reference before writing the transaction.
 		_, subtask = trace.NewTask(ctx, "hydra/world/access-object/clone-out-ref")
 		outRef = bls.GetRefWithOpArgs()
 		subtask.End()
+
+		// Persist the block transaction and return its result.
 		_, subtask = trace.NewTask(ctx, "hydra/world/access-object/write-transaction")
 		outRef.RootRef, _, berr = btx.Write(ctx, true)
 		subtask.End()
@@ -345,6 +356,7 @@ func CreateWorldObject(
 	objKey string,
 	cb AccessObjectCb,
 ) (ObjectState, *bucket.ObjectRef, error) {
+	// Confirm that the object key is not already present.
 	obj, exists, err := ws.GetObject(ctx, objKey)
 	ReleaseObjectState(obj)
 	if err == nil && exists {
@@ -354,10 +366,13 @@ func CreateWorldObject(
 		return nil, nil, err
 	}
 
+	// Build and persist the new object's root block.
 	objRef, err := AccessObject(ctx, ws.AccessWorldState, nil, cb)
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// Register the new object in world state.
 	objs, err := ws.CreateObject(ctx, objKey, objRef)
 	return objs, objRef, err
 }
@@ -374,17 +389,19 @@ func AccessWorldObject(
 	updateWorld bool,
 	cb AccessObjectCb,
 ) (*bucket.ObjectRef, bool, error) {
+	// Read-only world states cannot publish object updates.
 	if ws.GetReadOnly() {
 		updateWorld = false
 	}
 
+	// Look up the object and release its handle when this access returns.
 	obj, existed, err := ws.GetObject(ctx, objKey)
 	defer ReleaseObjectState(obj)
 	if err != nil {
 		return nil, false, err
 	}
 
-	// create object from scratch if it didn't exist.
+	// Create a root block and publish the object when it is new.
 	if !existed {
 		initRef, err := AccessObject(ctx, ws.AccessWorldState, nil, cb)
 		if err == nil && updateWorld {
@@ -395,6 +412,7 @@ func AccessWorldObject(
 		return initRef, true, err
 	}
 
+	// Update the existing object's root and publish it when dirty.
 	return AccessObjectState(ctx, obj, updateWorld, cb)
 }
 
@@ -411,21 +429,28 @@ func AccessObjectState(
 	ctx, task := trace.NewTask(ctx, "hydra/world/access-object-state")
 	defer task.End()
 
+	// Reject an absent object before opening its root reference.
 	if obj == nil {
 		return nil, false, ErrObjectNotFound
 	}
+
+	// Read the current object root before applying the callback.
 	taskCtx, subtask := trace.NewTask(ctx, "hydra/world/access-object-state/get-root-ref")
 	initRef, _, err := obj.GetRootRef(taskCtx)
 	subtask.End()
 	if err != nil {
 		return nil, false, err
 	}
+
+	// Apply the callback against the current object root.
 	taskCtx, subtask = trace.NewTask(ctx, "hydra/world/access-object-state/access-object")
 	outRef, err := AccessObject(taskCtx, obj.AccessWorldState, initRef, cb)
 	subtask.End()
 	if err != nil {
 		return nil, false, err
 	}
+
+	// Compare the original and updated roots to detect a dirty object.
 	var dirty bool
 	_, subtask = trace.NewTask(ctx, "hydra/world/access-object-state/compare-root-ref")
 	if initRef.GetBucketId() != "" && initRef.GetBucketId() != outRef.GetBucketId() {
@@ -435,6 +460,8 @@ func AccessObjectState(
 		dirty = true
 	}
 	subtask.End()
+
+	// Publish a changed root when the caller requested world updates.
 	if updateWorld && dirty {
 		taskCtx, subtask = trace.NewTask(ctx, "hydra/world/access-object-state/set-root-ref")
 		_, err = obj.SetRootRef(taskCtx, outRef)

--- a/dev/cli.go
+++ b/dev/cli.go
@@ -24,9 +24,11 @@ const downstreamSrcPath = "../.."
 
 // BuildApp constructs the spacewave-dev CLI application.
 func BuildApp() *cli.App {
+	// Configure the downstream source path for the devtool arguments.
 	args := bldr_devtool.NewDevtoolArgs()
 	args.BldrSrcPath = downstreamSrcPath
 
+	// Construct the CLI application and expose the devtool commands.
 	app := cli.NewApp()
 	app.Name = CLIName
 	app.HideVersion = true

--- a/dev/web-sources.go
+++ b/dev/web-sources.go
@@ -32,6 +32,7 @@ const (
 // materialized "@scope/name". Best effort: on failure the existing resolver
 // stages run and surface the original build error.
 func ensureWebSources(ctx context.Context, args *bldr_devtool.DevtoolArgs) {
+	// Resolve the downstream repository root.
 	le := args.Logger
 	repoRoot, err := args.FindRepoRoot()
 	if err != nil {
@@ -39,26 +40,34 @@ func ensureWebSources(ctx context.Context, args *bldr_devtool.DevtoolArgs) {
 		return
 	}
 
+	// Resolve the spacewave module directory from the module graph.
 	moduleDir, err := spacewaveModuleDir(ctx, repoRoot)
 	if err != nil {
 		le.WithError(err).Debug("ensure web sources: resolve spacewave module dir")
 		return
 	}
+
+	// Require the module's web source directory before linking it.
 	source := filepath.Join(moduleDir, webPkgName)
 	if info, statErr := os.Stat(source); statErr != nil || !info.IsDir() {
 		le.WithError(statErr).Debugf("ensure web sources: missing %s", source)
 		return
 	}
 
+	// Create the scope directory used for the materialized web package.
 	scope := filepath.Join(repoRoot, webPkgScopeDir)
 	if err := os.MkdirAll(scope, 0o755); err != nil {
 		le.WithError(err).Debug("ensure web sources: create scope dir")
 		return
 	}
+
+	// Reuse an existing link when it already targets the module source.
 	link := filepath.Join(scope, webPkgName)
 	if current, readErr := os.Readlink(link); readErr == nil && current == source {
 		return
 	}
+
+	// Remove a stale link before creating the current source link.
 	if err := os.Remove(link); err != nil && !os.IsNotExist(err) {
 		le.WithError(err).Debug("ensure web sources: clear stale link")
 		return
@@ -73,12 +82,15 @@ func ensureWebSources(ctx context.Context, args *bldr_devtool.DevtoolArgs) {
 // spacewaveModuleDir returns the on-disk source directory for the spacewave
 // module as resolved from repoRoot's module graph, downloading it if needed.
 func spacewaveModuleDir(ctx context.Context, repoRoot string) (string, error) {
+	// Ask Go to resolve the spacewave module directory.
 	cmd := exec.CommandContext(ctx, "go", "list", "-m", "-mod=mod", "-f", "{{.Dir}}", spacewaveModulePath)
 	cmd.Dir = repoRoot
 	out, err := cmd.Output()
 	if err != nil {
 		return "", errors.Wrap(err, "go list spacewave module")
 	}
+
+	// Require a non-empty module directory for source linking.
 	dir := strings.TrimSpace(string(out))
 	if dir == "" {
 		return "", errors.New("spacewave module dir is empty")

--- a/e2e/harness/resolve.go
+++ b/e2e/harness/resolve.go
@@ -20,6 +20,8 @@ func Resolve[A any](ctx context.Context, le *logrus.Entry, opts ResolveOptions, 
 
 func resolve[A any](ctx context.Context, le *logrus.Entry, opts ResolveOptions, shape Shape[A], hooks resolveHooks) (A, error) {
 	var zero A
+
+	// Compute the artifact content key and inspect existing generations.
 	key, err := shape.ContentKey(ctx)
 	if err != nil {
 		return zero, err
@@ -35,12 +37,14 @@ func resolve[A any](ctx context.Context, le *logrus.Entry, opts ResolveOptions, 
 		hooks.afterSnapshot()
 	}
 
+	// Acquire the build lock before rechecking concurrent generations.
 	lock, err := AcquireBuildLock(ctx, le, opts.LockDir, opts.LockName)
 	if err != nil {
 		return zero, err
 	}
 	defer lock.Release()
 
+	// Recheck generations created while waiting for the lock.
 	post, _, err := lookupGenerations(ctx, shape, key)
 	if err != nil {
 		return zero, err
@@ -53,6 +57,8 @@ func resolve[A any](ctx context.Context, le *logrus.Entry, opts ResolveOptions, 
 			return generation.Artifact, nil
 		}
 	}
+
+	// Build and validate a new artifact generation.
 	generation, err := shape.Build(ctx, key)
 	if err != nil {
 		return zero, err
@@ -64,10 +70,13 @@ func resolve[A any](ctx context.Context, le *logrus.Entry, opts ResolveOptions, 
 }
 
 func lookupGenerations[A any](ctx context.Context, shape Shape[A], key string) ([]Generation[A], map[string]struct{}, error) {
+	// Load generations for the requested artifact key.
 	generations, err := shape.Lookup(ctx, key)
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// Validate generation tokens and index them for freshness checks.
 	tokens := make(map[string]struct{}, len(generations))
 	for _, generation := range generations {
 		if generation.Token == "" {

--- a/e2e/scenario/registry.go
+++ b/e2e/scenario/registry.go
@@ -76,6 +76,7 @@ type Registry struct {
 
 // NewRegistry constructs a scenario registry from an explicit catalog.
 func NewRegistry(scenarios ...Scenario) *Registry {
+	// Track names while copying the validated scenario catalog.
 	seen := make(map[string]struct{}, len(scenarios))
 	out := make([]Scenario, len(scenarios))
 	for index, s := range scenarios {
@@ -95,6 +96,8 @@ func NewRegistry(scenarios ...Scenario) *Registry {
 			panic("duplicate scenario registration: " + s.Name)
 		}
 		seen[s.Name] = struct{}{}
+
+		// Clone tags so later caller mutations cannot alter the registry.
 		s.Tags = slices.Clone(s.Tags)
 		out[index] = s
 	}
@@ -113,8 +116,11 @@ func (r *Registry) All() []Scenario {
 
 // ParseTags splits a comma-separated tag selector and removes duplicates.
 func ParseTags(raw string) []string {
+	// Track tags already accepted from the selector.
 	seen := make(map[string]struct{})
 	var tags []string
+
+	// Normalize non-empty tags and discard duplicates.
 	for tag := range strings.SplitSeq(raw, ",") {
 		tag = strings.TrimSpace(tag)
 		if tag == "" {
@@ -126,6 +132,8 @@ func ParseTags(raw string) []string {
 		seen[tag] = struct{}{}
 		tags = append(tags, tag)
 	}
+
+	// Sort tags for stable selector behavior.
 	slices.Sort(tags)
 	return tags
 }
@@ -149,6 +157,8 @@ func (r *Registry) Run(ctx context.Context, rt runtime.Runtime, tags []string) R
 	scenarios := r.All()
 	selectedScenarios := make([]Scenario, 0, len(scenarios))
 	report := Report{Rows: make([]Row, len(scenarios))}
+
+	// Initialize report rows and select scenarios matching the requested tags.
 	for index, s := range scenarios {
 		report.Rows[index] = Row{
 			Scenario: s.Name,
@@ -161,6 +171,7 @@ func (r *Registry) Run(ctx context.Context, rt runtime.Runtime, tags []string) R
 		}
 	}
 
+	// Reset session boundaries and execute each selected scenario.
 	for _, s := range selectedScenarios {
 		row := Row{Scenario: s.Name, Runtime: rt.Name()}
 		if s.Session != runtime.SessionAny {
@@ -171,6 +182,8 @@ func (r *Registry) Run(ctx context.Context, rt runtime.Runtime, tags []string) R
 				continue
 			}
 		}
+
+		// Record failure, skip, or success for the scenario run.
 		if err := s.Run(ctx, rt); err != nil {
 			row.Status = StatusFail
 			row.Reason = err.Error()

--- a/forge/cluster/assign-job.go
+++ b/forge/cluster/assign-job.go
@@ -76,7 +76,7 @@ func (o *ClusterAssignJobOp) ApplyWorldOp(
 		return false, err
 	}
 
-	// assign the job to the cluster
+	// Link the job to the cluster.
 	err = worldHandle.SetGraphQuad(ctx, NewClusterToJobQuad(clusterKey, jobKey))
 	if err != nil {
 		return false, err

--- a/forge/cluster/assign-peer.go
+++ b/forge/cluster/assign-peer.go
@@ -73,13 +73,13 @@ func (o *ClusterAssignPeerOp) ApplyWorldOp(
 		return false, err
 	}
 
-	// if the peer id matches the current, return nil
+	// Skip the update when the peer ID is unchanged.
 	peerIDStr := peerID.String()
 	if o.GetPeerId() == peerIDStr {
 		return false, nil
 	}
 
-	// check the <type> of the cluster
+	// Confirm the cluster object type.
 	err = CheckClusterType(ctx, worldHandle, clusterKey)
 	if err != nil {
 		return false, err
@@ -105,13 +105,13 @@ func (o *ClusterAssignPeerOp) ApplyWorldOp(
 			return errors.Wrap(peer.ErrEmptyPeerID, "cluster")
 		}
 
-		// ensure the sender matches the cluster peer id
+		// Require the sender to match the cluster's current peer.
 		senderPeerIDStr := sender.String()
 		if senderPeerIDStr != clusterPeerIDStr {
 			return errors.Errorf("tx sender %s does not match cluster %s", senderPeerIDStr, clusterPeerIDStr)
 		}
 
-		// update the cluster peer id field
+		// Store the replacement cluster peer ID.
 		cluster.PeerId = peerIDStr
 		bcs.SetBlock(cluster, true)
 		return nil
@@ -120,7 +120,7 @@ func (o *ClusterAssignPeerOp) ApplyWorldOp(
 		return false, err
 	}
 
-	// clear any old keypair links
+	// Remove links to the previous cluster keypairs.
 	oldKpKeys, err := identity_world.ListObjectKeypairs(ctx, worldHandle, clusterKey)
 	if err != nil {
 		return false, err
@@ -137,13 +137,13 @@ func (o *ClusterAssignPeerOp) ApplyWorldOp(
 		}
 	}
 
-	// create the keypair and link to it if necessary
+	// Link the replacement peer keypair to the cluster.
 	_, _, err = identity_world.LinkObjectToKeypair(ctx, worldHandle, sender, clusterKey, peerID, "", nil)
 	if err != nil {
 		return false, err
 	}
 
-	// done
+	// Finish after the cluster links are updated.
 	return false, nil
 }
 

--- a/forge/cluster/assign-task.go
+++ b/forge/cluster/assign-task.go
@@ -66,7 +66,7 @@ func (o *ClusterAssignTaskOp) ApplyWorldOp(
 ) (sysErr bool, err error) {
 	clusterKey, jobKey, taskKey := o.GetClusterKey(), o.GetJobKey(), o.GetTaskKey()
 
-	// check the <type> of the job, cluster, and task objects
+	// Confirm the cluster, job, and task object types.
 	err = CheckClusterType(ctx, worldHandle, clusterKey)
 	if err != nil {
 		return false, err
@@ -82,7 +82,7 @@ func (o *ClusterAssignTaskOp) ApplyWorldOp(
 		return false, err
 	}
 
-	// unmarshal the cluster
+	// Load the cluster record and its controlling peer.
 	cluster, _, err := LookupCluster(ctx, worldHandle, clusterKey)
 	if err != nil {
 		return false, err
@@ -96,50 +96,50 @@ func (o *ClusterAssignTaskOp) ApplyWorldOp(
 		return false, errors.Wrap(peer.ErrEmptyPeerID, "cluster")
 	}
 
-	// ensure the sender matches the cluster peer id
+	// Require the sender to match the cluster's controlling peer.
 	senderPeerIDStr := sender.String()
 	if senderPeerIDStr != clusterPeerIDStr {
 		return false, errors.Errorf("tx sender %s does not match cluster %s", senderPeerIDStr, clusterPeerIDStr)
 	}
 
-	// ensure the cluster and job are linked
+	// Confirm the job is linked to the cluster.
 	err = EnsureClusterHasJob(ctx, worldHandle, clusterKey, jobKey)
 	if err != nil {
 		return false, err
 	}
 
-	// unmarshal the job
+	// Load the job record.
 	job, _, err := forge_job.LookupJob(ctx, worldHandle, jobKey)
 	if err != nil {
 		return false, err
 	}
 
-	// ensure the job is running
+	// Require the job to be running before assigning the task.
 	err = job.GetJobState().EnsureMatches(forge_job.State_JobState_RUNNING)
 	if err != nil {
 		return false, err
 	}
 
-	// ensure the job and task are linked
+	// Confirm the task is linked to the job.
 	err = forge_job.EnsureJobHasTask(ctx, worldHandle, jobKey, taskKey)
 	if err != nil {
 		return false, err
 	}
 
-	// update the task
+	// Assign the task to the cluster when it is unclaimed.
 	_, _, err = world.AccessWorldObject(ctx, worldHandle, taskKey, true, func(bcs *block.Cursor) error {
 		task, err := forge_task.UnmarshalTask(ctx, bcs)
 		if err != nil {
 			return err
 		}
 
-		// check if the task is assigned already
+		// Reject tasks that already have a peer assignment.
 		taskPeerID := task.GetPeerId()
 		if taskPeerID != "" {
 			return errors.Errorf("task already assigned to %s", taskPeerID)
 		}
 
-		// assign the task to the cluster
+		// Store the cluster peer assignment.
 		task.PeerId = clusterPeerIDStr
 		bcs.SetBlock(task, true)
 		return nil
@@ -148,13 +148,13 @@ func (o *ClusterAssignTaskOp) ApplyWorldOp(
 		return false, err
 	}
 
-	// create the keypair and link to it if necessary
+	// Link the cluster keypair to the assigned task.
 	_, _, err = identity_world.LinkObjectToKeypair(ctx, worldHandle, sender, taskKey, clusterPeerID, "", nil)
 	if err != nil {
 		return false, err
 	}
 
-	// done
+	// Finish after the task assignment is linked.
 	return false, nil
 }
 

--- a/forge/cluster/assign-worker.go
+++ b/forge/cluster/assign-worker.go
@@ -69,7 +69,7 @@ func (o *ClusterAssignWorkerOp) ApplyWorldOp(
 		return false, err
 	}
 
-	// assign the worker to the cluster
+	// Link the worker to the cluster.
 	err = worldHandle.SetGraphQuad(ctx, NewClusterToWorkerQuad(clusterKey, workerKey))
 	if err != nil {
 		return false, err

--- a/forge/cluster/controller/job-tracker.go
+++ b/forge/cluster/controller/job-tracker.go
@@ -87,13 +87,13 @@ func (jt *jobTracker) processState(
 ) (waitForChanges bool, err error) {
 	jobKey, clusterKey := jt.objKey, jt.c.objKey
 
-	// check the <type> of the job object
+	// Confirm the job object type.
 	err = forge_job.CheckJobType(ctx, ws, jobKey)
 	if err != nil {
 		return false, err
 	}
 
-	// unmarshal Job state
+	// Decode and validate the job state.
 	var job *forge_job.Job
 	_, err = world.AccessObject(ctx, ws.AccessWorldState, rootRef, func(bcs *block.Cursor) error {
 		var berr error
@@ -107,7 +107,7 @@ func (jt *jobTracker) processState(
 		return true, err
 	}
 
-	// promote any pending jobs to running
+	// Promote pending jobs to running.
 	jobState := job.GetJobState()
 	if jobState == forge_job.State_JobState_PENDING {
 		le.Debugf("starting job: %s", jobKey)
@@ -115,18 +115,18 @@ func (jt *jobTracker) processState(
 		return true, err
 	}
 
-	// completed job
+	// Stop when the job is no longer running.
 	if jobState != forge_job.State_JobState_RUNNING {
 		return true, nil
 	}
 
-	// look up any Task associated with the job
+	// Load the tasks linked to the job.
 	tasks, taskKeys, err := forge_job.CollectJobTasks(ctx, ws, jobKey)
 	if err != nil {
 		return true, err
 	}
 
-	// build list of non-complete Task
+	// Collect tasks that still need completion.
 	var pendingTasks []string
 	for i, task := range tasks {
 		taskState := task.GetTaskState()
@@ -135,11 +135,11 @@ func (jt *jobTracker) processState(
 		}
 	}
 
-	// update the list of task watchers
+	// Synchronize task watchers with the pending task set.
 	jt.c.le.Debugf("found %d pending tasks: %v", len(pendingTasks), pendingTasks)
 	jt.taskTrackers.SyncKeys(pendingTasks, true)
 
-	// if no tasks remain, promote to complete
+	// Complete the job when no tasks remain.
 	if len(pendingTasks) == 0 {
 		jt.c.le.Info("marking job as complete")
 		_, _, err = forge_cluster.CompleteJob(ctx, ws, clusterKey, jobKey, jt.c.peerID)
@@ -148,7 +148,7 @@ func (jt *jobTracker) processState(
 		}
 	}
 
-	// done
+	// Keep watching the job for state changes.
 	return true, nil
 }
 

--- a/forge/cluster/controller/task-tracker.go
+++ b/forge/cluster/controller/task-tracker.go
@@ -63,13 +63,13 @@ func (t *taskTracker) processState(
 ) (waitForChanges bool, err error) {
 	taskKey, jobKey, clusterKey := t.objKey, t.jt.objKey, t.jt.c.objKey
 
-	// check the <type> of the task object
+	// Confirm the task object type.
 	err = forge_task.CheckTaskType(ctx, ws, taskKey)
 	if err != nil {
 		return false, err
 	}
 
-	// unmarshal Task state
+	// Decode and validate the task state.
 	var task *forge_task.Task
 	_, err = world.AccessObject(ctx, ws.AccessWorldState, rootRef, func(bcs *block.Cursor) error {
 		var berr error
@@ -87,15 +87,15 @@ func (t *taskTracker) processState(
 	le.Debugf("task %q: %s", taskKey, taskState.String())
 
 	if t.prevState != taskState {
-		// re-scan job tasks to check if complete
+		// Wake the job tracker when the task state changes.
 		t.jt.objLoop.Wake()
 	}
 	t.prevState = taskState
 
-	// assign us to any task which is not assigned
+	// Assign unclaimed tasks to this cluster.
 	taskPeerID := task.GetPeerId()
 	if taskPeerID != "" && taskPeerID != t.jt.c.peerIDStr {
-		// assigned to someone else
+		// Leave tasks assigned to another cluster untouched.
 		return true, nil
 	}
 	if taskPeerID == "" {
@@ -110,7 +110,7 @@ func (t *taskTracker) processState(
 		}
 	}
 
-	// done
+	// Keep watching the task for state changes.
 	return true, nil
 }
 

--- a/forge/execution/controller/controller-exec.go
+++ b/forge/execution/controller/controller-exec.go
@@ -103,7 +103,7 @@ func (c *Controller) processExec(
 		defer cancel()
 	}
 
-	// resolve the controller config
+	// Resolve and validate the execution controller configuration.
 	cconf, err := ctrlConf.Resolve(resolveCtx, c.bus)
 	if err != nil {
 		if err == context.Canceled {
@@ -118,12 +118,12 @@ func (c *Controller) processExec(
 		return errors.Wrap(err, "validate exec controller config")
 	}
 
-	// ask the handler if it's ok to execute this controller
+	// Confirm the handler permits this controller execution.
 	if err := c.CheckExecControllerConfig(ctx, rCtrlConf); err != nil {
 		return err
 	}
 
-	// load the factory for the controller
+	// Load the factory for the configured controller.
 	factoryAv, _, factoryRef, err := bus.ExecOneOff(
 		ctx,
 		c.bus,
@@ -141,7 +141,7 @@ func (c *Controller) processExec(
 		return errors.New("load exec controller factory returned unexpected type")
 	}
 
-	// construct the controller, using the ExecutionController logger
+	// Construct the execution controller with its logger.
 	le := c.le
 	ctrl, err := fac.Construct(ctx, rCtrlConf, controller.ConstructOpts{
 		Logger: le,
@@ -150,10 +150,10 @@ func (c *Controller) processExec(
 		return errors.Wrap(err, "construct exec controller")
 	}
 
-	// lookup the target world engine if applicable
+	// Resolve the target world input when configured.
 	var targetWorld forge_target.InputValueWorld
 	if tgtWorldID := c.conf.GetInputWorld().GetEngineId(); tgtWorldID != "" {
-		// only set if there is not an Input set with the id
+		// Resolve the world only when the execution input is not already set.
 		v, rel, err := c.conf.GetInputWorld().ResolveValue(ctx, tgtBus)
 		if err != nil {
 			return err
@@ -166,7 +166,7 @@ func (c *Controller) processExec(
 		}
 	}
 
-	// build inputs map for passing to controller
+	// Resolve the controller input map against the target world.
 	inputsValMap, err := forge_value.
 		ValueSlice(exState.GetValueSet().GetInputs()).
 		BuildValueMap(true, true)
@@ -186,16 +186,15 @@ func (c *Controller) processExec(
 	}
 	defer inputsRelease()
 
-	// we expect all inputs to be resolved at this point.
+	// Reject unresolved inputs before controller execution.
 	if len(inputsUnresolved) != 0 {
 		inputNames := forge_target.GetInputsNames(inputsUnresolved)
 		return errors.Errorf("found %d unset inputs: %s", len(inputNames), inputNames)
 	}
 
-	// ensure the inputs match the ValueSet on the Execution.
+	// Compare resolved inputs with the execution snapshot.
 	inputValueSet := inputsMap.BuildValueSet()
 
-	// compare the value set with the stored inputs
 	var inputSet forge_value.ValueSlice = inputValueSet.GetInputs()
 	var exInputSet forge_value.ValueSlice = exState.GetValueSet().GetInputs()
 	addedInputs, removedInputs, changedInputs := exInputSet.Compare(inputSet)
@@ -205,12 +204,12 @@ func (c *Controller) processExec(
 		return errors.Errorf("found %d outdated inputs: %s", len(dirtyNames), dirtyNames)
 	}
 
-	// set the default "world" input if not already set
+	// Add the default world input when no explicit value exists.
 	if _, targetWorldOk := inputsMap[targetWorldInput]; !targetWorldOk && targetWorld != nil {
 		inputsMap[targetWorldInput] = targetWorld
 	}
 
-	// pass handles to the exec controller
+	// Build the execution handle and pass it to the controller.
 	execCtx := forge_target.WithExecCancelSignal(ctx, c.cancelCh)
 	execCtrlHandle := newExecControllerHandle(
 		execCtx,

--- a/forge/execution/controller/test/controller_test.go
+++ b/forge/execution/controller/test/controller_test.go
@@ -20,13 +20,12 @@ func TestExecutionController(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	// add the boilerplate controller factory
-	// referenced in the Target below
+	// Register the controller factories used by the target.
 	b, sr := tb.Bus, tb.StaticResolver
 	sr.AddFactory(boilerplate_controller.NewFactory(b))
 	sr.AddFactory(forge_lib_kvtx.NewFactory(b))
 
-	// End to end test of building a target and running in a testbed.
+	// Resolve and execute the end-to-end target.
 	tgt, err := target_mock.ResolveMockTarget(ctx, b)
 	if err != nil {
 		t.Fatal(err.Error())

--- a/forge/lib/git/clone/controller_test.go
+++ b/forge/lib/git/clone/controller_test.go
@@ -91,8 +91,9 @@ func TestGitClone(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	// ordinarily resolved by Task controller, set it manually
+	// Supply the value set that the Task controller normally resolves.
 	valueSet := &forge_target.ValueSet{}
+
 	// handle := forge_target.ExecControllerHandleWithAccess(ws.AccessWorldState)
 	ts := timestamp.Now()
 	finalState, err := tb.RunExecutionWithTarget(tgt, valueSet, ts)
@@ -106,7 +107,7 @@ func TestGitClone(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	// check repo output
+	// Verify that the clone output is present.
 	stv := valMap["repo"]
 	if stv.IsEmpty() {
 		t.Fatal("expected repo output to be set but was empty")

--- a/forge/lib/kvtx/controller_test.go
+++ b/forge/lib/kvtx/controller_test.go
@@ -79,7 +79,7 @@ func TestKvtx(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	// store the blob in a world object
+	// Store the input blob in a world object.
 	ts := timestamp.Now()
 	uniqueID := "kvtx-test"
 	handle := forge_target.ExecControllerHandleWithAccess(uniqueID, tb.Volume.GetPeerID(), tb.Engine, ws.AccessWorldState, ts)
@@ -95,6 +95,7 @@ func TestKvtx(t *testing.T) {
 
 	valueSet := &forge_target.ValueSet{}
 
+	// Resolve the world-object input for the target execution.
 	// TODO: ordinarily resolved by Task controller, set it manually
 	// remove this when the Task controller can resolve world objects.
 	inpSnapshot, err := forge_value.NewWorldObjectSnapshot(ctx, testObj, ws)
@@ -119,7 +120,7 @@ func TestKvtx(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	// check setTestValue output
+	// Verify the first value-set output contains the stored blob.
 	stv := valMap["setTestValue"]
 	if stv.IsEmpty() {
 		t.Fatal("expected setTestValue output to be set but was empty")
@@ -143,7 +144,7 @@ func TestKvtx(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	// check setTestValue output
+	// Verify the second value-set output.
 	stv = valMap["setTestValue2"]
 	if stv.IsEmpty() {
 		t.Fatal("expected setTestValue2 output to be set but was empty")
@@ -168,7 +169,7 @@ func TestKvtx(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	// check setTestValue3 output
+	// Verify the third output records the existing-key result.
 	stv = valMap["setTestValue3"]
 	if stv.IsEmpty() {
 		t.Fatal("expected setTestValue3 output to be set but was empty")
@@ -181,7 +182,7 @@ func TestKvtx(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	// check store output
+	// Verify the key-value store output and its persisted entries.
 	stv = valMap["store"]
 	if stv.IsEmpty() {
 		t.Fatal("expected store output to be set but was empty")
@@ -203,6 +204,7 @@ func TestKvtx(t *testing.T) {
 		if nkeys != 2 {
 			return errors.Errorf("expected %d keys but got %d", 2, nkeys)
 		}
+
 		// bug: vbcs is pointing to a node in iavl tree
 		tdata, tfound, err := btx.Get(ctx, []byte("test-1"))
 		if err != nil {

--- a/forge/target/value_test.go
+++ b/forge/target/value_test.go
@@ -29,7 +29,7 @@ func buildTestbedHandle(t *testing.T) (*testbed.Testbed, world.WorldState, ExecC
 	t.Cleanup(tb.Release)
 	hydra_all.AddFactories(tb.Bus, tb.StaticResolver)
 
-	// construct & mount world controller
+	// Construct and mount the world controller used by the handle.
 	engineID := "forge-target-test"
 	volumeID := tb.Volume.GetID()
 	bucketID := tb.BucketId
@@ -68,8 +68,9 @@ func TestStoreBlobValue(t *testing.T) {
 	tb, _, handle := buildTestbedHandle(t)
 	ctx := tb.Context
 
-	// Test storing large value
+	// Store a large blob value.
 	rnd := prng.BuildSeededReader([]byte("test-store-blob-value"))
+
 	dat := make([]byte, 250000) // 250kb
 	_, err := io.ReadFull(rnd, dat)
 	if err != nil {
@@ -80,7 +81,7 @@ func TestStoreBlobValue(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	// Test loading value
+	// Load the blob and compare its bytes with the stored value.
 	outData, err := LoadBlobValueToBytes(ctx, handle, fv)
 	if err != nil {
 		t.Fatal(err.Error())
@@ -95,14 +96,13 @@ func TestStoreMsgpackBlobValue(t *testing.T) {
 	tb, _, handle := buildTestbedHandle(t)
 	ctx := tb.Context
 
-	// Test storing value
+	// Store a structured value and load it back.
 	testValue := map[string]int{"test": 2}
 	fv, err := StoreMsgpackValue(ctx, handle, testValue)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
 
-	// Test loading value
 	loaded, err := LoadMsgpackValue(ctx, handle, fv, func() map[string]int {
 		return map[string]int{}
 	})
@@ -119,14 +119,14 @@ func TestStoreMsgpackBlockValue(t *testing.T) {
 	tb, _, handle := buildTestbedHandle(t)
 	ctx := tb.Context
 
-	// Test storing value directly in block
+	// Store a structured value in a msgpack block.
 	testValue := map[string]int{"test": 2}
 	fv, err := StoreMsgpackValue(ctx, handle, testValue)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
 
-	// Test loading value
+	// Load the block and verify its decoded value.
 	loaded, err := LoadMsgpackValue(ctx, handle, fv, func() map[string]int { return map[string]int{} })
 	if err != nil {
 		t.Fatal(err.Error())

--- a/identity/domain/controller/controller.go
+++ b/identity/domain/controller/controller.go
@@ -97,11 +97,12 @@ func (c *Controller) GetControllerInfo() *controller.Info {
 // Returning nil ends execution.
 // Returning an error triggers a retry with backoff.
 func (c *Controller) Execute(ctx context.Context) error {
+	// Record the execution context and domain logger.
 	c.ctx = ctx
-	// Acquire a handle to the node.
+
 	le := c.le.WithField("domain-id", c.domainInfo.GetDomainId())
 
-	// Construct the domain
+	// Construct and publish the controlled domain.
 	dm, err := c.ctor(
 		ctx,
 		le,
@@ -113,12 +114,14 @@ func (c *Controller) Execute(ctx context.Context) error {
 	defer dm.Close()
 	c.domainCh <- dm
 
+	// Execute the domain and wait for cancellation after a clean return.
 	c.le.Debug("executing identity domain controller")
 	err = dm.Execute(ctx)
 	if err == nil {
-		// indicated success, wait for ctx cancel
 		<-ctx.Done()
 	}
+
+	// Release the published domain and return its execution result.
 	select {
 	case <-c.domainCh:
 	default:

--- a/identity/domain/controller/ctrl-lookup-domain.go
+++ b/identity/domain/controller/ctrl-lookup-domain.go
@@ -40,6 +40,5 @@ func (c *Controller) resolveLookupIdentityDomain(
 		return nil, nil
 	}
 
-	// Return resolver.
 	return &lookupIdentityDomainResolver{c: c, ctx: ctx, dir: dir}, nil
 }

--- a/identity/domain/controller/ctrl-lookup-entity.go
+++ b/identity/domain/controller/ctrl-lookup-entity.go
@@ -42,6 +42,5 @@ func (c *Controller) resolveLookupEntity(
 		return nil, nil
 	}
 
-	// Return resolver.
 	return &lookupEntityResolver{c: c, ctx: ctx, dir: dir}, nil
 }

--- a/identity/domain/controller/ctrl-select-entity.go
+++ b/identity/domain/controller/ctrl-select-entity.go
@@ -21,7 +21,7 @@ type selectEntityResolver struct {
 // The resolver will not be retried after returning an error.
 // Values will be maintained from the previous call.
 func (o *selectEntityResolver) Resolve(ctx context.Context, handler directive.ResolverHandler) error {
-	// Ask the user for an entity id.
+	// Collect the entity ID requested by the user.
 	purpose := o.dir.SelectIdentityEntityPurpose()
 	domainID := o.dir.SelectIdentityEntityDomainID()
 	prevErr := o.dir.SelectIdentityEntityPrevError()
@@ -30,13 +30,15 @@ func (o *selectEntityResolver) Resolve(ctx context.Context, handler directive.Re
 	if err != nil {
 		return err
 	}
+
+	// Return an empty selection when the user provided no entity ID.
 	if entityID == "" {
 		o.c.le.Info("user provided empty entity id")
 		handler.AddValue(identity.SelectIdentityEntityValue(nil))
 		return nil
 	}
 
-	// Lookup the entity - via directive so other controllers can handle it.
+	// Resolve the entity through the directive bus.
 	le := o.c.le.
 		WithField("entity-id", entityID).
 		WithField("domain-id", domainID)
@@ -57,7 +59,7 @@ func (o *selectEntityResolver) Resolve(ctx context.Context, handler directive.Re
 	if val == nil || v1.IsNotFound() {
 		le.WithError(err).Warn("entity lookup returned not found")
 	} else {
-		// validate: ensure keypair signatures are valid
+		// Verify the returned entity keypair signatures.
 		kps, err := val.UnmarshalVerifyKeypairs()
 		if err != nil {
 			le.WithError(err).Error("entity lookup returned invalid entity")
@@ -71,6 +73,7 @@ func (o *selectEntityResolver) Resolve(ctx context.Context, handler directive.Re
 		}).Info("retrieved entity")
 	}
 
+	// Deliver the selected entity value.
 	handler.AddValue(val)
 	return nil
 }

--- a/identity/domain/service/client.go
+++ b/identity/domain/service/client.go
@@ -18,6 +18,7 @@ func LookupEntity(
 	localPriv crypto.PrivKey,
 	domainID, entityID string,
 ) (*identity.Entity, error) {
+	// Construct the identity-domain client and lookup request.
 	svc := NewSRPCIdentityDomainClient(cl)
 
 	req, err := NewLookupEntityReq(domainID, entityID, nil, 0)
@@ -25,11 +26,13 @@ func LookupEntity(
 		return nil, err
 	}
 
+	// Sign the lookup request for the remote domain service.
 	sigReq, err := req.SignReq(localPriv)
 	if err != nil {
 		return nil, err
 	}
 
+	// Submit the request and translate the response into an entity result.
 	resp, err := svc.LookupEntity(ctx, sigReq)
 	if err != nil {
 		return nil, err

--- a/identity/domain/service/lookup-entity.go
+++ b/identity/domain/service/lookup-entity.go
@@ -22,7 +22,6 @@ func NewLookupEntityReq(
 	ts *timestamp.Timestamp,
 	nonce uint64,
 ) (*LookupEntityReq, error) {
-	// fill
 	if nonce == 0 {
 		var b [8]byte
 		if _, err := rand.Read(b[:]); err != nil {
@@ -59,7 +58,7 @@ func (r *LookupEntityReq) Validate() error {
 
 // CheckTimestamp checks if the timestamp is within range.
 func (r *LookupEntityReq) CheckTimestamp(now time.Time) error {
-	// assert timestamp is within last 5 mins
+	// Enforce the allowed request clock skew.
 	reqTs := r.GetTimestamp().AsTime()
 	reqTsDiff := now.Sub(reqTs)
 	if reqTsDiff > time.Minute*5 || reqTsDiff < -1*time.Second*30 {

--- a/identity/entity-keypair-set.go
+++ b/identity/entity-keypair-set.go
@@ -18,17 +18,19 @@ const keypairEncContext = "identity sign EntityKeypair 2024-06-05T06:48:39.30967
 // The keypair must not already exist.
 // If Entity != nil, checks if the Entity matches the keypair.
 func (e *EntityKeypairSet) AppendKeypair(privKey crypto.PrivKey, ekp *EntityKeypair, ent *Entity) error {
-	// validate keypair
+	// Validate the keypair before signing or storing it.
 	if err := ekp.Validate(); err != nil {
 		return err
 	}
+
 	if ent != nil {
 		// Note: does not check if the entity keypair set contains the entity.
 		if err := ekp.ValidateMatchesEntity(ent); err != nil {
 			return err
 		}
 	}
-	// ensure that peer ids match
+
+	// Confirm that the private key matches the keypair peer ID.
 	kp := ekp.GetKeypair()
 	expectedPeerID, err := peer.IDFromPrivateKey(privKey)
 	if err != nil {
@@ -39,7 +41,7 @@ func (e *EntityKeypairSet) AppendKeypair(privKey crypto.PrivKey, ekp *EntityKeyp
 		return errors.Errorf("private key %s does not match keypair %s", expectedPeerIDString, kpPeerID)
 	}
 
-	// sign the keypair data w/ the private key
+	// Sign the keypair data with the private key.
 	kpData, err := ekp.MarshalBlock()
 	if err != nil {
 		return err
@@ -48,13 +50,15 @@ func (e *EntityKeypairSet) AppendKeypair(privKey crypto.PrivKey, ekp *EntityKeyp
 	if err != nil {
 		return err
 	}
-	// verify the signature matches (sanity check)
+
+	// Verify the generated signature against the private key's public key.
 	pubKey := privKey.GetPublic()
 	_, err = sig.VerifyWithPublic(keypairEncContext, pubKey, kpData)
 	if err != nil {
 		return err
 	}
-	// ensure no keypair exists with the peer id
+
+	// Reject an existing keypair with the same peer or public key.
 	for i, kpData := range e.GetEntityKeypairs() {
 		ekp := &EntityKeypair{}
 		var peerID peer.ID
@@ -74,7 +78,7 @@ func (e *EntityKeypairSet) AppendKeypair(privKey crypto.PrivKey, ekp *EntityKeyp
 		}
 	}
 
-	// append the signature + keypair
+	// Append the signed keypair data.
 	e.EntityKeypairs = append(e.EntityKeypairs, kpData)
 	e.EntityKeypairSignatures = append(e.EntityKeypairSignatures, sig)
 	return nil
@@ -88,9 +92,13 @@ func (e *EntityKeypairSet) UnmarshalVerifyKeypairs(ent *Entity) ([]*EntityKeypai
 	kpLen := len(keypairs)
 	keypairSigs := e.GetEntityKeypairSignatures()
 	sigLen := len(keypairSigs)
+
+	// Require one signature for every encoded keypair.
 	if kpLen != sigLen {
 		return nil, errors.Errorf("keypairs count must match signatures count: %d != %d", kpLen, sigLen)
 	}
+
+	// Decode and validate each keypair before checking its signature.
 	keypairVals := make([]*EntityKeypair, len(keypairs))
 	for i, kpData := range keypairs {
 		ekp := &EntityKeypair{}
@@ -108,6 +116,8 @@ func (e *EntityKeypairSet) UnmarshalVerifyKeypairs(ent *Entity) ([]*EntityKeypai
 		}
 		keypairVals[i] = ekp
 	}
+
+	// Verify each signature against the corresponding keypair payload.
 	for i, kpSig := range keypairSigs {
 		ekp := keypairVals[i]
 		pubKey, err := kpSig.ParsePubKey()

--- a/identity/entity_test.go
+++ b/identity/entity_test.go
@@ -16,7 +16,7 @@ func TestBuildEntity(t *testing.T) {
 
 	ent := NewEntity(domainID, entityID, entityUUID)
 
-	// generate 2 private keys + keypair objects
+	// Generate two private keys and their entity keypair records.
 	p1, _ := peer.NewPeer(nil)
 	p2, _ := peer.NewPeer(nil)
 	kp1, err := EntityKeypairWithPubKey(
@@ -36,7 +36,7 @@ func TestBuildEntity(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	// append them
+	// Append both signed keypairs to the entity.
 	ctx := context.Background()
 	p1Priv, err := p1.GetPrivKey(ctx)
 	if err != nil {
@@ -55,11 +55,10 @@ func TestBuildEntity(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	// verify
+	// Validate the completed entity and its keypair signatures.
 	if err := ent.Validate(); err != nil {
 		t.Fatal(err.Error())
 	}
 
-	// done
 	t.Logf("successfully created entity with %d keypairs", len(ent.GetEntityKeypairSet().GetEntityKeypairs()))
 }

--- a/identity/world/domain-info-update.go
+++ b/identity/world/domain-info-update.go
@@ -88,7 +88,7 @@ func (o *DomainInfoUpdateOp) ApplyWorldOp(
 ) (sysErr bool, err error) {
 	kpRef := o.GetDomainInfoRef()
 
-	// create / validate the objectref
+	// Resolve and validate the referenced domain information.
 	var di *identity_domain.DomainInfo
 	di, err = FollowDomainInfo(ctx, worldHandle.AccessWorldState, kpRef)
 	if err == nil && di.GetDomainId() == "" {
@@ -97,7 +97,6 @@ func (o *DomainInfoUpdateOp) ApplyWorldOp(
 	if err != nil {
 		return false, err
 	}
-
 	if err := di.Validate(); err != nil {
 		return false, err
 	}
@@ -105,7 +104,7 @@ func (o *DomainInfoUpdateOp) ApplyWorldOp(
 	domainID := di.GetDomainId()
 	objKey := NewDomainInfoKey(domainID)
 
-	// create the object if it doesn't exist.
+	// Update the existing domain object or create it at the referenced root.
 	obj, objFound, err := worldHandle.GetObject(ctx, objKey)
 	if err != nil {
 		return false, err
@@ -120,7 +119,7 @@ func (o *DomainInfoUpdateOp) ApplyWorldOp(
 		return false, err
 	}
 
-	// DomainInfo type -> types/identity/domain
+	// Index the new object as identity domain information.
 	if err := world_types.SetObjectType(ctx, worldHandle, objKey, DomainInfoTypeID); err != nil {
 		return false, err
 	}
@@ -135,14 +134,14 @@ func (o *DomainInfoUpdateOp) ApplyWorldObjectOp(
 	objectHandle world.ObjectState,
 	sender peer.ID,
 ) (sysErr bool, err error) {
-	// Applying to an existing object.
+	// Verify the referenced domain information before updating the object.
 	domainInfoRef := o.GetDomainInfoRef()
 	_, err = FollowDomainInfo(ctx, objectHandle.AccessWorldState, domainInfoRef)
 	if err != nil {
 		return false, err
 	}
 
-	// update the object
+	// Replace the object's root reference with the validated domain information.
 	_, err = objectHandle.SetRootRef(ctx, domainInfoRef)
 	return false, err
 }

--- a/identity/world/domain-info.go
+++ b/identity/world/domain-info.go
@@ -43,7 +43,7 @@ func FollowDomainInfo(
 	}
 	var domain *identity_domain.DomainInfo
 	_, err = world.AccessObject(ctx, accessState, domainInfoRef, func(bcs *block.Cursor) error {
-		// Confirm valid DomainInfo object.
+		// Decode the referenced domain information block.
 		var err error
 		domain, err = identity_domain.UnmarshalDomainInfo(ctx, bcs)
 		return err
@@ -117,7 +117,7 @@ func CollectAllDomainInfos(ctx context.Context, w world.WorldState) ([]*identity
 	}
 	slices.Sort(objKeys)
 
-	// collect list
+	// Resolve the collected domain information keys.
 	list, err := LookupDomainInfos(ctx, w, objKeys)
 	return list, objKeys, err
 }

--- a/identity/world/entities.go
+++ b/identity/world/entities.go
@@ -58,7 +58,7 @@ func FollowEntity(
 	}
 	var entity *identity.Entity
 	_, err = world.AccessObject(ctx, accessState, entityRef, func(bcs *block.Cursor) error {
-		// Confirm valid Entity object.
+		// Decode the referenced entity block.
 		var err error
 		entity, err = identity.UnmarshalEntity(ctx, bcs)
 		return err
@@ -133,7 +133,7 @@ func CollectAllEntities(ctx context.Context, w world.WorldState) ([]*identity.En
 	}
 	slices.Sort(objKeys)
 
-	// collect entity list
+	// Resolve the collected entity keys.
 	entityList, err := LookupEntities(ctx, w, objKeys)
 	return entityList, objKeys, err
 }

--- a/identity/world/entity-update.go
+++ b/identity/world/entity-update.go
@@ -85,7 +85,7 @@ func (o *EntityUpdateOp) ApplyWorldOp(
 ) (sysErr bool, err error) {
 	entityRef := o.GetEntityRef()
 
-	// create / validate the objectref
+	// Resolve and validate the referenced entity.
 	var entity *identity.Entity
 	entity, err = FollowEntity(ctx, worldHandle.AccessWorldState, entityRef)
 	if err != nil || entity == nil {
@@ -95,7 +95,7 @@ func (o *EntityUpdateOp) ApplyWorldOp(
 	domainID, entityID := entity.GetDomainId(), entity.GetEntityId()
 	objKey := NewEntityKey(domainID, entityID)
 
-	// create the entity if it doesn't exist.
+	// Update the existing entity object or create its initial type index.
 	obj, objFound, err := worldHandle.GetObject(ctx, objKey)
 	if err != nil {
 		return false, err
@@ -121,13 +121,13 @@ func (o *EntityUpdateOp) ApplyWorldOp(
 			return false, err
 		}
 
-		// Entity type
+		// Index the new object as an identity entity.
 		if err := world_types.SetObjectType(ctx, worldHandle, objKey, EntityTypeID); err != nil {
 			return false, err
 		}
 	}
 
-	// Add new keypairs to storage if they don't exist.
+	// Persist newly referenced keypairs and collect their object keys.
 	entityKps, err := entity.UnmarshalVerifyKeypairs()
 	if err != nil {
 		return false, err
@@ -141,7 +141,7 @@ func (o *EntityUpdateOp) ApplyWorldOp(
 		return false, err
 	}
 
-	// Create/update links to keypairs.
+	// Link the entity to each referenced keypair.
 	for _, kpObjKey := range kpObjectKeys {
 		kpQuad := NewObjectToKeypairQuad(objKey, kpObjKey)
 		if err := worldHandle.SetGraphQuad(ctx, kpQuad); err != nil {
@@ -149,7 +149,7 @@ func (o *EntityUpdateOp) ApplyWorldOp(
 		}
 	}
 
-	// Create/update link to domain info (if exists)
+	// Link the entity to its domain information when available.
 	diKey := NewDomainInfoKey(domainID)
 	_, diExists, err := worldHandle.GetObject(ctx, diKey)
 	if err != nil {
@@ -161,7 +161,6 @@ func (o *EntityUpdateOp) ApplyWorldOp(
 			return false, err
 		}
 	}
-
 	return false, nil
 }
 

--- a/identity/world/keypair-update.go
+++ b/identity/world/keypair-update.go
@@ -127,6 +127,8 @@ func EnsureKeypairsExist(
 ) ([]string, error) {
 	createdKp := make(map[string]struct{})
 	kpObjectKeys := make([]string, len(kps))
+
+	// Resolve object keys and reject duplicate keypair identities.
 	for nki, nkp := range kps {
 		pid, err := nkp.ParsePeerID()
 		if err != nil {
@@ -140,8 +142,9 @@ func EnsureKeypairsExist(
 		}
 		createdKp[objKey] = struct{}{}
 	}
+
+	// Persist each validated keypair.
 	for _, kp := range kps {
-		// store keypair
 		_, _, err := StoreKeypair(ctx, ws, sender, kp, overwrite)
 		if err != nil {
 			return nil, err
@@ -173,7 +176,7 @@ func (o *KeypairUpdateOp) ApplyWorldOp(
 ) (sysErr bool, err error) {
 	kpRef := o.GetKeypairRef()
 
-	// create / validate the objectref
+	// Resolve and validate the referenced keypair.
 	var kp *identity.Keypair
 	kp, err = FollowKeypair(ctx, worldHandle.AccessWorldState, kpRef)
 	if err == nil && kp.GetPeerId() == "" {
@@ -182,7 +185,6 @@ func (o *KeypairUpdateOp) ApplyWorldOp(
 	if err != nil {
 		return false, err
 	}
-
 	if err := kp.Validate(); err != nil {
 		return false, err
 	}
@@ -195,7 +197,7 @@ func (o *KeypairUpdateOp) ApplyWorldOp(
 	pidString := pid.String()
 	objKey := NewKeypairKey(pidString)
 
-	// create the object if it doesn't exist.
+	// Update the existing keypair object or create it with its type index.
 	obj, objFound, err := worldHandle.GetObject(ctx, objKey)
 	if err != nil {
 		return false, err
@@ -210,7 +212,7 @@ func (o *KeypairUpdateOp) ApplyWorldOp(
 		return false, err
 	}
 
-	// set keypair type ref
+	// Index the new object as an identity keypair.
 	if err := world_types.SetObjectType(ctx, worldHandle, objKey, KeypairTypeID); err != nil {
 		return false, err
 	}
@@ -225,14 +227,14 @@ func (o *KeypairUpdateOp) ApplyWorldObjectOp(
 	objectHandle world.ObjectState,
 	sender peer.ID,
 ) (sysErr bool, err error) {
-	// Applying to an existing object.
+	// Verify the referenced keypair before updating the object root.
 	keypairRef := o.GetKeypairRef()
 	_, err = FollowKeypair(ctx, objectHandle.AccessWorldState, keypairRef)
 	if err != nil {
 		return false, err
 	}
 
-	// update the object
+	// Replace the object's root reference with the validated keypair.
 	_, err = objectHandle.SetRootRef(ctx, keypairRef)
 	return false, err
 }

--- a/identity/world/keypairs.go
+++ b/identity/world/keypairs.go
@@ -59,7 +59,7 @@ func FollowKeypair(
 	}
 	var entity *identity.Keypair
 	_, err = world.AccessObject(ctx, accessState, keypairRef, func(bcs *block.Cursor) error {
-		// Confirm valid Keypair object.
+		// Decode the referenced keypair block.
 		var err error
 		entity, err = identity.UnmarshalKeypair(ctx, bcs)
 		return err
@@ -133,8 +133,9 @@ func CollectAllKeypairs(ctx context.Context, w world.WorldState) ([]*identity.Ke
 	}
 	slices.Sort(objKeys)
 
-	// collect list
+	// Resolve the collected keypair keys.
 	list, err := LookupKeypairs(ctx, w, objKeys)
+
 	return list, objKeys, err
 }
 
@@ -146,9 +147,8 @@ func ListKeypairEntities(ctx context.Context, w world.WorldState, keypairKeys ..
 		w,
 		keypairKeys,
 		func(p *cayley.Path) (*cayley.Path, error) {
-			// In(PredObjectToKeypair): list all objects linking to the Keypairs.
+			// Traverse incoming links and retain entity objects.
 			p = p.In(PredObjectToKeypair)
-			// Filter those objects to Entities
 			p = world_types.LimitNodesToTypes(p, EntityTypeID)
 			return p, nil
 		},

--- a/lint/nonavigate/nonavigate.go
+++ b/lint/nonavigate/nonavigate.go
@@ -41,6 +41,7 @@ func (p *plugin) GetLoadMode() string {
 }
 
 func run(pass *analysis.Pass) (any, error) {
+	// Inspect each file for forbidden navigation calls.
 	for _, file := range pass.Files {
 		ast.Inspect(file, func(n ast.Node) bool {
 			call, ok := n.(*ast.CallExpr)
@@ -52,6 +53,7 @@ func run(pass *analysis.Pass) (any, error) {
 				return true
 			}
 			if sel.Sel.Name == "Navigate" {
+				// Report navigation calls that destroy the WASM process.
 				pass.Report(analysis.Diagnostic{
 					Pos:     sel.Sel.Pos(),
 					Message: "Navigate triggers a full page reload destroying the WASM process and all workers; use page.Evaluate with pushState for client-side routing instead",

--- a/net/cli/daemonflags.go
+++ b/net/cli/daemonflags.go
@@ -92,6 +92,7 @@ func (a *DaemonArgs) ApplyFactories(b bus.Bus, sr *static.Resolver) {
 // ApplyToConfigSet applies controller configurations to a config set.
 // Map is from string descriptor to config object.
 func (a *DaemonArgs) ApplyToConfigSet(confSet configset.ConfigSet, overwrite bool) error {
+	// Apply each requested controller configuration through the local helper.
 	apply := func(id string, conf config.Config) {
 		if !overwrite {
 			if _, ok := confSet[id]; ok {
@@ -100,6 +101,8 @@ func (a *DaemonArgs) ApplyToConfigSet(confSet configset.ConfigSet, overwrite boo
 		}
 		confSet[id] = configset.NewControllerConfig(1, conf)
 	}
+
+	// Configure explicit peer establishment when requested.
 	if len(a.EstablishPeers.Value()) != 0 {
 		establishConf := &link_establish_controller.Config{
 			PeerIds: a.EstablishPeers.Value(),
@@ -109,10 +112,13 @@ func (a *DaemonArgs) ApplyToConfigSet(confSet configset.ConfigSet, overwrite boo
 		}
 		apply("establish-peers", establishConf)
 	}
+
+	// Keep established links open during long-lived streams.
 	if a.HoldOpenLinks {
 		apply("hold-open", &link_holdopen_controller.Config{})
 	}
 
+	// Configure the websocket listener and static peers.
 	if a.WebsocketListen != "" {
 		staticPeers, err := parseDialerAddrs(a.WebsocketPeers)
 		if err != nil {
@@ -125,6 +131,7 @@ func (a *DaemonArgs) ApplyToConfigSet(confSet configset.ConfigSet, overwrite boo
 		})
 	}
 
+	// Configure the UDP listener and static peers.
 	if a.UDPListen != "" {
 		staticPeers, err := parseDialerAddrs(a.UDPPeers)
 		if err != nil {
@@ -138,6 +145,7 @@ func (a *DaemonArgs) ApplyToConfigSet(confSet configset.ConfigSet, overwrite boo
 		})
 	}
 
+	// Configure the selected pubsub provider.
 	if a.Pubsub != "" {
 		conf, err := a.callPubsubProvider(strings.ToLower(a.Pubsub))
 		if err != nil {

--- a/net/cli/envelope.go
+++ b/net/cli/envelope.go
@@ -151,6 +151,7 @@ func (a *EnvelopeArgs) loadPrivKeys() ([]crypto.PrivKey, error) {
 
 // RunSeal seals data into an envelope.
 func (a *EnvelopeArgs) RunSeal(_ *cli.Context) error {
+	// Load recipient keys before reading and sealing the payload.
 	pubKeys, err := a.loadPubKeys()
 	if err != nil {
 		return err
@@ -164,7 +165,7 @@ func (a *EnvelopeArgs) RunSeal(_ *cli.Context) error {
 		return errors.New("input is empty")
 	}
 
-	// Build grant configs: one grant per key, one share each.
+	// Build one grant for each recipient key.
 	grants := make([]*envelope.EnvelopeGrantConfig, len(pubKeys))
 	for i := range pubKeys {
 		grants[i] = &envelope.EnvelopeGrantConfig{
@@ -177,6 +178,7 @@ func (a *EnvelopeArgs) RunSeal(_ *cli.Context) error {
 		return errors.New("threshold exceeds maximum value")
 	}
 
+	// Encrypt the payload into an envelope and serialize it.
 	env, err := envelope.BuildEnvelope(
 		rand.Reader,
 		a.Context,
@@ -191,6 +193,7 @@ func (a *EnvelopeArgs) RunSeal(_ *cli.Context) error {
 		return errors.Wrap(err, "build envelope")
 	}
 
+	// Write the serialized envelope to the selected output.
 	data, err := env.MarshalVT()
 	if err != nil {
 		return errors.Wrap(err, "marshal envelope")
@@ -201,11 +204,13 @@ func (a *EnvelopeArgs) RunSeal(_ *cli.Context) error {
 
 // RunUnseal unseals an envelope.
 func (a *EnvelopeArgs) RunUnseal(c *cli.Context) error {
+	// Load recipient keys before reading and unlocking the envelope.
 	privKeys, err := a.loadPrivKeys()
 	if err != nil {
 		return err
 	}
 
+	// Read and decode the sealed envelope.
 	data, err := a.readInput()
 	if err != nil {
 		return errors.Wrap(err, "read input")
@@ -216,11 +221,13 @@ func (a *EnvelopeArgs) RunUnseal(c *cli.Context) error {
 		return errors.Wrap(err, "unmarshal envelope")
 	}
 
+	// Unlock the payload with the available private keys.
 	payload, result, err := envelope.UnlockEnvelope(a.Context, env, privKeys)
 	if err != nil {
 		return errors.Wrap(err, "unlock envelope")
 	}
 
+	// Emit diagnostic unlock information when requested.
 	if c.Bool("info") {
 		dat, err := marshalEnvelopeInfoJSON(env, result)
 		if err != nil {

--- a/net/cli/pipe-listen.go
+++ b/net/cli/pipe-listen.go
@@ -15,7 +15,7 @@ import (
 
 // runListen runs the pipe command in listen/server mode.
 func (a *PipeArgs) runListen(ctx context.Context) error {
-	// Setup daemon with UDP transport
+	// Start the daemon and accept-handler transport.
 	d, cleanup, err := a.setupDaemon(ctx, a.ListenAddr, nil)
 	if err != nil {
 		return err
@@ -29,10 +29,10 @@ func (a *PipeArgs) runListen(ctx context.Context) error {
 	a.logStatus("Peer ID: %s", peerID.String())
 	a.logStatus("Listening on %s", a.ListenAddr)
 
-	// Create stream channel for accepting incoming streams
+	// Create the channel that receives accepted mounted streams.
 	streamCh := make(chan link.MountedStream, 1)
 
-	// Create and register the accept handler controller
+	// Register the controller that resolves incoming mounted streams.
 	acceptHandler := newPipeAcceptController(
 		b,
 		protocol.ID(a.ProtocolID),
@@ -46,7 +46,7 @@ func (a *PipeArgs) runListen(ctx context.Context) error {
 		return errors.Wrap(err, "add accept handler")
 	}
 
-	// Wait for incoming stream
+	// Wait for cancellation or the next accepted stream.
 	select {
 	case <-ctx.Done():
 		return ctx.Err()

--- a/net/cli/pipe.go
+++ b/net/cli/pipe.go
@@ -100,7 +100,7 @@ func (a *PipeArgs) Run(c *cli.Context) error {
 // setupDaemon creates an in-process daemon with UDP transport.
 // Returns the daemon and a cleanup function that releases controller references.
 func (a *PipeArgs) setupDaemon(ctx context.Context, listenAddr string, dialers map[string]*dialer.DialerOpts) (*daemon.Daemon, func(), error) {
-	// Create logger (quiet mode uses a no-op logger)
+	// Build the logger used by the daemon and transport controllers.
 	logger := logrus.New()
 	logger.SetLevel(logrus.WarnLevel)
 	if a.Quiet {
@@ -108,13 +108,13 @@ func (a *PipeArgs) setupDaemon(ctx context.Context, listenAddr string, dialers m
 	}
 	le := logrus.NewEntry(logger)
 
-	// Generate or load private key
+	// Load or generate the node private key.
 	privKey, err := a.loadOrGenerateKey(le)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "load/generate key")
 	}
 
-	// Create daemon
+	// Construct the daemon around the node identity.
 	d, err := daemon.NewDaemon(ctx, privKey, daemon.ConstructOpts{
 		LogEntry: le,
 	})
@@ -122,6 +122,7 @@ func (a *PipeArgs) setupDaemon(ctx context.Context, listenAddr string, dialers m
 		return nil, nil, errors.Wrap(err, "construct daemon")
 	}
 
+	// Register and start the hold-open controller.
 	b := d.GetControllerBus()
 	sr := d.GetStaticResolver()
 
@@ -137,7 +138,7 @@ func (a *PipeArgs) setupDaemon(ctx context.Context, listenAddr string, dialers m
 		return nil, nil, errors.Wrap(err, "start hold-open controller")
 	}
 
-	// Start UDP transport
+	// Start the UDP transport with the requested listen address.
 	_, _, udpRef, err := loader.WaitExecControllerRunning(
 		ctx,
 		b,
@@ -152,7 +153,7 @@ func (a *PipeArgs) setupDaemon(ctx context.Context, listenAddr string, dialers m
 		return nil, nil, errors.Wrap(err, "start UDP transport")
 	}
 
-	// Return cleanup function that releases all controller references
+	// Return cleanup for both controller references.
 	cleanup := func() {
 		udpRef.Release()
 		hoRef.Release()
@@ -209,6 +210,7 @@ func pipeStream(strm io.ReadWriteCloser, stdin io.Reader, stdout io.Writer) erro
 	go func() {
 		buf := make([]byte, 8192)
 		_, _ = io.CopyBuffer(strm, stdin, buf)
+
 		// Signal that stdin is done - close the stream to signal EOF to remote
 		strm.Close()
 	}()

--- a/net/crypto/tls/tls.go
+++ b/net/crypto/tls/tls.go
@@ -74,11 +74,13 @@ func WithKeyLogWriter(w io.Writer) IdentityOption {
 
 // NewIdentity creates a new TLS identity from a bifrost private key.
 func NewIdentity(privKey crypto.PrivKey, opts ...IdentityOption) (*Identity, error) {
+	// Apply identity options before generating the certificate template.
 	config := IdentityConfig{}
 	for _, opt := range opts {
 		opt(&config)
 	}
 
+	// Build a default certificate template when none was supplied.
 	var err error
 	if config.CertTemplate == nil {
 		config.CertTemplate, err = certTemplate()
@@ -87,6 +89,7 @@ func NewIdentity(privKey crypto.PrivKey, opts ...IdentityOption) (*Identity, err
 		}
 	}
 
+	// Bind the private key to the TLS certificate and assemble config.
 	cert, err := keyToCertificate(privKey, config.CertTemplate)
 	if err != nil {
 		return nil, err
@@ -111,6 +114,7 @@ func NewIdentity(privKey crypto.PrivKey, opts ...IdentityOption) (*Identity, err
 // certificate chain and returns the peer's public key via the channel. If the
 // peer ID is empty, the returned config will accept any peer.
 func (i *Identity) ConfigForPeer(remote peer.ID) (*tls.Config, <-chan crypto.PubKey) {
+	// Clone the base config and install peer certificate verification.
 	keyCh := make(chan crypto.PubKey, 1)
 	conf := i.config.Clone()
 	conf.VerifyConnection = func(cs tls.ConnectionState) (err error) {
@@ -125,10 +129,13 @@ func (i *Identity) ConfigForPeer(remote peer.ID) (*tls.Config, <-chan crypto.Pub
 			return errors.New("expected peer certificate")
 		}
 
+		// Extract and validate the signed peer public key.
 		pubKey, err := PubKeyFromCertChain(cs.PeerCertificates)
 		if err != nil {
 			return err
 		}
+
+		// Enforce the requested remote peer identity when constrained.
 		if remote != "" && !remote.MatchesPublicKey(pubKey) {
 			peerID, err := peer.IDFromPublicKey(pubKey)
 			if err != nil {
@@ -136,6 +143,8 @@ func (i *Identity) ConfigForPeer(remote peer.ID) (*tls.Config, <-chan crypto.Pub
 			}
 			return errors.Errorf("peer ID mismatch: expected %s, got %s", remote, peerID)
 		}
+
+		// Publish the verified public key to the transport caller.
 		keyCh <- pubKey
 		return nil
 	}
@@ -147,6 +156,8 @@ func PubKeyFromCertChain(chain []*x509.Certificate) (crypto.PubKey, error) {
 	if len(chain) != 1 {
 		return nil, errors.New("expected one certificate in the chain")
 	}
+
+	// Build a trust pool and locate the embedded signed-key extension.
 	cert := chain[0]
 	pool := x509.NewCertPool()
 	pool.AddCert(cert)
@@ -168,10 +179,13 @@ func PubKeyFromCertChain(chain []*x509.Certificate) (crypto.PubKey, error) {
 	if !found {
 		return nil, errors.New("expected certificate to contain the key extension")
 	}
+
+	// Verify the certificate chain before decoding the signed key.
 	if _, err := cert.Verify(x509.VerifyOptions{Roots: pool}); err != nil {
 		return nil, errors.Wrap(err, "certificate verification failed")
 	}
 
+	// Decode the signed public key and verify its certificate binding.
 	var sk signedKey
 	if _, err := asn1.Unmarshal(keyExt.Value, &sk); err != nil {
 		return nil, errors.Wrap(err, "unmarshalling signed certificate failed")
@@ -198,6 +212,7 @@ func PubKeyFromCertChain(chain []*x509.Certificate) (crypto.PubKey, error) {
 // and returns the signature within a pkix.Extension. This extension is included
 // in a certificate to cryptographically tie it to the bifrost private key.
 func GenerateSignedExtension(sk crypto.PrivKey, pubKey gocrypto.PublicKey) (pkix.Extension, error) {
+	// Marshal the identity key and certificate key before signing them.
 	keyBytes, err := crypto.MarshalPublicKey(sk.GetPublic())
 	if err != nil {
 		return pkix.Extension{}, err
@@ -210,6 +225,8 @@ func GenerateSignedExtension(sk crypto.PrivKey, pubKey gocrypto.PublicKey) (pkix
 	if err != nil {
 		return pkix.Extension{}, err
 	}
+
+	// Encode the signed key extension for certificate installation.
 	value, err := asn1.Marshal(signedKey{
 		PubKey:    keyBytes,
 		Signature: signature,

--- a/net/daemon/api/api_pubsub_subscribe.go
+++ b/net/daemon/api/api_pubsub_subscribe.go
@@ -19,6 +19,7 @@ var acquirePeerTimeout = time.Second * 10
 //
 // TODO: move this code to pubsub/api
 func (a *API) Subscribe(serv pubsub_api.SRPCPubSubService_SubscribeStream) error {
+	// Retain stream state and release the selected peer on exit.
 	ctx := serv.Context()
 
 	var channelID string
@@ -31,11 +32,15 @@ func (a *API) Subscribe(serv pubsub_api.SRPCPubSubService_SubscribeStream) error
 			handlePeerRef.Release()
 		}
 	}()
+
+	// Process subscription and publication requests until the stream closes.
 	for {
 		msg, err := serv.Recv()
 		if err != nil {
 			return err
 		}
+
+		// Resolve an explicitly supplied private key into a peer identity.
 		if msgPrivKey := msg.GetPrivKeyPem(); msgPrivKey != "" {
 			if len(handlePeerID) != 0 {
 				return errors.New("peer id or private key cannot be specified twice")
@@ -53,6 +58,8 @@ func (a *API) Subscribe(serv pubsub_api.SRPCPubSubService_SubscribeStream) error
 				return err
 			}
 		}
+
+		// Resolve a referenced local peer when no private key was supplied.
 		if msgPeerID := msg.GetPeerId(); msgPeerID != "" && len(msg.GetPrivKeyPem()) == 0 {
 			if len(handlePeerID) != 0 {
 				return errors.New("peer id cannot be specified twice")
@@ -68,6 +75,8 @@ func (a *API) Subscribe(serv pubsub_api.SRPCPubSubService_SubscribeStream) error
 				return errors.Errorf("peer not identified locally: %s", msgPeerID)
 			}
 		}
+
+		// Build the requested channel subscription and announce readiness.
 		if chid := msg.GetChannelId(); chid != "" {
 			if channelID != "" {
 				return errors.New("channel id cannot be specified twice")
@@ -76,7 +85,8 @@ func (a *API) Subscribe(serv pubsub_api.SRPCPubSubService_SubscribeStream) error
 				return errors.New("peer id must be specified before or with channel id")
 			}
 			channelID = chid
-			// acquire channel
+
+			// Acquire the peer key and build the channel subscription.
 			handlePeerPrivKey, err := handlePeer.GetPrivKey(ctx)
 			if err != nil {
 				return err
@@ -102,6 +112,7 @@ func (a *API) Subscribe(serv pubsub_api.SRPCPubSubService_SubscribeStream) error
 			if err != nil {
 				return err
 			}
+
 			// note: the defer call is for releasing the handler.
 			defer val.AddHandler(func(m pubsub.Message) {
 				go func() {
@@ -119,11 +130,14 @@ func (a *API) Subscribe(serv pubsub_api.SRPCPubSubService_SubscribeStream) error
 			return errors.New("channel id must be specified in first message")
 		}
 
+		// Publish any payload included in the current request.
 		pubReqData := msg.GetPublishRequest().GetData()
 		if len(pubReqData) != 0 {
 			if err := sub.Publish(pubReqData); err != nil {
 				return err
 			}
+
+			// Acknowledge the outgoing message when the caller supplied an ID.
 			if mid := msg.GetPublishRequest().GetIdentifier(); mid != 0 {
 				err = serv.Send(&pubsub_api.SubscribeResponse{
 					OutgoingStatus: &pubsub_api.OutgoingStatus{

--- a/net/envelope/build.go
+++ b/net/envelope/build.go
@@ -29,6 +29,7 @@ func BuildEnvelope(
 	keypairs []crypto.PubKey,
 	config *EnvelopeConfig,
 ) (*Envelope, error) {
+	// Validate the payload, recipients, and grant configuration.
 	if len(payload) == 0 {
 		return nil, ErrEmptyPayload
 	}

--- a/net/envelope/unlock.go
+++ b/net/envelope/unlock.go
@@ -22,6 +22,7 @@ func UnlockEnvelope(
 	env *Envelope,
 	privKeys []crypto.PrivKey,
 ) ([]byte, *EnvelopeUnlockResult, error) {
+	// Reject envelopes without grants or recipient keypairs.
 	if len(env.GetGrants()) == 0 {
 		return nil, nil, ErrNoGrants
 	}
@@ -82,6 +83,7 @@ func UnlockEnvelope(
 			continue
 		}
 		scrub.Scrub(innerData)
+
 		unlockedIndexes = append(unlockedIndexes, uint32(gi)) //nolint:gosec // gi bounded by grants slice length
 
 		// Extract shares from the grant, deduplicating by ID.
@@ -106,11 +108,13 @@ func UnlockEnvelope(
 		}
 	}
 
+	// Record recovered share progress before deciding whether to decrypt.
 	result := &EnvelopeUnlockResult{
 		SharesAvailable:      uint32(len(collected)), //nolint:gosec // bounded by grant share count
 		SharesNeeded:         sharesNeeded,
 		UnlockedGrantIndexes: unlockedIndexes,
 	}
+
 	if uint32(len(collected)) < sharesNeeded { //nolint:gosec // bounded by grant share count
 		return nil, result, nil
 	}

--- a/net/hash/hash.go
+++ b/net/hash/hash.go
@@ -80,13 +80,18 @@ func (h *Hash) CompareHash(other *Hash) bool {
 // Returns the hash of the data, hash type, and error
 // Returns an error if failed to validate.
 func (h *Hash) VerifyData(data []byte) ([]byte, error) {
+	// Compute the requested digest before checking its length and bytes.
 	hash, err := h.GetHashType().Sum(data)
 	if err != nil {
 		return nil, err
 	}
+
+	// Reject a digest with the wrong encoded length.
 	if len(hash) != len(h.GetHash()) {
 		return hash, ErrHashMismatch
 	}
+
+	// Reject a digest whose bytes differ from the computed value.
 	if !bytes.Equal(hash, h.GetHash()) {
 		return hash, ErrHashMismatch
 	}
@@ -100,6 +105,7 @@ func NewHash(ht HashType, h []byte) *Hash {
 
 // Sum constructs a hash type by summing an object.
 func Sum(ht HashType, data []byte) (*Hash, error) {
+	// Compute the digest and wrap it in the hash record.
 	h, err := ht.Sum(data)
 	if err != nil {
 		return nil, err
@@ -123,6 +129,8 @@ func (h *Hash) MarshalString() string {
 	if h == nil {
 		return ""
 	}
+
+	// Marshal the hash before encoding it for transport.
 	dat, err := h.MarshalVT()
 	if err != nil {
 		return ""
@@ -141,6 +149,7 @@ func (h *Hash) MarshalDigest() []byte {
 
 // ParseFromB58 parses the object ref from a base58 string.
 func (h *Hash) ParseFromB58(ref string) error {
+	// Decode the base58 value before unmarshalling the hash record.
 	dat, err := b58.Decode(ref)
 	if err != nil {
 		return err

--- a/net/http/bus-handler.go
+++ b/net/http/bus-handler.go
@@ -27,6 +27,7 @@ func NewBusHandler(b bus.Bus, clientID string, notFoundIfIdle bool) *BusHandler 
 
 // ServeHTTP serves the http request.
 func (h *BusHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	// Resolve the current handler for this request.
 	ctx := req.Context()
 	handler, _, handlerRef, err := ExLookupFirstHTTPHandler(
 		ctx,
@@ -40,17 +41,23 @@ func (h *BusHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	if handlerRef != nil {
 		defer handlerRef.Release()
 	}
+
+	// Return resolution errors to the caller.
 	if err != nil {
 		rw.WriteHeader(500)
+
 		_, _ = rw.Write([]byte(err.Error())) //nolint:gosec // internal error, not user-controlled
 		return
 	}
+
+	// Return not-found when no handler reference is available.
 	if handlerRef == nil {
 		rw.WriteHeader(404)
 		_, _ = rw.Write([]byte("404 not found"))
 		return
 	}
 
+	// Delegate the request to the resolved handler.
 	handler.ServeHTTP(rw, req)
 }
 

--- a/net/http/dir-lookup-http-handler_test.go
+++ b/net/http/dir-lookup-http-handler_test.go
@@ -66,6 +66,7 @@ func TestMatchServeMuxPattern(t *testing.T) {
 		},
 	}
 
+	// Exercise each method and path combination against the mux.
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			parsedURL, err := url.Parse(tt.url)

--- a/net/http/encoded-asset-brotli.go
+++ b/net/http/encoded-asset-brotli.go
@@ -17,9 +17,12 @@ import (
 // send Accept-Encoding: br, so this fallback is unreachable in the browser and
 // would otherwise add the decoder and its dictionary to the runtime bundle.
 func maybeServeDecodedBrotli(rw http.ResponseWriter, req *http.Request, hfs http.FileSystem) bool {
+	// Only decode explicit Brotli URLs for clients without Brotli support.
 	if !strings.HasSuffix(req.URL.Path, ".br") || acceptsEncoding(req, "br") {
 		return false
 	}
+
+	// Open the compressed asset and map filesystem errors to HTTP.
 	f, err := openHTTPFile(hfs, req.URL.Path)
 	if err != nil {
 		msg, code := ToHTTPError(err)
@@ -28,6 +31,7 @@ func maybeServeDecodedBrotli(rw http.ResponseWriter, req *http.Request, hfs http
 	}
 	defer f.Close()
 
+	// Decode the asset directly into the response body.
 	_, err = io.Copy(rw, brotli.NewReader(f))
 	if err != nil {
 		http.Error(rw, err.Error(), http.StatusInternalServerError)

--- a/net/http/encoded-asset-file-server.go
+++ b/net/http/encoded-asset-file-server.go
@@ -17,8 +17,12 @@ const encodedAssetVary = "Accept-Encoding"
 // asset headers for precompressed immutable files.
 func NewEncodedAssetFileServer(hfs http.FileSystem) http.Handler {
 	fileServer := http.FileServer(hfs)
+
+	// Apply immutable asset metadata before serving or decoding the file.
 	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		applyEncodedAssetHeaders(rw, req, hfs)
+
+		// Serve Brotli assets directly when the client lacks Brotli support.
 		if maybeServeDecodedBrotli(rw, req, hfs) {
 			return
 		}
@@ -27,15 +31,20 @@ func NewEncodedAssetFileServer(hfs http.FileSystem) http.Handler {
 }
 
 func applyEncodedAssetHeaders(rw http.ResponseWriter, req *http.Request, hfs http.FileSystem) {
+	// Classify the requested asset and its optional content encoding.
 	reqPath := req.URL.Path
 	contentType, encoded := encodedAssetContentType(reqPath)
 	if contentType == "" {
 		return
 	}
+
+	// Verify the encoded file exists before setting response headers.
 	st, err := statHTTPFile(hfs, reqPath)
 	if err != nil {
 		return
 	}
+
+	// Advertise the selected encoding and cache-vary behavior.
 	rw.Header().Set("Content-Type", contentType)
 	switch encoded {
 	case "gzip":
@@ -47,6 +56,8 @@ func applyEncodedAssetHeaders(rw http.ResponseWriter, req *http.Request, hfs htt
 			rw.Header().Set("Vary", encodedAssetVary)
 		}
 	}
+
+	// Set the encoded size after content negotiation succeeds.
 	if rw.Header().Get("Content-Encoding") == "" {
 		return
 	}
@@ -140,6 +151,8 @@ func cleanHTTPFilePath(name string) (string, error) {
 	if strings.Contains(name, "\\") {
 		return "", fs.ErrPermission
 	}
+
+	// Reject traversal components before normalizing the filesystem path.
 	for part := range strings.SplitSeq(name, "/") {
 		if part == ".." {
 			return "", fs.ErrPermission

--- a/net/http/http-handler-controller.go
+++ b/net/http/http-handler-controller.go
@@ -74,8 +74,8 @@ func (c *HTTPHandlerController) HandleDirective(
 ) ([]directive.Resolver, error) {
 	switch d := inst.GetDirective().(type) {
 	case LookupHTTPHandler:
+		// Match the request path and retain any prefix to strip.
 		rpath := d.LookupHTTPHandlerURL().Path
-		// if we have no filters, match all.
 		matched := len(c.pathPrefixes) == 0 && c.pathRe == nil
 		var stripPrefix string
 		if !matched && len(c.pathPrefixes) != 0 {
@@ -100,6 +100,7 @@ func (c *HTTPHandlerController) HandleDirective(
 					if val == nil {
 						return nil, nil
 					}
+
 					var handler LookupHTTPHandlerValue = val //nolint:staticcheck
 					if c.stripPathPrefix && len(stripPrefix) != 0 {
 						handler = http.StripPrefix(stripPrefix, handler)

--- a/net/http/http-handler.go
+++ b/net/http/http-handler.go
@@ -51,6 +51,7 @@ func (h *HTTPHandler) SetContext(ctx context.Context) {
 
 // ServeHTTP serves a http request.
 func (h *HTTPHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	// Resolve the current handler and retry if it is released before commit.
 	ctx := req.Context()
 	for {
 		var released sync.Once
@@ -62,21 +63,28 @@ func (h *HTTPHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 			})
 		})
 		resolveCancel()
+
+		// Return resolution failures to the requesting client.
 		if err != nil {
 			if resolveCtx.Err() != nil &&
 				(errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
 				err = errors.Wrap(context.Cause(resolveCtx), errHTTPHandlerResolveTimeout.Error())
 			}
 			rw.WriteHeader(500)
+
 			_, _ = rw.Write([]byte(err.Error())) //nolint:gosec // internal error, not user-controlled
 			return
 		}
+
+		// Return not-found when no handler is currently available.
 		if access == nil {
 			rw.WriteHeader(404)
 			_, _ = rw.Write([]byte("404 not found"))
 			accessRel()
 			return
 		}
+
+		// Serve through a cancellable context that tracks handler release.
 		serveCtx, serveCancel := context.WithCancel(ctx)
 		stateRw := newResponseStateWriter(rw)
 		go func() {
@@ -87,6 +95,8 @@ func (h *HTTPHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 				serveCancel()
 			}
 		}()
+
+		// Release the handler and preserve committed responses.
 		access.ServeHTTP(stateRw, req.WithContext(serveCtx))
 		serveCancel()
 		accessRel()

--- a/net/keypem/keyfile/keyfile.go
+++ b/net/keypem/keyfile/keyfile.go
@@ -15,6 +15,8 @@ import (
 func OpenOrWritePrivKey(le *logrus.Entry, privKeyPath string) (crypto.PrivKey, error) {
 	var privKey crypto.PrivKey
 	var err error
+
+	// Generate and persist a key when the configured file is absent.
 	if _, err := os.Stat(privKeyPath); err != nil {
 		if os.IsNotExist(err) {
 			if le != nil {
@@ -36,6 +38,7 @@ func OpenOrWritePrivKey(le *logrus.Entry, privKeyPath string) (crypto.PrivKey, e
 			}
 		}
 	} else {
+		// Load and parse the existing private-key file.
 		dat, err := os.ReadFile(privKeyPath)
 		if err != nil {
 			return privKey, err

--- a/net/keypem/keypem.go
+++ b/net/keypem/keypem.go
@@ -18,6 +18,7 @@ const PubPemType = "LIBP2P PUBLIC KEY"
 // Returns nil for the private key if not set.
 // Returns nil, nil, nil if nothing found in the pem.
 func ParseKeyPem(pemDat []byte) (crypto.PrivKey, crypto.PubKey, error) {
+	// Decode the first PEM block and classify its key type.
 	b, _ := pem.Decode(pemDat)
 	if b == nil {
 		return nil, nil, nil
@@ -25,12 +26,14 @@ func ParseKeyPem(pemDat []byte) (crypto.PrivKey, crypto.PubKey, error) {
 
 	switch b.Type {
 	case PrivPemType:
+		// Unmarshal a private key and derive its public counterpart.
 		pkey, err := crypto.UnmarshalPrivateKey(b.Bytes)
 		if err != nil {
 			return nil, nil, err
 		}
 		return pkey, pkey.GetPublic(), nil
 	case PubPemType:
+		// Unmarshal a standalone public key.
 		pkey, err := crypto.UnmarshalPublicKey(b.Bytes)
 		if err != nil {
 			return nil, nil, err

--- a/net/link/hold-open/controller_establish_link.go
+++ b/net/link/hold-open/controller_establish_link.go
@@ -13,11 +13,16 @@ func (c *Controller) handleEstablishLink(
 	di directive.Instance,
 	d link.EstablishLinkWithPeer,
 ) {
+	// Register a value handler for the target peer.
 	handler := newEstablishLinkHandler(c, c.le, di, d.EstablishLinkTargetPeerId())
+
+	// Retain the directive reference until controller close.
 	ref := di.AddReference(handler, true)
 	if ref == nil {
 		return
 	}
+
+	// Store the reference for cleanup and disposal.
 	handler.ref = ref
 	c.cleanupRefs = append(c.cleanupRefs, ref)
 }

--- a/net/link/hold-open/establish_link.go
+++ b/net/link/hold-open/establish_link.go
@@ -47,15 +47,19 @@ func newEstablishLinkHandler(
 
 // HandleValueAdded is called when a value is added to the directive.
 func (e *establishLinkHandler) HandleValueAdded(inst directive.Instance, val directive.AttachedValue) {
+	// Accept only mounted-link values from the directive.
 	vl, ok := val.GetValue().(link.MountedLink)
 	if !ok || vl == nil {
 		return
 	}
+
+	// Count active values and determine whether a rigid reference is needed.
 	e.mtx.Lock()
 	e.valCount++
 	nrr := e.rigidRef == nil
 	e.mtx.Unlock()
 
+	// Start holding the directive while at least one link remains.
 	if nrr {
 		e.le.
 			WithField("link-uuid", vl.GetLinkUUID()).
@@ -71,10 +75,13 @@ func (e *establishLinkHandler) HandleValueAdded(inst directive.Instance, val dir
 
 // HandleValueRemoved is called when a value is removed from the directive.
 func (e *establishLinkHandler) HandleValueRemoved(inst directive.Instance, val directive.AttachedValue) {
+	// Update the value count under the handler lock.
 	e.mtx.Lock()
 	if e.valCount > 0 {
 		e.valCount--
 	}
+
+	// Release the rigid reference when the final value is removed.
 	if e.valCount == 0 && e.rigidRef != nil {
 		go e.rigidRef.Release()
 		e.rigidRef = nil
@@ -85,6 +92,7 @@ func (e *establishLinkHandler) HandleValueRemoved(inst directive.Instance, val d
 // HandleInstanceDisposed is called when a directive instance is disposed.
 // This will occur if Close() is called on the directive instance.
 func (e *establishLinkHandler) HandleInstanceDisposed(inst directive.Instance) {
+	// Detach the controller reference and any rigid value reference.
 	e.mtx.Lock()
 
 	eref := e.ref
@@ -99,6 +107,7 @@ func (e *establishLinkHandler) HandleInstanceDisposed(inst directive.Instance) {
 	}
 	e.mtx.Unlock()
 
+	// Remove the disposed reference from controller cleanup state.
 	e.c.mtx.Lock()
 	for i, ref := range e.c.cleanupRefs {
 		if ref == eref {

--- a/net/link/solicit/controller/controller.go
+++ b/net/link/solicit/controller/controller.go
@@ -90,6 +90,7 @@ func NewController(le *logrus.Entry, conf *Config) (*Controller, error) {
 
 // buildLinkRoutine constructs the keyed routine for a link UUID.
 func (c *Controller) buildLinkRoutine(uuid uint64) (keyed.Routine, struct{}) {
+	// Snapshot the link state under the broadcast lock.
 	var ls *linkState
 	c.bcast.HoldLock(func(_ func(), _ func() <-chan struct{}) {
 		ls = c.links[uuid]
@@ -97,6 +98,8 @@ func (c *Controller) buildLinkRoutine(uuid uint64) (keyed.Routine, struct{}) {
 	if ls == nil || !ls.localIsLower {
 		return nil, struct{}{}
 	}
+
+	// Run the control stream only from the lower peer side.
 	return func(ctx context.Context) error {
 		return c.initiateControlStream(ctx, ls)
 	}, struct{}{}
@@ -136,12 +139,14 @@ func (c *Controller) handleSolicitProtocol(
 		rctx context.Context,
 		rh directive.ResolverHandler,
 	) error {
+		// Register the solicitation while its resolver is active.
 		ss := &solicitState{dir: d, handler: rh}
 		c.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
 			c.solicitations[ss] = struct{}{}
 			broadcast()
 		})
 
+		// Remove the solicitation when the resolver is disposed.
 		defer func() {
 			c.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
 				delete(c.solicitations, ss)
@@ -149,6 +154,7 @@ func (c *Controller) handleSolicitProtocol(
 			})
 		}()
 
+		// Keep the resolver idle until its context is canceled.
 		rh.MarkIdle(true)
 		<-rctx.Done()
 		return nil
@@ -162,6 +168,7 @@ func (c *Controller) handleMountedStream(
 	_ directive.Instance,
 	d link.HandleMountedStream,
 ) ([]directive.Resolver, error) {
+	// Route control and solicited protocol IDs to their handlers.
 	pid := d.HandleMountedStreamProtocolID()
 
 	if pid == ControlProtocolID {
@@ -188,6 +195,7 @@ func (c *Controller) handleEstablishLink(
 	di directive.Instance,
 	_ link.EstablishLinkWithPeer,
 ) ([]directive.Resolver, error) {
+	// Track mounted links through typed add/remove callbacks.
 	ref := di.AddReference(
 		directive.NewTypedCallbackHandler[link.MountedLink](
 			func(v directive.TypedAttachedValue[link.MountedLink]) {
@@ -208,6 +216,7 @@ func (c *Controller) handleEstablishLink(
 
 // addLink registers a new link for solicitation.
 func (c *Controller) addLink(ml link.MountedLink) {
+	// Snapshot link identity and derive the canonical session state.
 	uuid := ml.GetLinkUUID()
 	localPeer := ml.GetLocalPeer()
 	remotePeer := ml.GetRemotePeer()
@@ -219,6 +228,7 @@ func (c *Controller) addLink(ml link.MountedLink) {
 		WithField("remote-peer", remotePeer.String()).
 		WithField("is-lower", isLower)
 
+	// Build the per-link solicitation state.
 	ls := &linkState{
 		le:           le,
 		ml:           ml,
@@ -227,6 +237,7 @@ func (c *Controller) addLink(ml link.MountedLink) {
 		matched:      make(map[string]struct{}),
 	}
 
+	// Publish the link once while retaining references for duplicates.
 	var added bool
 	c.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
 		if existing := c.links[uuid]; existing != nil {
@@ -238,17 +249,23 @@ func (c *Controller) addLink(ml link.MountedLink) {
 		added = true
 		broadcast()
 	})
+
+	// Ignore duplicate link registrations.
 	if !added {
 		return
 	}
 
 	le.Debug("link added for solicitation")
+
+	// Start the keyed control routine for a newly published link.
 	c.linkRoutines.SetKey(uuid, true)
 }
 
 // removeLink removes a link from solicitation tracking.
 func (c *Controller) removeLink(uuid uint64) {
 	var ls *linkState
+
+	// Decrement the link reference and remove it when the count reaches zero.
 	c.bcast.HoldLock(func(broadcast func(), _ func() <-chan struct{}) {
 		ls = c.links[uuid]
 		if ls != nil {
@@ -262,6 +279,7 @@ func (c *Controller) removeLink(uuid uint64) {
 		}
 	})
 
+	// Stop the keyed routine after removing the final link reference.
 	if ls != nil {
 		ls.le.Debug("link removed from solicitation")
 		c.linkRoutines.RemoveKey(uuid)
@@ -271,6 +289,7 @@ func (c *Controller) removeLink(uuid uint64) {
 // initiateControlStream opens the bifrost/solicit control stream on a link.
 // Only called by the lower peer ID side via keyed routine.
 func (c *Controller) initiateControlStream(ctx context.Context, ls *linkState) error {
+	// Open the control stream and run its exchange loop.
 	ms, err := ls.ml.OpenMountedStream(ctx, ControlProtocolID, stream.OpenOpts{})
 	if err != nil {
 		ls.le.WithError(err).Warn("failed to open control stream")

--- a/net/peer/derive.go
+++ b/net/peer/derive.go
@@ -25,11 +25,13 @@ import (
 // the purpose of these requirements is to ensure that an attacker cannot trick
 // two different applications into using the same context string.
 func DeriveKey(context string, salt []byte, privKey crypto.PrivKey, out []byte) error {
+	// Convert the private key to its standard representation.
 	spKey, err := crypto.PrivKeyToStdKey(privKey)
 	if err != nil {
 		return err
 	}
 
+	// Derive shared material using the supported key type.
 	var material []byte
 	switch t := spKey.(type) {
 	case *ed25519.PrivateKey:
@@ -70,13 +72,13 @@ func DeriveKey(context string, salt []byte, privKey crypto.PrivKey, out []byte) 
 		return errors.Errorf("unhandled private key type: %s", privKey.Type().String())
 	}
 
-	// xor the material with context
+	// Mix the derivation context into the shared material.
 	contextb := []byte(context)
 	for i := range material {
 		material[i] = material[i] ^ contextb[i%len(contextb)]
 	}
 
-	// derive key with blake3
+	// Feed the domain separator, salt, and material into BLAKE3.
 	dkh := blake3.NewDeriveKey(context)
 	_, err = dkh.Write([]byte("bifrost/peer/derive-key"))
 	if err != nil {
@@ -88,6 +90,7 @@ func DeriveKey(context string, salt []byte, privKey crypto.PrivKey, out []byte) 
 			return err
 		}
 	}
+
 	_, err = dkh.Write(material) // never returns an error
 	if err != nil {
 		return err
@@ -110,11 +113,13 @@ func DeriveKey(context string, salt []byte, privKey crypto.PrivKey, out []byte) 
 // the purpose of these requirements is to ensure that an attacker cannot trick
 // two different applications into using the same context string.
 func DeriveEd25519Key(context string, salt []byte, privKey crypto.PrivKey) (crypto.PrivKey, crypto.PubKey, error) {
+	// Allocate the seed that will hold the derived Ed25519 key material.
 	seed := make([]byte, ed25519.SeedSize)
 	if err := DeriveKey(context, salt, privKey, seed); err != nil {
 		return nil, nil, err
 	}
 
+	// Construct the Ed25519 keypair from the derived seed.
 	key := ed25519.NewKeyFromSeed(seed)
 	return crypto.KeyPairFromStdKey(&key)
 }

--- a/net/peer/derive_test.go
+++ b/net/peer/derive_test.go
@@ -12,16 +12,19 @@ import (
 func TestDerive(t *testing.T) {
 	keys := BuildMockKeys(t)
 	for ki, key := range keys {
+		// Prepare the salt and context for this key.
 		var secret [32]byte
 		salt := []byte("peer/derive test salt")
 		cryptoCtx := fmt.Sprintf("bifrost/peer/derive_test keys[%d]", ki)
+
+		// Derive and record the symmetric secret.
 		err := DeriveKey(cryptoCtx, salt, key, secret[:])
 		if err != nil {
 			t.Fatal(err.Error())
 		}
 		t.Logf("keys[%d]: derived key: %s", ki, b58.Encode(secret[:]))
 
-		// derive private key
+		// Derive an Ed25519 key from the same context.
 		derivPriv, _, err := DeriveEd25519Key(cryptoCtx+" ed25519", salt, key)
 		if err == nil && derivPriv == nil {
 			err = errors.New("derived empty private key")
@@ -29,6 +32,8 @@ func TestDerive(t *testing.T) {
 		if err != nil {
 			t.Fatal(err.Error())
 		}
+
+		// Derive the peer identity of the new private key.
 		derivPrivID, err := IDFromPrivateKey(derivPriv)
 		if err != nil {
 			t.Fatal(err.Error())

--- a/net/peer/encrypt.go
+++ b/net/peer/encrypt.go
@@ -17,11 +17,13 @@ import (
 // e.g., "example.com 2019-12-25 16:18:03 session tokens v1"
 // The purpose of these requirements is to ensure that an attacker cannot trick two different applications into using the same context string.
 func EncryptToPubKey(pubKey crypto.PubKey, context string, msgSrc []byte) ([]byte, error) {
+	// Convert the public key to its standard representation.
 	spKey, err := crypto.PubKeyToStdKey(pubKey)
 	if err != nil {
 		return nil, err
 	}
 
+	// Dispatch encryption to the implementation for the key type.
 	switch t := spKey.(type) {
 	case ed25519.PublicKey:
 		return EncryptToEd25519(t, context, msgSrc)
@@ -35,11 +37,13 @@ func EncryptToPubKey(pubKey crypto.PubKey, context string, msgSrc []byte) ([]byt
 // Supported types: Ed25519
 // Context must be same as when encrypting.
 func DecryptWithPrivKey(privKey crypto.PrivKey, context string, ciphertext []byte) ([]byte, error) {
+	// Convert the private key to its standard representation.
 	spKey, err := crypto.PrivKeyToStdKey(privKey)
 	if err != nil {
 		return nil, err
 	}
 
+	// Dispatch decryption to the implementation for the key type.
 	switch t := spKey.(type) {
 	case *ed25519.PrivateKey:
 		return DecryptWithEd25519(*t, context, ciphertext)

--- a/net/peer/encrypt_test.go
+++ b/net/peer/encrypt_test.go
@@ -7,22 +7,27 @@ import (
 
 // TestEncrypt tests encrypt/decrypt with multiple key types
 func TestEncrypt(t *testing.T) {
+	// Exercise encryption and decryption for each supported key.
 	keys := BuildMockKeys(t)
 	for ki, privKey := range keys {
+		// Select the public key for this test iteration.
 		pubKey := privKey.GetPublic()
 
+		// Derive the peer identity used in the test message.
 		peerID, err := IDFromPublicKey(pubKey)
 		if err != nil {
 			t.Fatal(err.Error())
 		}
 
-		// super-secret message
+		// Build the test message and encryption context.
 		msg := "Hello to " + peerID.String() + "!"
 		context := "bifrost/peer/encrypt_test super-duper-secret"
 		dat, err := EncryptToPubKey(pubKey, context, []byte(msg))
 		if err != nil {
 			t.Fatal(err.Error())
 		}
+
+		// Record the ciphertext size for the current key.
 		t.Logf(
 			"keys[%d]: encrypted: len %d -> %d",
 			ki,
@@ -30,13 +35,18 @@ func TestEncrypt(t *testing.T) {
 			len(dat),
 		)
 
+		// Decrypt the ciphertext with the matching private key.
 		dec, err := DecryptWithPrivKey(privKey, context, dat)
 		if err != nil {
 			t.Fatal(err.Error())
 		}
+
+		// Verify that decryption restored the original message.
 		if !bytes.Equal(dec, []byte(msg)) {
 			t.Fatalf("keys[%d]: data did not match: %v != expected %v", ki, dec, []byte(msg))
 		}
+
+		// Record the successful plaintext size.
 		t.Logf(
 			"keys[%d]: decrypted correctly: len %d",
 			ki,

--- a/net/peer/id.go
+++ b/net/peer/id.go
@@ -27,6 +27,7 @@ func (id ID) String() string {
 
 // ShortString returns a short representation of the peer ID.
 func (id ID) ShortString() string {
+	// Compute the printable ID before deciding whether to abbreviate it.
 	pid := id.String()
 	if len(pid) <= 10 {
 		return pid
@@ -44,6 +45,7 @@ func (id ID) Validate() error {
 
 // MatchesPublicKey tests whether this ID was derived from the public key pk.
 func (id ID) MatchesPublicKey(pk crypto.PubKey) bool {
+	// Derive the candidate ID from the public key.
 	oid, err := IDFromPublicKey(pk)
 	if err != nil {
 		return false
@@ -60,19 +62,25 @@ func (id ID) MatchesPrivateKey(sk crypto.PrivKey) bool {
 //
 // All peer IDs embed the full public key using the IDENTITY multihash.
 func (id ID) ExtractPublicKey() (crypto.PubKey, error) {
+	// Decode the multihash and recover its embedded public key bytes.
 	code, digest, err := decodeMultihash([]byte(id))
 	if err != nil {
 		return nil, err
 	}
+
+	// Require the identity multihash form that carries a public key.
 	if code != mhIdentity {
 		return nil, ErrNoPublicKey
 	}
+
+	// Unmarshal the embedded public key.
 	return crypto.UnmarshalPublicKey(digest)
 }
 
 // IDFromBytes casts a byte slice to the ID type and validates that
 // the value is a well-formed multihash.
 func IDFromBytes(b []byte) (ID, error) {
+	// Validate the multihash before converting the bytes to an ID.
 	if _, _, err := decodeMultihash(b); err != nil {
 		return "", err
 	}
@@ -81,10 +89,13 @@ func IDFromBytes(b []byte) (ID, error) {
 
 // IDB58Decode returns a base58-decoded peer ID.
 func IDB58Decode(s string) (ID, error) {
+	// Decode the base58 representation before validating its multihash.
 	m, err := b58.Decode(s)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to parse peer ID")
 	}
+
+	// Validate and convert the decoded multihash.
 	return IDFromBytes(m)
 }
 
@@ -97,10 +108,13 @@ func IDB58Encode(id ID) string {
 //
 // The IDENTITY multihash is always used, embedding the full marshaled public key.
 func IDFromPublicKey(pk crypto.PubKey) (ID, error) {
+	// Marshal the public key into the identity multihash.
 	b, err := crypto.MarshalPublicKey(pk)
 	if err != nil {
 		return "", err
 	}
+
+	// Encode the validated public key bytes as a peer ID.
 	return ID(encodeMultihash(mhIdentity, b)), nil
 }
 
@@ -111,6 +125,7 @@ func IDFromPrivateKey(sk crypto.PrivKey) (ID, error) {
 
 // IDsToString converts a slice of IDs to strings.
 func IDsToString(ids []ID) []string {
+	// Convert each peer ID to its base58 representation.
 	out := make([]string, len(ids))
 	for i := range ids {
 		out[i] = ids[i].String()
@@ -126,6 +141,7 @@ func (es IDSlice) Swap(i, j int)      { es[i], es[j] = es[j], es[i] }
 func (es IDSlice) Less(i, j int) bool { return string(es[i]) < string(es[j]) }
 
 func (es IDSlice) String() string {
+	// Convert the slice to printable strings before joining it.
 	strs := make([]string, len(es))
 	for i, id := range es {
 		strs[i] = id.String()
@@ -144,19 +160,26 @@ func encodeMultihash(code uint64, digest []byte) []byte {
 
 // decodeMultihash decodes a multihash into its function code and digest.
 func decodeMultihash(b []byte) (code uint64, digest []byte, err error) {
+	// Reject an empty multihash.
 	if len(b) == 0 {
 		return 0, nil, errors.New("multihash too short")
 	}
+
+	// Decode the function code and advance past its varint.
 	code, n := binary.Uvarint(b)
 	if n <= 0 {
 		return 0, nil, errors.New("invalid multihash varint")
 	}
 	b = b[n:]
+
+	// Decode the digest length and advance to the digest.
 	dlen, n := binary.Uvarint(b)
 	if n <= 0 {
 		return 0, nil, errors.New("invalid multihash digest length varint")
 	}
 	b = b[n:]
+
+	// Verify that the encoded digest length matches the remaining bytes.
 	if uint64(len(b)) != dlen {
 		return 0, nil, errors.Errorf("multihash digest length mismatch: expected %d, got %d", dlen, len(b))
 	}

--- a/net/peer/mock_test.go
+++ b/net/peer/mock_test.go
@@ -9,9 +9,12 @@ import (
 
 // BuildMockKeys builds the set of mock keys that are expected to work.
 func BuildMockKeys(t *testing.T) []crypto.PrivKey {
+	// Generate the Ed25519 key used by the test cases.
 	edPriv, _, err := crypto.GenerateEd25519Key(rand.Reader)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
+
+	// Return the generated key as the supported test set.
 	return []crypto.PrivKey{edPriv}
 }

--- a/net/peer/peer.go
+++ b/net/peer/peer.go
@@ -24,6 +24,7 @@ type Peer interface {
 // NewPeer builds a new Peer object with a private key.
 // If privKey is nil, one will be generated.
 func NewPeer(privKey crypto.PrivKey) (Peer, error) {
+	// Generate an Ed25519 key when the caller did not supply one.
 	if privKey == nil {
 		var err error
 		privKey, _, err = crypto.GenerateEd25519Key(rand.Reader)
@@ -32,11 +33,13 @@ func NewPeer(privKey crypto.PrivKey) (Peer, error) {
 		}
 	}
 
+	// Derive the peer identity from the private key.
 	id, err := IDFromPrivateKey(privKey)
 	if err != nil {
 		return nil, err
 	}
 
+	// Assemble the in-memory peer with both key views.
 	return &peer{
 		privKey: privKey,
 		pubKey:  privKey.GetPublic(),
@@ -46,23 +49,31 @@ func NewPeer(privKey crypto.PrivKey) (Peer, error) {
 
 // NewPeerWithGenerateED25519 generates an ED25519 key and returns it + the peer.
 func NewPeerWithGenerateED25519() (Peer, crypto.PrivKey, crypto.PubKey, error) {
+	// Generate the keypair used by the new peer.
 	privKey, pubKey, err := crypto.GenerateEd25519Key(rand.Reader)
 	if err != nil {
 		return nil, nil, nil, err
 	}
+
+	// Build the peer from the generated private key.
 	p, err := NewPeer(privKey)
 	if err != nil {
 		return nil, nil, nil, err
 	}
+
+	// Return the peer and generated keypair.
 	return p, privKey, pubKey, nil
 }
 
 // NewPeerWithPubKey builds a Peer with a public key.
 func NewPeerWithPubKey(pubKey crypto.PubKey) (Peer, error) {
+	// Derive the peer identity from the public key.
 	id, err := IDFromPublicKey(pubKey)
 	if err != nil {
 		return nil, err
 	}
+
+	// Assemble a peer that exposes only the public key.
 	return &peer{
 		pubKey: pubKey,
 		peerID: id,

--- a/net/peer/signature.go
+++ b/net/peer/signature.go
@@ -22,6 +22,7 @@ func NewSignature(
 	data []byte,
 	inclPubKey bool,
 ) (*Signature, error) {
+	// Hash the data before constructing the signature body.
 	h, err := hash.Sum(hashType, data)
 	if err != nil {
 		return nil, err
@@ -48,11 +49,12 @@ func NewSignatureWithHashedData(
 	hashData []byte,
 	inclPubKey bool,
 ) (*Signature, error) {
+	// Validate the requested hash algorithm.
 	if err := hashType.Validate(); err != nil {
 		return nil, err
 	}
 
-	// prepend the encryption context and hash type
+	// Build the signed body from the context, hash type, and digest.
 	signBody := bytes.Join([][]byte{
 		[]byte(encContext),
 		[]byte(strconv.Itoa(int(hashType))),
@@ -60,11 +62,13 @@ func NewSignatureWithHashedData(
 	}, []byte(" - SIGN - "))
 	defer scrub.Scrub(signBody)
 
+	// Sign the constructed body with the private key.
 	sd, err := privKey.Sign(signBody)
 	if err != nil {
 		return nil, err
 	}
 
+	// Assemble the signature and optionally include the public key.
 	s := &Signature{HashType: hashType, SigData: sd}
 	if inclPubKey {
 		pkey, err := crypto.MarshalPublicKey(privKey.GetPublic())
@@ -79,12 +83,15 @@ func NewSignatureWithHashedData(
 
 // Validate checks the signature object (but not the signature itself).
 func (s *Signature) Validate() error {
+	// Validate the hash type and signature bytes.
 	if err := s.GetHashType().Validate(); err != nil {
 		return err
 	}
 	if len(s.GetSigData()) == 0 {
 		return ErrSignatureInvalid
 	}
+
+	// Validate the embedded public key when present.
 	if len(s.GetPubKey()) != 0 {
 		if _, err := s.ParsePubKey(); err != nil {
 			return errors.Wrap(err, "pub_key")
@@ -98,6 +105,7 @@ func (s *Signature) Validate() error {
 //
 // encContext must match the context used when creating the signature.
 func (s *Signature) VerifyWithPublic(encContext string, pubKey crypto.PubKey, data []byte) (bool, error) {
+	// Validate the signature metadata before hashing the data.
 	ht := s.GetHashType()
 	if ht == hash.HashType_HashType_UNKNOWN {
 		return false, errors.New("hash type missing")
@@ -109,14 +117,14 @@ func (s *Signature) VerifyWithPublic(encContext string, pubKey crypto.PubKey, da
 		return false, err
 	}
 
-	// hash the data
+	// Hash the data with the signature's declared algorithm.
 	dataHash, err := hash.Sum(ht, data)
 	if err != nil {
 		return false, err
 	}
 	defer scrub.Scrub(dataHash.Hash)
 
-	// prepend the encryption context and hash type
+	// Build the signed body from the context, hash type, and digest.
 	signBody := bytes.Join([][]byte{
 		[]byte(encContext),
 		[]byte(strconv.Itoa(int(ht))),
@@ -130,6 +138,7 @@ func (s *Signature) VerifyWithPublic(encContext string, pubKey crypto.PubKey, da
 // ParsePubKey parses the incldued public key.
 // Returns nil, nil if the pub key field was not set.
 func (s *Signature) ParsePubKey() (crypto.PubKey, error) {
+	// Return no key when the signature omitted its public key.
 	pubKey := s.GetPubKey()
 	if len(pubKey) == 0 {
 		return nil, nil

--- a/net/peer/signed-msg.go
+++ b/net/peer/signed-msg.go
@@ -21,36 +21,49 @@ func NewSignedMsg(
 	hashType hash.HashType,
 	innerData []byte,
 ) (*SignedMsg, error) {
+	// Derive the sender identity for the signed message.
 	peerID, err := IDFromPrivateKey(privKey)
 	if err != nil {
 		return nil, err
 	}
+
+	// Assemble the message envelope with the sender identity and body.
 	msg := &SignedMsg{
 		FromPeerId: IDB58Encode(peerID),
 		Data:       innerData,
 	}
+
+	// Sign the assembled message body.
 	if err := msg.Sign(encContext, privKey, hashType); err != nil {
 		return nil, err
 	}
+
+	// Return the signed message.
 	return msg, nil
 }
 
 // UnmarshalSignedMsg parses a signed message.
 func UnmarshalSignedMsg(data []byte) (*SignedMsg, error) {
+	// Decode the wire representation into a signed message.
 	m := &SignedMsg{}
 	err := m.UnmarshalVT(data)
 	if err != nil {
 		return nil, err
 	}
+
+	// Return the decoded message.
 	return m, err
 }
 
 // ComputeMessageID computes a message id for a signed message.
 func (m *SignedMsg) ComputeMessageID() string {
+	// Build the stable message-ID input from signature and sender fields.
 	inner := bytes.Join([][]byte{
 		m.GetSignature().GetSigData(),
 		[]byte(m.GetFromPeerId()),
 	}, nil)
+
+	// Hash and encode the message-ID input.
 	h := blake3.Sum256(inner)
 	return hex.EncodeToString(h[:])
 }
@@ -62,13 +75,18 @@ func (m *SignedMsg) ParseFromPeerID() (ID, error) {
 
 // ExtractPubKey extracts the public key from the peer id.
 func (m *SignedMsg) ExtractPubKey() (crypto.PubKey, ID, error) {
+	// Parse the sender identity from the message.
 	fromPeerID, err := m.ParseFromPeerID()
 	if err != nil {
 		return nil, ID(""), err
 	}
+
+	// Validate the sender identity before extracting its key.
 	if err := fromPeerID.Validate(); err != nil {
 		return nil, ID(""), errors.Wrap(err, "message peer id")
 	}
+
+	// Extract the public key embedded in the sender identity.
 	pubKey, err := fromPeerID.ExtractPublicKey()
 	if err != nil {
 		return nil, fromPeerID, err
@@ -80,6 +98,7 @@ func (m *SignedMsg) ExtractPubKey() (crypto.PubKey, ID, error) {
 //
 // encContext must match the context used when creating the signature.
 func (m *SignedMsg) ExtractAndVerify(encContext string) (crypto.PubKey, ID, error) {
+	// Validate the message body, sender identity, and signature.
 	if len(m.GetData()) == 0 {
 		return nil, "", ErrEmptyBody
 	}
@@ -90,16 +109,19 @@ func (m *SignedMsg) ExtractAndVerify(encContext string) (crypto.PubKey, ID, erro
 		return nil, "", errors.Wrap(err, "message signature")
 	}
 
+	// Extract the sender key and identity for verification.
 	pubKey, peerID, err := m.ExtractPubKey()
 	if err != nil {
 		return nil, peerID, err
 	}
 
+	// Verify the signature against the extracted public key.
 	sigErr := m.Verify(encContext, pubKey)
 	if sigErr != nil {
 		return pubKey, peerID, sigErr
 	}
 
+	// Return the verified sender key and identity.
 	return pubKey, peerID, nil
 }
 
@@ -110,11 +132,13 @@ func (m *SignedMsg) ExtractAndVerify(encContext string) (crypto.PubKey, ID, erro
 // format is "[application] [commit timestamp] [purpose]", e.g.,
 // "example.com 2019-12-25 16:18:03 session tokens v1".
 func (m *SignedMsg) Sign(encContext string, privKey crypto.PrivKey, hashType hash.HashType) error {
+	// Reject an empty message before signing its body.
 	innerData := m.GetData()
 	if len(innerData) == 0 {
 		return ErrEmptyBody
 	}
 
+	// Construct the signature over the message body.
 	sig, err := NewSignature(
 		encContext,
 		privKey,
@@ -125,6 +149,8 @@ func (m *SignedMsg) Sign(encContext string, privKey crypto.PrivKey, hashType has
 	if err != nil {
 		return err
 	}
+
+	// Attach the signature to the message.
 	m.Signature = sig
 	return nil
 }
@@ -133,7 +159,7 @@ func (m *SignedMsg) Sign(encContext string, privKey crypto.PrivKey, hashType has
 //
 // encContext must match the context used when creating the signature.
 func (m *SignedMsg) Verify(encContext string, pubKey crypto.PubKey) error {
-	// validate signature
+	// Verify the signature and normalize a false result without an error.
 	sigOk, sigErr := m.GetSignature().VerifyWithPublic(encContext, pubKey, m.GetData())
 	if !sigOk && sigErr == nil {
 		sigErr = ErrSignatureInvalid

--- a/net/peer/signed-msg_test.go
+++ b/net/peer/signed-msg_test.go
@@ -11,10 +11,13 @@ import (
 
 // TestSignedMsg tests signing a message.
 func TestSignedMsg(t *testing.T) {
+	// Create a peer and obtain its signing key.
 	p, err := NewPeer(nil)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
+
+	// Record the expected identity and private key.
 	ctx := context.Background()
 	exPeerID := p.GetPeerID()
 	privKey, err := p.GetPrivKey(ctx)
@@ -22,6 +25,7 @@ func TestSignedMsg(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
+	// Sign and immediately verify the test message.
 	encContext := "bifrost/peer TestSignedMsg"
 	msg := "hello world from signed message test"
 	smsg, err := NewSignedMsg(encContext, privKey, hash.RecommendedHashType, []byte(msg))
@@ -32,6 +36,7 @@ func TestSignedMsg(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
+	// Verify the sender identity returned by the signed message.
 	_, peerID, err := smsg.ExtractAndVerify(encContext)
 	if err != nil {
 		t.Fatal(err.Error())
@@ -40,12 +45,14 @@ func TestSignedMsg(t *testing.T) {
 		t.Fatalf("peer id mismatch: %s != %s", exPeerID.String(), peerID.String())
 	}
 
+	// Confirm that the original body remains intact.
 	if !bytes.Equal(smsg.Data, []byte(msg)) {
 		t.FailNow()
 	}
 }
 
 func TestSignedMsgExtractAndVerifyRejectsTamperedData(t *testing.T) {
+	// Create a peer and obtain its signing key.
 	p, err := NewPeer(nil)
 	if err != nil {
 		t.Fatal(err.Error())
@@ -55,12 +62,14 @@ func TestSignedMsgExtractAndVerifyRejectsTamperedData(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
+	// Sign a body that will be tampered with after signing.
 	encContext := "bifrost/peer TestSignedMsg tamper"
 	smsg, err := NewSignedMsg(encContext, privKey, hash.RecommendedHashType, []byte("signed body"))
 	if err != nil {
 		t.Fatal(err.Error())
 	}
 
+	// Replace the body and require signature verification to reject it.
 	smsg.Data = []byte("tampered body")
 	_, _, err = smsg.ExtractAndVerify(encContext)
 	if !errors.Is(err, ErrSignatureInvalid) {

--- a/net/protocol/id.go
+++ b/net/protocol/id.go
@@ -6,6 +6,7 @@ import "unicode/utf8"
 type ID string
 
 func (i ID) Validate() error {
+	// Reject empty and invalid UTF-8 protocol identifiers.
 	if i == "" {
 		return ErrEmptyProtocolID
 	}

--- a/net/pubsub/controller/controller.go
+++ b/net/pubsub/controller/controller.go
@@ -93,7 +93,7 @@ func (c *Controller) GetControllerInfo() *controller.Info {
 // Returning nil ends execution.
 // Returning an error triggers a retry with backoff.
 func (c *Controller) Execute(ctx context.Context) error {
-	// Fetch the peer if the peer ID is set.
+	// Resolve the configured peer before constructing the PubSub.
 	var cpeer peer.Peer
 	var err error
 	if len(c.peerID) != 0 {
@@ -116,7 +116,7 @@ func (c *Controller) Execute(ctx context.Context) error {
 	c.peerCtr.SetValue(&cpeer)
 	defer c.peerCtr.SetValue(nil)
 
-	// Construct the PubSub
+	// Construct and publish the controlled PubSub instance.
 	ps, err := c.ctor(
 		ctx,
 		c.le,
@@ -129,6 +129,7 @@ func (c *Controller) Execute(ctx context.Context) error {
 	defer ps.Close()
 	c.pubSubCtr.SetValue(&ps)
 
+	// Run the PubSub and surface fatal execution errors.
 	psErr := make(chan error, 1)
 	go func() {
 		c.le.Debug("executing pubsub")
@@ -137,6 +138,7 @@ func (c *Controller) Execute(ctx context.Context) error {
 		}
 	}()
 
+	// Track newly observed links until the controller context ends.
 	for {
 		var waitCh <-chan struct{}
 		c.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {

--- a/net/pubsub/floodsub/floodsub.go
+++ b/net/pubsub/floodsub/floodsub.go
@@ -90,10 +90,12 @@ func NewFloodSub(
 // Execute executes the PubSub routines.
 func (m *FloodSub) Execute(ctx context.Context) error {
 	m.le.Debug("floodsub starting")
+
 	// re-evaluate at most once every 100ms
 	evalTimer := time.NewTicker(time.Millisecond * 100)
 	defer evalTimer.Stop()
 
+	// Register incoming sessions before reconciling subscriptions.
 	pubbedChannels := make(map[string]struct{})
 	for {
 		var initSet []*SubscriptionOpts
@@ -103,6 +105,7 @@ func (m *FloodSub) Execute(ctx context.Context) error {
 			nctx, nctxCancel := context.WithCancel(ctx)
 			s.ctx = nctx
 			s.ctxCancel = nctxCancel
+
 			// if !s.initiator {
 			if initSet == nil {
 				initSet = make([]*SubscriptionOpts, 0, len(m.channels))
@@ -114,31 +117,39 @@ func (m *FloodSub) Execute(ctx context.Context) error {
 				}
 			}
 			s.packetCh <- &Packet{Subscriptions: initSet}
+
 			// }
 			go func() {
 				err := s.executeSession()
 				if err != nil && err != context.Canceled {
 					s.le.WithError(err).Warn("session exited with error")
 				}
+
 				// if s.initiator {
 				m.mtx.Lock()
 				if m.peers[s.tpl] == s {
 					delete(m.peers, s.tpl)
 				}
 				m.mtx.Unlock()
+
 				// }
 			}()
+
 			// if s.initiator {
 			m.peers[s.tpl] = s
+
 			// }
 		}
 		m.incSessions = nil
+
 		m.mtx.Unlock() // intentional mtx hold-break
 		initSet = nil
 
+		// Reconcile local subscriptions and collect peers to notify.
 		var xmitPeers []*streamHandler
 		var subChanges []*SubscriptionOpts
 		m.mtx.Lock()
+
 		// sweep empty channels
 		for chid, chm := range m.channels {
 			if len(chm) == 0 {
@@ -171,10 +182,12 @@ func (m *FloodSub) Execute(ctx context.Context) error {
 			}
 		}
 		m.mtx.Unlock()
+
 		for _, p := range xmitPeers { // xmitPeers is usually nil
 			p.writePacket(&Packet{Subscriptions: subChanges})
 		}
 
+		// Process wakeups and queued publications until evaluation is due.
 		var woken bool
 		for !woken {
 			select {
@@ -187,6 +200,7 @@ func (m *FloodSub) Execute(ctx context.Context) error {
 			}
 		}
 
+		// Re-enter reconciliation on the next timer tick.
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
@@ -279,6 +293,7 @@ func (m *FloodSub) AddPeerStream(
 		initiator: initiator,
 	}
 	m.mtx.Lock()
+
 	// if !initiator {
 	if e, ok := m.peers[tpl]; ok {
 		if e.ctxCancel != nil {
@@ -286,6 +301,7 @@ func (m *FloodSub) AddPeerStream(
 		}
 	}
 	m.peers[tpl] = sh
+
 	// }
 	m.incSessions = append(m.incSessions, sh)
 	m.mtx.Unlock()

--- a/net/pubsub/relay/controller.go
+++ b/net/pubsub/relay/controller.go
@@ -44,6 +44,7 @@ func NewController(b bus.Bus, le *logrus.Entry, peerID peer.ID, topics []string)
 // Returning nil ends execution.
 // Returning an error triggers a retry with backoff.
 func (c *Controller) Execute(ctx context.Context) error {
+	// Resolve the local peer and retain its reference for subscriptions.
 	cpeer, _, ref, err := peer.GetPeerWithID(ctx, c.bus, c.peerID, false, nil)
 	if err != nil {
 		return err
@@ -52,11 +53,13 @@ func (c *Controller) Execute(ctx context.Context) error {
 		defer ref.Release()
 	}
 
+	// Load the private key used to identify each topic subscription.
 	privKey, err := cpeer.GetPrivKey(ctx)
 	if err != nil {
 		return err
 	}
 
+	// Build and retain one subscription directive per configured topic.
 	for _, topic := range c.topics {
 		le := c.le.WithField("topic", topic)
 		_, diRef, err := c.bus.AddDirective(
@@ -70,6 +73,8 @@ func (c *Controller) Execute(ctx context.Context) error {
 		le.Info("establishing pubsub subscription")
 		defer diRef.Release()
 	}
+
+	// Keep subscriptions active until controller cancellation.
 	<-ctx.Done()
 	return nil
 }

--- a/net/pubsub/util/pubmessage/inner.go
+++ b/net/pubsub/util/pubmessage/inner.go
@@ -5,7 +5,8 @@ func (i *PubMessageInner) Validate() error {
 	if i.GetChannel() == "" {
 		return ErrInvalidChannelID
 	}
-	// allow empty
+
+	// Validate the optional timestamp when one is present.
 	if ts := i.GetTimestamp(); ts.GetSeconds() != 0 {
 		if err := ts.CheckValid(); err != nil {
 			return err

--- a/net/pubsub/util/pubmessage/pubmessage.go
+++ b/net/pubsub/util/pubmessage/pubmessage.go
@@ -18,6 +18,7 @@ func NewPubMessage(
 	hashType hash.HashType,
 	data []byte,
 ) (*peer.SignedMsg, *PubMessageInner, error) {
+	// Build and serialize the signed inner message.
 	inner := &PubMessageInner{
 		Data:      data,
 		Channel:   channelID,
@@ -28,12 +29,14 @@ func NewPubMessage(
 		return nil, inner, err
 	}
 
+	// Sign the serialized payload with the channel encryption context.
 	sig, err := peer.NewSignedMsg(pubMessageEncContext+channelID, privKey, hashType, innerData)
 	return sig, inner, err
 }
 
 // ExtractAndVerify extracts the inner message from a signed message.
 func ExtractAndVerify(msg *peer.SignedMsg) (*PubMessageInner, crypto.PubKey, peer.ID, error) {
+	// Decode and validate the signed inner message before verifying identity.
 	data := msg.GetData()
 
 	out := &PubMessageInner{}
@@ -45,6 +48,7 @@ func ExtractAndVerify(msg *peer.SignedMsg) (*PubMessageInner, crypto.PubKey, pee
 		return nil, nil, "", err
 	}
 
+	// Verify the signature against the decoded channel context.
 	pubKey, peerID, err := msg.ExtractAndVerify(pubMessageEncContext + out.GetChannel())
 	if err != nil {
 		return nil, nil, "", err

--- a/net/rpc/rpc-service-controller.go
+++ b/net/rpc/rpc-service-controller.go
@@ -87,8 +87,8 @@ func (c *RpcServiceController) HandleDirective(
 ) ([]directive.Resolver, error) {
 	switch d := inst.GetDirective().(type) {
 	case LookupRpcService:
+		// Match the service against configured prefixes, expressions, and IDs.
 		serviceID := d.LookupRpcServiceID()
-		// if we have no filters, match all.
 		matched := len(c.serviceIdPrefixes) == 0 && c.serviceIdRe == nil && len(c.serviceIdList) == 0
 		if !matched && len(c.serviceIdPrefixes) != 0 {
 			for _, prefix := range c.serviceIdPrefixes {
@@ -106,6 +106,8 @@ func (c *RpcServiceController) HandleDirective(
 				matched = true
 			}
 		}
+
+		// Apply the optional server filter after service matching.
 		if matched && c.serverIdRe != nil {
 			serverID := d.LookupRpcServerID()
 			matched = c.serverIdRe.MatchString(serverID)
@@ -120,6 +122,7 @@ func (c *RpcServiceController) HandleDirective(
 					if val == nil {
 						return nil, nil
 					}
+
 					var invoker LookupRpcServiceValue = val //nolint:staticcheck
 					if c.stripServiceIdPrefix {
 						invoker = srpc.NewPrefixInvoker(invoker, c.serviceIdPrefixes)

--- a/net/signaling/dir-signal-peer.go
+++ b/net/signaling/dir-signal-peer.go
@@ -55,6 +55,7 @@ func ExSignalPeer(
 	localPeerID, remotePeerID peer.ID,
 	returnIfIdle bool,
 ) (SignalPeerValue, func(), error) {
+	// Wait for the bus to provide a matching signaling session.
 	estl, _, ref, err := bus.ExecWaitValue[SignalPeerValue](
 		ctx,
 		b,
@@ -69,11 +70,14 @@ func ExSignalPeer(
 	if err != nil {
 		return nil, nil, err
 	}
+
+	// Release an idle directive that produced no session.
 	if estl == nil {
 		ref.Release()
 		return nil, nil, nil
 	}
 
+	// Return the session and its release callback.
 	return estl, ref.Release, nil
 }
 

--- a/net/signaling/rpc/client/client.go
+++ b/net/signaling/rpc/client/client.go
@@ -91,6 +91,7 @@ func NewClientWithBus(
 	protocolID protocol.ID,
 	serviceID string,
 ) (*Client, error) {
+	// Apply default protocol and service identifiers.
 	if protocolID == "" {
 		protocolID = signaling_rpc.ProtocolID
 	}
@@ -141,6 +142,7 @@ func (c *Client) SetListenHandler(listenHandler ClientListenHandler) {
 
 // executeListenRoutine is the routine to run the Listen RPC.
 func (c *Client) executeListenRoutine(ctx context.Context, handler ClientListenHandler) error {
+	// Open the listen stream and notify the handler when it closes.
 	c.le.Debug("signaling: starting to listen for incoming sessions")
 	strm, err := c.client.Listen(ctx, &signaling_rpc.ListenRequest{})
 	if err != nil {
@@ -379,13 +381,16 @@ func (c *Client) newPeerTracker(peerIDStr string) (keyed.Routine, *clientPeerTra
 
 // execute executes the clientPeerTracker.
 func (s *clientPeerTracker) execute(ctx context.Context) error {
+	// Open the long-lived signaling session for this peer tracker.
 	sess, err := s.c.client.Session(ctx)
 	if err != nil {
 		return errors.Wrap(err, "open signaling rpc session")
 	}
 
+	// Route session failures through the tracker error channel.
 	errCh := make(chan error, 2)
 
+	// Define state transitions for close, open, receive, and acknowledgements.
 	handleClose := func() {
 		s.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
 			if s.open != nil {
@@ -460,11 +465,13 @@ func (s *clientPeerTracker) execute(ctx context.Context) error {
 		})
 	}
 
+	// Close the session and clear all tracker state on exit.
 	defer func() {
 		_ = sess.Close()
 		handleClose()
 	}()
 
+	// Register this peer identity with the remote signaling server.
 	err = sess.Send(&signaling_rpc.SessionRequest{
 		Body: &signaling_rpc.SessionRequest_Init{
 			Init: &signaling_rpc.SessionInit{
@@ -476,6 +483,7 @@ func (s *clientPeerTracker) execute(ctx context.Context) error {
 		return errors.Wrap(err, "send signaling init")
 	}
 
+	// Consume remote session responses in a dedicated receiver.
 	go func() {
 		for {
 			resp, err := sess.Recv()
@@ -509,6 +517,7 @@ func (s *clientPeerTracker) execute(ctx context.Context) error {
 		}
 	}()
 
+	// Reconcile queued sends, cancellations, and acknowledgements.
 	for {
 
 		if err := ctx.Err(); err != nil {
@@ -551,6 +560,7 @@ func (s *clientPeerTracker) execute(ctx context.Context) error {
 			waitCh = getWaitCh()
 		})
 
+		// Acknowledge messages consumed by the caller.
 		if ackRecvMsg != 0 {
 			err := sess.Send(&signaling_rpc.SessionRequest{
 				SessionSeqno: sessSeqno,
@@ -563,6 +573,7 @@ func (s *clientPeerTracker) execute(ctx context.Context) error {
 			}
 		}
 
+		// Cancel messages withdrawn before transmission.
 		if cancelMsg != 0 {
 			err := sess.Send(&signaling_rpc.SessionRequest{
 				SessionSeqno: sessSeqno,
@@ -575,6 +586,7 @@ func (s *clientPeerTracker) execute(ctx context.Context) error {
 			}
 		}
 
+		// Transmit the next queued message.
 		if sendMsg != nil {
 			err := sess.Send(&signaling_rpc.SessionRequest{
 				SessionSeqno: sessSeqno,

--- a/net/signaling/rpc/client/session-tracker.go
+++ b/net/signaling/rpc/client/session-tracker.go
@@ -38,6 +38,7 @@ func (c *Controller) newSessionTracker(peerIDStr string) (keyed.Routine, *sessio
 
 // execute executes the sessionTracker.
 func (s *sessionTracker) execute(ctx context.Context) error {
+	// Wait for the signaling client and attach a peer reference.
 	client, err := s.c.client.WaitValue(ctx, nil)
 	if err != nil {
 		return err
@@ -46,6 +47,7 @@ func (s *sessionTracker) execute(ctx context.Context) error {
 	signalRef := client.AddPeerRef(s.peerID.String())
 	defer signalRef.Release()
 
+	// Publish a handle directive when listening is enabled.
 	if !s.c.conf.GetDisableListen() {
 		sess := NewSessionWithRef(signalRef)
 		di, dirRef, err := s.c.b.AddDirective(

--- a/net/signaling/rpc/server/listen.go
+++ b/net/signaling/rpc/server/listen.go
@@ -22,6 +22,7 @@ func (s *Server) Listen(req *signaling.ListenRequest, strm signaling.SRPCSignali
 		}
 	*/
 
+	// Register the peer and supersede any previous listen stream.
 	// Register this peer
 	s.mtx.Lock()
 	tkr, existed := s.getPeer(pidStr)
@@ -33,6 +34,7 @@ func (s *Server) Listen(req *signaling.ListenRequest, strm signaling.SRPCSignali
 	listenNonce := tkr.listenNonce
 	s.mtx.Unlock()
 
+	// Clear the registration when this listen stream exits.
 	// Cleanup when we exit
 	defer func() {
 		s.mtx.Lock()
@@ -46,6 +48,7 @@ func (s *Server) Listen(req *signaling.ListenRequest, strm signaling.SRPCSignali
 		s.mtx.Unlock()
 	}()
 
+	// Reconcile desired peer notifications with the last sent state.
 	sentWant := make(map[string]struct{})
 	for {
 		s.mtx.Lock()
@@ -69,6 +72,7 @@ func (s *Server) Listen(req *signaling.ListenRequest, strm signaling.SRPCSignali
 		waitCh := tkr.getWaitCh()
 		s.mtx.Unlock()
 
+		// Notify the peer about removed session requests.
 		if txNotWant != "" {
 			if err := strm.Send(&signaling.ListenResponse{
 				Body: &signaling.ListenResponse_ClearPeer{ClearPeer: txNotWant},
@@ -78,6 +82,7 @@ func (s *Server) Listen(req *signaling.ListenRequest, strm signaling.SRPCSignali
 			delete(sentWant, txNotWant)
 		}
 
+		// Notify the peer about new session requests.
 		if txWant != "" {
 			if err := strm.Send(&signaling.ListenResponse{
 				Body: &signaling.ListenResponse_SetPeer{SetPeer: txWant},
@@ -87,6 +92,7 @@ func (s *Server) Listen(req *signaling.ListenRequest, strm signaling.SRPCSignali
 			sentWant[txWant] = struct{}{}
 		}
 
+		// Wait for a state change or stream cancellation.
 		if txNotWant == "" && txWant == "" {
 			select {
 			case <-ctx.Done():

--- a/net/signaling/rpc/signaling.go
+++ b/net/signaling/rpc/signaling.go
@@ -17,6 +17,7 @@ var ProtocolID = protocol.ID("bifrost/signaling")
 const encContext = "bifrost/signaling/rpc session msg 2024-06-05T02:45:07.208906Z"
 
 // NewSessionMsg creates a new SessionMsg with the provided data signed.
+// Sign and package the session payload with its sequence number.
 func NewSessionMsg(privKey crypto.PrivKey, hashType hash.HashType, msg []byte, seqno uint64) (*SessionMsg, error) {
 	signedMsg, err := peer.NewSignedMsg(encContext, privKey, hashType, msg)
 	if err != nil {

--- a/net/sim/simulate/assertions.go
+++ b/net/sim/simulate/assertions.go
@@ -12,6 +12,7 @@ import (
 // TestConnectivity tests for basic connectivity between two peers.
 // Uses an echo test: dials the Echo controller.
 func TestConnectivity(ctx context.Context, px0, px1 *Peer) error {
+	// Open a link and stream from the first peer to the second.
 	tb0 := px0.testbed
 
 	_, esRef, err := tb0.Bus.AddDirective(link.NewEstablishLinkWithPeer(
@@ -37,7 +38,7 @@ func TestConnectivity(ctx context.Context, px0, px1 *Peer) error {
 	}
 	defer ms1Rel()
 
-	// expect px0 stream remote peer to equal px1
+	// Verify that the stream reports the expected remote peer.
 	mns1rp := ms1.GetLink().GetRemotePeer().String()
 	if px1p := px1.GetPeerID().String(); px1p != mns1rp {
 		return errors.Errorf(
@@ -46,7 +47,8 @@ func TestConnectivity(ctx context.Context, px0, px1 *Peer) error {
 			px1p,
 		)
 	}
-	// expect px0 stream local peer to equal px0
+
+	// Verify that the stream reports the expected local peer.
 	mns1lp := ms1.GetLink().GetLocalPeer().String()
 	if px0p := px0.GetPeerID().String(); px0p != mns1lp {
 		return errors.Errorf(

--- a/net/sim/simulate/peer.go
+++ b/net/sim/simulate/peer.go
@@ -42,6 +42,7 @@ type Peer struct {
 
 // newPeer constructs a new Peer.
 func newPeer(ctx context.Context, le *logrus.Entry, gp *graph.Peer, verbose bool) (*Peer, error) {
+	// Collect cleanup callbacks before constructing the testbed.
 	var rels []func()
 	rel := func() {
 		for _, r := range rels {
@@ -49,6 +50,7 @@ func newPeer(ctx context.Context, le *logrus.Entry, gp *graph.Peer, verbose bool
 		}
 	}
 
+	// Build the peer testbed and register its static factories.
 	np := &Peer{
 		graphPeer:     gp,
 		le:            le.WithField("sim-peer", gp.ID()),
@@ -56,9 +58,11 @@ func newPeer(ctx context.Context, le *logrus.Entry, gp *graph.Peer, verbose bool
 	}
 
 	var ctxCancel func()
+
 	np.ctx, ctxCancel = context.WithCancel(ctx) //nolint:gosec // cancel stored in rels and released by Close
 	rels = append(rels, ctxCancel)
 
+	// Start the peer testbed with the graph peer's private key.
 	var err error
 	np.testbed, err = testbed.NewTestbed(
 		np.ctx,
@@ -78,6 +82,7 @@ func newPeer(ctx context.Context, le *logrus.Entry, gp *graph.Peer, verbose bool
 		extraFactoryCtor(np.testbed.Bus, np.testbed.StaticResolver)
 	}
 
+	// Start the in-process transport controller with configured dialers.
 	tpc, _, tp1Ref, err := loader.WaitExecControllerRunningTyped[*transport_controller.Controller](
 		np.ctx,
 		np.testbed.Bus,
@@ -106,6 +111,7 @@ func newPeer(ctx context.Context, le *logrus.Entry, gp *graph.Peer, verbose bool
 	np.inproc = tp.(*inproc.Inproc)
 	np.transportController = tpc
 
+	// Start the config-set controller without applying peer config yet.
 	_, _, tp2Ref, err := bus.ExecOneOff(
 		np.ctx,
 		np.testbed.Bus,
@@ -119,6 +125,7 @@ func newPeer(ctx context.Context, le *logrus.Entry, gp *graph.Peer, verbose bool
 	}
 	rels = append(rels, tp2Ref.Release)
 
+	// Retain release callbacks until the simulator finishes startup.
 	// Don't call ApplyConfigSet yet until the simulator is fully started.
 	np.rels = rels
 	return np, nil

--- a/net/sim/simulate/simulate.go
+++ b/net/sim/simulate/simulate.go
@@ -33,10 +33,13 @@ func NewSimulator(
 	grp *graph.Graph,
 	opts ...SimulatorOption,
 ) (*Simulator, error) {
+	// Initialize simulator state and apply construction options.
 	s := &Simulator{
 		le:    le,
 		peers: make(map[string]*Peer),
 	}
+
+	// Create the simulator cancellation context before starting peers.
 	s.ctx, s.ctxCancel = context.WithCancel(ctx)
 
 	for _, opt := range opts {
@@ -47,7 +50,7 @@ func NewSimulator(
 		}
 	}
 
-	// Instantiate the nodes
+	// Instantiate graph peers and prepare their in-process links.
 	allNodes := grp.AllNodes()
 	le.Debugf("processing %d nodes in graph", len(allNodes))
 	var allPeers []*Peer
@@ -70,11 +73,11 @@ func NewSimulator(
 		}
 		allPeers = append(allPeers, pushedPeer)
 
-		// get the list of linked peers
+		// Discover peers linked through the graph.
 		linkedPeers := peer.GetLinkedPeers(grp)
 		le.Debugf("peer %s has %d linked peers", peerIDStr, len(linkedPeers))
 
-		// add each linked peer
+		// Connect each discovered peer in both directions.
 		for _, lpeer := range linkedPeers {
 			lpeerPeerIDStr := lpeer.GetPeerID().String()
 			op, ok := s.peers[lpeerPeerIDStr]
@@ -95,7 +98,7 @@ func NewSimulator(
 		}
 	}
 
-	// Finish startup
+	// Apply each peer's deferred configuration after all links exist.
 	for _, addedPeer := range allPeers {
 		if err := addedPeer.finishSetup(); err != nil {
 			s.ctxCancel()

--- a/net/sim/tests/common.go
+++ b/net/sim/tests/common.go
@@ -11,6 +11,8 @@ import (
 
 func AddPeer(t *testing.T, g *graph.Graph) *graph.Peer {
 	ctx := context.Background()
+
+	// Add a generated graph peer for the test.
 	p, err := graph.GenerateAddPeer(ctx, g)
 	if err != nil {
 		t.Fatal(err.Error())

--- a/net/stream/echo/stream_handler.go
+++ b/net/stream/echo/stream_handler.go
@@ -30,6 +30,7 @@ func (m *MountedStreamHandler) HandleMountedStream(
 	ctx context.Context,
 	strm link.MountedStream,
 ) error {
+	// Hold the source link while echoing the mounted stream.
 	_, elRef, err := m.bus.AddDirective(
 		link.NewEstablishLinkWithPeer(strm.GetLink().GetLocalPeer(), strm.GetPeerID()),
 		nil,
@@ -37,15 +38,22 @@ func (m *MountedStreamHandler) HandleMountedStream(
 	if err != nil {
 		return err
 	}
+
+	// Echo the stream asynchronously so the handler returns promptly.
 	go func() {
+		// Release the link reference when the echo routine exits.
 		defer elRef.Release()
+
+		// Prepare the echo stream and cancellation context.
 		m.le.Debug("echoing stream")
 		s := strm.GetStream()
 		subCtx, subCtxCancel := context.WithCancel(ctx)
 		defer subCtxCancel()
+
+		// Proxy the stream back to itself until either side closes.
 		ioproxy.ProxyStreams(s, s, subCtxCancel)
 
-		// wait to release EstablishLink ref
+		// Wait for the proxy to finish before releasing the reference.
 		<-subCtx.Done()
 	}()
 	return nil

--- a/net/stream/forwarding/stream_handler.go
+++ b/net/stream/forwarding/stream_handler.go
@@ -35,6 +35,7 @@ func (m *MountedStreamHandler) HandleMountedStream(
 	ctx context.Context,
 	strm link.MountedStream,
 ) error {
+	// Hold the source link while forwarding the mounted stream.
 	_, elRef, err := m.bus.AddDirective(
 		link.NewEstablishLinkWithPeer(strm.GetLink().GetLocalPeer(), strm.GetPeerID()),
 		nil,
@@ -42,14 +43,17 @@ func (m *MountedStreamHandler) HandleMountedStream(
 	if err != nil {
 		return err
 	}
+
+	// Forward the stream asynchronously so the handler returns promptly.
 	go func() {
+		// Retain the source stream and release its link reference on exit.
 		s := strm.GetStream()
 		defer func() {
 			elRef.Release()
 			s.Close()
 		}()
 
-		// Attempt to dial the target.
+		// Dial the configured target multiaddress.
 		m.le.Debug("dialing to forward stream")
 		conn, err := (&manet.Dialer{}).DialContext(ctx, m.dialMa)
 		if err != nil {
@@ -57,10 +61,13 @@ func (m *MountedStreamHandler) HandleMountedStream(
 			return
 		}
 
+		// Proxy the target connection until either side closes.
 		m.le.Debug("connection opened")
 		subCtx, subCtxCancel := context.WithCancel(ctx)
 		defer subCtxCancel()
 		ioproxy.ProxyStreams(conn, s, subCtxCancel)
+
+		// Wait for the proxy to finish before closing the connection.
 		<-subCtx.Done()
 		m.le.Debug("connection closing")
 

--- a/net/stream/listening/listening.go
+++ b/net/stream/listening/listening.go
@@ -91,18 +91,20 @@ func (c *Controller) GetControllerInfo() *controller.Info {
 func (c *Controller) Execute(ctx context.Context) error {
 	le := c.le
 
-	// Listen on the multiaddress
+	// Listen on the configured multiaddress.
 	listener, err := manet.Listen(c.listenMa)
 	if err != nil {
 		return err
 	}
 	defer listener.Close()
 
+	// Start accepting connections while the listener remains active.
 	errCh := make(chan error, 1)
 	go func() {
 		errCh <- c.acceptPump(ctx, listener)
 	}()
 
+	// Wait for cancellation or an accept-loop failure.
 	le.Debug("listening on multiaddr")
 	select {
 	case <-ctx.Done():
@@ -115,11 +117,13 @@ func (c *Controller) Execute(ctx context.Context) error {
 // acceptPump accepts incoming connections.
 func (c *Controller) acceptPump(ctx context.Context, listener manet.Listener) error {
 	for {
+		// Accept each incoming connection and hand it to a stream routine.
 		conn, err := listener.Accept()
 		if err != nil {
 			return err
 		}
 
+		// Log and dispatch the accepted connection.
 		c.le.Debug("accepted connection")
 		go c.handleConn(ctx, conn)
 	}
@@ -130,9 +134,11 @@ var openStreamTimeout = time.Second * 10
 
 // handleConn handles a connection.
 func (c *Controller) handleConn(ctx context.Context, conn manet.Conn) {
+	// Bound stream establishment and release its timeout context on return.
 	openCtx, openCtxCancel := context.WithTimeout(ctx, openStreamTimeout)
 	defer openCtxCancel()
 
+	// Open the configured mounted stream for the remote endpoint.
 	opts := stream.OpenOpts{}
 	mstrm, rel, err := link.OpenStreamWithPeerEx(
 		openCtx,
@@ -145,10 +151,12 @@ func (c *Controller) handleConn(ctx context.Context, conn manet.Conn) {
 	)
 	if err != nil {
 		conn.Close()
+
 		// c.le.WithError(err).Warn("unable to open stream to handle conn")
 		return
 	}
 
+	// Proxy the network connection through the mounted stream.
 	strm := mstrm.GetStream()
 	ioproxy.ProxyStreams(conn, strm, func() {
 		rel()

--- a/net/stream/packet/packet.go
+++ b/net/stream/packet/packet.go
@@ -31,20 +31,24 @@ func NewSession(
 
 // SendMsg tries to send a message on the wire.
 func (s *Session) SendMsg(msg protobuf_go_lite.Message) error {
+	// Measure and bound the serialized message.
 	size := msg.SizeVT()
 	if size > math.MaxInt32 {
 		return errors.New("message too large: exceeds maximum uint32 value")
 	}
 
+	// Allocate the length-prefixed packet and marshal the payload.
 	pktBuf := make([]byte, size+4)
 	binary.LittleEndian.PutUint32(pktBuf[:4], uint32(size))
 	if _, err := msg.MarshalToSizedBufferVT(pktBuf[4:]); err != nil {
 		return err
 	}
 
+	// Serialize writes under the session send lock.
 	s.sendMtx.Lock()
 	defer s.sendMtx.Unlock()
 
+	// Write the complete packet to the underlying stream.
 	if _, err := s.Write(pktBuf); err != nil {
 		return err
 	}
@@ -53,20 +57,24 @@ func (s *Session) SendMsg(msg protobuf_go_lite.Message) error {
 
 // RecvMsg tries to receive a message on the wire.
 func (s *Session) RecvMsg(msg protobuf_go_lite.Message) error {
+	// Serialize reads under the session receive lock.
 	var hdr [4]byte
 	s.readMtx.Lock()
 	defer s.readMtx.Unlock()
 
+	// Read the fixed-size message length prefix.
 	if _, err := io.ReadFull(s.ReadWriteCloser, hdr[:]); err != nil {
 		return err
 	}
 
+	// Decode and validate the payload length.
 	messageLen := binary.LittleEndian.Uint32(hdr[:])
 	if messageLen > 0 {
 		if messageLen > s.maxMessageSize {
 			return errors.Errorf("invalid message len: %d", messageLen)
 		}
 
+		// Read and decode the payload bytes.
 		data := make([]byte, messageLen)
 		if _, err := io.ReadFull(s.ReadWriteCloser, data); err != nil {
 			return err
@@ -75,6 +83,7 @@ func (s *Session) RecvMsg(msg protobuf_go_lite.Message) error {
 		return msg.UnmarshalVT(data)
 	}
 
+	// Reset the destination for an empty message.
 	msg.Reset()
 	return nil
 }

--- a/net/stream/relay/stream_handler.go
+++ b/net/stream/relay/stream_handler.go
@@ -40,6 +40,7 @@ func (m *MountedStreamHandler) HandleMountedStream(
 	ctx context.Context,
 	strm link.MountedStream,
 ) error {
+	// Capture the local and remote identities for the hold-open directive.
 	localPeerID, remotePeerID := strm.GetLink().GetLocalPeer(), strm.GetPeerID()
 	_, elRef, err := m.bus.AddDirective(
 		link.NewEstablishLinkWithPeer(localPeerID, remotePeerID),
@@ -49,29 +50,37 @@ func (m *MountedStreamHandler) HandleMountedStream(
 		return err
 	}
 
+	// Relay the stream asynchronously so the handler returns promptly.
 	go func() {
+		// Retain the incoming stream and release its link reference on exit.
 		s := strm.GetStream()
 		defer func() {
 			elRef.Release()
 			s.Close()
 		}()
 
-		// Emit directive to relay stream to target peer
+		// Open the target stream using the incoming stream's options.
 		m.le.Debug("relaying stream to target peer")
 		outMstrm, rel, err := link.OpenStreamWithPeerEx(ctx, m.bus, m.targetProtocolID, localPeerID, m.targetPeerID, 0, strm.GetOpenOpts())
 		if err != nil {
 			m.le.WithError(err).Warn("unable to relay stream to target peer")
 			return
 		}
+
+		// Release the target link reference after opening the stream.
 		rel()
 
+		// Keep the target stream open for the proxy lifetime.
 		outStrm := outMstrm.GetStream()
 		defer outStrm.Close()
 
+		// Proxy both streams until the shared context is canceled.
 		m.le.Debug("connection opened")
 		subCtx, subCtxCancel := context.WithCancel(ctx)
 		defer subCtxCancel()
 		ioproxy.ProxyStreams(s, outStrm, subCtxCancel)
+
+		// Wait for the proxy to finish before closing the connection.
 		<-subCtx.Done()
 		m.le.Debug("connection closing")
 

--- a/net/stream/srpc/server/server.go
+++ b/net/stream/srpc/server/server.go
@@ -125,6 +125,7 @@ func (s *Server) ResolveHandleMountedStream(
 	di directive.Instance,
 	dir link.HandleMountedStream,
 ) ([]directive.Resolver, error) {
+	// Match the incoming protocol against the configured protocol set.
 	inProtocol := dir.HandleMountedStreamProtocolID()
 	var match bool
 	if slices.Contains(s.protocolIDs, inProtocol) {
@@ -134,6 +135,7 @@ func (s *Server) ResolveHandleMountedStream(
 		return nil, nil
 	}
 
+	// Match the incoming local peer against the configured peer set.
 	inPeerID := dir.HandleMountedStreamLocalPeerID()
 	inPeerIDString := inPeerID.String()
 	if len(s.peerIDs) != 0 {
@@ -148,6 +150,7 @@ func (s *Server) ResolveHandleMountedStream(
 		}
 	}
 
+	// Return the mounted-stream resolver for matching requests.
 	return directive.Resolvers(newMountedStreamResolver(s)), nil
 }
 
@@ -157,7 +160,7 @@ func (s *Server) ResolveHandleMountedStream(
 // additional goroutines to manage the lifecycle of the stream.
 // Typically EstablishLink is asserted in HandleMountedStream.
 func (s *Server) HandleMountedStream(ctx context.Context, ms link.MountedStream) error {
-	// keep the link open
+	// Keep the link referenced while the SRPC server handles the stream.
 	var elRef directive.Reference
 	var err error
 	if !s.disableEstablishLink {
@@ -169,10 +172,15 @@ func (s *Server) HandleMountedStream(ctx context.Context, ms link.MountedStream)
 			return err
 		}
 	}
+
+	// Handle the stream asynchronously and release the link reference on exit.
 	go func() {
+		// Attach mounted-stream context and serve the SRPC stream.
 		strm := ms.GetStream()
 		sctx := link.WithMountedStreamContext(ctx, ms)
 		s.server.HandleStream(sctx, strm)
+
+		// Close the stream before releasing the optional link reference.
 		strm.Close()
 		if elRef != nil {
 			elRef.Release()

--- a/net/stream/srpc/srpc.go
+++ b/net/stream/srpc/srpc.go
@@ -57,8 +57,10 @@ func NewMultiOpenStreamFunc(
 		msgHandler srpc.PacketDataHandler,
 		closeHandler srpc.CloseHandler,
 	) (srpc.PacketWriter, error) {
+		// Try each configured destination until one establishes a stream.
 		var lastErr error
 		for _, destPeer := range destPeers {
+			// Create the attempt context with the configured timeout policy.
 			var estCtx context.Context
 			var estCtxCancel context.CancelFunc
 			if timeoutDur > 0 {
@@ -67,6 +69,7 @@ func NewMultiOpenStreamFunc(
 				estCtx, estCtxCancel = context.WithCancel(ctx)
 			}
 
+			// Establish the SRPC stream for this destination.
 			le := le.WithField("server-peer-id", destPeer.String())
 			writer, err := EstablishSrpcStream(
 				estCtx,
@@ -77,12 +80,16 @@ func NewMultiOpenStreamFunc(
 				msgHandler,
 				closeHandler,
 			)
+
+			// Release the attempt context before handling the result.
 			estCtxCancel()
 			if err != nil {
-				// detect deadline exceeded
+				// Normalize cancellation caused by the attempt deadline.
 				if err == context.Canceled && estCtx.Err() != nil && ctx.Err() == nil {
 					err = context.DeadlineExceeded
 				}
+
+				// Record the failed destination before trying the next one.
 				le.WithError(err).Warn("unable to establish srpc conn")
 				lastErr = err
 				continue
@@ -90,6 +97,7 @@ func NewMultiOpenStreamFunc(
 			return writer, nil
 		}
 
+		// Return a terminal error when no destination succeeded.
 		if lastErr == nil {
 			lastErr = errors.New("connection failed")
 		}
@@ -111,6 +119,7 @@ func EstablishSrpcStream(
 	msgHandler srpc.PacketDataHandler,
 	closeHandler srpc.CloseHandler,
 ) (srpc.PacketWriter, error) {
+	// Open and retain the mounted stream for the SRPC read pump.
 	ms, msRel, err := link.OpenStreamWithPeerEx(
 		ctx,
 		b,
@@ -122,6 +131,7 @@ func EstablishSrpcStream(
 		return nil, err
 	}
 
+	// Start the read pump and release the mounted-stream reference on exit.
 	rw := srpc.NewPacketReadWriter(ms.GetStream())
 	go func() {
 		rw.ReadPump(msgHandler, closeHandler)

--- a/net/testbed/testbed.go
+++ b/net/testbed/testbed.go
@@ -45,6 +45,7 @@ type TestbedOpts struct {
 // NewTestbed constructs a new core bus with a attached kvtx in-memory volume,
 // logger, and other core controllers required for a test to function.
 func NewTestbed(ctx context.Context, le *logrus.Entry, opts TestbedOpts) (*Testbed, error) {
+	// Create the testbed release callbacks and retain the requested private key.
 	var rels []func()
 	t := &Testbed{
 		Context: ctx,
@@ -57,6 +58,7 @@ func NewTestbed(ctx context.Context, le *logrus.Entry, opts TestbedOpts) (*Testb
 		},
 	}
 
+	// Build the in-memory controller bus and register common factories.
 	b, sr, err := core.NewTestingBus(ctx, le)
 	if err != nil {
 		return nil, err
@@ -65,6 +67,7 @@ func NewTestbed(ctx context.Context, le *logrus.Entry, opts TestbedOpts) (*Testb
 	t.Bus = b
 	sr.AddFactory(stream_echo.NewFactory(t.Bus))
 
+	// Generate a peer identity when the testbed requests one.
 	if !opts.NoPeer && t.PrivKey == nil {
 		npeer, err := peer.NewPeer(nil)
 		if err != nil {
@@ -75,6 +78,8 @@ func NewTestbed(ctx context.Context, le *logrus.Entry, opts TestbedOpts) (*Testb
 			return nil, err
 		}
 	}
+
+	// Derive the public peer ID from the configured private key.
 	if t.PrivKey != nil {
 		pid, err := peer.IDFromPrivateKey(t.PrivKey)
 		if err != nil {
@@ -83,8 +88,8 @@ func NewTestbed(ctx context.Context, le *logrus.Entry, opts TestbedOpts) (*Testb
 		t.PeerID = pid
 	}
 
+	// Start the peer controller unless peer setup is disabled.
 	if !opts.NoPeer {
-		// start peer controller
 		peerConfig, err := peer_controller.NewConfigWithPrivKey(t.PrivKey)
 		if err != nil {
 			return nil, err
@@ -103,6 +108,7 @@ func NewTestbed(ctx context.Context, le *logrus.Entry, opts TestbedOpts) (*Testb
 		rels = append(rels, peerRef.Release)
 	}
 
+	// Start the echo stream controller unless echo is disabled.
 	if !opts.NoEcho {
 		_, _, echoRef, err := bus.ExecOneOff(
 			ctx,

--- a/net/tptaddr/controller/res-establish-link.go
+++ b/net/tptaddr/controller/res-establish-link.go
@@ -67,8 +67,7 @@ func (o *establishLinkResolver) Resolve(ctx context.Context, handler directive.R
 	}
 	defer ref.Release()
 
-	// mark idle based on the lookup tpt addr value directive
-	// handle any non-nil resolver errors if isIdle
+	// Route lookup idle and disposal errors through the resolver wait channel.
 	errCh := make(chan error, 1)
 	handleErr := func(err error) {
 		select {

--- a/net/tptaddr/lookup-tpt-addr.go
+++ b/net/tptaddr/lookup-tpt-addr.go
@@ -28,6 +28,7 @@ type LookupTptAddrValue = string
 //
 // Note: waits to return until all resolvers become idle.
 func ExLookupTptAddr(ctx context.Context, b bus.Bus, destPeerID peer.ID, waitOne bool) ([]LookupTptAddrValue, directive.Instance, directive.Reference, error) {
+	// Collect matching transport addresses through the directive bus.
 	out, di, valsRef, err := bus.ExecCollectValues[LookupTptAddrValue](
 		ctx,
 		b,

--- a/net/tptaddr/static/controller.go
+++ b/net/tptaddr/static/controller.go
@@ -29,6 +29,7 @@ type Controller struct {
 //
 // Returns a list of errors for skipped addresses.
 func ParsePeerAddressMap(addressesWithPeerIDs []string) (map[string][]string, []error) {
+	// Prepare the peer address index before validating each configured address.
 	var errs []error
 	peers := make(map[string][]string)
 	for _, addr := range addressesWithPeerIDs {
@@ -46,6 +47,8 @@ func ParsePeerAddressMap(addressesWithPeerIDs []string) (map[string][]string, []
 		pidString := pid.String()
 		peers[pidString] = append(peers[pidString], tptaddr)
 	}
+
+	// Sort and deduplicate each peer's transport addresses.
 	for k, sl := range peers {
 		slices.Sort(sl)
 		sl = slices.Compact(sl)
@@ -56,6 +59,7 @@ func ParsePeerAddressMap(addressesWithPeerIDs []string) (map[string][]string, []
 
 // NewController constructs a new controller.
 func NewController(conf *Config) (*Controller, error) {
+	// Parse configured addresses and reject the first invalid entry.
 	peers, errs := ParsePeerAddressMap(conf.GetAddresses())
 	if len(errs) != 0 {
 		return nil, errs[0]

--- a/net/tptaddr/tptaddr_test.go
+++ b/net/tptaddr/tptaddr_test.go
@@ -34,11 +34,13 @@ func TestTptAddr(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
+	// Derive both peer identities from the generated testbed keys.
 	tb1PeerID, err := peer.IDFromPrivateKey(tb1.PrivKey)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
 
+	// Derive the server identity used by the in-process transport.
 	tb2PeerID, err := peer.IDFromPrivateKey(tb2.PrivKey)
 	if err != nil {
 		t.Fatal(err.Error())

--- a/net/transport/common/conn/conn.go
+++ b/net/transport/common/conn/conn.go
@@ -58,12 +58,14 @@ func NewTransport(
 	// if nil, the dialer will not function
 	addrDialer AddrDialFunc,
 ) (*Transport, error) {
+	// Resolve and clone connection options before applying defaults.
 	if opts == nil {
 		opts = &Opts{}
 	} else {
 		opts = opts.CloneVT()
 	}
 
+	// Resolve the packet MTU and buffer count.
 	mtu := opts.GetMtu()
 	if mtu <= 0 {
 		mtu = defaultMtu
@@ -74,13 +76,15 @@ func NewTransport(
 		bufSize = 10
 	}
 
+	// Ensure QUIC options exist.
 	if opts.Quic == nil {
 		opts.Quic = &transport_quic.Opts{}
 	}
 
-	// override some quic opts
+	// Disable QUIC path MTU discovery because this transport fixes the MTU.
 	opts.Quic.DisablePathMtuDiscovery = true // known mtu
 
+	// Build the ordered transport state.
 	tpt := &Transport{
 		ctx:     ctx,
 		le:      le,
@@ -92,12 +96,14 @@ func NewTransport(
 
 	var dialFn transport_quic.DialFunc
 	if addrDialer != nil {
+		// Dial the underlying address and wrap it as a packet connection.
 		dialFn = func(dctx context.Context, addr string) (*quic.Conn, net.Addr, error) {
 			c, na, err := addrDialer(dctx, addr)
 			if err != nil {
 				return nil, nil, err
 			}
 
+			// Negotiate a QUIC session over the packet connection.
 			pc := rwc.NewPacketConn(ctx, c, laddr, na, mtu, int(bufSize))
 			conn, _, err := transport_quic.DialSession(ctx, le, opts.GetQuic(), pc, tpt.GetIdentity(), na, "")
 			if err != nil {
@@ -108,6 +114,7 @@ func NewTransport(
 		}
 	}
 
+	// Install the QUIC-backed transport implementation.
 	var err error
 	tpt.Transport, err = transport_quic.NewTransport(
 		ctx,
@@ -138,6 +145,7 @@ func (t *Transport) HandleConn(
 	raddr net.Addr,
 	peerID peer.ID,
 ) (*Link, error) {
+	// Resolve a missing remote address from the expected peer identity.
 	if raddr == nil {
 		if len(peerID) == 0 {
 			return nil, transport_quic.ErrRemoteUnspecified
@@ -145,6 +153,7 @@ func (t *Transport) HandleConn(
 		raddr = peer.NewNetAddr(peerID)
 	}
 
+	// Wrap the ordered connection as a packet connection for QUIC.
 	pc := rwc.NewPacketConn(
 		t.ctx,
 		c,

--- a/net/transport/common/dialer/dialer.go
+++ b/net/transport/common/dialer/dialer.go
@@ -50,31 +50,42 @@ func (d *Dialer) GetLogger() *logrus.Entry {
 // Execute executes the dialer, with backoff.
 func (d *Dialer) Execute(ctx context.Context) (link.Link, error) {
 	for {
+		// Attempt the transport dial for the configured peer and address.
 		d.le.Debug("attempting to dial peer")
 		lnk, fatal, err := d.tptDialer.DialPeer(ctx, d.peerID, d.address)
+
+		// Reset backoff after a successful link.
 		if err == nil {
 			d.backoff.Reset()
 			return lnk, nil
 		}
+
+		// Stop retrying when the caller has canceled the dial.
 		if ctx.Err() != nil {
 			return nil, context.Canceled
 		}
 
+		// Select the next retry delay after a failed attempt.
 		bo := d.backoff.NextBackOff()
+
+		// Return fatal dial errors without retrying.
 		if fatal {
 			d.le.WithError(err).Warn("dialer errored fatally")
 			return nil, err
 		}
 
+		// Record the retryable dial failure and selected backoff.
 		d.le.
 			WithError(err).
 			WithField("backoff", bo.String()).
 			Warn("dialer errored")
 
+		// Stop when the backoff policy is exhausted.
 		if bo == -1 {
 			return nil, errors.New("dial backoff max duration exceeded")
 		}
 
+		// Wait for cancellation or the retry delay before dialing again.
 		select {
 		case <-ctx.Done():
 			return nil, context.Canceled

--- a/net/transport/common/pconn/pconn.go
+++ b/net/transport/common/pconn/pconn.go
@@ -63,15 +63,18 @@ func NewTransport(
 	// may be nil
 	staticPeerMap map[string]*dialer.DialerOpts,
 ) (*Transport, error) {
+	// Resolve packet transport options before deriving the local identity.
 	if opts == nil {
 		opts = &Opts{}
 	}
 
+	// Derive the local peer identity for the transport.
 	peerID, err := peer.IDFromPrivateKey(privKey)
 	if err != nil {
 		return nil, err
 	}
 
+	// Build the packet transport state.
 	tpt := &Transport{
 		ctx:           ctx,
 		le:            le,
@@ -86,14 +89,15 @@ func NewTransport(
 
 	var dialFn transport_quic.DialFunc
 	if addrParser != nil {
+		// Parse the dial address and negotiate QUIC over the packet transport.
 		dialFn = func(ctx context.Context, addr string) (*quic.Conn, net.Addr, error) {
-			// parse the addr to a net.Addr
+			// Parse the dial address into a network address.
 			na, err := addrParser(addr)
 			if err != nil {
 				return nil, na, err
 			}
 
-			// dial via quic
+			// Dial a QUIC session through the shared packet transport.
 			conn, _, err := transport_quic.DialSessionViaTransport(
 				ctx,
 				le,
@@ -110,7 +114,7 @@ func NewTransport(
 		}
 	}
 
-	// Build quic transport
+	// Install the QUIC transport and retain its packet listener.
 	tpt.Transport, err = transport_quic.NewTransport(
 		ctx,
 		le,
@@ -125,6 +129,7 @@ func NewTransport(
 		return nil, err
 	}
 
+	// Build the QUIC listener configuration and bind it to the packet socket.
 	tpt.quicConfig = transport_quic.BuildQuicConfig(opts.GetQuic())
 	tpt.quicTpt = &quic.Transport{Conn: pc}
 
@@ -138,11 +143,13 @@ func (t *Transport) GetPeerID() peer.ID {
 
 // Execute executes the transport as configured, returning any fatal error.
 func (t *Transport) Execute(ctx context.Context) error {
+	// Log the listener identity before accepting incoming sessions.
 	t.le.
 		WithField("local-addr", t.LocalAddr().String()).
 		WithField("peer-id", t.peerID.String()).
 		Info("starting to listen with quic + tls")
-	// Configure TLS to allow any incoming remote peer.
+
+	// Configure TLS to accept incoming sessions from any peer.
 	tlsConf := transport_quic.BuildIncomingTlsConf(t.GetIdentity(), "")
 	ln, err := t.quicTpt.Listen(tlsConf, t.quicConfig)
 	if err != nil {
@@ -151,7 +158,7 @@ func (t *Transport) Execute(ctx context.Context) error {
 	defer t.pc.Close()
 	defer ln.Close()
 
-	// accept new connections
+	// Accept sessions and register each resulting link.
 	for {
 		sess, err := ln.Accept(ctx)
 		if err != nil {

--- a/net/transport/common/quic/config.go
+++ b/net/transport/common/quic/config.go
@@ -11,6 +11,7 @@ import (
 
 // BuildQuicConfig constructs the quic config.
 func BuildQuicConfig(opts *Opts) *quic.Config {
+	// Resolve the configured idle timeout.
 	maxIdleTimeout := time.Second * 10
 	if ntDur := opts.GetMaxIdleTimeoutDur(); ntDur != "" {
 		nt, err := time.ParseDuration(ntDur)
@@ -19,11 +20,13 @@ func BuildQuicConfig(opts *Opts) *quic.Config {
 		}
 	}
 
+	// Resolve the configured incoming stream limit.
 	maxIncStreams := 100000
 	if mis := opts.GetMaxIncomingStreams(); mis > 0 {
 		maxIncStreams = int(mis)
 	}
 
+	// Resolve the keepalive period from the timeout and options.
 	keepAlivePeriod := maxIdleTimeout / 2
 	if opts.GetDisableKeepAlive() {
 		keepAlivePeriod = 0
@@ -34,6 +37,7 @@ func BuildQuicConfig(opts *Opts) *quic.Config {
 		}
 	}
 
+	// Build the QUIC configuration from the resolved limits.
 	return &quic.Config{
 		// We don't use datagrams (yet), but this is necessary for WebTransport
 		EnableDatagrams:         !opts.GetDisableDatagrams(),
@@ -50,17 +54,22 @@ func BuildQuicConfig(opts *Opts) *quic.Config {
 //
 // rpeer can be empty to indicate accepting any remote peer.
 func BuildIncomingTlsConf(identity *p2ptls.Identity, rpeer peer.ID) *tls.Config {
+	// Configure ALPN and the peer-aware TLS callback.
 	var tlsConf tls.Config
 	tlsConf.NextProtos = []string{Alpn}
 	tlsConf.GetConfigForClient = func(_ *tls.ClientHelloInfo) (*tls.Config, error) {
-		// note: if rpeer is empty, allows any incoming peer id.
+		// Resolve the peer-specific TLS configuration for each client.
 		conf, _ := identity.ConfigForPeer(rpeer)
+
+		// Require the QUIC ALPN and disable session tickets.
 		conf.NextProtos = []string{Alpn}
+
 		// TODO: https://github.com/golang/go/issues/60506
 		conf.SessionTicketsDisabled = true
 		return conf, nil
 	}
 
+	// Disable session tickets on the listener configuration.
 	// TODO: https://github.com/golang/go/issues/60506
 	tlsConf.SessionTicketsDisabled = true
 	return &tlsConf

--- a/net/transport/common/quic/link.go
+++ b/net/transport/common/quic/link.go
@@ -57,15 +57,20 @@ func NewLink(
 	sess *quic.Conn,
 	closed func(),
 ) (*Link, error) {
+	// Determine the remote identity from the negotiated session.
 	remotePeerID, remotePubKey, err := DetermineSessionIdentity(sess)
 	if err != nil {
 		return nil, err
 	}
 
+	// Compute link addresses and deterministic identifiers.
 	remoteAddr := sess.RemoteAddr()
+
 	nctx, nctxCancel := context.WithCancel(ctx) //nolint:gosec // cancel stored on Link and called by Close
 	uuid := NewLinkUUID(localAddr, remoteAddr, remotePeerID)
 	remoteTransportUUID := NewTransportUUID(remoteAddr.String(), remotePeerID)
+
+	// Assemble the link state with local and remote session metadata.
 	return &Link{
 		ctx:       nctx,
 		ctxCancel: nctxCancel,
@@ -140,14 +145,18 @@ func (l *Link) OpenStream(opts stream.OpenOpts) (stream.Stream, error) {
 
 // AcceptStream accepts a stream from the link.
 func (l *Link) AcceptStream() (stream.Stream, stream.OpenOpts, error) {
+	// Accept the next QUIC stream and handle link cancellation.
 	qstream, err := l.sess.AcceptStream(l.ctx)
 	if l.ctx.Err() != nil {
-		// detect link shutdown, avoid logging unnecessary errors
+		// Close a partially accepted stream after link shutdown.
 		if qstream != nil {
 			_ = qstream.Close()
 		}
 		return nil, stream.OpenOpts{}, context.Canceled
+
 	}
+
+	// Translate clean QUIC closure to EOF and preserve other errors.
 	if err != nil {
 		if isCleanAcceptClose(err) {
 			return nil, stream.OpenOpts{}, io.EOF
@@ -155,6 +164,7 @@ func (l *Link) AcceptStream() (stream.Stream, stream.OpenOpts, error) {
 		return nil, stream.OpenOpts{}, err
 	}
 
+	// Return the accepted stream with default open options.
 	opts := stream.OpenOpts{}
 	return qstream, opts, nil
 }
@@ -162,10 +172,13 @@ func (l *Link) AcceptStream() (stream.Stream, stream.OpenOpts, error) {
 // Close closes the connection.
 func (l *Link) Close() error {
 	l.closedOnce.Do(func() {
+		// Cancel the link context before invoking the close callback.
 		l.ctxCancel()
 		if closed := l.closed; closed != nil {
 			closed()
 		}
+
+		// Close the QUIC session after invoking the close callback.
 		if l.sess != nil {
 			_ = l.sess.CloseWithError(0, "")
 		}

--- a/net/transport/common/quic/quic.go
+++ b/net/transport/common/quic/quic.go
@@ -66,28 +66,34 @@ func NewTransport(
 	opts *Opts,
 	dialFn DialFunc,
 ) (*Transport, error) {
+	// Resolve defaults before deriving the local identity.
 	if opts == nil {
 		opts = &Opts{}
 	}
 
+	// Derive the local peer identity.
 	peerID, err := peer.IDFromPrivateKey(privKey)
 	if err != nil {
 		return nil, err
 	}
 
+	// Derive a deterministic transport UUID when none was supplied.
 	if uuid == 0 {
 		uuid = NewTransportUUID("conn", peerID)
 	}
 
+	// Derive a local address when none was supplied.
 	if laddr == nil {
 		laddr = peer.NewNetAddr(peerID)
 	}
 
+	// Build the TLS identity used by QUIC sessions.
 	identity, err := p2ptls.NewIdentity(privKey)
 	if err != nil {
 		return nil, err
 	}
 
+	// Assemble the transport state and link registries.
 	return &Transport{
 		ctx:      ctx,
 		le:       le,
@@ -129,17 +135,19 @@ func (t *Transport) LocalAddr() net.Addr {
 // was established. DialPeer will then not be called again for the same peer
 // ID and address tuple until the yielded link is lost.
 func (t *Transport) DialPeer(ctx context.Context, peerID peer.ID, as string) (link.Link, bool, error) {
+	// Reject dialing when this transport has no dial function.
 	if t.dialFn == nil {
 		return nil, false, ErrDialUnimplemented
 	}
 
-	// abort if we already have a peer with the same addr connected
+	// Reject duplicate links for the same address and peer.
 	ok, err := CheckAlreadyConnected(t, as, peerID)
 	if ok || err != nil {
 		// returns an error if already connected w/ different peer id
 		return nil, false, err
 	}
 
+	// Reuse or register the address dialer under the transport lock.
 	var dl *Dialer
 	t.mtx.Lock()
 	if edl, dialerOk := t.dialers[as]; dialerOk {
@@ -150,6 +158,7 @@ func (t *Transport) DialPeer(ctx context.Context, peerID peer.ID, as string) (li
 		dl, err = NewDialer(t.ctx, t, peerID, as)
 		if err == nil {
 			t.dialers[as] = dl
+
 			// start a separate goroutine to execute the dialer.
 			go dl.Execute()
 		}
@@ -159,7 +168,7 @@ func (t *Transport) DialPeer(ctx context.Context, peerID peer.ID, as string) (li
 		return nil, false, err
 	}
 
-	// wait for dialer to finish
+	// Await the registered dialer result.
 	lnk, err := dl.result.Await(ctx)
 	if err != nil {
 		return nil, false, err
@@ -194,6 +203,7 @@ func (t *Transport) Execute(ctx context.Context) error {
 // if peerID is empty, allows any peer ID on the remote end
 // raddr can be nil if peerID is NOT empty
 func (t *Transport) HandleConn(ctx context.Context, dial bool, pc net.PacketConn, raddr net.Addr, peerID peer.ID) (*Link, error) {
+	// Resolve a missing remote address from the expected peer identity.
 	if raddr == nil {
 		if len(peerID) == 0 {
 			return nil, ErrRemoteUnspecified
@@ -201,6 +211,7 @@ func (t *Transport) HandleConn(ctx context.Context, dial bool, pc net.PacketConn
 		raddr = peer.NewNetAddr(peerID)
 	}
 
+	// Negotiate a session as a dialer or listener.
 	var sess *quic.Conn
 	var err error
 
@@ -229,6 +240,7 @@ func (t *Transport) HandleConn(ctx context.Context, dial bool, pc net.PacketConn
 		return nil, err
 	}
 
+	// Build the link from the negotiated session and publish failures cleanly.
 	lnk, err := t.HandleSession(ctx, sess)
 	if err != nil {
 		t.le.WithError(err).Warn("cannot build link for session")
@@ -241,6 +253,7 @@ func (t *Transport) HandleConn(ctx context.Context, dial bool, pc net.PacketConn
 
 // HandleSession handles a new Quic session, creating & registering a link.
 func (t *Transport) HandleSession(ctx context.Context, sess *quic.Conn) (*Link, error) {
+	// Allocate a session ID before constructing the link.
 	t.mtx.Lock()
 	sessID := t.sessionCounter
 	t.sessionCounter++
@@ -266,8 +279,10 @@ func (t *Transport) HandleSession(ctx context.Context, sess *quic.Conn) (*Link, 
 		return nil, err
 	}
 
+	// Register the link and replace any prior session at this address.
 	t.mtx.Lock()
-	// Clear any ongoing dial attempt for this addr.
+
+	// Clear any ongoing dial attempt for this address.
 	raddr := lnk.RemoteAddr()
 	if raddr != nil {
 		rs := raddr.String()
@@ -323,6 +338,7 @@ func (t *Transport) handleLinkLost(addrStr string, lnk *Link) {
 	}
 	t.mtx.Unlock()
 
+	// Notify the handler only when this link remains the registered address entry.
 	if t.handler != nil && rel {
 		t.handler.HandleLinkLost(lnk)
 	}

--- a/net/transport/common/quic/session.go
+++ b/net/transport/common/quic/session.go
@@ -28,21 +28,26 @@ func DialSession(
 	addr net.Addr,
 	rpeer peer.ID,
 ) (*quic.Conn, crypto.PubKey, error) {
+	// Build the peer-specific TLS configuration and QUIC settings.
 	tlsConf, keyCh := identity.ConfigForPeer(rpeer)
 	tlsConf.NextProtos = []string{Alpn}
 	quicConfig := BuildQuicConfig(opts)
 
+	// Dial the QUIC session over the packet connection.
 	sess, err := quic.Dial(ctx, pconn, addr, tlsConf, quicConfig)
 	if err != nil {
 		return nil, nil, err
 	}
 
+	// Wait for the authenticated remote public key.
 	var remotePubKey crypto.PubKey
 	select {
 	case remotePubKey = <-keyCh:
 	case <-ctx.Done():
 		return nil, nil, ctx.Err()
 	}
+
+	// Require the TLS verifier to provide the remote public key.
 	if remotePubKey == nil {
 		return nil, nil, errors.New("expected remote pub key to be set")
 	}
@@ -63,21 +68,26 @@ func DialSessionViaTransport(
 	addr net.Addr,
 	rpeer peer.ID,
 ) (*quic.Conn, crypto.PubKey, error) {
+	// Build the peer-specific TLS configuration and QUIC settings.
 	tlsConf, keyCh := identity.ConfigForPeer(rpeer)
 	tlsConf.NextProtos = []string{Alpn}
 	quicConfig := BuildQuicConfig(opts)
 
+	// Dial the QUIC session through the shared transport.
 	sess, err := tpt.Dial(ctx, addr, tlsConf, quicConfig)
 	if err != nil {
 		return nil, nil, err
 	}
 
+	// Wait for the authenticated remote public key.
 	var remotePubKey crypto.PubKey
 	select {
 	case remotePubKey = <-keyCh:
 	case <-ctx.Done():
 		return nil, nil, ctx.Err()
 	}
+
+	// Require the TLS verifier to provide the remote public key.
 	if remotePubKey == nil {
 		return nil, nil, errors.New("expected remote pub key to be set")
 	}
@@ -97,15 +107,18 @@ func ListenSession(
 	identity *p2ptls.Identity,
 	rpeer peer.ID,
 ) (*quic.Conn, error) {
+	// Build the listener configuration and TLS verifier.
 	quicConfig := BuildQuicConfig(opts)
 	tlsConf := BuildIncomingTlsConf(identity, rpeer)
 
+	// Start listening for the incoming QUIC handshake.
 	le.Debug("listening for incoming handshake with quic + tls")
 	ln, err := quic.Listen(pconn, tlsConf, quicConfig)
 	if err != nil {
 		return nil, err
 	}
 
+	// Accept one session and close the listener on failure.
 	sess, err := ln.Accept(ctx)
 	if err != nil {
 		_ = ln.Close()
@@ -117,12 +130,15 @@ func ListenSession(
 
 // DetermineSessionIdentity determines the identity from the session cert chain.
 func DetermineSessionIdentity(sess *quic.Conn) (peer.ID, crypto.PubKey, error) {
+	// Extract the remote public key from the session certificate chain.
 	connState := sess.ConnectionState()
 	certs := connState.TLS.PeerCertificates
 	remotePubKey, err := p2ptls.PubKeyFromCertChain(certs)
 	if err != nil {
 		return "", nil, err
 	}
+
+	// Derive the remote peer identity from its public key.
 	remotePeerID, err := peer.IDFromPublicKey(remotePubKey)
 	if err != nil {
 		return "", nil, err

--- a/net/transport/common/quic/util.go
+++ b/net/transport/common/quic/util.go
@@ -7,12 +7,17 @@ import (
 
 // CheckAlreadyConnected checks if a address and peer id is already connected.
 func CheckAlreadyConnected(t *Transport, addr string, peerID peer.ID) (bool, error) {
+	// Look up an existing link for the requested address.
 	lnk, ok := t.LookupLinkWithAddr(addr)
 	if !ok {
 		return false, nil
 	}
+
+	// Compare the existing link's peer identity with the requested peer.
 	lnkPeer := lnk.GetRemotePeer().String()
 	desiredPeer := peerID.String()
+
+	// Reject an address already bound to a different peer.
 	if lnkPeer != desiredPeer {
 		return false, errors.Errorf(
 			"already connected to %s with different peer id: %s != requested %s",
@@ -21,5 +26,7 @@ func CheckAlreadyConnected(t *Transport, addr string, peerID peer.ID) (bool, err
 			desiredPeer,
 		)
 	}
+
+	// Confirm that the existing link matches the requested peer.
 	return true, nil
 }

--- a/net/transport/controller/establish-header.go
+++ b/net/transport/controller/establish-header.go
@@ -15,10 +15,15 @@ func NewStreamEstablish(protocolID protocol.ID) *StreamEstablish {
 }
 
 func marshalStreamEstablishHeader(msg *StreamEstablish) []byte {
+	// Compute the payload size and allocate space for its length prefix.
 	datLen := msg.SizeVT()
 	outBuf := make([]byte, 0, datLen+9)
+
 	// Ignore gosec linter here: SizeVT will never exceed uint64 max.
+	// Encode the payload length as a varint prefix.
 	outBuf = protobuf_go_lite.AppendVarint(outBuf, uint64(datLen)) //nolint:gosec
+
+	// Reserve the payload area and marshal the message into it.
 	prefixLen := len(outBuf)
 	outBuf = outBuf[:len(outBuf)+datLen]
 	msgFinalLen, _ := msg.MarshalToVT(outBuf[prefixLen:])
@@ -41,6 +46,7 @@ func readAtLeast(r io.Reader, n, min int, buf []byte) (int, error) {
 }
 
 func readStreamEstablishHeader(r io.Reader) (*StreamEstablish, error) {
+	// Read the fixed prefix bytes needed to decode the header length.
 	b := make([]byte, 4)
 	var err error
 	_, err = readAtLeast(r, 0, 4, b)
@@ -48,21 +54,22 @@ func readStreamEstablishHeader(r io.Reader) (*StreamEstablish, error) {
 		return nil, err
 	}
 
-	// Read the header length varint
+	// Decode and validate the header length varint.
 	headerLen, headerLenBytes := protobuf_go_lite.ConsumeVarint(b)
 	if headerLenBytes <= 0 {
 		return nil, errors.New("invalid stream establish varint prefix")
 	}
+
 	if headerLenBytes > len(b) { // this should not be possible
 		headerLenBytes = len(b)
 	}
 
-	// use MaxInt32 for compat with 32-bit systems
+	// Enforce the platform-safe maximum header size.
 	if headerLen > math.MaxInt32 {
 		return nil, errors.New("header too large: exceeds maximum uint32 value")
 	}
 
-	// header len is at most 100,000 bytes
+	// Enforce the configured header size bounds.
 	if headerLen > streamEstablishMaxPacketSize || headerLen == 0 {
 		return nil, errors.Errorf(
 			"stream establish header length invalid: %d (expected <= %d)",
@@ -71,6 +78,7 @@ func readStreamEstablishHeader(r io.Reader) (*StreamEstablish, error) {
 		)
 	}
 
+	// Fill the header buffer from the prefix and remaining reader bytes.
 	headerBuf := make([]byte, int(headerLen))
 	copy(headerBuf, b[headerLenBytes:])
 	n := len(b) - headerLenBytes
@@ -78,7 +86,7 @@ func readStreamEstablishHeader(r io.Reader) (*StreamEstablish, error) {
 		return nil, err
 	}
 
-	// decode stream establish header
+	// Decode the establishment message from the complete header.
 	estHeader := &StreamEstablish{}
 	if err := estHeader.UnmarshalVT(headerBuf); err != nil {
 		return nil, err

--- a/net/transport/controller/link-dialer.go
+++ b/net/transport/controller/link-dialer.go
@@ -32,6 +32,7 @@ type linkDialer struct {
 
 // buildLinkDialer constructs a new link dialer.
 func (c *Controller) buildLinkDialer(key linkDialerKey) (keyed.Routine, *linkDialer) {
+	// Allocate the keyed dialer state and result container.
 	ld := &linkDialer{c: c, key: key, opts: promise.NewPromise[*dialer.DialerOpts]()}
 	ld.lnk = ccontainer.NewCContainer[link.Link](nil)
 	return ld.executeLinkDialer, ld
@@ -41,26 +42,33 @@ func (c *Controller) buildLinkDialer(key linkDialerKey) (keyed.Routine, *linkDia
 func (l *linkDialer) executeLinkDialer(
 	ctx context.Context,
 ) error {
+	// Wait for the transport needed by this dial attempt.
 	tpt, err := l.c.GetTransport(ctx)
 	if err != nil {
 		return err
 	}
 
+	// Require a transport implementation that can dial peers.
 	tptDialer, ok := tpt.(dialer.TransportDialer)
 	if !ok {
 		return dialer.ErrNotTransportDialer
 	}
 
+	// Wait for the caller to provide dial options.
 	dialOpts, err := l.opts.Await(ctx)
 	if err != nil {
 		return err
 	}
 
+	// Scope the dial attempt to the routine context.
 	subCtx, subCtxCancel := context.WithCancel(ctx)
 	defer subCtxCancel()
 
+	// Execute the dial with the resolved address and peer.
 	dialer := dialer.NewDialer(l.c.le, tptDialer, dialOpts, l.key.peerID, l.key.dialAddress)
 	lnk, err := dialer.Execute(subCtx)
+
+	// Normalize cancellation before returning dial errors.
 	if ctx.Err() != nil {
 		return context.Canceled
 	}
@@ -68,7 +76,7 @@ func (l *linkDialer) executeLinkDialer(
 		return err
 	}
 
-	// success
+	// Publish the established link to waiters.
 	l.lnk.SetValue(lnk)
 	return nil
 }

--- a/net/transport/controller/mounted-link.go
+++ b/net/transport/controller/mounted-link.go
@@ -64,20 +64,28 @@ func (l *mountedLink) OpenMountedStream(
 	protocolID protocol.ID,
 	opts stream.OpenOpts,
 ) (link.MountedStream, error) {
+	// Build the establishment header for the requested protocol.
 	estMsg := NewStreamEstablish(protocolID)
 
+	// Open the underlying stream on the link.
 	strm, err := l.link.OpenStream(opts)
 	if err != nil {
 		return nil, err
 	}
 
+	// Bound header negotiation by a write deadline.
 	_ = strm.SetWriteDeadline(time.Now().Add(streamEstablishTimeout))
+
+	// Write the establishment header and close failed streams.
 	if _, err := writeStreamEstablishHeader(strm, estMsg); err != nil {
 		_ = strm.Close()
 		return nil, err
 	}
 
+	// Clear the negotiation deadline after the header is sent.
 	_ = strm.SetDeadline(time.Time{})
+
+	// Log the mounted stream when verbose transport logging is enabled.
 	if l.c.verbose {
 		l.c.le.
 			WithFields(logrus.Fields{
@@ -89,6 +97,7 @@ func (l *mountedLink) OpenMountedStream(
 			Debug("opened stream with peer")
 	}
 
+	// Return the stream with its negotiated protocol metadata.
 	return newMountedStream(strm, opts, protocolID, l), nil
 }
 

--- a/net/transport/controller/transport-handler.go
+++ b/net/transport/controller/transport-handler.go
@@ -25,12 +25,13 @@ func newTransportHandler(ctx context.Context, c *Controller) *transportHandler {
 
 // HandleLinkEstablished is called by the transport when a link is established.
 func (h *transportHandler) HandleLinkEstablished(lnk link.Link) {
+	// Capture link identity for registration and logging.
 	le := h.c.loggerForLink(lnk)
 
 	luuid := lnk.GetUUID()
 	remotePeer := lnk.GetRemotePeer()
 
-	// if this is called we always store
+	// Await the constructed transport before accepting the link.
 	tpt, err := h.tpt.Await(h.ctx)
 	if err != nil {
 		le.WithError(err).Warn("link established while transport exited, closing link")
@@ -38,8 +39,9 @@ func (h *transportHandler) HandleLinkEstablished(lnk link.Link) {
 		return
 	}
 
-	// use MaybeAsync to avoid deadlocks if the transport author was not careful.
+	// Reconcile the link under the controller broadcast lock.
 	h.c.bcast.HoldLockMaybeAsync(func(broadcast func(), getWaitCh func() <-chan struct{}) {
+		// Require an active execution context before registering links.
 		execCtx := h.c.execCtx
 		if execCtx == nil {
 			le.Warn("link established while transport exited, closing link")
@@ -47,7 +49,7 @@ func (h *transportHandler) HandleLinkEstablished(lnk link.Link) {
 			return
 		}
 
-		// quick sanity check
+		// Reject self-dialed links before registration.
 		if remotePeer == h.c.peerID {
 			le.Warn("self-dial detected, closing link")
 			go lnk.Close()
@@ -57,17 +59,18 @@ func (h *transportHandler) HandleLinkEstablished(lnk link.Link) {
 		el, elOk := h.c.links[luuid]
 		if elOk {
 			if el.lnk == lnk {
-				// duplicate HandleLinkEstablished call
+				// Ignore duplicate callbacks for the same link instance.
 				le.Debug("duplicate handle-link-established call")
 				return
 			}
 
-			// close dupe
+			// Close the previous link before replacing it.
 			le.Debug("closing existing link identical to incoming link")
 			h.c.flushEstablishedLink(el, true)
 			broadcast()
 		}
 
+		// Build the mounted and established link state.
 		mlnk := newMountedLink(h.c, tpt, lnk)
 		el, err := newEstablishedLink(h.c.le, execCtx, h.c.bus, lnk, mlnk, tpt, h.c)
 		if err != nil {
@@ -76,6 +79,7 @@ func (h *transportHandler) HandleLinkEstablished(lnk link.Link) {
 			return
 		}
 
+		// Publish the new link in both indexes.
 		h.c.links[luuid] = el
 		h.c.linksByPeerID[remotePeer] = append(h.c.linksByPeerID[remotePeer], el)
 
@@ -87,7 +91,7 @@ func (h *transportHandler) HandleLinkEstablished(lnk link.Link) {
 // HandleLinkLost is called when a link is lost.
 func (h *transportHandler) HandleLinkLost(lnk link.Link) {
 	h.c.bcast.HoldLockMaybeAsync(func(broadcast func(), getWaitCh func() <-chan struct{}) {
-		// fast path: clear by uuid
+		// Remove the link by UUID on the common loss path.
 		luuid := lnk.GetUUID()
 		if el, elOk := h.c.links[luuid]; elOk {
 			delete(h.c.links, luuid)
@@ -96,8 +100,7 @@ func (h *transportHandler) HandleLinkLost(lnk link.Link) {
 			return
 		}
 
-		// slow path: equality check
-		// only taken if the uuid somehow changed on the link.
+		// Fall back to identity comparison if the UUID changed.
 		for k, l := range h.c.links {
 			if l.lnk == lnk {
 				delete(h.c.links, k)

--- a/net/transport/inproc/addr.go
+++ b/net/transport/inproc/addr.go
@@ -25,13 +25,18 @@ func NewAddr(peerID peer.ID) *Addr {
 
 // ParseAddr parses an address.
 func ParseAddr(addr string) (net.Addr, error) {
+	// Require the in-process address scheme before decoding its peer ID.
 	if !strings.HasPrefix(addr, scheme) {
 		return nil, errors.Errorf("expected inproc prefix: %s", addr)
 	}
+
+	// Decode the peer identity embedded in the address.
 	pid, err := peer.IDB58Decode(addr[len(scheme):])
 	if err != nil {
 		return nil, err
 	}
+
+	// Rebuild the typed address from the decoded peer identity.
 	return NewAddr(pid), nil
 }
 

--- a/net/transport/inproc/inproc.go
+++ b/net/transport/inproc/inproc.go
@@ -53,22 +53,28 @@ func NewInproc(
 	pKey crypto.PrivKey,
 	c transport.TransportHandler,
 ) (transport.Transport, error) {
+	// Derive the local peer identity for this in-process transport.
 	peerID, err := peer.IDFromPrivateKey(pKey)
 	if err != nil {
 		return nil, err
 	}
 
+	// Build the local address and transport state.
 	localAddr := NewAddr(peerID)
 	ip := &Inproc{
 		le:        le,
 		localAddr: localAddr,
 		remotes:   make(map[string]*packetConn),
 	}
+
+	// Create the packet connection that routes to known remotes.
 	npc := newPacketConn(
 		ctx,
 		localAddr,
 		ip.writeToAddr,
 	)
+
+	// Construct the packet-backed transport.
 	ip.Transport, err = pconn.NewTransport(
 		ctx,
 		le,
@@ -83,6 +89,8 @@ func NewInproc(
 	if err != nil {
 		return nil, err
 	}
+
+	// Retain the packet connection for future remote wiring.
 	ip.packetConn = npc
 	return ip, nil
 }
@@ -127,6 +135,7 @@ func (t *Inproc) MatchTransportType(transportType string) bool {
 // ConnectToInproc connects the inproc to a remote inproc.
 // Will overwrite any existing connection
 func (t *Inproc) ConnectToInproc(ctx context.Context, other *Inproc) {
+	// Record the remote packet endpoint under its address.
 	oa := other.localAddr.String()
 	t.mtx.Lock()
 	t.remotes[oa] = other.packetConn
@@ -135,6 +144,7 @@ func (t *Inproc) ConnectToInproc(ctx context.Context, other *Inproc) {
 
 // DisconnectInproc disconnects a previously connected inproc.
 func (t *Inproc) DisconnectInproc(ctx context.Context, other *Inproc) {
+	// Remove the remote packet endpoint from the routing table.
 	oa := other.localAddr.String()
 	t.mtx.Lock()
 	delete(t.remotes, oa)
@@ -143,16 +153,21 @@ func (t *Inproc) DisconnectInproc(ctx context.Context, other *Inproc) {
 
 // writeToAddr routes outgoing packets.
 func (t *Inproc) writeToAddr(ctx context.Context, p []byte, addr net.Addr) (int, error) {
+	// Resolve the remote endpoint while holding the routing mutex.
 	oa := addr.String()
 	t.mtx.Lock()
 	out, outOk := t.remotes[oa]
 	t.mtx.Unlock()
+
+	// Reject packets for an endpoint that is not connected.
 	if !outOk {
 		return 0, &net.AddrError{
 			Addr: oa,
 			Err:  "remote transport not connected",
 		}
 	}
+
+	// Deliver the packet to the remote in-process connection.
 	return out.HandlePacket(ctx, p, t.localAddr)
 }
 

--- a/net/transport/inproc/pconn.go
+++ b/net/transport/inproc/pconn.go
@@ -60,6 +60,7 @@ type incPacket struct {
 // an Error with Timeout() == true after a fixed time limit;
 // see SetDeadline and SetReadDeadline.
 func (c *packetConn) ReadFrom(p []byte) (n int, addr net.Addr, err error) {
+	// Apply the configured read deadline to the packet context.
 	deadline := c.rd
 	ctx := c.ctx
 	if !deadline.IsZero() {
@@ -68,6 +69,7 @@ func (c *packetConn) ReadFrom(p []byte) (n int, addr net.Addr, err error) {
 		defer ctxCancel()
 	}
 
+	// Wait for a packet or context cancellation.
 	var pkt *incPacket
 	select {
 	case <-ctx.Done():
@@ -75,6 +77,7 @@ func (c *packetConn) ReadFrom(p []byte) (n int, addr net.Addr, err error) {
 	case pkt = <-c.packetCh:
 	}
 
+	// Copy the packet payload and report truncation.
 	copy(p, pkt.data)
 	if len(p) < len(pkt.data) {
 		return len(p), pkt.addr, io.ErrShortBuffer
@@ -84,9 +87,12 @@ func (c *packetConn) ReadFrom(p []byte) (n int, addr net.Addr, err error) {
 
 // HandlePacket intakes a packet, returning it from ReadFrom.
 func (c *packetConn) HandlePacket(ctx context.Context, p []byte, addr net.Addr) (int, error) {
+	// Copy the payload before publishing it to readers.
 	data := make([]byte, len(p))
 	copy(data, p)
 	pkt := &incPacket{data: data, addr: addr}
+
+	// Publish the packet unless the caller has canceled.
 	select {
 	case <-ctx.Done():
 		return 0, ctx.Err()
@@ -101,6 +107,7 @@ func (c *packetConn) HandlePacket(ctx context.Context, p []byte, addr net.Addr) 
 // see SetDeadline and SetWriteDeadline.
 // On packet-oriented connections, write timeouts are rare.
 func (c *packetConn) WriteTo(p []byte, addr net.Addr) (n int, err error) {
+	// Apply the configured write deadline to the packet context.
 	deadline := c.wd
 	ctx := c.ctx
 	if !deadline.IsZero() {
@@ -109,6 +116,7 @@ func (c *packetConn) WriteTo(p []byte, addr net.Addr) (n int, err error) {
 		defer ctxCancel()
 	}
 
+	// Route the packet to the connected remote endpoint.
 	return c.writer(ctx, p, addr)
 }
 

--- a/net/transport/udp/udp.go
+++ b/net/transport/udp/udp.go
@@ -42,10 +42,13 @@ func NewUDP(
 	listenAddr string,
 	staticPeerMap map[string]*dialer.DialerOpts,
 ) (*UDP, error) {
+	// Open the UDP packet socket on the configured address.
 	pc, err := net.ListenPacket("udp", listenAddr)
 	if err != nil {
 		return nil, err
 	}
+
+	// Increase socket buffers when the listener is a UDP socket.
 	if uc, ok := pc.(*net.UDPConn); ok {
 		if err := uc.SetReadBuffer(ExtendedSockBuf); err != nil {
 			le.WithError(err).Warn("unable to set read buffer on conn")
@@ -55,6 +58,7 @@ func NewUDP(
 		}
 	}
 
+	// Construct the packet-backed transport around the socket.
 	pct, err := pconn.NewTransport(
 		ctx,
 		le,
@@ -71,6 +75,8 @@ func NewUDP(
 	if err != nil {
 		return nil, err
 	}
+
+	// Return the initialized UDP transport.
 	return &UDP{
 		Transport: pct,
 	}, nil

--- a/net/transport/webrtc/session.go
+++ b/net/transport/webrtc/session.go
@@ -153,11 +153,15 @@ func (s *sessionTracker) executeXmitSignal(ctx context.Context, sig *outgoingSig
 			err = pkgerrors.Errorf("xmit signal panic: %v\n%s", e, debug.Stack())
 		}
 	}()
+
+	// Encode the signal for the remote peer before transmission.
 	msgEnc, err := EncodeWebRtcSignal(sig.sig, s.peerPub)
 	if err != nil {
 		return pkgerrors.Wrap(err, "encode web rtc signal")
 	}
 	defer scrub.Scrub(msgEnc)
+
+	// Send the encrypted signal and mark it delivered.
 	if err := sig.sess.Send(ctx, msgEnc); err != nil {
 		return pkgerrors.Wrap(err, "send signaling message")
 	}
@@ -170,21 +174,25 @@ func (s *sessionTracker) executeLink(ctx context.Context, dcRwc datachannel.Read
 	// Packet conn: maximum packet size should be larger than the MTU quic uses.
 	// Use one that aligns with one memory page (4096 bytes)
 	// Buffer 8 packets at a time.
+	// Wrap the data channel as a packet connection with peer addresses.
 	localAddr := peer.NewNetAddr(s.w.peerID)
 	remoteAddr := peer.NewNetAddr(s.peerID)
 	pc := rwc.NewRwcPacketConn(dcRwc, localAddr, remoteAddr)
+
+	// Resolve the QUIC role from the deterministic offerer selection.
 	role := "client"
 	if s.offerer {
 		role = "server"
 	}
 	s.le.WithField("quic-role", role).Info("webrtc quic phase: data channel ready")
 
-	// Configure quic with settings specific to webRTC
+	// Configure QUIC for WebRTC data-channel transport.
 	linkOpts := s.w.conf.GetQuic().CloneVT()
 	if linkOpts == nil {
 		linkOpts = &transport_quic.Opts{}
 	}
 	linkOpts.DisableDatagrams = true
+
 	// Keep QUIC keepalive enabled for WebRTC links. The link rides a datachannel
 	// and can sit idle (a quiet resource stream, a lull between bursts) longer
 	// than MaxIdleTimeout; without keepalive PINGs quic-go reaps it with an idle
@@ -196,7 +204,7 @@ func (s *sessionTracker) executeLink(ctx context.Context, dcRwc datachannel.Read
 	linkOpts.DisablePathMtuDiscovery = true
 	linkOpts.MaxIdleTimeoutDur = "60s"
 
-	// Invert it so that the answerer dials the Quic link.
+	// Negotiate QUIC with the offerer listening and answerer dialing.
 	// This evenly splits responsibilities between the peers.
 	//
 	// Assuming peer A is the offerer and B the answerer:
@@ -238,6 +246,7 @@ func (s *sessionTracker) executeLink(ctx context.Context, dcRwc datachannel.Read
 	}
 	s.le.WithField("quic-role", role).Info("webrtc quic phase: handshake complete")
 
+	// Prepare link-close signaling before constructing the QUIC link.
 	errCh := make(chan error, 1)
 	var nextLink *transport_quic.Link
 	var wasClosed atomic.Bool
@@ -256,6 +265,7 @@ func (s *sessionTracker) executeLink(ctx context.Context, dcRwc datachannel.Read
 		errCh <- io.EOF
 	}
 
+	// Construct the link and report any construction failure.
 	nextLink, err = transport_quic.NewLink(
 		ctx,
 		s.le,
@@ -271,7 +281,7 @@ func (s *sessionTracker) executeLink(ctx context.Context, dcRwc datachannel.Read
 	}
 	s.le.WithField("quic-role", role).Info("webrtc quic phase: link constructed")
 
-	// Link established.
+	// Publish the link under the broadcast lock and notify the handler.
 	s.w.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
 		s.link = nextLink
 		broadcast()
@@ -279,14 +289,14 @@ func (s *sessionTracker) executeLink(ctx context.Context, dcRwc datachannel.Read
 	s.w.handler.HandleLinkEstablished(nextLink)
 	s.le.WithField("quic-role", role).Info("webrtc quic phase: link published")
 
-	// Cleanup link on exit
+	// Close the link if this execution exits before its close callback.
 	defer func() {
 		if !wasClosed.Load() {
 			go nextLink.Close()
 		}
 	}()
 
-	// Wait for the context to be canceled or routine canceled
+	// Wait for cancellation or link closure.
 	select {
 	case <-ctx.Done():
 		return context.Canceled
@@ -414,6 +424,7 @@ func (s *sessionTracker) newSession() (*session, <-chan struct{}, error) {
 		_ = pc.Close()
 		return nil, nil, err
 	}
+
 	// pc.OnDataChannel(sess.onDataChannel)
 	if s.w.GetVerbose() {
 		s.le.Debug("session constructed")
@@ -431,6 +442,7 @@ func (s *session) createDataChannel(
 
 	negotiated := true
 	protocol := dataChannelID
+
 	ordered := false // Allow unordered data since Quic can handle it.
 	var channelID uint16 = 1
 	return createDataChannel(dataChannelID, &webrtc.DataChannelInit{
@@ -526,6 +538,7 @@ func (s *session) onDataChannelOpen() {
 	if s.t.w.GetVerbose() {
 		s.t.le.Debugf("data channel open: %v", s.dc.Label())
 	}
+
 	// We set DetachDataChannels in the WebRTC settings engine.
 	rwc, err := s.dc.Detach()
 	if err != nil {
@@ -693,17 +706,22 @@ func (s *sessionTracker) execute(ctx context.Context) (err error) {
 	// Currently processed local sequence number.
 	var lastLocalSeqno, currRemoteSeqno uint64
 	var currLinkRwc datachannel.ReadWriteCloser
+
 	_ = currRemoteSeqno // TODO: remote restarted SDP?
+
 	// lastAppliedRemoteSdp is the SDP string we last applied via
 	// SetRemoteDescription. A byte-identical duplicate is ignored to avoid an
 	// unnecessary renegotiation / ICE restart.
 	var lastAppliedRemoteSdp string
+
 	// Which ICE candidate index did we send last?
 	var lastSentICE int
+
 	// sentIceComplete records whether the end-of-candidates marker has been
 	// transmitted for the current negotiation generation. It is reset whenever
 	// lastSentICE resets (a new local offer/answer regathers candidates).
 	var sentIceComplete bool
+
 	// pendingRemoteIce buffers remote ICE candidates that arrive before the
 	// remote description is set. pion's AddICECandidate requires a remote
 	// description, and the offerer routinely receives the answerer's trickled
@@ -714,6 +732,7 @@ func (s *sessionTracker) execute(ctx context.Context) (err error) {
 
 	for {
 		phase = "wait for session change"
+
 		// Wait for something to change or for an incoming signal.
 		var currIncomingSignal *incomingSignal
 
@@ -816,6 +835,7 @@ func (s *sessionTracker) execute(ctx context.Context) (err error) {
 		// Construct or tear down link as necessary.
 		if currDcRwc != currLinkRwc {
 			phase = "update link routine"
+
 			// Update the link routine and wait for the old link to exit.
 			waitReturn, changed, _, _ := linkRoutine.SetState(currDcRwc)
 			if changed && waitReturn != nil {
@@ -832,6 +852,7 @@ func (s *sessionTracker) execute(ctx context.Context) (err error) {
 		sdpType := currRxSdp.GetSdpType()
 		if sdpType != "" {
 			phase = "handle remote sdp"
+
 			// Enforce offerer always does the offering.
 			if s.offerer {
 				if sdpType != "answer" {
@@ -901,6 +922,7 @@ func (s *sessionTracker) execute(ctx context.Context) (err error) {
 			if err != nil {
 				return pkgerrors.Wrap(err, "parse remote ice candidate")
 			}
+
 			// Apply the candidate once a remote description exists; otherwise
 			// buffer it. pion drops candidates added with no remote description,
 			// and the offerer commonly receives the answerer's candidates before
@@ -954,6 +976,7 @@ func (s *sessionTracker) execute(ctx context.Context) (err error) {
 		// Transmit at most once at a time, we need to make sure to process remote messages in a timely fashion.
 		if len(currTxICE) != 0 {
 			phase = "transmit local ice"
+
 			// make sure waitCh hasn't proced already
 			select {
 			case <-ctx.Done():

--- a/net/transport/webrtc/signal.go
+++ b/net/transport/webrtc/signal.go
@@ -15,23 +15,27 @@ var SignalingCryptContext = "github.com/s4wave/spacewave/net 2024-01-15 17:58:55
 
 // EncodeWebRtcSignal marshals and encrypts the WebRtcSignal message.
 func EncodeWebRtcSignal(s *WebRtcSignal, dstPeer crypto.PubKey) ([]byte, error) {
+	// Marshal the signal before encrypting its serialized bytes.
 	msgSrc, err := s.MarshalVT()
 	if err != nil {
 		return nil, err
 	}
 	defer scrub.Scrub(msgSrc)
 
+	// Encrypt the serialized signal for the destination peer.
 	return peer.EncryptToPubKey(dstPeer, SignalingCryptContext, msgSrc)
 }
 
 // DecodeWebRtcSignal decrypts and unmarshals the WebRtcSignal message.
 func DecodeWebRtcSignal(msg []byte, privKey crypto.PrivKey) (*WebRtcSignal, error) {
+	// Decrypt the signal before unmarshaling its body.
 	msgDec, err := peer.DecryptWithPrivKey(privKey, SignalingCryptContext, msg)
 	if err != nil {
 		return nil, err
 	}
 	defer scrub.Scrub(msgDec)
 
+	// Unmarshal the decrypted signal.
 	out := &WebRtcSignal{}
 	if err := out.UnmarshalVT(msgDec); err != nil {
 		return nil, err
@@ -41,7 +45,7 @@ func DecodeWebRtcSignal(msg []byte, privKey crypto.PrivKey) (*WebRtcSignal, erro
 
 // Validate validates the WebRtcSignal message.
 func (m *WebRtcSignal) Validate() error {
-	// Validate body
+	// Validate the concrete signal body variant.
 	switch b := m.GetBody().(type) {
 	case *WebRtcSignal_RequestOffer:
 	case *WebRtcSignal_Sdp:
@@ -70,12 +74,15 @@ func NewWebRtcSdp(txSeqno uint64, desc *webrtc.SessionDescription) *WebRtcSdp {
 
 // Validate validates the WebRtcSdp message.
 func (s *WebRtcSdp) Validate() error {
+	// Require a non-empty and recognized SDP type.
 	if s.GetSdpType() == "" {
 		return errors.New("sdp_type: cannot be empty")
 	}
 	if s.ParseSDPType() == webrtc.SDPTypeUnknown {
 		return errors.Errorf("sdp_type: unknown sdp type: %v", s.GetSdpType())
 	}
+
+	// Parse the SDP payload to validate its structure.
 	if _, err := s.ParseSDP(); err != nil {
 		return err
 	}
@@ -121,10 +128,13 @@ func (s *WebRtcIce) Validate() error {
 
 // NewWebRtcIce constructs a new WebRtcIce from a ICECandidateInit.
 func NewWebRtcIce(candidate *webrtc.ICECandidateInit) (*WebRtcIce, error) {
+	// Marshal the ICE candidate before storing its JSON representation.
 	data, err := marshalICECandidateInit(candidate)
 	if err != nil {
 		return nil, err
 	}
+
+	// Return the encoded ICE candidate message.
 	return &WebRtcIce{Candidate: string(data)}, nil
 }
 

--- a/net/transport/webrtc/webrtc.go
+++ b/net/transport/webrtc/webrtc.go
@@ -127,6 +127,7 @@ func NewWebRTC(
 	c transport.TransportHandler,
 	opts ...Option,
 ) (*WebRTC, error) {
+	// Apply non-nil options to the transport configuration.
 	var o options
 	for _, opt := range opts {
 		if opt != nil {
@@ -134,21 +135,25 @@ func NewWebRTC(
 		}
 	}
 
+	// Resolve the configured transport type.
 	tptType := conf.GetTransportType()
 	if tptType == "" {
 		tptType = TransportType
 	}
 
+	// Derive the local peer identity.
 	peerID, err := peer.IDFromPrivateKey(pKey)
 	if err != nil {
 		return nil, err
 	}
 
+	// Build the TLS identity used by signaling sessions.
 	identity, err := p2ptls.NewIdentity(pKey)
 	if err != nil {
 		return nil, err
 	}
 
+	// Clone or initialize the QUIC options.
 	quicOpts := conf.GetQuic()
 	if quicOpts == nil {
 		quicOpts = &transport_quic.Opts{}
@@ -156,18 +161,19 @@ func NewWebRTC(
 		quicOpts = quicOpts.CloneVT()
 	}
 
-	// set webrtc-signal-rpc-specific quic opts
+	// Configure QUIC for WebRTC data channels.
 	quicOpts.DisableDatagrams = true
 	quicOpts.DisableKeepAlive = false
 	quicOpts.DisablePathMtuDiscovery = true
 
-	// Setup the webrtc API
+	// Build the WebRTC API and configuration.
 	settingEngine := webrtc.SettingEngine{}
 	settingEngine.DetachDataChannels()
 	applyICEOptions(&settingEngine, &o)
 	webrtcApi := webrtc.NewAPI(webrtc.WithSettingEngine(settingEngine))
 	webrtcConf := conf.WebRtc.ToWebRtcConfiguration()
 
+	// Assemble the transport state.
 	tpt := &WebRTC{
 		ctx:        ctx,
 		b:          b,
@@ -185,7 +191,7 @@ func NewWebRTC(
 		identity:   identity,
 	}
 
-	// The session tracker starts when we want a session with a remote peer.
+	// Initialize ingress leases and keyed session trackers.
 	tpt.incomingSessions = make(map[string]*signalIngress)
 	tpt.sessionTrackers = keyed.NewKeyedRefCount[string, *sessionTracker](
 		tpt.newSessionTracker,
@@ -241,10 +247,10 @@ func (w *WebRTC) GetPeerDialer(ctx context.Context, peerID peer.ID) (*dialer.Dia
 
 // Execute executes the transport as configured, returning any fatal error.
 func (w *WebRTC) Execute(ctx context.Context) error {
-	// Startup session trackers and signaling client
+	// Start session trackers for the execution context.
 	w.sessionTrackers.SetContext(ctx, true)
 
-	// If listening isn't disabled, handle incoming signals.
+	// Register the signaling handler when listening is enabled.
 	if !w.conf.GetDisableListen() {
 		handler := NewWebRTCSignalHandler(w)
 		relSignalHandler, err := w.b.AddController(ctx, handler, nil)
@@ -272,8 +278,7 @@ func (w *WebRTC) DialPeer(
 	peerID peer.ID,
 	addr string,
 ) (olnk link.Link, fatal bool, err error) {
-	// Ignore the address, since there is no address associated w/ WebRTC connections.
-	// Get the peer ID string
+	// Resolve the peer identity and reject blocked peers.
 	peerIDStr := peerID.String()
 	if slices.Contains(w.conf.GetBlockPeers(), peerIDStr) {
 		return nil, false, nil
@@ -285,9 +290,10 @@ func (w *WebRTC) DialPeer(
 	var lnk *transport_quic.Link
 
 	w.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
-		// Add the session reference.
+		// Add or reuse the keyed session tracker reference.
 		var existed bool
 		ref, tkr, existed, err = w.addSessionTrackerRef(peerIDStr)
+
 		// Notify signal handlers if it didn't exist
 		if err == nil && !existed {
 			broadcast()
@@ -304,7 +310,7 @@ func (w *WebRTC) DialPeer(
 		return nil, false, err
 	}
 
-	// Wait for the link to be established
+	// Wait until the session tracker publishes a link.
 	for lnk == nil {
 		select {
 		case <-ctx.Done():
@@ -312,6 +318,7 @@ func (w *WebRTC) DialPeer(
 		case <-waitCh:
 		}
 
+		// Refresh the link snapshot and wait channel under the broadcast lock.
 		w.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
 			lnk = tkr.link
 			waitCh = getWaitCh()
@@ -323,6 +330,7 @@ func (w *WebRTC) DialPeer(
 
 // Close closes the transport, returning any errors closing.
 func (w *WebRTC) Close() error {
+	// Stop session trackers and release the signaling handler.
 	w.sessionTrackers.ClearContext()
 	w.bcast.HoldLock(func(broadcast func(), getWaitCh func() <-chan struct{}) {
 		if w.relSignalHandler != nil {
@@ -335,13 +343,13 @@ func (w *WebRTC) Close() error {
 
 // addSessionTrackerRef validates the peer id string and adds a session tracker ref.
 func (w *WebRTC) addSessionTrackerRef(peerIDStr string) (*keyed.KeyedRef[string, *sessionTracker], *sessionTracker, bool, error) {
-	// assert that we can extract the public key from the peer id
+	// Parse the remote identity and public key before tracking its session.
 	peerID, peerPub, err := peer.ParsePeerIDWithPubKey(peerIDStr)
 	if err != nil {
 		return nil, nil, false, err
 	}
 
-	// assert that we are not trying to open a session with ourselves
+	// Reject attempts to establish a session with the local peer.
 	if w.peerID.MatchesPublicKey(peerPub) {
 		return nil, nil, false, errors.New("signaling: cannot self-dial")
 	}

--- a/net/transport/websocket/http/http.go
+++ b/net/transport/websocket/http/http.go
@@ -31,21 +31,25 @@ type WebSocketHttp struct {
 
 // NewWebSocketHttp builds a new WebSocket http handler controller.
 func NewWebSocketHttp(le *logrus.Entry, b bus.Bus, conf *Config) (*WebSocketHttp, error) {
+	// Resolve the configured peer identity before registering handlers.
 	peerID, err := conf.ParseTransportPeerID()
 	if err != nil {
 		return nil, err
 	}
 
+	// Create the mux that will serve configured HTTP patterns.
 	mux := http.NewServeMux()
 	ctrl := &WebSocketHttp{mux: mux}
 
-	// Ensure no duplicate patterns (causes a panic in net/http)
+	// Track patterns so net/http does not receive duplicates.
 	seenPatterns := make(map[string]struct{}, len(conf.GetHttpPatterns())+len(conf.GetPeerHttpPatterns()))
 	checkPattern := func(httpPattern string) bool {
+		// Ignore empty patterns before checking registrations.
 		if len(httpPattern) == 0 {
 			return false
 		}
 
+		// Reject patterns already registered on this mux.
 		if _, ok := seenPatterns[httpPattern]; ok {
 			le.
 				WithField("http-pattern", httpPattern).
@@ -53,22 +57,26 @@ func NewWebSocketHttp(le *logrus.Entry, b bus.Bus, conf *Config) (*WebSocketHttp
 			return false
 		}
 
+		// Record the accepted pattern for later registrations.
 		seenPatterns[httpPattern] = struct{}{}
 		return true
 	}
 
+	// Register WebSocket endpoint patterns.
 	for _, httpPattern := range conf.GetHttpPatterns() {
 		if checkPattern(httpPattern) {
 			mux.HandleFunc(httpPattern, ctrl.ServeWebSocketHTTP)
 		}
 	}
 
+	// Register peer identity endpoint patterns.
 	for _, peerHttpPattern := range conf.GetPeerHttpPatterns() {
 		if checkPattern(peerHttpPattern) {
 			mux.HandleFunc(peerHttpPattern, ctrl.ServePeerHTTP)
 		}
 	}
 
+	// Construct the transport controller with the WebSocket factory.
 	ctrl.Controller = transport_controller.NewController(
 		le,
 		b,
@@ -123,6 +131,7 @@ func (t *WebSocketHttp) ServePeerHTTP(rw http.ResponseWriter, req *http.Request)
 	}
 
 	rw.WriteHeader(200)
+
 	_, _ = rw.Write([]byte(tpt.GetPeerID().String())) //nolint:gosec // peer ID is not user-controlled
 }
 

--- a/net/transport/websocket/packet-conn.go
+++ b/net/transport/websocket/packet-conn.go
@@ -33,6 +33,7 @@ func (c *PacketConn) LocalAddr() net.Addr {
 
 // ReadMessage reads a single message from the connection.
 func (c *PacketConn) ReadMessage() ([]byte, error) {
+	// Apply the configured read deadline to the connection context.
 	ctx := c.ctx
 	if rd := c.rd; !rd.IsZero() {
 		var cancel context.CancelFunc
@@ -40,18 +41,21 @@ func (c *PacketConn) ReadMessage() ([]byte, error) {
 		defer cancel()
 	}
 
+	// Read the next WebSocket message.
 	_, data, err := c.ws.Read(ctx)
 	return data, err
 }
 
 // ReadFrom reads a packet from the connection.
 func (c *PacketConn) ReadFrom(p []byte) (n int, addr net.Addr, err error) {
+	// Return EOF when the connection context is already closed.
 	select {
 	case <-c.ctx.Done():
 		return 0, nil, io.EOF
 	default:
 	}
 
+	// Read one message and translate clean closure to EOF.
 	data, err := c.ReadMessage()
 	if err != nil {
 		if isCleanReadClose(err) {
@@ -59,6 +63,8 @@ func (c *PacketConn) ReadFrom(p []byte) (n int, addr net.Addr, err error) {
 		}
 		return 0, nil, err
 	}
+
+	// Copy the message payload and report truncation.
 	dlen := len(data)
 	copy(p, data)
 	if len(p) < len(data) {
@@ -69,12 +75,15 @@ func (c *PacketConn) ReadFrom(p []byte) (n int, addr net.Addr, err error) {
 
 // WriteMessage writes a single message to the connection.
 func (c *PacketConn) WriteMessage(msg []byte) error {
+	// Apply the configured write deadline to the connection context.
 	ctx := c.ctx
 	if wd := c.wd; !wd.IsZero() {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithDeadline(ctx, wd)
 		defer cancel()
 	}
+
+	// Write the message as a binary WebSocket frame.
 	return c.ws.Write(ctx, websocket.MessageBinary, msg)
 }
 
@@ -83,6 +92,7 @@ func (c *PacketConn) WriteMessage(msg []byte) error {
 // fixed time limit; see SetDeadline and SetWriteDeadline.
 // On packet-oriented connections, write timeouts are rare.
 func (c *PacketConn) WriteTo(p []byte, addr net.Addr) (n int, err error) {
+	// Verify that packet writes target the bound remote address.
 	if addr != c.raddr {
 		as := addr.String()
 		rs := c.raddr.String()
@@ -90,6 +100,8 @@ func (c *PacketConn) WriteTo(p []byte, addr net.Addr) (n int, err error) {
 			return 0, errors.Errorf("packet conn bound to %s and cannot write to %s", rs, as)
 		}
 	}
+
+	// Write the packet payload after validating its destination.
 	if err := c.WriteMessage(p); err != nil {
 		return 0, err
 	}
@@ -148,10 +160,12 @@ func (c *PacketConn) Close() error {
 }
 
 func isCleanReadClose(err error) bool {
+	// Treat cancellation, EOF, and normal closure as clean reads.
 	if err == context.Canceled || errors.Is(err, context.Canceled) || errors.Is(err, io.EOF) {
 		return true
 	}
 
+	// Recognize normal WebSocket closure statuses.
 	switch websocket.CloseStatus(err) {
 	case websocket.StatusNormalClosure, websocket.StatusGoingAway:
 		return true

--- a/net/transport/websocket/websocket.go
+++ b/net/transport/websocket/websocket.go
@@ -51,11 +51,13 @@ func NewWebSocket(
 	pKey crypto.PrivKey,
 	c transport.TransportHandler,
 ) (*WebSocket, error) {
+	// Derive the local peer identity used by the transport and packet addresses.
 	peerID, err := peer.IDFromPrivateKey(pKey)
 	if err != nil {
 		return nil, err
 	}
 
+	// Resolve and clone the configured QUIC options.
 	quicOpts := conf.GetQuic()
 	if quicOpts == nil {
 		quicOpts = &transport_quic.Opts{}
@@ -63,21 +65,24 @@ func NewWebSocket(
 		quicOpts = quicOpts.CloneVT()
 	}
 
-	// set websocket-specific quic opts
+	// Disable QUIC features that WebSocket cannot carry.
 	quicOpts.DisableDatagrams = true
 	quicOpts.DisablePathMtuDiscovery = true
 
-	// websocket manages connection lifecycle, not quic
+	// Let WebSocket own connection liveness instead of QUIC.
 	quicOpts.DisableKeepAlive = true
 	quicOpts.MaxIdleTimeoutDur = "24h"
 
+	// Build the transport shell before wiring its dial function.
 	tpt := &WebSocket{
 		ctx:  ctx,
 		le:   le,
 		conf: conf,
 	}
 
+	// Dial WebSocket connections and negotiate a QUIC session over each one.
 	var dialFn transport_quic.DialFunc = func(dctx context.Context, addr string) (*quic.Conn, net.Addr, error) {
+		// Establish the WebSocket connection with the QUIC subprotocol.
 		conn, _, err := websocket.Dial(dctx, addr, &websocket.DialOptions{
 			// Negotiate the bifrost quic sub-protocol ID.
 			Subprotocols: []string{transport_quic.Alpn},
@@ -85,10 +90,11 @@ func NewWebSocket(
 		if err != nil {
 			return nil, nil, err
 		}
+
+		// Wrap the WebSocket and negotiate the QUIC session.
 		laddr := peer.NewNetAddr(peerID)
 		raddr := saddr.NewStringAddr("ws", addr)
 		pc := NewPacketConn(ctx, conn, laddr, raddr)
-		// Negotiate quic session.
 		qconn, _, err := transport_quic.DialSession(ctx, le, quicOpts, pc, tpt.GetIdentity(), raddr, "")
 		if err != nil {
 			return nil, raddr, err
@@ -96,6 +102,7 @@ func NewWebSocket(
 		return qconn, raddr, nil
 	}
 
+	// Install the QUIC-backed transport implementation.
 	tpt.Transport, err = transport_quic.NewTransport(
 		ctx,
 		le,
@@ -130,11 +137,13 @@ func (w *WebSocket) GetPeerDialer(ctx context.Context, peerID peer.ID) (*dialer.
 // Execute executes the transport as configured, returning any fatal error.
 func (w *WebSocket) Execute(ctx context.Context) error {
 	// note: w.Transport.Execute is unnecessary (no-op for quic)
+	// Skip listening when no HTTP address is configured.
 	listenAddr := w.conf.GetListenAddr()
 	if listenAddr == "" {
 		return nil
 	}
 
+	// Run the HTTP listener until the transport or caller stops it.
 	errCh := make(chan error, 1)
 	go func() {
 		errCh <- w.ListenHTTP(ctx, listenAddr)
@@ -152,10 +161,13 @@ func (w *WebSocket) Execute(ctx context.Context) error {
 
 // ListenHTTP listens for incoming HTTP connections on an address.
 func (w *WebSocket) ListenHTTP(ctx context.Context, addr string) error {
+	// Log the listening endpoint before constructing the HTTP server.
 	w.le.WithFields(logrus.Fields{
 		"addr":    addr,
 		"peer-id": w.GetPeerID().String(),
 	}).Debug("listening for http/ws")
+
+	// Configure the HTTP server with the transport lifecycle context.
 	server := &http.Server{
 		BaseContext: func(net.Listener) context.Context {
 			return ctx
@@ -164,6 +176,8 @@ func (w *WebSocket) ListenHTTP(ctx context.Context, addr string) error {
 		Handler:           w,
 		ReadHeaderTimeout: time.Second * 10,
 	}
+
+	// Serve requests, then shut down and close the server.
 	err := server.ListenAndServe()
 	if serr := server.Shutdown(ctx); serr != nil && serr != context.Canceled {
 		w.le.WithError(serr).Warn("graceful shutdown failed")
@@ -174,31 +188,32 @@ func (w *WebSocket) ListenHTTP(ctx context.Context, addr string) error {
 
 // ServeHTTP serves the websocket upgraded HTTP endpoint.
 func (w *WebSocket) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	// Return a not-found response and record the rejected request.
 	returnNotFound := func() {
 		rw.WriteHeader(404)
 		_, _ = rw.Write([]byte("404 - Page not found\n"))
 		httplog.WithLoggerFields(w.le, req, 404).Debug("request not found")
 	}
 
+	// Read the configured paths used to route this request.
 	httpPath := req.URL.Path
 	confPath := w.conf.GetHttpPath()
 	httpPeerPath := w.conf.GetHttpPeerPath()
 
-	// Serve peer ID if enabled
+	// Serve the local peer ID endpoint when it is configured.
 	if httpPeerPath != "" && httpPath == httpPeerPath {
-		// Serve peer ID
 		rw.WriteHeader(200)
 		_, _ = rw.Write([]byte(w.GetPeerID().String()))
 		return
 	}
 
-	// Filter http path if set
+	// Reject requests outside the configured WebSocket path.
 	if confPath != "" && req.URL.Path != confPath {
 		returnNotFound()
 		return
 	}
 
-	// Accept websocket
+	// Upgrade the request and negotiate the QUIC subprotocol.
 	c, err := websocket.Accept(rw, req, &websocket.AcceptOptions{
 		// Negotiate the bifrost quic sub-protocol ID.
 		Subprotocols: []string{transport_quic.Alpn},
@@ -216,6 +231,7 @@ func (w *WebSocket) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	// Attach the upgraded connection to a QUIC link.
 	raddr := saddr.NewStringAddr("ws", req.RemoteAddr)
 	pc := NewPacketConn(req.Context(), c, w.LocalAddr(), raddr)
 	lnk, err := w.HandleConn(w.ctx, false, pc, raddr, "")
@@ -228,7 +244,7 @@ func (w *WebSocket) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	// hold the HTTP request open until something closes.
+	// Keep the HTTP request open until the transport, link, or request closes.
 	httplog.
 		WithLoggerFields(w.le, req, 200).
 		Debug("started websocket conn")
@@ -237,6 +253,8 @@ func (w *WebSocket) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	case <-lnk.GetContext().Done():
 	case <-req.Context().Done():
 	}
+
+	// Close the packet connection and link after the request lifecycle ends.
 	_ = pc.Close()
 	_ = lnk.Close()
 }

--- a/net/util/confparse/keys.go
+++ b/net/util/confparse/keys.go
@@ -23,6 +23,7 @@ func ParsePeer(
 	// The peer ID should contain the public key.
 	peerId string,
 ) (peer.Peer, error) {
+	// Prefer the configured private key, then public key, then peer ID.
 	pkey, err := ParsePrivateKey(privKey)
 	if err != nil {
 		return nil, err
@@ -31,6 +32,7 @@ func ParsePeer(
 		return peer.NewPeer(pkey)
 	}
 
+	// Fall back to the configured public key when no private key is present.
 	pub, err := ParsePublicKey(pubKey)
 	if err != nil {
 		return nil, err
@@ -39,6 +41,7 @@ func ParsePeer(
 		return peer.NewPeerWithPubKey(pub)
 	}
 
+	// Resolve the peer ID only after key-based forms are absent.
 	peerID, err := ParsePeerID(peerId)
 	if err != nil {
 		return nil, err

--- a/net/util/confparse/urls.go
+++ b/net/util/confparse/urls.go
@@ -28,6 +28,7 @@ func ValidateURL(uri string, allowEmpty bool) error {
 //
 // Removes any empty values.
 func ParseURLs(urlStrs []string, allowEmpty bool) ([]*url.URL, error) {
+	// Parse each configured URL and omit allowed empty entries.
 	urls := make([]*url.URL, 0, len(urlStrs))
 	for i, urlStr := range urlStrs {
 		v, err := ParseURL(urlStr)

--- a/net/util/randstring/randstring.go
+++ b/net/util/randstring/randstring.go
@@ -18,14 +18,18 @@ const (
 // Pass nil to use a random seed.
 // https://stackoverflow.com/questions/22892120
 func RandString(src *mrand.Rand, n int) string {
+	// Seed a local generator when the caller did not provide one.
 	if src == nil {
 		var seed [32]byte
 		_, _ = rand.Read(seed[:])
+
 		src = mrand.New(mrand.NewChaCha8(seed)) //nolint:gosec
 	}
 
+	// Build the requested identifier from random alphabet indexes.
 	sb := strings.Builder{}
 	sb.Grow(n)
+
 	// A src.Int64() generates 64 random bits, enough for letterIdxMax characters!
 	for i, cache, remain := n-1, src.Int64(), letterIdxMax; i >= 0; {
 		if remain == 0 {

--- a/net/util/rwc/conn.go
+++ b/net/util/rwc/conn.go
@@ -72,6 +72,7 @@ func (p *Conn) RemoteAddr() net.Addr {
 // Read can be made to time out and return an error after a fixed
 // time limit; see SetDeadline and SetReadDeadline.
 func (p *Conn) Read(b []byte) (n int, err error) {
+	// Apply the configured read deadline to the connection context.
 	deadline := p.rd
 	ctx := p.ctx
 	if !deadline.IsZero() {
@@ -80,6 +81,7 @@ func (p *Conn) Read(b []byte) (n int, err error) {
 		defer ctxCancel()
 	}
 
+	// Wait for the next buffered payload or a connection close.
 	var pkt []byte
 	var ok bool
 	select {
@@ -98,6 +100,7 @@ func (p *Conn) Read(b []byte) (n int, err error) {
 		}
 	}
 
+	// Copy the payload into the caller's buffer and release its arena slot.
 	pl := len(pkt)
 	copy(b, pkt)
 	p.ar.Put(&pkt)
@@ -109,10 +112,12 @@ func (p *Conn) Read(b []byte) (n int, err error) {
 
 // Write writes data to the connection.
 func (p *Conn) Write(pkt []byte) (n int, err error) {
+	// Write the complete payload, retrying partial writes.
 	if len(pkt) == 0 {
 		return 0, nil
 	}
 
+	// Continue writing until the entire payload is transmitted.
 	written := 0
 	for written < len(pkt) {
 		n, err = p.rwc.Write(pkt[written:])
@@ -202,6 +207,7 @@ func (p *Conn) rxPump() (rerr error) {
 		close(p.packetCh)
 	}()
 
+	// Read packets until cancellation or the underlying stream closes.
 	for {
 		select {
 		case <-p.ctx.Done():
@@ -209,6 +215,7 @@ func (p *Conn) rxPump() (rerr error) {
 		default:
 		}
 
+		// Read into a reusable packet buffer and enqueue received bytes.
 		pktBuf := p.getArenaBuf(int(connPktSize))
 		n, err := p.rwc.Read(pktBuf)
 		if n == 0 {

--- a/net/util/rwc/packet-conn.go
+++ b/net/util/rwc/packet-conn.go
@@ -85,6 +85,7 @@ func (p *PacketConn) RemoteAddr() net.Addr {
 // ReadFrom can be made to time out and return an error after a
 // fixed time limit; see SetDeadline and SetReadDeadline.
 func (p *PacketConn) ReadFrom(pk []byte) (n int, addr net.Addr, err error) {
+	// Apply the configured read deadline to the connection context.
 	deadline := p.rd
 	ctx := p.ctx
 	if !deadline.IsZero() {
@@ -93,6 +94,7 @@ func (p *PacketConn) ReadFrom(pk []byte) (n int, addr net.Addr, err error) {
 		defer ctxCancel()
 	}
 
+	// Wait for the next complete packet or a connection close.
 	var pkt []byte
 	var ok bool
 	select {
@@ -108,6 +110,7 @@ func (p *PacketConn) ReadFrom(pk []byte) (n int, addr net.Addr, err error) {
 		}
 	}
 
+	// Copy the packet into the caller's buffer and return its address.
 	pl := len(pkt)
 	copy(pk, pkt)
 	p.ar.Put(&pkt)
@@ -122,10 +125,12 @@ func (p *PacketConn) ReadFrom(pk []byte) (n int, addr net.Addr, err error) {
 // fixed time limit; see SetDeadline and SetWriteDeadline.
 // On packet-oriented connections, write timeouts are rare.
 func (p *PacketConn) WriteTo(pkt []byte, addr net.Addr) (n int, err error) {
+	// Reject empty packets before checking the destination address.
 	if len(pkt) == 0 {
 		return 0, nil
 	}
 
+	// Enforce the packet connection's bound remote address.
 	if addr != p.raddr {
 		as := addr.String()
 		rs := p.raddr.String()
@@ -134,11 +139,13 @@ func (p *PacketConn) WriteTo(pkt []byte, addr net.Addr) (n int, err error) {
 		}
 	}
 
+	// Encode the payload length and write one framed packet.
 	pktLen := len(pkt)
 	if pktLen > math.MaxInt32 {
 		return 0, errors.New("message too large: exceeds maximum uint32 value")
 	}
 
+	// Reserve an arena buffer for the length-prefixed packet.
 	buf := p.getArenaBuf(pktLen + 4)
 	binary.LittleEndian.PutUint32(buf, uint32(pktLen))
 
@@ -235,6 +242,7 @@ func (p *PacketConn) rxPump() (rerr error) {
 		close(p.packetCh)
 	}()
 
+	// Read and validate each packet header from the underlying stream.
 	var header [4]byte
 	for {
 		select {
@@ -243,11 +251,13 @@ func (p *PacketConn) rxPump() (rerr error) {
 		default:
 		}
 
+		// Read the fixed-size packet header.
 		_, err := io.ReadFull(p.rwc, header[:])
 		if err != nil {
 			return err
 		}
 
+		// Reject packet lengths outside the configured bounds.
 		pktLen := binary.LittleEndian.Uint32(header[:])
 		if pktLen == 0 {
 			return errors.New("received header indicating zero packet size")
@@ -256,6 +266,7 @@ func (p *PacketConn) rxPump() (rerr error) {
 			return errors.Errorf("indicated packet size %d larger than max size %d", pktLen, p.maxPacketSize)
 		}
 
+		// Read the payload and enqueue it for callers.
 		pktBuf := p.getArenaBuf(int(pktLen))
 		_, err = io.ReadFull(p.rwc, pktBuf)
 		if err != nil {

--- a/net/util/rwc/rwc.go
+++ b/net/util/rwc/rwc.go
@@ -30,6 +30,7 @@ func (r *ReadWriteCloser) Write(p []byte) (n int, err error) {
 
 // Close closes both streams.
 func (r *ReadWriteCloser) Close() error {
+	// Close both streams before reporting either error.
 	er1 := r.reader.Close()
 	er2 := r.writer.Close()
 	if er1 != nil {

--- a/plugin/cli/controller.go
+++ b/plugin/cli/controller.go
@@ -49,12 +49,16 @@ func NewFactory(b bus.Bus) controller.Factory {
 
 // HandleDirective asks if the handler can resolve the directive.
 func (c *Controller) HandleDirective(ctx context.Context, di directive.Instance) ([]directive.Resolver, error) {
+	// Inspect the requested RPC service directive.
 	switch d := di.GetDirective().(type) {
 	case bifrost_rpc.LookupRpcService:
+		// Resolve the CLI terminal service when its ID matches.
 		if d.LookupRpcServiceID() == s4wave_cli_terminal.SRPCCliTerminalServiceServiceID {
 			return directive.R(bifrost_rpc.NewLookupRpcServiceResolver(c.mux), nil)
 		}
 	}
+
+	// Leave unsupported RPC services unresolved.
 	return nil, nil
 }
 

--- a/plugin/cli/terminal-service.go
+++ b/plugin/cli/terminal-service.go
@@ -532,7 +532,10 @@ type browserCommandOptions struct {
 }
 
 func parseBrowserCommandOptions(args []string, allowWatch bool) (browserCommandOptions, error) {
+	// Initialize defaults shared by all browser CLI commands.
 	opts := browserCommandOptions{outputFormat: "text", sessionIdx: 1}
+
+	// Parse flags and retain positional command arguments.
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
 		switch {

--- a/plugin/sql/controller.go
+++ b/plugin/sql/controller.go
@@ -71,12 +71,14 @@ func NewFactory(b bus.Bus) controller.Factory {
 
 // Execute registers SQL ObjectTypes, WorldOps, viewers, and Quickstart metadata.
 func (c *Controller) Execute(ctx context.Context) error {
+	// Connect to the core plugin resources.
 	resources, err := s4wave_plugin.ConnectPluginResources(ctx, c.GetBus(), "spacewave-core")
 	if err != nil {
 		return err
 	}
 	defer resources.Release()
 
+	// Resolve the core root resource client.
 	rootRef := resources.Client.AccessRootResource()
 	rootClient, err := rootRef.GetClient()
 	if err != nil {
@@ -85,6 +87,7 @@ func (c *Controller) Execute(ctx context.Context) error {
 	}
 	defer rootRef.Release()
 
+	// Register SQL resources and retain their references for the controller lifetime.
 	refs, err := c.registerSQL(ctx, resources.Client, rootClient)
 	if err != nil {
 		releaseRefs(refs)
@@ -92,33 +95,42 @@ func (c *Controller) Execute(ctx context.Context) error {
 	}
 	defer releaseRefs(refs)
 
+	// Keep registrations active until the controller context ends.
 	<-ctx.Done()
 	return nil
 }
 
 // HandleDirective asks if the handler can resolve the directive.
 func (c *Controller) HandleDirective(ctx context.Context, di directive.Instance) ([]directive.Resolver, error) {
+	// Inspect the directive type requested by the bus.
 	switch d := di.GetDirective().(type) {
 	case bifrost_rpc.LookupRpcService:
+		// Resolve the SQL resource service when its ID matches.
 		if d.LookupRpcServiceID() == resource.SRPCResourceServiceServiceID {
 			return directive.R(bifrost_rpc.NewLookupRpcServiceResolver(c.mux), nil)
 		}
 	case blocktype.LookupBlockType:
+		// Require a block type ID before creating a resolver.
 		typeID := d.LookupBlockTypeID()
 		if typeID == "" {
 			return nil, nil
 		}
 		return directive.R(directive.NewFuncResolver(func(ctx context.Context, handler directive.ResolverHandler) error {
+			// Resolve the SQL block type from its registered ID.
 			blockType, err := lookupSQLBlockType(typeID)
 			if err != nil {
 				return err
 			}
+
+			// Publish the block type when the registry contains it.
 			if blockType != nil {
 				_, _ = handler.AddValue(blockType)
 			}
 			return nil
 		}), nil)
 	}
+
+	// Leave unsupported directives unresolved.
 	return nil, nil
 }
 
@@ -127,6 +139,7 @@ func (c *Controller) registerSQL(
 	client *resource_client.Client,
 	rootClient srpc.Client,
 ) ([]resource_client.ResourceRef, error) {
+	// Track resource references so registrations can be released together.
 	var refs []resource_client.ResourceRef
 	retain := func(label string, resourceID uint32) error {
 		if resourceID == 0 {
@@ -136,6 +149,7 @@ func (c *Controller) registerSQL(
 		return nil
 	}
 
+	// Register SQL object types with the core registry.
 	otSvc := s4wave_objecttype_registry.NewSRPCObjectTypeRegistryResourceServiceClient(rootClient)
 	for _, typeID := range sqlObjectTypeIDs {
 		resp, err := otSvc.RegisterObjectType(ctx, &s4wave_objecttype_registry.RegisterObjectTypeRequest{
@@ -150,6 +164,7 @@ func (c *Controller) registerSQL(
 		}
 	}
 
+	// Register SQL world operations with the core registry.
 	woSvc := s4wave_worldop_registry.NewSRPCWorldOpRegistryResourceServiceClient(rootClient)
 	for _, opID := range sqlWorldOpIDs {
 		resp, err := woSvc.RegisterWorldOp(ctx, &s4wave_worldop_registry.RegisterWorldOpRequest{
@@ -164,6 +179,7 @@ func (c *Controller) registerSQL(
 		}
 	}
 
+	// Register the SQL quickstart metadata.
 	qsSvc := s4wave_quickstart_registry.NewSRPCQuickstartRegistryResourceServiceClient(rootClient)
 	quickstart, err := qsSvc.RegisterQuickstart(ctx, &s4wave_quickstart_registry.RegisterQuickstartRequest{
 		Registration: &s4wave_quickstart_registry.QuickstartRegistration{
@@ -184,6 +200,7 @@ func (c *Controller) registerSQL(
 		return refs, err
 	}
 
+	// Register SQL viewers with the core registry.
 	viewerSvc := s4wave_viewer_registry.NewSRPCViewerRegistryResourceServiceClient(rootClient)
 	for _, viewer := range sqlViewerRegistrations {
 		resp, err := viewerSvc.RegisterViewer(ctx, &s4wave_viewer_registry.RegisterViewerRequest{Registration: viewer})
@@ -199,6 +216,7 @@ func (c *Controller) registerSQL(
 }
 
 func releaseRefs(refs []resource_client.ResourceRef) {
+	// Release registrations in reverse order of acquisition.
 	for i := len(refs) - 1; i >= 0; i-- {
 		refs[i].Release()
 	}

--- a/prototypes/git-clone-test/main.go
+++ b/prototypes/git-clone-test/main.go
@@ -11,16 +11,18 @@ import (
 )
 
 func main() {
+	// Resolve the requested repository URL.
 	url := "."
 	if len(os.Args) > 1 {
 		url = os.Args[1]
 	}
 
+	// Prepare in-memory storage and a filesystem for the recursive clone.
 	log.Printf("cloning %s (recursive)...", url)
-
 	fs := billy_memfs.New()
 	storer := memory.NewStorage()
 
+	// Clone the repository and report the result.
 	_, err := git.Clone(storer, fs, &git.CloneOptions{
 		URL:               url,
 		RecurseSubmodules: git.DefaultSubmoduleRecursionDepth,

--- a/prototypes/opfs/store/handle-cache.go
+++ b/prototypes/opfs/store/handle-cache.go
@@ -27,6 +27,7 @@ func newHandleCache() *handleCache {
 // acquire increments the refcount for a file (or opens it if not cached).
 // The caller must provide the FileHandle to open from if not cached.
 func (c *handleCache) acquire(name string, fh *opfs.FileHandle) (opfs.FileOps, error) {
+	// Lock the cache while resolving or opening the named handle.
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -35,6 +36,7 @@ func (c *handleCache) acquire(name string, fh *opfs.FileHandle) (opfs.FileOps, e
 		return e.handle, nil
 	}
 
+	// Open and retain a new handle when the cache has no entry.
 	ops, err := fh.OpenFileOps()
 	if err != nil {
 		return nil, err
@@ -45,6 +47,7 @@ func (c *handleCache) acquire(name string, fh *opfs.FileHandle) (opfs.FileOps, e
 
 // release decrements the refcount, closing the handle when it reaches zero.
 func (c *handleCache) release(name string) {
+	// Lock the cache while decrementing the named handle reference.
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -54,6 +57,7 @@ func (c *handleCache) release(name string) {
 	}
 	e.refcount--
 	if e.refcount <= 0 {
+		// Close and remove handles whose final reference was released.
 		_ = e.handle.Close()
 		delete(c.entries, name)
 	}
@@ -61,6 +65,7 @@ func (c *handleCache) release(name string) {
 
 // closeAll closes all cached handles.
 func (c *handleCache) closeAll() {
+	// Close every cached handle while holding the cache lock.
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	for name, e := range c.entries {

--- a/prototypes/opfs/store/store.go
+++ b/prototypes/opfs/store/store.go
@@ -29,10 +29,13 @@ type Store struct {
 // NewStore creates a new OPFS store rooted at the given directory.
 // It creates a "data" subdirectory for key-value storage.
 func NewStore(root *opfs.DirectoryHandle) (*Store, error) {
+	// Create the data directory that stores key-value files.
 	data, err := root.GetDirectoryHandle("data", true)
 	if err != nil {
 		return nil, err
 	}
+
+	// Assemble the store handles and file cache.
 	s := &Store{
 		root:  root,
 		data:  data,
@@ -43,6 +46,7 @@ func NewStore(root *opfs.DirectoryHandle) (*Store, error) {
 
 // Open creates a new OPFS store in a subdirectory of the OPFS root.
 func Open(name string) (*Store, error) {
+	// Resolve or create the named OPFS root directory.
 	root, err := opfs.GetRootDirectory()
 	if err != nil {
 		return nil, err
@@ -56,10 +60,13 @@ func Open(name string) (*Store, error) {
 
 // NewTransaction returns a new transaction against the store.
 func (s *Store) NewTransaction(ctx context.Context, write bool) (kvtx.Tx, error) {
+	// Create a read transaction shared by either transaction mode.
 	readTx := newTx(s, false)
 	if !write {
 		return readTx, nil
 	}
+
+	// Wrap write transactions with the transaction cache and discard callback.
 	return kvtx_txcache.NewTxWithCbs(readTx, true, readTx.Discard, func() (kvtx.Tx, error) {
 		return newTx(s, true), nil
 	}, true)

--- a/sdk/apt/import.go
+++ b/sdk/apt/import.go
@@ -53,6 +53,7 @@ func ImportDebPackage(
 	packageKey string,
 	deb []byte,
 ) (*AptPackage, *block.BlockRef, error) {
+	// Validate the world and package identifiers before importing data.
 	if ws == nil {
 		return nil, nil, errors.New("world state is required")
 	}
@@ -66,17 +67,20 @@ func ImportDebPackage(
 		return nil, nil, err
 	}
 
+	// Parse the Debian package and compute its checksums.
 	parsed, err := ParseDebPackage(deb)
 	if err != nil {
 		return nil, nil, err
 	}
 	parsed.Checksums = AptPackageChecksums(deb)
 
+	// Resolve the existing package target, if any.
 	objectState, existing, err := lookupAptPackageImportTarget(ctx, ws, packageKey)
 	if err != nil {
 		return nil, nil, err
 	}
 
+	// Allocate storage and complete the imported package state.
 	cursor, err := ws.BuildStorageCursor(ctx)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "build storage cursor")
@@ -92,6 +96,7 @@ func ImportDebPackage(
 		return nil, nil, err
 	}
 
+	// Create and initialize a package object when none exists.
 	if objectState == nil {
 		op := NewAddAptPackageOp(repositoryKey, packageKey, parsed)
 		if _, _, err := ws.ApplyWorldOp(ctx, op, ""); err != nil {
@@ -107,6 +112,7 @@ func ImportDebPackage(
 		return aptPackage, debRef, nil
 	}
 
+	// Update the existing package and restore its repository graph link.
 	if err := updateImportedAptPackage(ctx, objectState, existing, aptPackage); err != nil {
 		return nil, nil, err
 	}

--- a/sdk/canvas/canvas.go
+++ b/sdk/canvas/canvas.go
@@ -153,6 +153,7 @@ func (r *CanvasResource) UpdateCanvas(ctx context.Context, req *UpdateCanvasRequ
 		updated.HiddenGraphLinks = filtered
 	}
 
+	// Set layout metadata for updated nodes.
 	if setLayout := req.GetSetLayoutMetadata(); len(setLayout) > 0 {
 		if updated.LayoutMetadata == nil {
 			updated.LayoutMetadata = make(map[string]*CanvasLayoutMetadata, len(setLayout))
@@ -165,6 +166,7 @@ func (r *CanvasResource) UpdateCanvas(ctx context.Context, req *UpdateCanvasRequ
 		}
 	}
 
+	// Remove layout metadata for deleted nodes.
 	for _, id := range req.GetRemoveLayoutMetadataNodeIds() {
 		delete(updated.LayoutMetadata, id)
 	}

--- a/testbed/testbed.go
+++ b/testbed/testbed.go
@@ -44,10 +44,12 @@ type Testbed struct {
 
 // NewTestbed constructs a new world testbed from a Hydra testbed.
 func NewTestbed(tb *testbed.Testbed, opts ...Option) (t *Testbed, tbErr error) {
+	// Reject a missing base testbed before allocating resources.
 	if tb == nil {
 		return nil, errors.New("testbed cannot be nil")
 	}
 
+	// Track cleanup callbacks for resources acquired below.
 	var rels []func()
 	defer func() {
 		if tbErr != nil {
@@ -57,6 +59,7 @@ func NewTestbed(tb *testbed.Testbed, opts ...Option) (t *Testbed, tbErr error) {
 		}
 	}()
 
+	// Parse options controlling world verbosity and storage backends.
 	var worldVerbose bool
 	var storages []storage.Storage
 	for _, opt := range opts {
@@ -70,27 +73,35 @@ func NewTestbed(tb *testbed.Testbed, opts ...Option) (t *Testbed, tbErr error) {
 		}
 	}
 
+	// Initialize the extended testbed and its shared controller handles.
 	t = &Testbed{Testbed: tb}
 	ctx, b, sr := tb.Context, tb.Bus, tb.StaticResolver
 
+	// Register core, engine, and storage controller factories.
 	core.AddFactories(b, sr)
 	sr.AddFactory(boilerplate_controller.NewFactory(tb.Bus))
 	sr.AddFactory(world_block_engine.NewFactory(tb.Bus))
 	sr.AddFactory(storage_volume.NewFactory(tb.Bus))
 
+	// Assign stable identifiers for the world engine resources.
 	t.EngineID = "testbed-engine"
 	t.EngineVolumeID = tb.Volume.GetID()
 	t.EngineBucketID = tb.BucketId
 	t.EngineObjectStoreID = t.EngineID + "-store"
 
+	// Build the engine transform configuration.
 	transformConf, err := newEngineTransformConfig(t.EngineBucketID)
 	if err != nil {
 		return nil, err
 	}
+
+	// Prepare the initial bucket reference for engine startup.
 	initRef := &bucket.ObjectRef{
 		BucketId:      t.EngineBucketID,
 		TransformConf: transformConf,
 	}
+
+	// Build the world engine configuration from the testbed identifiers.
 	engConf := world_block_engine.NewConfig(
 		t.EngineID,
 		t.EngineVolumeID, t.EngineBucketID,
@@ -100,6 +111,8 @@ func NewTestbed(tb *testbed.Testbed, opts ...Option) (t *Testbed, tbErr error) {
 		false,
 	)
 	engConf.Verbose = worldVerbose
+
+	// Start the world engine and retain its release callback.
 	worldCtrl, worldCtrlRef, err := world_block_engine.StartEngineWithConfig(
 		ctx,
 		b,
@@ -111,6 +124,7 @@ func NewTestbed(tb *testbed.Testbed, opts ...Option) (t *Testbed, tbErr error) {
 	rels = append(rels, worldCtrlRef.Release)
 	t.EngineController = worldCtrl
 
+	// Resolve the running engine and expose its bus-backed state.
 	engh, err := worldCtrl.GetWorldEngine(ctx)
 	if err != nil {
 		return nil, err
@@ -119,17 +133,24 @@ func NewTestbed(tb *testbed.Testbed, opts ...Option) (t *Testbed, tbErr error) {
 	t.BusEngine = world.NewBusEngine(ctx, b, t.EngineID)
 	t.WorldState = world.NewEngineWorldState(t.BusEngine, true)
 
+	// Select the storage controller identifier.
 	storageID := "default"
 	t.StorageID = storageID
+
+	// Supply the default in-memory storage when no backend was requested.
 	if len(storages) == 0 {
 		storages = []storage.Storage{storage_inmem.NewInmemStorage()}
 	}
+
+	// Register each configured storage backend and reject nil entries.
 	for _, st := range storages {
 		if st == nil {
 			return nil, errors.New("storage backend cannot be nil")
 		}
 		st.AddFactories(b, sr)
 	}
+
+	// Build and attach the storage controller.
 	storageCtrl := storage_controller.BuildStorageController(
 		storageID,
 		storages,
@@ -146,14 +167,18 @@ func NewTestbed(tb *testbed.Testbed, opts ...Option) (t *Testbed, tbErr error) {
 
 // Default constructs the default testbed arrangement.
 func Default(ctx context.Context, opts ...Option) (*Testbed, error) {
+	// Initialize the default testbed logger.
 	log := logrus.New()
 	log.SetLevel(logrus.DebugLevel)
 	le := logrus.NewEntry(log)
 
+	// Construct the base controller-bus testbed.
 	tb, err := testbed.NewTestbed(ctx, le)
 	if err != nil {
 		return nil, err
 	}
+
+	// Extend the base testbed with world resources.
 	tb2, err := NewTestbed(tb, opts...)
 	if err != nil {
 		tb.Release()
@@ -164,14 +189,18 @@ func Default(ctx context.Context, opts ...Option) (*Testbed, error) {
 
 // WithTestbedOptions constructs the testbed with the given testbed options.
 func WithTestbedOptions(ctx context.Context, testbedOptions []testbed.Option, worldOpts []Option) (*Testbed, error) {
+	// Initialize the configured testbed logger.
 	log := logrus.New()
 	log.SetLevel(logrus.DebugLevel)
 	le := logrus.NewEntry(log)
 
+	// Construct the base testbed with caller options.
 	tb, err := testbed.NewTestbed(ctx, le, testbedOptions...)
 	if err != nil {
 		return nil, err
 	}
+
+	// Extend the base testbed with world options.
 	tb2, err := NewTestbed(tb, worldOpts...)
 	if err != nil {
 		tb.Release()

--- a/testbed/transform_config.go
+++ b/testbed/transform_config.go
@@ -12,9 +12,11 @@ import (
 )
 
 func newEngineTransformConfig(engineBucketID string) (*block_transform.Config, error) {
+	// Derive the engine transform key from its bucket identifier.
 	key := make([]byte, 32)
 	blake3.DeriveKey("hydra/world/testbed "+engineBucketID, []byte("testbed"), key)
 
+	// Compose compression and encrypted block transforms.
 	return block_transform.NewConfig([]config.Config{
 		&transform_gzip.Config{},
 		&transform_blockenc.Config{


### PR DESCRIPTION
Separate multi-action Go functions into semantic paragraphs so each stage can be scanned without decoding an uninterrupted statement block. Add or revise comments where a paragraph's purpose is not obvious, while keeping condensed one-action functions compact and preserving contract comments.

Preserve all non-string Go tokens. Update two migration errors to name the source World and DAG size provider instead of a generic owner.