### PR TITLE
perf(trace): attribute projected image reads

### DIFF
--- a/bldr/web/fetch/fetch-rw.go
+++ b/bldr/web/fetch/fetch-rw.go
@@ -1,7 +1,9 @@
 package web_fetch
 
 import (
+	"context"
 	"net/http"
+	"runtime/trace"
 	"strconv"
 	"sync"
 
@@ -14,6 +16,7 @@ const maxFetchResponseDataPacketBytes = 16 * 1024
 type FetchResponseWriter struct {
 	strm            SRPCFetchService_FetchStream
 	header          http.Header
+	traceCtx        context.Context
 	writeHeaderOnce sync.Once
 	status          int
 	// declaredLen is the parsed Content-Length header captured when the
@@ -27,6 +30,7 @@ type FetchResponseWriter struct {
 func NewFetchResponseWriter(strm SRPCFetchService_FetchStream) *FetchResponseWriter {
 	return &FetchResponseWriter{
 		strm:        strm,
+		traceCtx:    strm.Context(),
 		header:      http.Header{},
 		declaredLen: -1,
 	}
@@ -55,6 +59,10 @@ func (w *FetchResponseWriter) WriteHeader(statusCode int) {
 
 // Write writes the data to the connection as part of an HTTP reply.
 func (w *FetchResponseWriter) Write(p []byte) (int, error) {
+	if trace.IsEnabled() {
+		_, task := trace.NewTask(w.traceCtx, "bldr/web/fetch/serve-http/write-body")
+		defer task.End()
+	}
 	// write header if not already written
 	w.WriteHeader(200)
 	if w.err != nil {

--- a/bldr/web/fetch/fetch.go
+++ b/bldr/web/fetch/fetch.go
@@ -4,6 +4,7 @@ import (
 	context "context"
 	"io"
 	"net/http"
+	"runtime/trace"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -139,8 +140,19 @@ func HandleFetch(
 	// construct response writer
 	rw := NewFetchResponseWriter(strm)
 
-	// serve http
-	if err := serveFetchHTTP(rw, httpRequest, handler); err != nil {
+	// Trace the complete handler window and propagate its task to downstream work.
+	var handlerTask *trace.Task
+	if trace.IsEnabled() {
+		handlerCtx, task := trace.NewTask(httpRequest.Context(), "bldr/web/fetch/serve-http")
+		handlerTask = task
+		rw.traceCtx = handlerCtx
+		httpRequest = httpRequest.WithContext(handlerCtx)
+	}
+	err = serveFetchHTTP(rw, httpRequest, handler)
+	if handlerTask != nil {
+		handlerTask.End()
+	}
+	if err != nil {
 		return err
 	}
 

--- a/core/space/http/download/controller.go
+++ b/core/space/http/download/controller.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"net/http"
 	"net/url"
+	"runtime/trace"
 	"strings"
 
 	"github.com/aperturerobotics/controllerbus/bus"
@@ -74,6 +75,11 @@ func (c *Controller) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	le := c.GetLogger()
 	b := c.GetBus()
 	ctx := r.Context()
+	if trace.IsEnabled() {
+		var task *trace.Task
+		ctx, task = trace.NewTask(ctx, "core/space-http-download/serve")
+		defer task.End()
+	}
 
 	req, err := space_http_downloadurl.Parse(r.URL.Path)
 	if err != nil {
@@ -99,12 +105,15 @@ func (c *Controller) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	defer fsh.Release()
 
+	// Carry the file-server trace context into the Billy filesystem.
+	fileCtx := ctx
+	if trace.IsEnabled() {
+		var fileTask *trace.Task
+		fileCtx, fileTask = trace.NewTask(ctx, "core/space-http-download/serve/file-server")
+		defer fileTask.End()
+	}
 	// Build an http.FileSystem from the FSHandle.
-	hfs := unixfs_access_http.NewFileSystem(ctx, fsh, "", "")
-
-	// Rewrite the request URL to serve the specific file.
-	nr := r.Clone(ctx)
-	nr.URL = &url.URL{Path: "/" + req.ProjectedPath}
+	hfs := unixfs_access_http.NewFileSystem(fileCtx, fsh, "", "")
 
 	// Set Content-Disposition unless inline mode is requested.
 	if r.URL.Query().Get("inline") == "" {
@@ -116,6 +125,8 @@ func (c *Controller) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Serve the file using the standard http.FileServer.
+	nr := r.Clone(fileCtx)
+	nr.URL = &url.URL{Path: "/" + req.ProjectedPath}
 	handler := unixfs_access_http.NewFileServer(hfs)
 	handler.ServeHTTP(w, nr)
 }

--- a/db/block/blob/chunked.go
+++ b/db/block/blob/chunked.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"math"
+	"runtime/trace"
 
 	"github.com/pkg/errors"
 	"github.com/s4wave/spacewave/db/block"
@@ -144,7 +145,15 @@ func fetchChunkDataNoCursorCache(
 	if cache != nil && cache.idx == chunkIdx && cache.data != nil {
 		return cache.data, nil
 	}
-	data, err := chunk.FetchDataNoCache(ctx, chunkCursor, false)
+	var data []byte
+	var err error
+	if trace.IsEnabled() {
+		_, task := trace.NewTask(ctx, "db/block/blob/chunk-fetch")
+		data, err = chunk.FetchDataNoCache(ctx, chunkCursor, false)
+		task.End()
+	} else {
+		data, err = chunk.FetchDataNoCache(ctx, chunkCursor, false)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/db/block/cursor.go
+++ b/db/block/cursor.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"runtime/trace"
 )
 
 // Cursor tracks traversal of a block reference DAG structure with an associated
@@ -612,8 +613,15 @@ func (c *Cursor) fetch(ctx context.Context) ([]byte, []byte, bool, error) {
 	}
 	storedData := data
 	if xfrm := c.transformer(); xfrm != nil {
-		storedData = bytes.Clone(data)
-		data, err = xfrm.DecodeBlock(data)
+		if trace.IsEnabled() {
+			_, task := trace.NewTask(ctx, "db/block/cursor/fetch/decode")
+			storedData = bytes.Clone(data)
+			data, err = xfrm.DecodeBlock(data)
+			task.End()
+		} else {
+			storedData = bytes.Clone(data)
+			data, err = xfrm.DecodeBlock(data)
+		}
 		if err != nil {
 			return nil, nil, false, err
 		}

--- a/db/block/file/handle.go
+++ b/db/block/file/handle.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"math"
+	"runtime/trace"
 
 	"github.com/pkg/errors"
 	"github.com/s4wave/spacewave/db/block"
@@ -115,17 +116,33 @@ func (r *Handle) Read(p []byte) (n int, err error) {
 	if len(p) == 0 {
 		return 0, nil
 	}
+
+	traceEnabled := trace.IsEnabled()
+	readCtx := r.ctx
+	if traceEnabled {
+		var task *trace.Task
+		readCtx, task = trace.NewTask(readCtx, "db/block/file/handle/read")
+		defer task.End()
+	}
 	totalSize := r.root.GetTotalSize()
 	if r.idx >= totalSize {
 		return 0, io.EOF
 	}
 
 	for n < len(p) && r.idx < totalSize {
-		if err := r.evaluateCurrentRange(); err != nil {
-			if n > 0 && err == io.EOF {
+		var evalErr error
+		if traceEnabled {
+			_, task := trace.NewTask(readCtx, "db/block/file/handle/read/evaluate-range")
+			evalErr = r.evaluateCurrentRange()
+			task.End()
+		} else {
+			evalErr = r.evaluateCurrentRange()
+		}
+		if evalErr != nil {
+			if n > 0 && evalErr == io.EOF {
 				return n, nil
 			}
-			return n, err
+			return n, evalErr
 		}
 
 		idx := r.idx
@@ -157,7 +174,14 @@ func (r *Handle) Read(p []byte) (n int, err error) {
 			continue
 		}
 
-		blobReadN, err := r.currentBlob.Read(p[n : n+readN])
+		var blobReadN int
+		if traceEnabled {
+			_, task := trace.NewTask(readCtx, "db/block/file/handle/read/blob-read")
+			blobReadN, err = r.currentBlob.Read(p[n : n+readN])
+			task.End()
+		} else {
+			blobReadN, err = r.currentBlob.Read(p[n : n+readN])
+		}
 		if blobReadN > 0 {
 			nextIdx := min(r.idx+uint64(blobReadN), readEnd) //nolint:gosec
 			r.idx = nextIdx

--- a/db/unixfs/billy/billy-fs-file.go
+++ b/db/unixfs/billy/billy-fs-file.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 	"io/fs"
+	"runtime/trace"
 	"sync/atomic"
 	"time"
 
@@ -262,6 +263,10 @@ func (f *BillyFSFile) ReadFrom(r io.Reader) (n int64, err error) {
 
 // Read reads data from the file node, advancing the file handle offset.
 func (f *BillyFSFile) Read(p []byte) (n int, err error) {
+	if trace.IsEnabled() {
+		_, task := trace.NewTask(f.ctx, "db/unixfs/billy/file/read")
+		defer task.End()
+	}
 	idx := f.idx.Load()
 	rn, err := f.h.ReadAt(f.ctx, idx, p)
 	if rn != 0 {


### PR DESCRIPTION
The projected image diagnostic spent most of its response window inside block transform decode, but existing runtime trace tasks stopped at OPFS lookup. This adds guarded runtime tasks from browser fetch handling through UnixFS, chunk fetch, and block decode so the trace assigns each boundary without changing requests, storage semantics, or sampling.

All tasks are created only while runtime tracing is enabled. Normal fetches retain the existing allocation and data paths.