### PR TITLE
feat(blockshard): bound OPFS segment read cache

### DIFF
--- a/bldr/web/bldr/opfs-worker.test.ts
+++ b/bldr/web/bldr/opfs-worker.test.ts
@@ -28,10 +28,16 @@ function makeWritable(writes: Uint8Array[]) {
   }
 }
 
-function makeFile(name: string, bytes: Uint8Array, writes: Uint8Array[]) {
+function makeFile(
+  name: string,
+  bytes: Uint8Array,
+  writes: Uint8Array[],
+  calls: DirCall[],
+) {
   return {
     name,
     async getFile() {
+      calls.push({ method: 'getFile', name, opts: undefined })
       return {
         size: bytes.byteLength,
         async arrayBuffer() {
@@ -68,7 +74,7 @@ function makeDir(
     },
     async getFileHandle(n: string, opts: unknown) {
       calls.push({ method: 'getFileHandle', name: n, opts })
-      return makeFile(n, fileBytes, writes)
+      return makeFile(n, fileBytes, writes, calls)
     },
     async removeEntry(n: string, opts: unknown) {
       calls.push({ method: 'removeEntry', name: n, opts })
@@ -90,7 +96,13 @@ describe('opfs-worker dispatchOp', () => {
     vi.resetModules()
     calls = []
     writes = []
-    const root = makeDir('', calls, writes, ['a.txt', 'b.txt'], new Uint8Array([1, 2, 3, 4]))
+    const root = makeDir(
+      '',
+      calls,
+      writes,
+      ['a.txt', 'b.txt'],
+      new Uint8Array([1, 2, 3, 4]),
+    )
     vi.stubGlobal('navigator', { storage: { getDirectory: async () => root } })
     ;({ dispatchOp } = await import('./opfs-worker.js'))
   })
@@ -106,7 +118,9 @@ describe('opfs-worker dispatchOp', () => {
 
   test('getDirectory decodes dir, name, create', async () => {
     await dispatchOp('getRoot', {})
-    expect(await dispatchOp('getDirectory', { dir: 1, name: 'sub', create: true })).toEqual({
+    expect(
+      await dispatchOp('getDirectory', { dir: 1, name: 'sub', create: true }),
+    ).toEqual({
       id: 2,
     })
     expect(calls).toContainEqual({
@@ -118,7 +132,9 @@ describe('opfs-worker dispatchOp', () => {
 
   test('openFile resolves dir + name without creating', async () => {
     await dispatchOp('getRoot', {})
-    expect(await dispatchOp('openFile', { dir: 1, name: 'db' })).toEqual({ id: 2 })
+    expect(await dispatchOp('openFile', { dir: 1, name: 'db' })).toEqual({
+      id: 2,
+    })
     expect(calls).toContainEqual({
       method: 'getFileHandle',
       name: 'db',
@@ -149,26 +165,69 @@ describe('opfs-worker dispatchOp', () => {
     }
   })
 
+  test('read snapshots resolve once, reuse ranges, and release tokens', async () => {
+    await dispatchOp('getRoot', {})
+    const opened = await dispatchOp('openReadSnapshot', {
+      dir: 1,
+      name: 'segment.sst',
+    })
+    const snapshot = handleID(opened)
+    expect(opened).toEqual({ id: snapshot, size: 4 })
+
+    const first = await dispatchOp('readSnapshotAt', {
+      snapshot,
+      offset: 1,
+      length: 2,
+    })
+    const second = await dispatchOp('readSnapshotAt', {
+      snapshot,
+      offset: 3,
+      length: 4,
+    })
+    expect(Array.from(new Uint8Array(first as ArrayBuffer))).toEqual([2, 3])
+    expect(Array.from(new Uint8Array(second as ArrayBuffer))).toEqual([4])
+    expect(calls.filter((call) => call.method === 'getFile')).toHaveLength(1)
+
+    await expect(
+      dispatchOp('closeReadSnapshot', { snapshot }),
+    ).resolves.toBeNull()
+    await expect(
+      dispatchOp('readSnapshotAt', { snapshot, offset: 0, length: 1 }),
+    ).rejects.toThrow(/unknown read snapshot/)
+  })
+
   test('listDirectory returns the entry names', async () => {
     await dispatchOp('getRoot', {})
-    expect(await dispatchOp('listDirectory', { dir: 1 })).toEqual(['a.txt', 'b.txt'])
+    expect(await dispatchOp('listDirectory', { dir: 1 })).toEqual([
+      'a.txt',
+      'b.txt',
+    ])
   })
 
   test('createWriteStream then streamWrite decode the stream handle and bytes', async () => {
     await dispatchOp('getRoot', {})
-    const stream = handleID(await dispatchOp('createWriteStream', { dir: 1, name: 's' }))
-    expect(await dispatchOp('streamWrite', { stream, data: new Uint8Array([5, 6]).buffer })).toBe(2)
+    const stream = handleID(
+      await dispatchOp('createWriteStream', { dir: 1, name: 's' }),
+    )
+    expect(
+      await dispatchOp('streamWrite', {
+        stream,
+        data: new Uint8Array([5, 6]).buffer,
+      }),
+    ).toBe(2)
     expect(Array.from(writes[writes.length - 1])).toEqual([5, 6])
   })
 
   test('a missing required field rejects with a TypeError', async () => {
     await dispatchOp('getRoot', {})
-    await expect(dispatchOp('getDirectory', { dir: 1, create: true })).rejects.toThrow(
-      /expected string field name/,
-    )
+    await expect(
+      dispatchOp('getDirectory', { dir: 1, create: true }),
+    ).rejects.toThrow(/expected string field name/)
   })
 
   test('an unknown op rejects', async () => {
-    await expect(dispatchOp('frobnicate', {})).rejects.toThrow(/unsupported OPFS op/)
+    await expect(dispatchOp('frobnicate', {})).rejects.toThrow(
+      /unsupported OPFS op/,
+    )
   })
 })

--- a/bldr/web/bldr/opfs-worker.ts
+++ b/bldr/web/bldr/opfs-worker.ts
@@ -23,6 +23,7 @@ let nextHandleID = 1
 const directories = new Map<number, FileSystemDirectoryHandle>()
 const files = new Map<number, FileEntry>()
 const writeStreams = new Map<number, FileSystemWritableFileStream>()
+const readSnapshots = new Map<number, File>()
 
 function nextID(): number {
   return nextHandleID++
@@ -109,7 +110,11 @@ function bytesField(args: unknown, name: string): Uint8Array<ArrayBuffer> {
     return new Uint8Array(value)
   }
   if (ArrayBuffer.isView(value)) {
-    const view = new Uint8Array(value.buffer, value.byteOffset, value.byteLength)
+    const view = new Uint8Array(
+      value.buffer,
+      value.byteOffset,
+      value.byteLength,
+    )
     const copy = new Uint8Array(view.byteLength)
     copy.set(view)
     return copy
@@ -133,10 +138,21 @@ function getFileEntry(id: number): FileEntry {
   return entry
 }
 
+function getReadSnapshot(id: number): File {
+  const file = readSnapshots.get(id)
+  if (!file) {
+    throw new DOMException(`unknown read snapshot: ${id}`, 'NotFoundError')
+  }
+  return file
+}
+
 function getWriteStream(id: number): FileSystemWritableFileStream {
   const stream = writeStreams.get(id)
   if (!stream) {
-    throw new DOMException(`unknown write stream handle: ${id}`, 'NotFoundError')
+    throw new DOMException(
+      `unknown write stream handle: ${id}`,
+      'NotFoundError',
+    )
   }
   return stream
 }
@@ -283,6 +299,38 @@ async function opOpenFile(
   return { id: storeFile(handle) }
 }
 
+async function opOpenReadSnapshot(
+  args: unknown,
+): Promise<{ id: number; size: number }> {
+  const handle = await fileHandleFromArgs(args, false)
+  const file = await handle.getFile()
+  const id = nextID()
+  readSnapshots.set(id, file)
+  return { id, size: file.size }
+}
+
+async function opReadSnapshotAt(args: unknown): Promise<ArrayBuffer> {
+  const snapshotID = handleField(args, 'snapshot')
+  const offset = numberField(args, 'offset')
+  const length = numberField(args, 'length')
+  if (length <= 0) {
+    return new ArrayBuffer(0)
+  }
+  const file = getReadSnapshot(snapshotID)
+  if (offset >= file.size) {
+    return new ArrayBuffer(0)
+  }
+  const end = Math.min(offset + length, file.size)
+  return file.slice(offset, end).arrayBuffer()
+}
+
+function opCloseReadSnapshot(args: unknown): null {
+  const snapshotID = handleField(args, 'snapshot')
+  getReadSnapshot(snapshotID)
+  readSnapshots.delete(snapshotID)
+  return null
+}
+
 async function opReadAt(args: unknown): Promise<ArrayBuffer> {
   const fileID = handleField(args, 'file')
   const offset = numberField(args, 'offset')
@@ -400,6 +448,12 @@ async function dispatchOp(op: string, args: unknown): Promise<unknown> {
       return opOpenFile(args, false)
     case 'createFile':
       return opOpenFile(args, true)
+    case 'openReadSnapshot':
+      return opOpenReadSnapshot(args)
+    case 'readSnapshotAt':
+      return opReadSnapshotAt(args)
+    case 'closeReadSnapshot':
+      return opCloseReadSnapshot(args)
     case 'readAt':
       return opReadAt(args)
     case 'writeAt':

--- a/bldr/web/runtime/wasm/go-process.test.ts
+++ b/bldr/web/runtime/wasm/go-process.test.ts
@@ -483,6 +483,14 @@ describe('patchTinyGoRuntimeImports', () => {
     const largeReadArrayBuffer = vi.fn(async () => {
       throw new Error('oversized file should not be materialized')
     })
+    const snapshotBytes = new Uint8Array([21, 22, 23, 24])
+    const snapshotGetFile = vi.fn(async () => ({
+      size: snapshotBytes.byteLength,
+      slice: (start: number, end: number) => {
+        const part = snapshotBytes.slice(start, end)
+        return { arrayBuffer: async () => part.buffer }
+      },
+    }))
     const dir = {
       getFileHandle: async (name: string, opts?: { create?: boolean }) => {
         if (name === 'read.bin') {
@@ -501,6 +509,9 @@ describe('patchTinyGoRuntimeImports', () => {
               arrayBuffer: largeReadArrayBuffer,
             }),
           }
+        }
+        if (name === 'snapshot.bin') {
+          return { getFile: snapshotGetFile }
         }
         if (name === 'single.bin' && opts?.create === true) {
           return {
@@ -550,6 +561,26 @@ describe('patchTinyGoRuntimeImports', () => {
     const takeStoredBytes = gojs['bldr.opfs.takeStoredBytes'] as
       | ((bytesID: number, ptr: number, len: number) => number)
       | undefined
+    const openReadSnapshot = gojs['bldr.opfs.openReadSnapshotRef'] as
+      | ((
+          opID: number,
+          dirRef: bigint,
+          namePtr: number,
+          nameLen: number,
+        ) => void)
+      | undefined
+    const readSnapshotAt = gojs['bldr.opfs.readSnapshotAtRef'] as
+      | ((
+          opID: number,
+          snapshotID: number,
+          dstPtr: number,
+          dstLen: number,
+          off: bigint,
+        ) => void)
+      | undefined
+    const closeReadSnapshot = gojs['bldr.opfs.closeReadSnapshotRef'] as
+      | ((opID: number, snapshotID: number) => void)
+      | undefined
     const writeFile = gojs['bldr.opfs.writeFileRef'] as
       | ((
           opID: number,
@@ -585,6 +616,9 @@ describe('patchTinyGoRuntimeImports', () => {
     if (
       !readFile ||
       !takeStoredBytes ||
+      !openReadSnapshot ||
+      !readSnapshotAt ||
+      !closeReadSnapshot ||
       !writeFile ||
       !openWriteStream ||
       !writeStream ||
@@ -604,6 +638,40 @@ describe('patchTinyGoRuntimeImports', () => {
     expect(takeStoredBytes(read.id, 80, read.len)).toBe(1)
     expect(Array.from(mem.subarray(80, 83))).toEqual([4, 5, 6])
     expect(takeStoredBytes(read.id, 80, read.len)).toBe(0)
+    const snapshotNameLen = writeString(256, 'snapshot.bin')
+    const openedSnapshot = await waitOPFS(
+      314,
+      () => openReadSnapshot(314, tinyGoObjectRef(7), 256, snapshotNameLen),
+      ([id = 0, size = 0]) => ({ id, size }),
+    )
+    expect(openedSnapshot.size).toBe(snapshotBytes.byteLength)
+    const firstSnapshotRead = await waitOPFS(
+      315,
+      () => readSnapshotAt(315, openedSnapshot.id, 320, 2, 1n),
+      ([n = 0]) => n,
+    )
+    expect(firstSnapshotRead).toBe(2)
+    expect(Array.from(mem.subarray(320, 322))).toEqual([22, 23])
+    const secondSnapshotRead = await waitOPFS(
+      316,
+      () => readSnapshotAt(316, openedSnapshot.id, 336, 4, 3n),
+      ([n = 0]) => n,
+    )
+    expect(secondSnapshotRead).toBe(1)
+    expect(Array.from(mem.subarray(336, 337))).toEqual([24])
+    expect(snapshotGetFile).toHaveBeenCalledTimes(1)
+    const snapshotClosed = await waitOPFS(
+      317,
+      () => closeReadSnapshot(317, openedSnapshot.id),
+      ([closed = 0]) => closed,
+    )
+    expect(snapshotClosed).toBe(1)
+    const closedSnapshotCode = await waitOPFS(
+      318,
+      () => readSnapshotAt(318, openedSnapshot.id, 320, 1, 0n),
+      ([code = 0]) => -code,
+    )
+    expect(closedSnapshotCode).toBe(1)
 
     const largeReadNameLen = writeString(96, 'large-read.bin')
     const largeReadCode = await waitOPFS(
@@ -1424,6 +1492,7 @@ describe('GoWasmProcess', () => {
           'fetch-requests',
           'web-lock-requests',
           'opfs-write-streams',
+          'opfs-read-snapshots',
           'opfs-runtime-tasks',
           'callback-queue',
           'blockshard-storage',
@@ -1885,7 +1954,7 @@ describe('GoWasmProcess', () => {
     expect(consoleError).toHaveBeenCalledWith('other failure')
   })
 
-  it('aborts TinyGo OPFS write streams when the runtime exits', async () => {
+  it('releases TinyGo OPFS streams and read snapshots when the runtime exits', async () => {
     const opfsResolves = new Map<number, (values: number[]) => void>()
     const opfsRejects = new Map<number, (code: number) => void>()
     const waitOPFS = <T>(
@@ -1903,6 +1972,7 @@ describe('GoWasmProcess', () => {
       aborts: number
       createWritableAfterExit: number
       startRejected: boolean
+      snapshotID: number
       resolveAbortCleanup?: () => void
       rejectPendingWrite?: (reason?: unknown) => void
       resolveLateAbort?: () => void
@@ -1914,6 +1984,7 @@ describe('GoWasmProcess', () => {
       aborts: 0,
       createWritableAfterExit: 0,
       startRejected: false,
+      snapshotID: 0,
     }
     const opfsResolve = (
       opID: number,
@@ -1948,6 +2019,18 @@ describe('GoWasmProcess', () => {
     })
     const dir = {
       getFileHandle: async (name: string, opts?: { create?: boolean }) => {
+        if (name === 'snapshot.bin' && opts?.create !== true) {
+          const bytes = new Uint8Array([1, 2, 3])
+          return {
+            getFile: async () => ({
+              size: bytes.byteLength,
+              slice: (start: number, end: number) => {
+                const part = bytes.slice(start, end)
+                return { arrayBuffer: async () => part.buffer }
+              },
+            }),
+          }
+        }
         if (opts?.create !== true) {
           throw new Error('unexpected file handle request')
         }
@@ -2023,6 +2106,10 @@ describe('GoWasmProcess', () => {
           'after.bin',
           new Uint8Array(memory.buffer, 80, 9),
         )
+        new TextEncoder().encodeInto(
+          'snapshot.bin',
+          new Uint8Array(memory.buffer, 96, 12),
+        )
         const gojs = this.importObject.gojs as Record<string, unknown>
         const openWriteStream = gojs['bldr.opfs.openWriteStreamRef'] as
           | ((
@@ -2040,8 +2127,16 @@ describe('GoWasmProcess', () => {
               dataLen: number,
             ) => void)
           | undefined
-        if (!openWriteStream || !writeStream) {
-          throw new Error('OPFS write stream import bridge was not installed')
+        const openReadSnapshot = gojs['bldr.opfs.openReadSnapshotRef'] as
+          | ((
+              opID: number,
+              dirRef: bigint,
+              namePtr: number,
+              nameLen: number,
+            ) => void)
+          | undefined
+        if (!openWriteStream || !writeStream || !openReadSnapshot) {
+          throw new Error('OPFS import bridge was not installed')
         }
 
         const streamID = await waitOPFS(
@@ -2050,6 +2145,12 @@ describe('GoWasmProcess', () => {
           ([id = 0]) => id,
         )
         expect(streamID).toBeGreaterThan(0)
+        state.snapshotID = await waitOPFS(
+          200,
+          () => openReadSnapshot(200, tinyGoObjectRef(7), 96, 12),
+          ([id = 0]) => id,
+        )
+        expect(state.snapshotID).toBeGreaterThan(0)
         new Uint8Array(memory.buffer).set([1, 2, 3], 48)
         writeStream(202, streamID, 48, 3)
         openWriteStream(203, tinyGoObjectRef(7), 64, 8)
@@ -2102,6 +2203,17 @@ describe('GoWasmProcess', () => {
     await lateAbort
     state.resolveAbortCleanup?.()
     await expect(started).rejects.toThrow('runtime trap')
+    const finalBudget = snapshotTinyGoBrowserBudgetReport()
+    const finalGeneration = finalBudget.generations.at(-1)
+    expect(finalGeneration?.state).toBe('exited')
+    expect(
+      finalGeneration?.owners.find(
+        (owner) => owner.owner === 'opfs-read-snapshots',
+      ),
+    ).toMatchObject({
+      currentCount: 0,
+      highWaterCount: 1,
+    })
     expect(state.aborts).toBe(2)
     expect(state.createWritableAfterExit).toBe(0)
     expect(state.lateCallbacks).toBe(0)

--- a/bldr/web/runtime/wasm/go-process.ts
+++ b/bldr/web/runtime/wasm/go-process.ts
@@ -46,6 +46,7 @@ export type TinyGoBrowserBudgetOwner =
   | 'fetch-requests'
   | 'web-lock-requests'
   | 'opfs-write-streams'
+  | 'opfs-read-snapshots'
   | 'opfs-runtime-tasks'
   | 'callback-queue'
   | 'blockshard-storage'
@@ -154,6 +155,15 @@ const tinyGoOPFSWriteStreams = new Map<
     chain: Promise<void>
   }
 >()
+let tinyGoOPFSReadSnapshotID = 1
+const tinyGoOPFSReadSnapshots = new Map<
+  number,
+  {
+    go: TinyGoRuntime
+    file: File
+  }
+>()
+const tinyGoOPFSReadSnapshotCounts = new WeakMap<TinyGoRuntime, number>()
 const tinyGoOPFSRuntimeTasks = new WeakMap<TinyGoRuntime, Set<Promise<void>>>()
 const tinyGoExitedRuntimes = new WeakSet<TinyGoRuntime>()
 const tinyGoCallbackQueue: (() => void)[] = []
@@ -169,6 +179,7 @@ const tinyGoBrowserBudgetOwners: TinyGoBrowserBudgetOwner[] = [
   'fetch-requests',
   'web-lock-requests',
   'opfs-write-streams',
+  'opfs-read-snapshots',
   'opfs-runtime-tasks',
   'callback-queue',
   'blockshard-storage',
@@ -189,6 +200,7 @@ const tinyGoBrowserBudgetReservations: Record<
   'fetch-requests': { reservedCount: 16 },
   'web-lock-requests': { reservedCount: 16 },
   'opfs-write-streams': { reservedBytes: 8 * 1024 * 1024 },
+  'opfs-read-snapshots': {},
   'opfs-runtime-tasks': { reservedCount: 32 },
   'callback-queue': { reservedCount: 256 },
   'blockshard-storage': { reservedBytes: 16 * 1024 * 1024 },
@@ -589,6 +601,23 @@ function rejectTinyGoOPFSOp(
   rejectTinyGoOPFSHelper(go, opID, code)
 }
 
+function rejectTinyGoOPFSReadSnapshotOp(
+  go: TinyGoRuntime,
+  opID: number,
+  reason: unknown,
+): void {
+  const invalidated =
+    typeof reason === 'object' &&
+    reason !== null &&
+    'name' in reason &&
+    reason.name === 'NotReadableError'
+  rejectTinyGoOPFSHelper(
+    go,
+    opID,
+    invalidated ? tinyGoPromiseErrorNotFound : tinyGoPromiseErrorCode(reason),
+  )
+}
+
 async function readTinyGoOPFSFileBytes(file: File): Promise<Uint8Array> {
   if (file.size > tinyGoOPFSReadFileMaxBytes) {
     throw new RangeError(
@@ -745,6 +774,30 @@ function abortTinyGoOPFSWriteStreamsForGo(go: TinyGoRuntime): void {
       void abortTinyGoOPFSWriteStream(id)
     }
   }
+}
+
+function updateTinyGoOPFSReadSnapshotCount(
+  go: TinyGoRuntime,
+  delta: number,
+): void {
+  const count = Math.max(0, (tinyGoOPFSReadSnapshotCounts.get(go) ?? 0) + delta)
+  tinyGoOPFSReadSnapshotCounts.set(go, count)
+  syncTinyGoBudgetOwnerCount(
+    tinyGoRuntimeGeneration(go),
+    'opfs-read-snapshots',
+    count,
+  )
+}
+
+function releaseTinyGoOPFSReadSnapshotsForGo(go: TinyGoRuntime): void {
+  let released = 0
+  for (const [id, snapshot] of tinyGoOPFSReadSnapshots) {
+    if (snapshot.go === go) {
+      tinyGoOPFSReadSnapshots.delete(id)
+      released++
+    }
+  }
+  updateTinyGoOPFSReadSnapshotCount(go, -released)
 }
 
 function copyUint8Array(bytes: Uint8Array): Uint8Array<ArrayBuffer> {
@@ -2167,6 +2220,33 @@ export function patchTinyGoRuntimeImports(go: TinyGoRuntime) {
       .then((handle) => resolveTinyGoOPFSRef(go, opID, handle))
       .catch((reason) => rejectTinyGoOPFSOp(go, opID, reason))
   }
+  gojs['bldr.opfs.openReadSnapshotRef'] ??= (
+    opID: number,
+    dirRef: bigint,
+    namePtr: number,
+    nameLen: number,
+  ) => {
+    const dir = tinyGoUnboxValue(go, dirRef) as FileSystemDirectoryHandle
+    const name = readTinyGoString(go, namePtr, nameLen)
+    const task = dir
+      .getFileHandle(name)
+      .then((handle) => handle.getFile())
+      .then((file) => {
+        if (tinyGoExitedRuntimes.has(go)) {
+          return
+        }
+        const snapshotID = tinyGoOPFSReadSnapshotID++
+        tinyGoOPFSReadSnapshots.set(snapshotID, { go, file })
+        updateTinyGoOPFSReadSnapshotCount(go, 1)
+        resolveTinyGoOPFSHelper(go, opID, snapshotID, file.size)
+      })
+      .catch((reason) => {
+        if (!tinyGoExitedRuntimes.has(go)) {
+          rejectTinyGoOPFSOp(go, opID, reason)
+        }
+      })
+    trackTinyGoOPFSRuntimeTask(go, task)
+  }
   gojs['bldr.opfs.fileExistsRef'] ??= (
     opID: number,
     dirRef: bigint,
@@ -2299,6 +2379,61 @@ export function patchTinyGoRuntimeImports(go: TinyGoRuntime) {
         resolveTinyGoOPFSHelper(go, opID, bytes.byteLength)
       })
       .catch((reason) => rejectTinyGoOPFSOp(go, opID, reason))
+  }
+  gojs['bldr.opfs.readSnapshotAtRef'] ??= (
+    opID: number,
+    snapshotID: number,
+    dstPtr: number,
+    dstLen: number,
+    off: bigint,
+  ) => {
+    const snapshot = tinyGoOPFSReadSnapshots.get(snapshotID)
+    if (!snapshot || snapshot.go !== go) {
+      rejectTinyGoOPFSHelper(go, opID, tinyGoPromiseErrorNotFound)
+      return
+    }
+
+    const offset = Number(off)
+    const task = (async () => {
+      if (offset >= snapshot.file.size || dstLen === 0) {
+        resolveTinyGoOPFSHelper(go, opID, 0)
+        return
+      }
+      const end = Math.min(offset + dstLen, snapshot.file.size)
+      const buf = await snapshot.file.slice(offset, end).arrayBuffer()
+      if (
+        tinyGoExitedRuntimes.has(go) ||
+        tinyGoOPFSReadSnapshots.get(snapshotID) !== snapshot
+      ) {
+        return
+      }
+      const bytes = new Uint8Array(buf)
+      if (bytes.byteLength !== 0) {
+        tinyGoMemoryView(go, dstPtr, bytes.byteLength).set(bytes)
+      }
+      resolveTinyGoOPFSHelper(go, opID, bytes.byteLength)
+    })().catch((reason) => {
+      if (
+        !tinyGoExitedRuntimes.has(go) &&
+        tinyGoOPFSReadSnapshots.get(snapshotID) === snapshot
+      ) {
+        rejectTinyGoOPFSReadSnapshotOp(go, opID, reason)
+      }
+    })
+    trackTinyGoOPFSRuntimeTask(go, task)
+  }
+  gojs['bldr.opfs.closeReadSnapshotRef'] ??= (
+    opID: number,
+    snapshotID: number,
+  ) => {
+    const snapshot = tinyGoOPFSReadSnapshots.get(snapshotID)
+    if (!snapshot || snapshot.go !== go) {
+      rejectTinyGoOPFSHelper(go, opID, tinyGoPromiseErrorNotFound)
+      return
+    }
+    tinyGoOPFSReadSnapshots.delete(snapshotID)
+    updateTinyGoOPFSReadSnapshotCount(go, -1)
+    resolveTinyGoOPFSHelper(go, opID, 1)
   }
   gojs['bldr.opfs.listDirectoryRef'] ??= (opID: number, dirRef: bigint) => {
     const dir = tinyGoUnboxValue(go, dirRef) as FileSystemDirectoryHandle
@@ -2679,6 +2814,7 @@ export class GoWasmProcess {
     } finally {
       tinyGoExitedRuntimes.add(go)
       abortTinyGoOPFSWriteStreamsForGo(go)
+      releaseTinyGoOPFSReadSnapshotsForGo(go)
       await awaitTinyGoOPFSRuntimeTasks(go)
       updateTinyGoRuntimeGenerationMemory(generation)
       finishTinyGoRuntimeGeneration(go)

--- a/db/opfs/chrometest/cachetestprog/main.go
+++ b/db/opfs/chrometest/cachetestprog/main.go
@@ -1,0 +1,377 @@
+//go:build js
+
+package main
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"syscall/js"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/s4wave/spacewave/db/opfs"
+	"github.com/s4wave/spacewave/db/volume/js/opfs/blockshard"
+	"github.com/s4wave/spacewave/db/volume/js/opfs/segment"
+)
+
+type config struct {
+	scenario   string
+	root       string
+	worker     int
+	workers    int
+	iterations int
+	batch      int
+	shards     int
+}
+
+type blockEvent struct {
+	typ       string
+	worker    int
+	iteration int
+}
+
+type blockEventSub struct {
+	ch chan blockEvent
+	bc js.Value
+	cb js.Func
+}
+
+type blockEventPub struct {
+	bc js.Value
+}
+
+func main() {
+	// Parse one worker scenario from the browser launch arguments.
+	started := time.Now()
+	c, err := parseConfig(testArgs())
+
+	// Run the selected storage action.
+	if err == nil {
+		err = run(context.Background(), c)
+	}
+
+	// Return one result before the WebAssembly runtime exits.
+	postResult(c, time.Since(started), err)
+}
+
+func testArgs() []string {
+	if len(os.Args) >= 8 {
+		return os.Args
+	}
+	value := js.Global().Get("__OPFS_CHROMETEST_ARGS")
+	if value.IsUndefined() || value.IsNull() {
+		return os.Args
+	}
+	args := make([]string, value.Get("length").Int())
+	for i := range args {
+		args[i] = value.Index(i).String()
+	}
+	return args
+}
+
+func parseConfig(args []string) (*config, error) {
+	if len(args) < 8 {
+		return nil, errors.Errorf("expected 7 args, got %d", len(args)-1)
+	}
+	worker, err := strconv.Atoi(args[3])
+	if err != nil {
+		return nil, errors.Wrap(err, "parse worker")
+	}
+	workers, err := strconv.Atoi(args[4])
+	if err != nil {
+		return nil, errors.Wrap(err, "parse workers")
+	}
+	iterations, err := strconv.Atoi(args[5])
+	if err != nil {
+		return nil, errors.Wrap(err, "parse iterations")
+	}
+	batch, err := strconv.Atoi(args[6])
+	if err != nil {
+		return nil, errors.Wrap(err, "parse batch")
+	}
+	shards, err := strconv.Atoi(args[7])
+	if err != nil {
+		return nil, errors.Wrap(err, "parse shards")
+	}
+	return &config{
+		scenario:   args[1],
+		root:       args[2],
+		worker:     worker,
+		workers:    workers,
+		iterations: iterations,
+		batch:      batch,
+		shards:     shards,
+	}, nil
+}
+
+func run(ctx context.Context, c *config) error {
+	opfs.InstallRemoteDriverFromGlobal()
+	switch c.scenario {
+	case "clear":
+		return clearRoot(c.root)
+	case "block-writer":
+		return runBlockWriter(ctx, c)
+	case "block-reader":
+		return runBlockReader(ctx, c, false)
+	case "block-reader-compact":
+		return runBlockReader(ctx, c, true)
+	case "block-verify":
+		return runBlockVerify(ctx, c)
+	default:
+		return errors.Errorf("unknown cache probe scenario %q", c.scenario)
+	}
+}
+
+func clearRoot(rootName string) error {
+	// Open the browser OPFS root.
+	root, err := opfs.GetRoot()
+	if err != nil {
+		return err
+	}
+
+	// Reset and recreate the named shared-volume directory.
+	err = opfs.DeleteEntry(root, rootName, true)
+	if err != nil && !opfs.IsNotFound(err) {
+		return err
+	}
+	_, err = opfs.GetDirectory(root, rootName, true)
+	return err
+}
+
+func runBlockWriter(ctx context.Context, c *config) error {
+	// Open one publishing engine and its cross-runtime event channel.
+	e, release, err := openBlockEngine(ctx, c)
+	if err != nil {
+		return err
+	}
+	defer release()
+	events := newBlockEventPub(c.root)
+	defer events.Close()
+
+	// Publish deterministic batches and announce each visible generation.
+	for i := range c.iterations {
+		entries := make([]segment.Entry, c.batch)
+		for j := range entries {
+			key := blockKey(c.worker, i, j)
+			entries[j] = segment.Entry{Key: key, Value: blockValue(key)}
+		}
+		if err := e.Put(ctx, entries); err != nil {
+			return errors.Wrap(err, "write concurrent blocks")
+		}
+		events.Post(blockEvent{typ: "block-written", worker: c.worker, iteration: i})
+	}
+
+	// Announce completion after every published batch is durable.
+	events.Post(blockEvent{typ: "block-writer-done", worker: c.worker})
+	return nil
+}
+
+func runBlockReader(ctx context.Context, c *config, compact bool) error {
+	// Open one reader before the publishers start.
+	e, release, err := openBlockEngine(ctx, c)
+	if err != nil {
+		return err
+	}
+	defer release()
+	events := newBlockEventSub(c)
+	defer events.Close()
+	postReady(c)
+
+	// Consume publication events until every writer completes.
+	done := make([]bool, c.workers)
+	var found int
+	var doneCount int
+	for doneCount < c.workers {
+		event, err := events.Next(ctx)
+		if err != nil {
+			return err
+		}
+		switch event.typ {
+		case "block-written":
+			for j := range c.batch {
+				key := blockKey(event.worker, event.iteration, j)
+				value, ok, err := e.GetContext(ctx, key)
+				if err != nil {
+					return errors.Wrap(err, "read concurrent block")
+				}
+				if !ok {
+					continue
+				}
+				if string(value) != string(blockValue(key)) {
+					return errors.Errorf("block value mismatch key=%s", string(key))
+				}
+				found++
+			}
+		case "block-writer-done":
+			if event.worker < 0 || event.worker >= len(done) {
+				return errors.Errorf("invalid writer id %d", event.worker)
+			}
+			if !done[event.worker] {
+				done[event.worker] = true
+				doneCount++
+			}
+		}
+	}
+	if found == 0 {
+		return errors.New("reader found no concurrently written blocks")
+	}
+	if !compact {
+		return nil
+	}
+
+	// Compact through the live reader before checking all values.
+	if err := e.CompactOnce(ctx); err != nil {
+		return errors.Wrap(err, "compact shared block volume")
+	}
+	return verifyBlocks(ctx, c, e, "after compaction")
+}
+
+func runBlockVerify(ctx context.Context, c *config) error {
+	e, release, err := openBlockEngine(ctx, c)
+	if err != nil {
+		return err
+	}
+	defer release()
+	return verifyBlocks(ctx, c, e, "after remount")
+}
+
+func verifyBlocks(ctx context.Context, c *config, e *blockshard.Engine, phase string) error {
+	for w := range c.workers {
+		for i := range c.iterations {
+			for j := range c.batch {
+				key := blockKey(w, i, j)
+				value, found, err := e.GetContext(ctx, key)
+				if err != nil {
+					return errors.Wrap(err, "read block "+phase)
+				}
+				if !found {
+					return errors.Errorf("missing block %s key=%s", phase, string(key))
+				}
+				if string(value) != string(blockValue(key)) {
+					return errors.Errorf("bad block %s key=%s", phase, string(key))
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func openBlockEngine(ctx context.Context, c *config) (*blockshard.Engine, func(), error) {
+	dir, err := openTestDirectory(c.root, []string{"blocks"})
+	if err != nil {
+		return nil, nil, err
+	}
+	settings := blockshard.DefaultSettings()
+	settings.ShardCount = c.shards
+	e, err := blockshard.NewEngineWithSettings(ctx, dir, c.root+"/blocks", settings)
+	if err != nil {
+		return nil, nil, err
+	}
+	return e, e.Close, nil
+}
+
+func openTestDirectory(rootName string, parts []string) (js.Value, error) {
+	root, err := opfs.GetRoot()
+	if err != nil {
+		return js.Undefined(), err
+	}
+	path := append([]string{rootName}, parts...)
+	return opfs.GetDirectoryPath(root, path, true)
+}
+
+func blockKey(worker, iteration, entry int) []byte {
+	return []byte("b/" + strconv.Itoa(worker) + "/" + zeroPad(iteration, 5) + "/" + zeroPad(entry, 3))
+}
+
+func blockValue(key []byte) []byte {
+	return []byte("value:" + string(key))
+}
+
+func zeroPad(n, width int) string {
+	value := strconv.Itoa(n)
+	for len(value) < width {
+		value = "0" + value
+	}
+	return value
+}
+
+func newBlockEventSub(c *config) *blockEventSub {
+	ch := make(chan blockEvent, c.workers*c.iterations+c.workers+8)
+	bc := js.Global().Get("BroadcastChannel").New(blockEventChannel(c.root))
+	cb := js.FuncOf(func(_ js.Value, args []js.Value) any {
+		data := args[0].Get("data")
+		ch <- blockEvent{
+			typ:       data.Get("type").String(),
+			worker:    data.Get("worker").Int(),
+			iteration: data.Get("iteration").Int(),
+		}
+		return nil
+	})
+	bc.Set("onmessage", cb)
+	return &blockEventSub{ch: ch, bc: bc, cb: cb}
+}
+
+func (s *blockEventSub) Next(ctx context.Context) (blockEvent, error) {
+	select {
+	case event := <-s.ch:
+		return event, nil
+	case <-ctx.Done():
+		return blockEvent{}, ctx.Err()
+	}
+}
+
+func (s *blockEventSub) Close() {
+	s.bc.Set("onmessage", js.Null())
+	s.bc.Call("close")
+	s.cb.Release()
+}
+
+func newBlockEventPub(root string) *blockEventPub {
+	return &blockEventPub{bc: js.Global().Get("BroadcastChannel").New(blockEventChannel(root))}
+}
+
+func (p *blockEventPub) Post(event blockEvent) {
+	obj := js.Global().Get("Object").New()
+	obj.Set("type", event.typ)
+	obj.Set("worker", event.worker)
+	obj.Set("iteration", event.iteration)
+	p.bc.Call("postMessage", obj)
+}
+
+func (p *blockEventPub) Close() {
+	p.bc.Call("close")
+}
+
+func blockEventChannel(root string) string {
+	return "opfs-chrometest:" + root
+}
+
+func postReady(c *config) {
+	obj := js.Global().Get("Object").New()
+	obj.Set("kind", "ready")
+	obj.Set("scenario", c.scenario)
+	obj.Set("worker", c.worker)
+	js.Global().Call("postMessage", obj)
+}
+
+func postResult(c *config, duration time.Duration, err error) {
+	// Build the shared worker result fields.
+	obj := js.Global().Get("Object").New()
+	obj.Set("kind", "result")
+	if c != nil {
+		obj.Set("scenario", c.scenario)
+		obj.Set("worker", c.worker)
+	}
+
+	// Attach the terminal status.
+	obj.Set("durationMs", duration.Milliseconds())
+	obj.Set("ok", true)
+	if err != nil {
+		obj.Set("ok", false)
+		obj.Set("error", err.Error())
+	}
+
+	// Publish the terminal result to the browser harness.
+	js.Global().Call("postMessage", obj)
+}

--- a/db/opfs/chrometest/chrome_test.go
+++ b/db/opfs/chrometest/chrome_test.go
@@ -3305,6 +3305,8 @@ self.BLDR_TINYGO_PROMISE_AWAIT ??= (promise, resolve, reject) => {
 }
 self.__BLDR_TINYGO_OPFS_WRITE_STREAM_ID ??= 1
 self.__BLDR_TINYGO_OPFS_WRITE_STREAMS ??= new Map()
+self.__BLDR_TINYGO_OPFS_READ_SNAPSHOT_ID ??= 1
+self.__BLDR_TINYGO_OPFS_READ_SNAPSHOTS ??= new Map()
 self.__BLDR_TINYGO_ABORT_OPFS_WRITE_STREAM ??= (streamID, strict = false) => {
   const stream = self.__BLDR_TINYGO_OPFS_WRITE_STREAMS.get(streamID)
   if (!stream) {
@@ -3505,6 +3507,9 @@ class OpfsChrometestBridgeClient {
       if (pending.op === 'closeFile') {
         this.handles.delete(pending.args.file)
       }
+      if (pending.op === 'closeReadSnapshot') {
+        this.handles.delete(pending.args.snapshot)
+      }
       if (pending.op === 'streamClose' || pending.op === 'streamAbort') {
         this.handles.delete(pending.args.stream)
       }
@@ -3647,6 +3652,26 @@ self.onmessage = async (event) => {
         .then((handle) => self.__BLDR_TINYGO_OPFS_RESOLVE_REF(opID, handle))
         .catch((reason) => self.__BLDR_TINYGO_OPFS_REJECT(opID, self.BLDR_TINYGO_PROMISE_ERROR_CODE(reason)))
     }
+    go.importObject.gojs['bldr.opfs.openReadSnapshotRef'] ??= (opID, dirRef, namePtr, nameLen) => {
+      const dir = self.__BLDR_TINYGO_UNBOX_VALUE(go, dirRef)
+      const name = self.__BLDR_TINYGO_READ_STRING(go, namePtr, nameLen)
+      const task = dir.getFileHandle(name)
+        .then((handle) => handle.getFile())
+        .then((file) => {
+          if (self.__BLDR_TINYGO_RUNTIME_EXITED) {
+            return
+          }
+          const snapshotID = self.__BLDR_TINYGO_OPFS_READ_SNAPSHOT_ID++
+          self.__BLDR_TINYGO_OPFS_READ_SNAPSHOTS.set(snapshotID, file)
+          self.__BLDR_TINYGO_OPFS_RESOLVE(opID, snapshotID, file.size)
+        })
+        .catch((reason) => {
+          if (!self.__BLDR_TINYGO_RUNTIME_EXITED) {
+            self.__BLDR_TINYGO_OPFS_REJECT(opID, self.BLDR_TINYGO_PROMISE_ERROR_CODE(reason))
+          }
+        })
+      self.__BLDR_TINYGO_TRACK_OPFS_TASK(task)
+    }
     go.importObject.gojs['bldr.opfs.fileExistsRef'] ??= (opID, dirRef, namePtr, nameLen) => {
       const dir = self.__BLDR_TINYGO_UNBOX_VALUE(go, dirRef)
       const name = self.__BLDR_TINYGO_READ_STRING(go, namePtr, nameLen)
@@ -3738,6 +3763,52 @@ self.onmessage = async (event) => {
           self.__BLDR_TINYGO_OPFS_RESOLVE(opID, bytes.byteLength)
         })
         .catch((reason) => self.__BLDR_TINYGO_OPFS_REJECT(opID, self.BLDR_TINYGO_PROMISE_ERROR_CODE(reason)))
+    }
+    go.importObject.gojs['bldr.opfs.readSnapshotAtRef'] ??= (opID, snapshotID, dstPtr, dstLen, off) => {
+      const file = self.__BLDR_TINYGO_OPFS_READ_SNAPSHOTS.get(snapshotID)
+      if (!file) {
+        self.__BLDR_TINYGO_OPFS_REJECT(opID, 1)
+        return
+      }
+      const offset = Number(off)
+      const task = (async () => {
+        if (offset >= file.size || dstLen === 0) {
+          self.__BLDR_TINYGO_OPFS_RESOLVE(opID, 0)
+          return
+        }
+        const end = Math.min(offset + dstLen, file.size)
+        const buf = await file.slice(offset, end).arrayBuffer()
+        if (
+          self.__BLDR_TINYGO_RUNTIME_EXITED ||
+          self.__BLDR_TINYGO_OPFS_READ_SNAPSHOTS.get(snapshotID) !== file
+        ) {
+          return
+        }
+        const bytes = new Uint8Array(buf)
+        if (bytes.byteLength !== 0) {
+          self.__BLDR_TINYGO_MEMORY_VIEW(go, dstPtr, bytes.byteLength).set(bytes)
+        }
+        self.__BLDR_TINYGO_OPFS_RESOLVE(opID, bytes.byteLength)
+      })().catch((reason) => {
+        if (
+          !self.__BLDR_TINYGO_RUNTIME_EXITED &&
+          self.__BLDR_TINYGO_OPFS_READ_SNAPSHOTS.get(snapshotID) === file
+        ) {
+          const code = reason?.name === 'NotReadableError'
+            ? 1
+            : self.BLDR_TINYGO_PROMISE_ERROR_CODE(reason)
+          self.__BLDR_TINYGO_OPFS_REJECT(opID, code)
+        }
+      })
+      self.__BLDR_TINYGO_TRACK_OPFS_TASK(task)
+    }
+    go.importObject.gojs['bldr.opfs.closeReadSnapshotRef'] ??= (opID, snapshotID) => {
+      if (!self.__BLDR_TINYGO_OPFS_READ_SNAPSHOTS.has(snapshotID)) {
+        self.__BLDR_TINYGO_OPFS_REJECT(opID, 1)
+        return
+      }
+      self.__BLDR_TINYGO_OPFS_READ_SNAPSHOTS.delete(snapshotID)
+      self.__BLDR_TINYGO_OPFS_RESOLVE(opID, 1)
     }
     go.importObject.gojs['bldr.opfs.listDirectoryRef'] ??= (opID, dirRef) => {
       const dir = self.__BLDR_TINYGO_UNBOX_VALUE(go, dirRef)
@@ -3932,6 +4003,7 @@ self.onmessage = async (event) => {
     for (const [streamID] of self.__BLDR_TINYGO_OPFS_WRITE_STREAMS) {
       void self.__BLDR_TINYGO_ABORT_OPFS_WRITE_STREAM(streamID)
     }
+    self.__BLDR_TINYGO_OPFS_READ_SNAPSHOTS.clear()
     await self.__BLDR_TINYGO_AWAIT_OPFS_TASKS()
   }
 }

--- a/db/opfs/chrometest/chrome_test.go
+++ b/db/opfs/chrometest/chrome_test.go
@@ -23,6 +23,7 @@ const (
 	runEnv                          = "RUN_OPFS_CHROME_TEST"
 	profileEnv                      = "RUN_OPFS_CHROME_PROFILE"
 	tinyGoEnv                       = "RUN_OPFS_CHROME_TINYGO"
+	cacheProbeEnv                   = "RUN_OPFS_CHROME_CACHE_PROBE"
 	tinyGoProfileEnv                = "RUN_OPFS_CHROME_TINYGO_PROFILE"
 	tinyGoOptEnv                    = "RUN_OPFS_CHROME_TINYGO_OPT"
 	tinyGoGCEnv                     = "RUN_OPFS_CHROME_TINYGO_GC"
@@ -130,6 +131,116 @@ func TestOpfsChromeConcurrentBlockReadersWriters(t *testing.T) {
 		batch:      batch,
 		shards:     defaultShards,
 	})
+}
+
+func TestOpfsChromeSharedVolumeCacheLifecycle(t *testing.T) {
+	requireChromeProfile(t, chromeSmoke, chromeStress)
+	runSharedVolumeCacheLifecycle(t, false)
+}
+
+func TestOpfsChromeRemoteSharedVolumeCacheLifecycle(t *testing.T) {
+	requireChromeProfile(t, chromeSmoke)
+	runSharedVolumeCacheLifecycle(t, true)
+}
+
+func runSharedVolumeCacheLifecycle(t *testing.T, remote bool) {
+	t.Helper()
+	// Open one browser session for the shared volume cell.
+	h := newChromeHarness(t)
+	s := h.newSession(t)
+	defer s.close(t)
+
+	// Clear a driver-specific volume root before starting runtimes.
+	mode := "direct"
+	if remote {
+		mode = "remote"
+	}
+	root := "opfs-chrome-" + mode + "-cache-lifecycle-" + time.Now().Format("150405.000000000")
+	s.runWorker(t, workerArgs{
+		scenario: "clear",
+		root:     root,
+		remote:   remote,
+	})
+
+	// Start both reader runtimes before publishing from writer runtimes.
+	const (
+		writers    = 2
+		iterations = 16
+		batch      = 8
+	)
+	args := []workerArgs{
+		{
+			scenario:   "block-reader",
+			root:       root,
+			worker:     0,
+			workers:    writers,
+			iterations: iterations,
+			batch:      batch,
+			shards:     defaultShards,
+			remote:     remote,
+		},
+		{
+			scenario:   "block-reader-compact",
+			root:       root,
+			worker:     1,
+			workers:    writers,
+			iterations: iterations,
+			batch:      batch,
+			shards:     defaultShards,
+			remote:     remote,
+		},
+	}
+	for i := range writers {
+		args = append(args, workerArgs{
+			scenario:   "block-writer",
+			root:       root,
+			worker:     i,
+			workers:    writers,
+			iterations: iterations,
+			batch:      batch,
+			shards:     defaultShards,
+			remote:     remote,
+		})
+	}
+
+	// Run the simultaneous publish and compaction cell.
+	s.runWorkersStaged(t, args[:2], args[2:])
+
+	// Remount one fresh runtime and verify every durable block.
+	s.runWorker(t, workerArgs{
+		scenario:   "block-verify",
+		root:       root,
+		workers:    writers,
+		iterations: iterations,
+		batch:      batch,
+		shards:     defaultShards,
+		remote:     remote,
+	})
+}
+
+func TestOpfsChromeRemoteDriverCacheLifecycle(t *testing.T) {
+	requireChromeProfile(t, chromeSmoke)
+
+	// Open one browser session around a live bridge replacement.
+	h := newChromeHarness(t)
+	s := h.newSession(t)
+	defer s.close(t)
+
+	// Clear the direct root before the remote bridge owns the volume.
+	root := "opfs-chrome-remote-cache-lifecycle-" + time.Now().Format("150405.000000000")
+	s.runWorker(t, workerArgs{
+		scenario: "clear",
+		root:     root,
+	})
+
+	// Swap the bridge, remount, and report remaining remote handles.
+	result := s.runRemoteSwapWorker(t, workerArgs{
+		scenario: "remote-cache-lifecycle",
+		root:     root,
+		shards:   defaultShards,
+		remote:   true,
+	})
+	t.Logf("remote driver live handles after remount and release: %d", result.remoteHandles)
 }
 
 // TestOpfsChromeMaterializeFanout measures how the block feed pattern changes
@@ -1914,6 +2025,16 @@ func (s *chromeSession) runTerminatedReadyWorker(t testing.TB, worker workerArgs
 	return results[0]
 }
 
+func (s *chromeSession) runRemoteSwapWorker(t testing.TB, worker workerArgs) workerResult {
+	t.Helper()
+	results := s.runWorkersScript(t, `async ({ worker }) => {
+  return await window.runOpfsRemoteSwapWorker(worker)
+}`, map[string]any{
+		"worker": mapSingleWorkerArg(worker),
+	})
+	return results[0]
+}
+
 func (s *chromeSession) runWorkersScript(t testing.TB, script string, args map[string]any) []workerResult {
 	t.Helper()
 	results, err := s.evalWorkersScript(t, script, args, runWorkersScriptTimeout(t))
@@ -1924,7 +2045,7 @@ func (s *chromeSession) runWorkersScript(t testing.TB, script string, args map[s
 		if !res.ok {
 			t.Fatalf("worker scenario=%s worker=%d failed: %s", res.scenario, res.worker, res.err)
 		}
-		t.Logf("worker scenario=%s worker=%d ok=%t duration=%dms", res.scenario, res.worker, res.ok, res.durationMS)
+		t.Logf("worker scenario=%s worker=%d ok=%t duration=%dms remote_handles=%d", res.scenario, res.worker, res.ok, res.durationMS, res.remoteHandles)
 	}
 	return results
 }
@@ -2011,6 +2132,9 @@ func runWorkersScriptTimeout(t testing.TB) time.Duration {
 }
 
 func buildAssets(dir string) error {
+	if err := buildOpfsBridgeWorker(dir); err != nil {
+		return err
+	}
 	if err := buildWasm(filepath.Join(dir, "testprog.wasm")); err != nil {
 		return err
 	}
@@ -2030,6 +2154,34 @@ func buildAssets(dir string) error {
 	return nil
 }
 
+func buildOpfsBridgeWorker(dir string) error {
+	// Resolve the repository source for the real bridge worker.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	root, err := repoRoot()
+	if err != nil {
+		return err
+	}
+
+	// Compile the TypeScript worker as a browser module.
+	cmd := exec.CommandContext(
+		ctx,
+		"bun",
+		"build",
+		filepath.Join(root, "bldr/web/bldr/opfs-worker.ts"),
+		"--outfile",
+		filepath.Join(dir, "opfs-worker.js"),
+		"--target",
+		"browser",
+	)
+	cmd.Dir = root
+	data, err := cmd.CombinedOutput()
+	if err != nil {
+		return errors.Errorf("build OPFS bridge worker failed: %v\n%s", err, data)
+	}
+	return nil
+}
+
 func buildWasm(out string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
 	defer cancel()
@@ -2037,13 +2189,19 @@ func buildWasm(out string) error {
 	if err != nil {
 		return err
 	}
+
+	// Select the storage-focused worker when the TinyGo cache probe requests it.
+	program := "./db/opfs/chrometest/testprog"
+	if os.Getenv(cacheProbeEnv) == "1" || strings.EqualFold(os.Getenv(cacheProbeEnv), "true") {
+		program = "./db/opfs/chrometest/cachetestprog"
+	}
 	if os.Getenv(tinyGoEnv) == "1" || strings.EqualFold(os.Getenv(tinyGoEnv), "true") {
 		envelope, err := resolveTinyGoBuildEnvelope()
 		if err != nil {
 			return err
 		}
 		args := append([]string{"build"}, envelope.args()...)
-		args = append(args, "-o", out, "./db/opfs/chrometest/testprog")
+		args = append(args, "-o", out, program)
 		fmt.Fprintf(
 			os.Stderr,
 			"opfs chrometest wasm build: compiler=tinygo version=%q envelope=%s args=%q\n",
@@ -2071,7 +2229,7 @@ func buildWasm(out string) error {
 		)
 		return nil
 	}
-	cmd := exec.CommandContext(ctx, "go", "build", "-o", out, "./db/opfs/chrometest/testprog")
+	cmd := exec.CommandContext(ctx, "go", "build", "-o", out, program)
 	cmd.Env = append(os.Environ(), "GOOS=js", "GOARCH=wasm")
 	cmd.Dir = root
 	data, err := cmd.CombinedOutput()
@@ -2362,9 +2520,10 @@ func decodeWorkerResults(raw any) ([]workerResult, error) {
 				m,
 				"durationMs",
 			),
-			writeMS:    intField(m, "writeMs"),
-			blocks:     intField(m, "blocks"),
-			publishGen: intField(m, "publishGen"),
+			writeMS:       intField(m, "writeMs"),
+			blocks:        intField(m, "blocks"),
+			publishGen:    intField(m, "publishGen"),
+			remoteHandles: intField(m, "remoteHandles"),
 		}
 	}
 	return results, nil
@@ -2386,6 +2545,7 @@ func mapSingleWorkerArg(arg workerArgs) map[string]any {
 		"workers":    arg.workers,
 		"iterations": arg.iterations,
 		"batch":      arg.batch,
+		"remote":     arg.remote,
 		"shards":     arg.shards,
 	}
 }
@@ -2428,17 +2588,19 @@ type workerArgs struct {
 	iterations int
 	batch      int
 	shards     int
+	remote     bool
 }
 
 type workerResult struct {
-	scenario   string
-	worker     int
-	ok         bool
-	err        string
-	durationMS int
-	writeMS    int
-	blocks     int
-	publishGen int
+	scenario      string
+	worker        int
+	ok            bool
+	err           string
+	durationMS    int
+	writeMS       int
+	blocks        int
+	publishGen    int
+	remoteHandles int
 }
 
 type workerScriptEnvelope struct {
@@ -2556,6 +2718,16 @@ const indexHTML = `<!doctype html>
         }
         const started = workers.map((args) => runWorker(args))
         return await waitWorkers([...ready, ...started])
+      }
+
+      window.runOpfsRemoteSwapWorker = async (args) => {
+        const worker = runWorker(args)
+        const ready = await worker.ready
+        if (ready.kind === 'result') {
+          return compactResults([ready])
+        }
+        await worker.swapBridge()
+        return await waitWorkers([worker])
       }
 
       window.runOpfsBlockedLockWorkers = async (holderArgs, workers) => {
@@ -2723,14 +2895,48 @@ const indexHTML = `<!doctype html>
         return String(reason)
       }
 
+      function openOpfsBridge() {
+        return new Promise((resolve, reject) => {
+          const bridge = new Worker('/opfs-worker.js', { type: 'module' })
+          const channel = new MessageChannel()
+          bridge.onerror = (event) => {
+            bridge.terminate()
+            reject(new Error(event.message))
+          }
+          channel.port1.onmessage = (event) => {
+            if (event.data?.opfsWorkerReady !== true) {
+              return
+            }
+            channel.port1.onmessage = null
+            resolve({ worker: bridge, port: channel.port1 })
+          }
+          bridge.postMessage({}, [channel.port2])
+        })
+      }
       function runWorker(args) {
         let readyResolve
+        let bridgeWorker
         recordWorkerProgress(args, 'start')
         const worker = new Worker('/worker.js', { type: 'classic' })
         const ready = new Promise((resolve) => {
           readyResolve = resolve
         })
         const done = new Promise((resolve) => {
+          const fail = (message) => {
+            worker.terminate()
+            bridgeWorker?.terminate()
+            window.__opfsChromeWorkerWatchdog.exception(message)
+            const data = {
+              kind: 'result',
+              scenario: args.scenario,
+              worker: args.worker ?? 0,
+              ok: false,
+              error: message,
+            }
+            recordWorkerProgress(data, 'worker-error')
+            readyResolve(data)
+            resolve(data)
+          }
           worker.onmessage = (event) => {
             const data = event.data
             if (data.kind === 'ready') {
@@ -2746,30 +2952,40 @@ const indexHTML = `<!doctype html>
             if (data.kind === 'result') {
               recordWorkerProgress(data, data.ok ? 'result-ok' : 'result-error')
               worker.terminate()
+              bridgeWorker?.terminate()
               readyResolve(data)
               resolve(data)
             }
           }
           worker.onerror = (event) => {
-            worker.terminate()
-            window.__opfsChromeWorkerWatchdog.exception(event.message)
-            const data = {
-              kind: 'result',
-              scenario: args.scenario,
-              worker: args.worker ?? 0,
-              ok: false,
-              error: event.message,
-            }
-            recordWorkerProgress(data, 'worker-error')
-            readyResolve(data)
-            resolve(data)
+            fail(event.message)
           }
-          worker.postMessage(args)
+          void (async () => {
+            if (!args.remote) {
+              worker.postMessage(args)
+              return
+            }
+            const bridge = await openOpfsBridge()
+            bridgeWorker = bridge.worker
+            worker.postMessage(args, [bridge.port])
+          })().catch((reason) => {
+            fail(describeBrowserError(reason))
+          })
         })
         return {
           ready,
           done,
-          stop: () => worker.terminate(),
+          stop: () => {
+            worker.terminate()
+            bridgeWorker?.terminate()
+          },
+          swapBridge: async () => {
+            const bridge = await openOpfsBridge()
+            const previous = bridgeWorker
+            bridgeWorker = bridge.worker
+            worker.postMessage({ kind: 'opfsBridgeSwap' }, [bridge.port])
+            previous?.terminate()
+          },
         }
       }
 
@@ -3262,8 +3478,82 @@ self.onunhandledrejection = (event) => {
   __opfsChrometestPostUnhandled(event.reason)
 }
 
+
+class OpfsChrometestBridgeClient {
+  constructor(port) {
+    this.port = port
+    this.nextID = 1
+    this.pending = new Map()
+    this.handles = new Map()
+    port.onmessage = (event) => {
+      const response = event.data
+      const pending = this.pending.get(response?.id)
+      if (!pending) {
+        return
+      }
+      this.pending.delete(response.id)
+      if (!response.ok) {
+        const error = new Error(response.error?.message ?? 'OPFS bridge request failed')
+        error.name = response.error?.name ?? 'Error'
+        pending.reject(error)
+        return
+      }
+      const result = response.result
+      if (result && typeof result.id === 'number') {
+        this.handles.set(result.id, pending.op)
+      }
+      if (pending.op === 'closeFile') {
+        this.handles.delete(pending.args.file)
+      }
+      if (pending.op === 'streamClose' || pending.op === 'streamAbort') {
+        this.handles.delete(pending.args.stream)
+      }
+      pending.resolve(result)
+    }
+    port.start()
+  }
+
+  get liveHandles() {
+    return this.handles.size
+  }
+
+  request(op, args) {
+    const id = this.nextID++
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { op, args, resolve, reject })
+      this.port.postMessage({ id, op, args })
+    })
+  }
+
+  close() {
+    for (const pending of this.pending.values()) {
+      const error = new Error('OPFS bridge closed')
+      error.name = 'AbortError'
+      pending.reject(error)
+    }
+    this.pending.clear()
+    this.handles.clear()
+    this.port.close()
+  }
+}
+
+function installOpfsChrometestBridge(port) {
+  const previous = self.__spacewaveOpfsBridgePort
+  const client = new OpfsChrometestBridgeClient(port)
+  previous?.close()
+  self.__spacewaveOpfsBridgePort = client
+  self.__spacewaveInstallOpfsRemoteDriver?.(client)
+}
+
 self.onmessage = async (event) => {
+  if (event.data?.kind === 'opfsBridgeSwap') {
+    installOpfsChrometestBridge(event.ports[0])
+    return
+  }
   const args = event.data
+  if (args.remote) {
+    installOpfsChrometestBridge(event.ports[0])
+  }
   __opfsChrometestCurrentArgs = args
   const go = new Go()
   self.__BLDR_TINYGO_CURRENT_GO = go

--- a/db/opfs/chrometest/testprog/main.go
+++ b/db/opfs/chrometest/testprog/main.go
@@ -182,6 +182,7 @@ func parseConfig(args []string) (*config, error) {
 }
 
 func run(ctx context.Context, c *config) error {
+	opfs.InstallRemoteDriverFromGlobal()
 	switch c.scenario {
 	case "pipe-write-loop":
 		return runPipeWriteLoop(c)
@@ -224,9 +225,13 @@ func run(ctx context.Context, c *config) error {
 	case "block-writer":
 		return runBlockWriter(ctx, c)
 	case "block-reader":
-		return runBlockReader(ctx, c)
+		return runBlockReader(ctx, c, false)
+	case "block-reader-compact":
+		return runBlockReader(ctx, c, true)
 	case "block-verify":
 		return runBlockVerify(ctx, c)
+	case "remote-cache-lifecycle":
+		return runRemoteCacheLifecycle(ctx, c)
 	case "block-orphan-segment":
 		return runBlockOrphanSegment(c)
 	case "block-orphan-verify-clean":
@@ -1150,7 +1155,8 @@ func runBlockWriter(ctx context.Context, c *config) error {
 	return nil
 }
 
-func runBlockReader(ctx context.Context, c *config) error {
+func runBlockReader(ctx context.Context, c *config, compact bool) error {
+	// Open one reader runtime before the writers start.
 	e, release, err := openBlockEngine(ctx, c)
 	if err != nil {
 		return err
@@ -1160,6 +1166,7 @@ func runBlockReader(ctx context.Context, c *config) error {
 	defer events.Close()
 	postReady(c)
 
+	// Read each published batch until every writer reports completion.
 	done := make([]bool, c.workers)
 	var found int
 	var doneCount int
@@ -1170,7 +1177,7 @@ func runBlockReader(ctx context.Context, c *config) error {
 		}
 		switch ev.typ {
 		case "block-written":
-			for j := 0; j < c.batch; j++ {
+			for j := range c.batch {
 				key := blockKey(ev.worker, ev.iteration, j)
 				val, ok, err := e.GetContext(ctx, key)
 				if err != nil {
@@ -1196,9 +1203,11 @@ func runBlockReader(ctx context.Context, c *config) error {
 			continue
 		}
 	}
+
+	// Confirm final visibility when publication events raced manifest refresh.
 	if found == 0 {
-		for w := 0; w < c.workers; w++ {
-			for i := 0; i < c.iterations; i++ {
+		for w := range c.workers {
+			for i := range c.iterations {
 				key := blockKey(w, i, 0)
 				val, ok, err := e.GetContext(ctx, key)
 				if err != nil {
@@ -1213,10 +1222,35 @@ func runBlockReader(ctx context.Context, c *config) error {
 			}
 		}
 	}
-	if found > 0 {
+	if found == 0 {
+		return errors.New("reader found no concurrently written blocks")
+	}
+	if !compact {
 		return nil
 	}
-	return errors.New("reader found no concurrently written blocks")
+
+	// Compact through the live reader and verify every retained value.
+	if err := e.CompactOnce(ctx); err != nil {
+		return errors.Wrap(err, "compact shared block volume")
+	}
+	for w := range c.workers {
+		for i := range c.iterations {
+			for j := range c.batch {
+				key := blockKey(w, i, j)
+				val, ok, err := e.GetContext(ctx, key)
+				if err != nil {
+					return errors.Wrap(err, "read block after compaction")
+				}
+				if !ok {
+					return errors.Errorf("missing block after compaction key=%s", string(key))
+				}
+				if string(val) != string(blockValue(key)) {
+					return errors.Errorf("bad block after compaction key=%s", string(key))
+				}
+			}
+		}
+	}
+	return nil
 }
 
 func runBlockVerify(ctx context.Context, c *config) error {
@@ -1242,6 +1276,114 @@ func runBlockVerify(ctx context.Context, c *config) error {
 				}
 			}
 		}
+	}
+	return nil
+}
+
+func runRemoteCacheLifecycle(ctx context.Context, c *config) error {
+	// Install and require the bridge-backed driver.
+	if !opfs.InstallRemoteDriverFromGlobal() {
+		return errors.New("remote OPFS driver was not installed")
+	}
+	driver, ok := opfs.DefaultDriver.(*opfs.RemoteDriver)
+	if !ok {
+		return errors.Errorf("OPFS driver is %T, want *opfs.RemoteDriver", opfs.DefaultDriver)
+	}
+
+	// Populate the block cache through the first bridge.
+	e, release, err := openBlockEngine(ctx, c)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if release != nil {
+			release()
+		}
+	}()
+	key := []byte("remote-cache-key")
+	value := []byte("remote-cache-value")
+	if err := e.Put(ctx, []segment.Entry{{Key: key, Value: value}}); err != nil {
+		return errors.Wrap(err, "write remote cache block")
+	}
+	got, found, err := e.GetContext(ctx, key)
+	if err != nil {
+		return errors.Wrap(err, "read remote cache block")
+	}
+	if !found || string(got) != string(value) {
+		return errors.Errorf("remote cache read returned found=%t value=%q", found, got)
+	}
+
+	// Retain one raw file token that must become stale on replacement.
+	root, err := opfs.GetRoot()
+	if err != nil {
+		return err
+	}
+	dir, err := opfs.GetDirectory(root, c.root, true)
+	if err != nil {
+		return err
+	}
+	const filename = "remote-stale-handle"
+	if err := opfs.WriteFile(dir, filename, []byte("stale")); err != nil {
+		return err
+	}
+	stale, err := opfs.OpenAsyncFile(dir, filename)
+	if err != nil {
+		return err
+	}
+
+	// Replace the bridge and reject every token from its prior id space.
+	postReady(c)
+	if err := driver.WaitSwap(ctx); err != nil {
+		return err
+	}
+	if _, err := stale.Size(); err == nil {
+		return errors.New("stale remote file handle remained usable after bridge swap")
+	}
+	if err := stale.Close(); err == nil {
+		return errors.New("stale remote file close unexpectedly succeeded")
+	}
+	release()
+	release = nil
+
+	// Remount the block cache through fresh directory and file tokens.
+	fresh, freshRelease, err := openBlockEngine(ctx, c)
+	if err != nil {
+		return errors.Wrap(err, "remount block engine after bridge swap")
+	}
+	defer freshRelease()
+	got, found, err = fresh.GetContext(ctx, key)
+	if err != nil {
+		return errors.Wrap(err, "read remote cache block after remount")
+	}
+	if !found || string(got) != string(value) {
+		return errors.Errorf("remote cache remount returned found=%t value=%q", found, got)
+	}
+
+	// Verify remote deletion errors and explicit fresh-token release.
+	root, err = opfs.GetRoot()
+	if err != nil {
+		return err
+	}
+	dir, err = opfs.GetDirectory(root, c.root, false)
+	if err != nil {
+		return err
+	}
+	if err := opfs.DeleteEntry(dir, "missing-entry", false); !opfs.IsNotFound(err) {
+		return errors.Errorf("remote missing delete error=%v, want NotFoundError", err)
+	}
+	file, err := opfs.OpenAsyncFile(dir, filename)
+	if err != nil {
+		return err
+	}
+	buf := make([]byte, len("stale"))
+	if _, err := file.ReadAt(buf, 0); err != nil {
+		return err
+	}
+	if string(buf) != "stale" {
+		return errors.Errorf("remote remount file value=%q", buf)
+	}
+	if err := file.Close(); err != nil {
+		return err
 	}
 	return nil
 }
@@ -4751,6 +4893,7 @@ func postProgress(c *config, phase string, values ...int) {
 var benchExtra map[string]int64
 
 func postResult(c *config, dur time.Duration, err error) {
+	// Build the common result and optional benchmark fields.
 	obj := js.Global().Get("Object").New()
 	obj.Set("kind", "result")
 	if c != nil {
@@ -4761,11 +4904,21 @@ func postResult(c *config, dur time.Duration, err error) {
 	for k, v := range benchExtra {
 		obj.Set(k, v)
 	}
+
+	// Attach the current bridge handle count when this worker is remote.
+	remote := js.Global().Get("__spacewaveOpfsBridgePort")
+	if remote.Type() == js.TypeObject {
+		handles := remote.Get("liveHandles")
+		if handles.Type() == js.TypeNumber {
+			obj.Set("remoteHandles", handles.Int())
+		}
+	}
+
+	// Attach the terminal status and publish the result.
+	obj.Set("ok", true)
 	if err != nil {
 		obj.Set("ok", false)
 		obj.Set("error", err.Error())
-	} else {
-		obj.Set("ok", true)
 	}
 	js.Global().Call("postMessage", obj)
 }

--- a/db/opfs/opfs.go
+++ b/db/opfs/opfs.go
@@ -57,6 +57,7 @@ type Driver interface {
 	GetDirectory(parent js.Value, name string, create bool) (js.Value, error)
 	GetDirectoryPath(parent js.Value, path []string, create bool) (js.Value, error)
 	OpenAsyncFile(dir js.Value, name string) (*AsyncFile, error)
+	OpenReadSnapshot(dir js.Value, name string) (*ReadSnapshot, error)
 	CreateAsyncFile(dir js.Value, name string) (*AsyncFile, error)
 	WriteFile(dir js.Value, name string, data []byte) error
 	CreateWriteStream(dir js.Value, name string) (*WriteStream, error)

--- a/db/opfs/opfs_test.go
+++ b/db/opfs/opfs_test.go
@@ -178,6 +178,71 @@ func TestAsyncFileReadWrite(t *testing.T) {
 	f.Close()
 }
 
+func TestReadSnapshotRetainsImmutableFile(t *testing.T) {
+	// Create one immutable source file and resolve its snapshot.
+	root, err := GetRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer DeleteEntry(root, "test-read-snapshot", true) //nolint
+	dir, err := GetDirectory(root, "test-read-snapshot", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	original := []byte("hello immutable snapshot")
+	if err := WriteFile(dir, "segment.sst", original); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := OpenReadSnapshot(dir, "segment.sst")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Record size once and preserve repeated range and EOF behavior.
+	size, err := snapshot.Size()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if size != int64(len(original)) {
+		t.Fatalf("snapshot size = %d, want %d", size, len(original))
+	}
+	buf := make([]byte, 9)
+	n, err := snapshot.ReadAt(buf, 6)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(buf[:n]); got != "immutable" {
+		t.Fatalf("snapshot range = %q, want immutable", got)
+	}
+	buf = make([]byte, 5)
+	n, err = snapshot.ReadAt(buf, int64(len(original)-3))
+	if n != 3 || err != io.EOF {
+		t.Fatalf("snapshot final read = (%d, %v), want (3, EOF)", n, err)
+	}
+	if got := string(buf[:n]); got != "hot" {
+		t.Fatalf("snapshot final bytes = %q, want hot", got)
+	}
+
+	// Classify browser reclamation as missing for manifest refresh and retry.
+	if err := DeleteEntry(dir, "segment.sst", false); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := snapshot.ReadAt(buf, 0); !IsNotFound(err) {
+		t.Fatalf("snapshot read after reclamation = %v, want not found", err)
+	}
+
+	// Release the retained reference once and reject later reads.
+	if err := snapshot.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := snapshot.Close(); err != nil {
+		t.Fatalf("second close: %v", err)
+	}
+	if _, err := snapshot.ReadAt(buf, 0); err == nil {
+		t.Fatal("read after close succeeded")
+	}
+}
+
 func TestSyncFile(t *testing.T) {
 	if !SyncAvailable() {
 		t.Skip("sync access handles not available (SharedWorker context)")

--- a/db/opfs/opfs_tinygo.go
+++ b/db/opfs/opfs_tinygo.go
@@ -28,6 +28,15 @@ func tinyGoOPFSGetDirectoryRef(opID uint32, parentRef uint64, namePtr unsafe.Poi
 //go:wasmimport gojs bldr.opfs.openFileRef
 func tinyGoOPFSOpenFileRef(opID uint32, dirRef uint64, namePtr unsafe.Pointer, nameLen uint32, create uint32)
 
+//go:wasmimport gojs bldr.opfs.openReadSnapshotRef
+func tinyGoOPFSOpenReadSnapshotRef(opID uint32, dirRef uint64, namePtr unsafe.Pointer, nameLen uint32)
+
+//go:wasmimport gojs bldr.opfs.readSnapshotAtRef
+func tinyGoOPFSReadSnapshotAtRef(opID uint32, snapshotID uint32, dstPtr unsafe.Pointer, dstLen uint32, off int64)
+
+//go:wasmimport gojs bldr.opfs.closeReadSnapshotRef
+func tinyGoOPFSCloseReadSnapshotRef(opID uint32, snapshotID uint32)
+
 //go:wasmimport gojs bldr.opfs.fileExistsRef
 func tinyGoOPFSFileExistsRef(opID uint32, dirRef uint64, namePtr unsafe.Pointer, nameLen uint32)
 
@@ -166,6 +175,27 @@ func openAsyncFileWithTinyGoImport(dir js.Value, name string, create bool) (*Asy
 	return &AsyncFile{name: name, handle: handle}, nil
 }
 
+func openReadSnapshotWithTinyGoImport(dir js.Value, name string) (*ReadSnapshot, error) {
+	// Resolve and retain one immutable JavaScript File through the runtime table.
+	nameBytes := []byte(name)
+	values, err := invokeOPFSHelper(func(opID int) {
+		tinyGoOPFSOpenReadSnapshotRef(uint32(opID), tinyGoJSRef(dir), tinyGoBytesPtr(nameBytes), uint32(len(nameBytes)))
+		runtime.KeepAlive(nameBytes)
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(values) < 2 || values[0] == 0 {
+		return nil, errors.New("opfs snapshot helper returned incomplete result")
+	}
+	return &ReadSnapshot{
+		driver:   BrowserDriver{},
+		name:     name,
+		tinyGoID: values[0],
+		size:     int64(values[1]),
+	}, nil
+}
+
 func fileExistsWithTinyGoImport(dir js.Value, name string) (bool, error) {
 	nameBytes := []byte(name)
 	exists, err := invokeOPFSIntHelper(func(opID int) {
@@ -228,6 +258,44 @@ func (f *AsyncFile) readAtWithTinyGoImport(p []byte, off int64) (int, error) {
 		return 0, io.EOF
 	}
 	return n, nil
+}
+
+func (s *ReadSnapshot) readAtWithTinyGoImport(p []byte, off int64) (int, error) {
+	// Copy the requested range from the retained JavaScript File into Go memory.
+	n, err := invokeOPFSIntHelper(func(opID int) {
+		tinyGoOPFSReadSnapshotAtRef(
+			uint32(opID),
+			uint32(s.tinyGoID),
+			tinyGoBytesPtr(p),
+			uint32(len(p)),
+			off,
+		)
+	})
+	if err != nil {
+		return 0, err
+	}
+	if n > len(p) {
+		return 0, errors.Errorf("read exceeded buffer for snapshot %s: read %d into %d", s.name, n, len(p))
+	}
+	return n, nil
+}
+
+func (s *ReadSnapshot) closeWithTinyGoImport() error {
+	// Release the retained JavaScript File token once.
+	if s.tinyGoID == 0 {
+		return nil
+	}
+	released, err := invokeOPFSIntHelper(func(opID int) {
+		tinyGoOPFSCloseReadSnapshotRef(uint32(opID), uint32(s.tinyGoID))
+	})
+	if err != nil {
+		return err
+	}
+	if released != 1 {
+		return errors.Errorf("close read snapshot %s: snapshot unavailable", s.name)
+	}
+	s.tinyGoID = 0
+	return nil
 }
 
 func (f *AsyncFile) writeAtWithTinyGoImport(p []byte, off int64, keepExisting bool) (int, error) {

--- a/db/opfs/opfs_tinygo_imports_other.go
+++ b/db/opfs/opfs_tinygo_imports_other.go
@@ -20,6 +20,10 @@ func openAsyncFileWithTinyGoImport(_ js.Value, _ string, _ bool) (*AsyncFile, er
 	return nil, errors.New("tinygo OPFS import helper unavailable")
 }
 
+func openReadSnapshotWithTinyGoImport(_ js.Value, _ string) (*ReadSnapshot, error) {
+	return nil, errors.New("tinygo OPFS import helper unavailable")
+}
+
 func fileExistsWithTinyGoImport(_ js.Value, _ string) (bool, error) {
 	return false, errors.New("tinygo OPFS import helper unavailable")
 }
@@ -42,6 +46,14 @@ func (f *AsyncFile) truncateWithTinyGoImport(_ int64) error {
 
 func (f *AsyncFile) readAtWithTinyGoImport(_ []byte, _ int64) (int, error) {
 	return 0, errors.New("tinygo OPFS import helper unavailable")
+}
+
+func (s *ReadSnapshot) readAtWithTinyGoImport(_ []byte, _ int64) (int, error) {
+	return 0, errors.New("tinygo OPFS import helper unavailable")
+}
+
+func (s *ReadSnapshot) closeWithTinyGoImport() error {
+	return errors.New("tinygo OPFS import helper unavailable")
 }
 
 func (f *AsyncFile) writeAtWithTinyGoImport(_ []byte, _ int64, _ bool) (int, error) {

--- a/db/opfs/read-snapshot.go
+++ b/db/opfs/read-snapshot.go
@@ -1,0 +1,152 @@
+//go:build js
+
+package opfs
+
+import (
+	"io"
+	"sync"
+	"syscall/js"
+
+	"github.com/pkg/errors"
+	"github.com/s4wave/spacewave/db/opfs/jsutil"
+)
+
+type readSnapshotDriver interface {
+	readSnapshotAt(snapshot *ReadSnapshot, p []byte, off int64) (int, error)
+	closeReadSnapshot(snapshot *ReadSnapshot) error
+}
+
+// ReadSnapshot retains one immutable OPFS File and its resolved size.
+type ReadSnapshot struct {
+	// driver and runtime references select the direct, TinyGo, or remote path.
+	driver   readSnapshotDriver
+	name     string
+	handle   js.Value
+	tinyGoID int
+	size     int64
+
+	// mu serializes reads with exactly-once release.
+	mu       sync.Mutex
+	closed   bool
+	closeErr error
+}
+
+// OpenReadSnapshot opens an immutable view of an existing file.
+func OpenReadSnapshot(dir js.Value, name string) (*ReadSnapshot, error) {
+	return DefaultDriver.OpenReadSnapshot(dir, name)
+}
+
+// OpenReadSnapshot resolves one immutable File and records its size.
+func (d BrowserDriver) OpenReadSnapshot(dir js.Value, name string) (*ReadSnapshot, error) {
+	// Use retained JavaScript references when TinyGo cannot hold File directly.
+	if jsutil.UseTinyGoHelpers() {
+		return openReadSnapshotWithTinyGoImport(dir, name)
+	}
+
+	// Resolve the mutable directory entry to one immutable File exactly once.
+	fileHandle, err := AwaitPromise(jsutil.Call(dir, "getFileHandle", name))
+	if err != nil {
+		return nil, errors.Wrap(err, "getFileHandle")
+	}
+	file, err := AwaitPromise(jsutil.Call(fileHandle, "getFile"))
+	if err != nil {
+		return nil, errors.Wrap(err, "getFile")
+	}
+	return &ReadSnapshot{
+		driver: d,
+		name:   name,
+		handle: file,
+		size:   int64(file.Get("size").Int()),
+	}, nil
+}
+
+// ReadAt reads immutable bytes starting at off.
+func (s *ReadSnapshot) ReadAt(p []byte, off int64) (int, error) {
+	// Serialize reads with release so the driver reference stays live.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return 0, errors.New("opfs read snapshot is closed")
+	}
+
+	// Validate and clamp the request to the recorded immutable size.
+	if off < 0 {
+		return 0, errors.New("opfs read snapshot has negative offset")
+	}
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if off >= s.size {
+		return 0, io.EOF
+	}
+	readLen := min(int64(len(p)), s.size-off)
+
+	// Read only the in-bounds prefix through the selected runtime driver.
+	n, err := s.driver.readSnapshotAt(s, p[:readLen], off)
+	if n < 0 || n > int(readLen) {
+		return 0, errors.Errorf("read snapshot %s returned invalid count %d for %d bytes", s.name, n, readLen)
+	}
+	if err != nil {
+		return n, classifyReadSnapshotError(err)
+	}
+	if n != int(readLen) || readLen < int64(len(p)) {
+		return n, io.EOF
+	}
+	return n, nil
+}
+
+func classifyReadSnapshotError(err error) error {
+	// Treat a reclaimed immutable File as missing so manifest refresh can retry.
+	var jsErr *JSError
+	if errors.As(err, &jsErr) && jsErr.Name == "NotReadableError" {
+		return &JSError{Name: "NotFoundError", Message: jsErr.Error()}
+	}
+	return err
+}
+
+func (BrowserDriver) readSnapshotAt(snapshot *ReadSnapshot, p []byte, off int64) (int, error) {
+	// Route TinyGo reads through the retained JavaScript reference table.
+	if jsutil.UseTinyGoHelpers() {
+		return snapshot.readAtWithTinyGoImport(p, off)
+	}
+
+	// Slice the retained File without resolving its directory entry again.
+	blob := jsutil.Call(snapshot.handle, "slice", off, off+int64(len(p)))
+	buffer, err := AwaitPromise(jsutil.Call(blob, "arrayBuffer"))
+	if err != nil {
+		return 0, errors.Wrap(err, "arrayBuffer")
+	}
+	bytes := jsutil.NewUint8Array(buffer)
+	n := bytes.Get("length").Int()
+	js.CopyBytesToGo(p[:n], bytes)
+	return n, nil
+}
+
+// Size returns the size recorded when the immutable snapshot was opened.
+func (s *ReadSnapshot) Size() (int64, error) {
+	return s.size, nil
+}
+
+// Close releases the retained File or runtime token exactly once.
+func (s *ReadSnapshot) Close() error {
+	// Mark release before calling the driver so failures cannot double-release.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return s.closeErr
+	}
+	s.closed = true
+	s.closeErr = s.driver.closeReadSnapshot(s)
+	return s.closeErr
+}
+
+func (BrowserDriver) closeReadSnapshot(snapshot *ReadSnapshot) error {
+	// Release TinyGo's explicit retained reference when present.
+	if jsutil.UseTinyGoHelpers() {
+		return snapshot.closeWithTinyGoImport()
+	}
+
+	// Drop the standard Go JavaScript reference to the immutable File.
+	snapshot.handle = js.Undefined()
+	return nil
+}

--- a/db/opfs/remote-driver.go
+++ b/db/opfs/remote-driver.go
@@ -21,6 +21,7 @@ const (
 	remoteHandleKindDirectory = "directory"
 	remoteHandleKindFile      = "file"
 	remoteHandleKindStream    = "stream"
+	remoteHandleKindSnapshot  = "snapshot"
 )
 
 // RemoteDriver routes OPFS File System Access operations over a worker bridge.
@@ -235,6 +236,44 @@ func (d *RemoteDriver) OpenAsyncFile(dir js.Value, name string) (*AsyncFile, err
 	return &AsyncFile{driver: d, name: name, handle: handle}, nil
 }
 
+// OpenReadSnapshot resolves one immutable File in the remote worker.
+func (d *RemoteDriver) OpenReadSnapshot(dir js.Value, name string) (*ReadSnapshot, error) {
+	// Resolve the remote directory before creating a worker-side snapshot token.
+	dirID, err := d.handleID(dir, remoteHandleKindDirectory)
+	if err != nil {
+		return nil, err
+	}
+	result, err := d.call("openReadSnapshot", remoteArgs(
+		"dir", dirID,
+		"name", name,
+	))
+	if err != nil {
+		return nil, err
+	}
+
+	// Validate the full token response before admitting it to the driver table.
+	snapshotID, err := remoteHandleID(result)
+	if err != nil {
+		return nil, err
+	}
+	size, err := remoteInt(result, "size")
+	if err != nil {
+		_, _ = d.call("closeReadSnapshot", remoteArgs("snapshot", snapshotID))
+		return nil, err
+	}
+	handle, err := d.newHandle(result, remoteHandleKindSnapshot)
+	if err != nil {
+		_, _ = d.call("closeReadSnapshot", remoteArgs("snapshot", snapshotID))
+		return nil, err
+	}
+	return &ReadSnapshot{
+		driver: d,
+		name:   name,
+		handle: handle,
+		size:   size,
+	}, nil
+}
+
 // CreateAsyncFile opens or creates a remote file.
 func (d *RemoteDriver) CreateAsyncFile(dir js.Value, name string) (*AsyncFile, error) {
 	dirID, err := d.handleID(dir, remoteHandleKindDirectory)
@@ -429,6 +468,36 @@ func (d *RemoteDriver) readAsyncFileAt(f *AsyncFile, p []byte, off int64) (int, 
 		return 0, err
 	}
 	return remoteCopyBytes(p, result, "readAt")
+}
+
+func (d *RemoteDriver) readSnapshotAt(snapshot *ReadSnapshot, p []byte, off int64) (int, error) {
+	// Resolve and validate the worker token before each range request.
+	snapshotID, err := d.handleID(snapshot.handle, remoteHandleKindSnapshot)
+	if err != nil {
+		return 0, err
+	}
+	result, err := d.call("readSnapshotAt", remoteArgs(
+		"snapshot", snapshotID,
+		"offset", off,
+		"length", len(p),
+	))
+	if err != nil {
+		return 0, err
+	}
+	return remoteCopyBytes(p, result, "readSnapshotAt")
+}
+
+func (d *RemoteDriver) closeReadSnapshot(snapshot *ReadSnapshot) error {
+	// Release the worker token before removing its local identity.
+	snapshotID, err := d.handleID(snapshot.handle, remoteHandleKindSnapshot)
+	if err != nil {
+		return err
+	}
+	_, err = d.call("closeReadSnapshot", remoteArgs("snapshot", snapshotID))
+	if err == nil {
+		d.removeHandle(snapshotID)
+	}
+	return err
 }
 
 func (d *RemoteDriver) writeAsyncFileAt(ctx context.Context, f *AsyncFile, p []byte, off int64) (int, error) {

--- a/db/opfs/remote-driver_test.go
+++ b/db/opfs/remote-driver_test.go
@@ -47,6 +47,36 @@ func TestRemoteDriverInstallPortSwapGeneration(t *testing.T) {
 	}
 }
 
+// TestRemoteReadSnapshotBecomesStaleOnSwap proves a bridge replacement rejects
+// every retained snapshot token from the previous worker.
+func TestRemoteReadSnapshotBecomesStaleOnSwap(t *testing.T) {
+	// Seed one snapshot identity in the first bridge generation.
+	d := NewRemoteDriver(makeBridgePort(t))
+	handle, err := d.newHandle(js.ValueOf(9), remoteHandleKindSnapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot := &ReadSnapshot{
+		driver: d,
+		name:   "segment.sst",
+		handle: handle,
+		size:   8,
+	}
+
+	// Swap workers and reject the old token before issuing another request.
+	d.installPort(makeBridgePort(t))
+	if _, err := snapshot.ReadAt(make([]byte, 1), 0); err == nil {
+		t.Fatal("stale snapshot read succeeded after bridge swap")
+	}
+	closeErr := snapshot.Close()
+	if closeErr == nil {
+		t.Fatal("stale snapshot close succeeded after bridge swap")
+	}
+	if retryErr := snapshot.Close(); retryErr != closeErr {
+		t.Fatalf("second close error = %v, want %v", retryErr, closeErr)
+	}
+}
+
 // TestRemoteDriverWaitSwapWakesOnSwap proves a waiter parked before a swap wakes
 // once the bridge port is replaced.
 func TestRemoteDriverWaitSwapWakesOnSwap(t *testing.T) {

--- a/db/volume/js/opfs/blockshard/blockshard_test.go
+++ b/db/volume/js/opfs/blockshard/blockshard_test.go
@@ -557,24 +557,28 @@ func TestShardCachesSegmentFiles(t *testing.T) {
 	}
 	seg := &m.Segments[0]
 
-	f1, err := e.shards[0].getSegmentFile(context.Background(), seg)
+	lease1, err := e.shards[0].acquireSegment(context.Background(), seg)
 	if err != nil {
 		t.Fatal(err)
 	}
-	f2, err := e.shards[0].getSegmentFile(context.Background(), seg)
+	file1 := lease1.entry.file
+	lease1.Release()
+
+	lease2, err := e.shards[0].acquireSegment(context.Background(), seg)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if f1 != f2 {
+	file2 := lease2.entry.file
+	lease2.Release()
+	if file1 != file2 {
 		t.Fatal("expected cached segment file handle")
 	}
 
 	e.shards[0].mu.Lock()
 	e.shards[0].setManifestLocked(&Manifest{Generation: m.Generation + 1})
-	_, ok := e.shards[0].segmentFileCache[seg.Filename]
 	e.shards[0].mu.Unlock()
-	if ok {
-		t.Fatal("expected segment file cache eviction after manifest update")
+	if stats := e.cache.snapshot(); stats.LiveHandles != 0 {
+		t.Fatalf("live cache handles after manifest update: got %d want 0", stats.LiveHandles)
 	}
 }
 
@@ -763,15 +767,18 @@ func TestBlockStoreFlushDoesNotCompactForegroundSegments(t *testing.T) {
 	)
 	defer cleanup()
 
+	// Publish two foreground segments at the inline compaction trigger.
 	store := NewBlockStore(e, block.DefaultHashType)
-	for _, data := range [][]byte{
-		[]byte("value-a"),
-		[]byte("value-b"),
+	for _, entry := range []segment.Entry{
+		{Key: []byte("key-a"), Value: []byte("value-a")},
+		{Key: []byte("key-b"), Value: []byte("value-b")},
 	} {
-		if _, _, err := store.PutBlock(context.Background(), data, nil); err != nil {
+		if err := e.Put(context.Background(), []segment.Entry{entry}); err != nil {
 			t.Fatal(err)
 		}
 	}
+
+	// Flush the store without adding a durability or compaction boundary.
 	if err := store.Flush(context.Background()); err != nil {
 		t.Fatal(err)
 	}
@@ -1528,15 +1535,12 @@ func assertShardEntry(t testing.TB, shard *Shard, key, want []byte) {
 		if string(key) < string(seg.MinKey) || string(key) > string(seg.MaxKey) {
 			continue
 		}
-		lookup, err := shard.getLookup(context.Background(), seg)
+		lease, err := shard.acquireSegment(context.Background(), seg)
 		if err != nil {
 			t.Fatal(err)
 		}
-		f, err := shard.getSegmentFile(context.Background(), seg)
-		if err != nil {
-			t.Fatal(err)
-		}
-		val, found, tombstone, err := lookup.Locate(f, key, true)
+		val, found, tombstone, err := lease.lookup.Locate(lease, key, true)
+		lease.Release()
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/db/volume/js/opfs/blockshard/blockshard_test.go
+++ b/db/volume/js/opfs/blockshard/blockshard_test.go
@@ -514,8 +514,8 @@ func TestCachedSegmentFileCachesWindow(t *testing.T) {
 	if got := string(buf); got != want {
 		t.Fatalf("first read got %q want %q", got, want)
 	}
-	if rd.reads != 2 {
-		t.Fatalf("reads after cross-block call: got %d want 2", rd.reads)
+	if rd.reads != 1 {
+		t.Fatalf("reads after cross-block call: got %d want 1", rd.reads)
 	}
 
 	buf = make([]byte, 8)
@@ -527,7 +527,7 @@ func TestCachedSegmentFileCachesWindow(t *testing.T) {
 	if got := string(buf); got != want {
 		t.Fatalf("cached overlap got %q want %q", got, want)
 	}
-	if rd.reads != 2 {
+	if rd.reads != 1 {
 		t.Fatalf("cached overlap should not reread: got %d reads", rd.reads)
 	}
 
@@ -535,8 +535,47 @@ func TestCachedSegmentFileCachesWindow(t *testing.T) {
 	if _, err := f.ReadAt(buf, int64(cachedSegmentBlockSize*2)); err != nil {
 		t.Fatal(err)
 	}
-	if rd.reads != 3 {
+	if rd.reads != 2 {
 		t.Fatalf("third block should reread once: got %d reads", rd.reads)
+	}
+}
+
+func TestCachedSegmentFileSplitsMissingRunsAroundResidentSpan(t *testing.T) {
+	// Build three aligned immutable blocks and retain the middle block first.
+	data := bytes.Repeat([]byte("abcdefghijklmnopqrstuvwxyz"), (cachedSegmentBlockSize*3)/26+2)
+	rd := &fakeSegmentReader{buf: data[:cachedSegmentBlockSize*3]}
+	f := newCachedSegmentFile(rd, int64(len(rd.buf)))
+	var middle [1]byte
+	if _, err := f.ReadAt(middle[:], cachedSegmentBlockSize); err != nil {
+		t.Fatal(err)
+	}
+	if rd.reads != 1 {
+		t.Fatalf("middle block reads: got %d want 1", rd.reads)
+	}
+
+	// Read across the file with one missing fill on each side of the resident block.
+	got := make([]byte, len(rd.buf))
+	if _, err := f.ReadAt(got, 0); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, rd.buf) {
+		t.Fatal("split span read returned different bytes")
+	}
+	if rd.reads != 3 {
+		t.Fatalf("split span reads: got %d want 3", rd.reads)
+	}
+
+	// Preserve final-file short-read semantics from the retained last span.
+	var tail [8]byte
+	n, err := f.ReadAt(tail[:], int64(len(rd.buf)-4))
+	if n != 4 || err != io.EOF {
+		t.Fatalf("final read: bytes=%d err=%v want bytes=4 err=EOF", n, err)
+	}
+	if !bytes.Equal(tail[:n], rd.buf[len(rd.buf)-4:]) {
+		t.Fatal("final read returned different bytes")
+	}
+	if rd.reads != 3 {
+		t.Fatalf("retained final span reread: got %d reads", rd.reads)
 	}
 }
 

--- a/db/volume/js/opfs/blockshard/cache-coordinator.go
+++ b/db/volume/js/opfs/blockshard/cache-coordinator.go
@@ -26,22 +26,29 @@ type cacheResourceKind uint8
 
 const (
 	cacheResourceLookup cacheResourceKind = iota
-	cacheResourceBlock
+	cacheResourceSpan
 )
 
 type cacheResource struct {
 	entry    *cacheEntry
 	kind     cacheResourceKind
-	blockOff int64
+	span     *cachedSpan
 	bytes    uint64
 	pins     int
 	prev     *cacheResource
 	next     *cacheResource
+	resident bool
 }
 
-type cachedBlock struct {
-	data     []byte
+// cachedSpan retains one admitted backing allocation and its cache resource.
+type cachedSpan struct {
+	segmentDataSpan
 	resource *cacheResource
+}
+
+// cachedBlock maps one aligned offset to its shared admitted span.
+type cachedBlock struct {
+	span *cachedSpan
 }
 
 type cacheEntry struct {
@@ -51,6 +58,8 @@ type cacheEntry struct {
 	lookup         *segment.LookupMeta
 	lookupResource *cacheResource
 	blocks         map[int64]*cachedBlock
+	blockSpans     int
+	fills          map[segmentFillRange]*segmentFill
 	leases         int
 	loading        chan struct{}
 	removed        bool
@@ -198,6 +207,7 @@ func (c *cacheCoordinator) acquireSegment(
 		entry = &cacheEntry{
 			key:     key,
 			blocks:  make(map[int64]*cachedBlock),
+			fills:   make(map[segmentFillRange]*segmentFill),
 			leases:  1,
 			loading: make(chan struct{}),
 		}
@@ -353,81 +363,154 @@ func (c *cacheCoordinator) releaseLease(lease *segmentCacheLease) {
 	c.closeFiles(closers)
 }
 
-func (c *cacheCoordinator) getBlock(
+func (c *cacheCoordinator) startSpanFill(
 	entry *cacheEntry,
 	lease *segmentCacheLease,
 	blockOff int64,
-) ([]byte, bool) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	block := entry.blocks[blockOff]
-	if block == nil {
-		c.stats.Misses++
-		return nil, false
-	}
-	c.stats.Hits++
-	c.pinResourceLocked(lease, block.resource)
-	return block.data, true
-}
-
-func (c *cacheCoordinator) admitBlock(
-	entry *cacheEntry,
-	lease *segmentCacheLease,
-	blockOff int64,
-	data []byte,
-) []byte {
-	// Reuse a concurrent winner before reserving another allocation.
+	endBlock int64,
+	size int64,
+) (segmentDataSpan, *segmentFill, bool) {
+	// Reuse and pin a resident span covering the next requested block.
 	c.mu.Lock()
 	if block := entry.blocks[blockOff]; block != nil {
-		c.pinResourceLocked(lease, block.resource)
+		c.stats.Hits++
+		c.pinResourceLocked(lease, block.span.resource)
+		span := block.span.segmentDataSpan
 		c.mu.Unlock()
-		return block.data
+		return span, nil, false
 	}
 
-	// Keep reads operation-local after retirement or engine close.
-	if entry.removed || c.closed {
-		c.stats.Bypasses++
+	// Bound the fill at the next resident block, request edge, or file edge.
+	end := min(endBlock+cachedSegmentBlockSize, size)
+	var misses uint64
+	for off := blockOff; off <= endBlock; off += cachedSegmentBlockSize {
+		if off != blockOff && entry.blocks[off] != nil {
+			end = off
+			break
+		}
+		misses++
+	}
+	c.stats.Misses += misses
+	key := segmentFillRange{start: blockOff, end: end}
+
+	// Join an equal in-flight range without starting another snapshot read.
+	if entry.fills == nil {
+		entry.fills = make(map[segmentFillRange]*segmentFill)
+	}
+	if fill := entry.fills[key]; fill != nil {
+		c.stats.SharedFills++
+		c.cond.Broadcast()
 		c.mu.Unlock()
-		return data
+		return segmentDataSpan{}, fill, false
 	}
 
-	// Preserve the per-segment span limit without evicting a pinned block.
+	// Publish this caller as the range leader.
+	fill := &segmentFill{key: key, done: make(chan struct{})}
+	entry.fills[key] = fill
+	c.mu.Unlock()
+	return segmentDataSpan{}, fill, true
+}
+
+func (c *cacheCoordinator) awaitSpanFill(
+	fill *segmentFill,
+	lease *segmentCacheLease,
+) (segmentDataSpan, error) {
+	// Wait for the leader to publish bytes or its exact failure.
+	<-fill.done
+	if fill.err != nil {
+		return segmentDataSpan{}, fill.err
+	}
+
+	// Pin the admitted resource when it still resides in the cache.
+	c.mu.Lock()
+	if fill.resource != nil && fill.resource.resident {
+		c.pinResourceLocked(lease, fill.resource)
+	}
+	c.mu.Unlock()
+	return fill.span, nil
+}
+
+func (c *cacheCoordinator) finishSpanFill(
+	entry *cacheEntry,
+	lease *segmentCacheLease,
+	fill *segmentFill,
+	span segmentDataSpan,
+	fillErr error,
+) (segmentDataSpan, error) {
+	// Publish completion state before waking equal-range waiters.
+	c.mu.Lock()
+	fill.span = span
+	fill.err = fillErr
 	var closers []*cachedSegmentFile
-	if len(entry.blocks) >= maxCachedSegmentBlocks {
-		resource := c.oldestBlockLocked(entry)
+	admit := fillErr == nil
+
+	// Keep successful bytes operation-local after retirement or an unequal race.
+	if admit && (entry.removed || c.closed) {
+		c.stats.Bypasses++
+		admit = false
+	}
+	if admit {
+		for off := fill.key.start; off < fill.key.end; off += cachedSegmentBlockSize {
+			if entry.blocks[off] != nil {
+				c.stats.Bypasses++
+				admit = false
+				break
+			}
+		}
+	}
+
+	// Preserve the per-segment span count without evicting a pinned span.
+	if admit && entry.blockSpans >= maxCachedSegmentSpans {
+		resource := c.oldestSpanLocked(entry)
 		if resource == nil {
 			c.stats.Bypasses++
-			c.mu.Unlock()
-			return data
+			admit = false
 		}
-		c.removeResourceLocked(resource, true)
+		if resource != nil {
+			c.removeResourceLocked(resource, true)
+		}
 	}
 
-	// Reserve exact backing capacity or return the operation-local allocation.
-	charge := uint64(cap(data))
-	reservedClosers, admitted := c.reserveBytesLocked(charge)
-	closers = append(closers, reservedClosers...)
-	if !admitted {
-		c.stats.Bypasses++
-		c.mu.Unlock()
-		c.closeFiles(closers)
-		return data
+	// Reserve the exact backing allocation through the engine byte budget.
+	charge := uint64(cap(span.data))
+	if admit {
+		var admitted bool
+		var reservedClosers []*cachedSegmentFile
+		reservedClosers, admitted = c.reserveBytesLocked(charge)
+		closers = append(closers, reservedClosers...)
+		if !admitted {
+			c.stats.Bypasses++
+			admit = false
+		}
 	}
 
-	// Publish and pin the admitted block before exposing it to the reader.
-	resource := &cacheResource{
-		entry:    entry,
-		kind:     cacheResourceBlock,
-		blockOff: blockOff,
-		bytes:    charge,
+	// Publish one resource and all aligned block views of its backing allocation.
+	if admit {
+		cached := &cachedSpan{segmentDataSpan: span}
+		resource := &cacheResource{
+			entry: entry,
+			kind:  cacheResourceSpan,
+			span:  cached,
+			bytes: charge,
+		}
+		cached.resource = resource
+		for off := fill.key.start; off < fill.key.end; off += cachedSegmentBlockSize {
+			entry.blocks[off] = &cachedBlock{span: cached}
+		}
+		entry.blockSpans++
+		fill.resource = resource
+		c.addResourceLocked(resource)
+		c.pinResourceLocked(lease, resource)
+		c.stats.Admissions++
 	}
-	entry.blocks[blockOff] = &cachedBlock{data: data, resource: resource}
-	c.addResourceLocked(resource)
-	c.pinResourceLocked(lease, resource)
-	c.stats.Admissions++
+
+	// Remove the in-flight identity and wake every waiter with the same result.
+	delete(entry.fills, fill.key)
+	close(fill.done)
+	c.cond.Broadcast()
 	c.mu.Unlock()
 	c.closeFiles(closers)
-	return data
+	return span, fillErr
 }
 
 func (c *cacheCoordinator) recordRead(n int) {
@@ -519,7 +602,7 @@ func (c *cacheCoordinator) snapshot() cacheStats {
 
 func (c *cacheCoordinator) hasActiveLeasesLocked() bool {
 	for _, entry := range c.entries {
-		if entry.leases != 0 || entry.loading != nil {
+		if entry.leases != 0 || entry.loading != nil || len(entry.fills) != 0 {
 			return true
 		}
 	}
@@ -581,9 +664,9 @@ func (c *cacheCoordinator) oldestEvictableLocked(forHandle bool) *cacheResource 
 	return nil
 }
 
-func (c *cacheCoordinator) oldestBlockLocked(entry *cacheEntry) *cacheResource {
+func (c *cacheCoordinator) oldestSpanLocked(entry *cacheEntry) *cacheResource {
 	for resource := c.lruHead; resource != nil; resource = resource.next {
-		if resource.entry == entry && resource.kind == cacheResourceBlock && resource.pins == 0 {
+		if resource.entry == entry && resource.kind == cacheResourceSpan && resource.pins == 0 {
 			return resource
 		}
 	}
@@ -591,7 +674,8 @@ func (c *cacheCoordinator) oldestBlockLocked(entry *cacheEntry) *cacheResource {
 }
 
 func (c *cacheCoordinator) addResourceLocked(resource *cacheResource) {
-	// Link the resource at the recency tail.
+	// Mark the resource resident and link it at the recency tail.
+	resource.resident = true
 	resource.prev = c.lruTail
 	if c.lruTail == nil {
 		c.lruHead = resource
@@ -607,7 +691,7 @@ func (c *cacheCoordinator) addResourceLocked(resource *cacheResource) {
 	switch resource.kind {
 	case cacheResourceLookup:
 		c.stats.MetadataBytes += resource.bytes
-	case cacheResourceBlock:
+	case cacheResourceSpan:
 		c.stats.BlockBytes += resource.bytes
 	}
 }
@@ -652,14 +736,14 @@ func (c *cacheCoordinator) removeIdleResourcesLocked(entry *cacheEntry, eviction
 		c.removeResourceLocked(entry.lookupResource, eviction)
 	}
 	for _, block := range entry.blocks {
-		if block.resource.pins == 0 {
-			c.removeResourceLocked(block.resource, eviction)
+		if block.span.resource != nil && block.span.resource.pins == 0 {
+			c.removeResourceLocked(block.span.resource, eviction)
 		}
 	}
 }
 
 func (c *cacheCoordinator) removeResourceLocked(resource *cacheResource, eviction bool) {
-	if resource.pins != 0 {
+	if !resource.resident || resource.pins != 0 {
 		return
 	}
 
@@ -676,6 +760,7 @@ func (c *cacheCoordinator) removeResourceLocked(resource *cacheResource, evictio
 	if resource.next != nil {
 		resource.next.prev = resource.prev
 	}
+	resource.resident = false
 
 	// Remove the typed payload from its segment entry.
 	entry := resource.entry
@@ -684,8 +769,16 @@ func (c *cacheCoordinator) removeResourceLocked(resource *cacheResource, evictio
 		entry.lookup = nil
 		entry.lookupResource = nil
 		c.stats.MetadataBytes -= resource.bytes
-	case cacheResourceBlock:
-		delete(entry.blocks, resource.blockOff)
+	case cacheResourceSpan:
+		span := resource.span
+		for off := span.start; off < span.start+int64(len(span.data)); off += cachedSegmentBlockSize {
+			if block := entry.blocks[off]; block != nil && block.span == span {
+				delete(entry.blocks, off)
+			}
+		}
+		entry.blockSpans--
+		span.resource = nil
+		resource.span = nil
 		c.stats.BlockBytes -= resource.bytes
 	}
 
@@ -698,7 +791,11 @@ func (c *cacheCoordinator) removeResourceLocked(resource *cacheResource, evictio
 
 func (c *cacheCoordinator) detachIdleEntryLocked(entry *cacheEntry) *cachedSegmentFile {
 	// Keep entries with active operations or resident resources attached.
-	if entry.leases != 0 || entry.loading != nil || entry.lookupResource != nil || len(entry.blocks) != 0 {
+	if entry.leases != 0 ||
+		entry.loading != nil ||
+		len(entry.fills) != 0 ||
+		entry.lookupResource != nil ||
+		len(entry.blocks) != 0 {
 		return nil
 	}
 	if current := c.entries[entry.key]; current != entry {

--- a/db/volume/js/opfs/blockshard/cache-coordinator.go
+++ b/db/volume/js/opfs/blockshard/cache-coordinator.go
@@ -1,0 +1,765 @@
+//go:build js
+
+package blockshard
+
+import (
+	"context"
+	"io"
+	"sync"
+	"unsafe"
+
+	"github.com/pkg/errors"
+	"github.com/s4wave/spacewave/db/volume/js/opfs/segment"
+)
+
+const (
+	defaultCacheByteLimit   = 64 * 1024 * 1024
+	defaultCacheHandleLimit = 512
+)
+
+type cacheKey struct {
+	shardID  int
+	filename string
+}
+
+type cacheResourceKind uint8
+
+const (
+	cacheResourceLookup cacheResourceKind = iota
+	cacheResourceBlock
+)
+
+type cacheResource struct {
+	entry    *cacheEntry
+	kind     cacheResourceKind
+	blockOff int64
+	bytes    uint64
+	pins     int
+	prev     *cacheResource
+	next     *cacheResource
+}
+
+type cachedBlock struct {
+	data     []byte
+	resource *cacheResource
+}
+
+type cacheEntry struct {
+	key cacheKey
+
+	file           *cachedSegmentFile
+	lookup         *segment.LookupMeta
+	lookupResource *cacheResource
+	blocks         map[int64]*cachedBlock
+	leases         int
+	loading        chan struct{}
+	removed        bool
+}
+
+// cacheStats reports the engine-local immutable segment cache state.
+type cacheStats struct {
+	ChargedBytes     uint64
+	MetadataBytes    uint64
+	BlockBytes       uint64
+	PinnedBytes      uint64
+	PeakChargedBytes uint64
+	LiveHandles      uint64
+	PeakLiveHandles  uint64
+	Admissions       uint64
+	Bypasses         uint64
+	Evictions        uint64
+	Hits             uint64
+	Misses           uint64
+	SharedFills      uint64
+	ReadCalls        uint64
+	FetchedBytes     uint64
+	ReleaseErrors    uint64
+}
+
+type cacheCoordinator struct {
+	// mu guards every field below it.
+	mu   sync.Mutex
+	cond *sync.Cond
+
+	byteLimit   uint64
+	handleLimit uint64
+	entries     map[cacheKey]*cacheEntry
+	lruHead     *cacheResource
+	lruTail     *cacheResource
+	stats       cacheStats
+	closed      bool
+}
+
+func newCacheCoordinator(byteLimit, handleLimit uint64) *cacheCoordinator {
+	c := &cacheCoordinator{
+		byteLimit:   byteLimit,
+		handleLimit: handleLimit,
+		entries:     make(map[cacheKey]*cacheEntry),
+	}
+	c.cond = sync.NewCond(&c.mu)
+	return c
+}
+
+func newDefaultCacheCoordinator() *cacheCoordinator {
+	return newCacheCoordinator(defaultCacheByteLimit, defaultCacheHandleLimit)
+}
+
+type segmentCacheLease struct {
+	cache     *cacheCoordinator
+	entry     *cacheEntry
+	lookup    *segment.LookupMeta
+	localFile *cachedSegmentFile
+	resources map[*cacheResource]struct{}
+	once      sync.Once
+}
+
+func (l *segmentCacheLease) ReadAt(p []byte, off int64) (int, error) {
+	if l.localFile != nil {
+		return l.localFile.ReadAt(p, off)
+	}
+	return l.entry.file.readAt(p, off, l)
+}
+
+func (l *segmentCacheLease) Size() (int64, error) {
+	if l.localFile != nil {
+		return l.localFile.Size()
+	}
+	return l.entry.file.Size()
+}
+
+func (l *segmentCacheLease) Release() {
+	l.once.Do(func() {
+		if l.localFile != nil {
+			if err := closeSegmentReader(l.localFile.rd); err != nil {
+				l.cache.recordReleaseError()
+			}
+			return
+		}
+		l.cache.releaseLease(l)
+	})
+}
+
+func (c *cacheCoordinator) acquireSegment(
+	ctx context.Context,
+	key cacheKey,
+	meta *SegmentMeta,
+	open func() (segmentReader, error),
+) (*segmentCacheLease, error) {
+	for {
+		// Reject acquisitions after engine close begins.
+		c.mu.Lock()
+		if c.closed {
+			c.mu.Unlock()
+			return nil, errors.New("blockshard cache is closed")
+		}
+		entry := c.entries[key]
+
+		// Wait for the current metadata loader without holding the cache mutex.
+		if entry != nil && entry.loading != nil {
+			loading := entry.loading
+			c.mu.Unlock()
+			select {
+			case <-loading:
+				continue
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}
+
+		// Reuse an admitted entry or become its metadata loader.
+		if entry != nil && !entry.removed {
+			lease := c.newLeaseLocked(entry)
+
+			// Return resident metadata under the new lease pin.
+			if entry.lookupResource != nil {
+				lease.lookup = entry.lookup
+				c.pinResourceLocked(lease, entry.lookupResource)
+				c.mu.Unlock()
+				return lease, nil
+			}
+
+			// Reload evicted metadata through the retained file handle.
+			entry.loading = make(chan struct{})
+			c.mu.Unlock()
+			lookup, err := loadLookupMeta(ctx, lease, meta)
+			return c.finishLookupLoad(lease, lookup, err)
+		}
+
+		// Use operation-local state when the handle budget cannot admit the entry.
+		closers, admitted := c.reserveHandleLocked()
+		if !admitted || entry != nil {
+			c.stats.Bypasses++
+			c.mu.Unlock()
+			c.closeFiles(closers)
+			return c.acquireLocal(ctx, meta, open)
+		}
+
+		// Publish the handle reservation before opening the immutable file.
+		entry = &cacheEntry{
+			key:     key,
+			blocks:  make(map[int64]*cachedBlock),
+			leases:  1,
+			loading: make(chan struct{}),
+		}
+		c.entries[key] = entry
+		c.stats.LiveHandles++
+		c.stats.PeakLiveHandles = max(c.stats.PeakLiveHandles, c.stats.LiveHandles)
+		lease := &segmentCacheLease{
+			cache:     c,
+			entry:     entry,
+			resources: make(map[*cacheResource]struct{}),
+		}
+		c.mu.Unlock()
+		c.closeFiles(closers)
+
+		// Open the file and load metadata outside the coordinator mutex.
+		rd, err := open()
+		if err != nil {
+			c.failLookupLoad(lease)
+			return nil, err
+		}
+		entry.file = newCoordinatedSegmentFile(rd, int64(meta.Size), c, entry)
+		lookup, err := loadLookupMeta(ctx, lease, meta)
+		return c.finishLookupLoad(lease, lookup, err)
+	}
+}
+
+func (c *cacheCoordinator) acquireLocal(
+	ctx context.Context,
+	meta *SegmentMeta,
+	open func() (segmentReader, error),
+) (*segmentCacheLease, error) {
+	// Open one operation-local reader outside the admitted handle budget.
+	rd, err := open()
+	if err != nil {
+		return nil, err
+	}
+	lease := &segmentCacheLease{cache: c, localFile: newCachedSegmentFile(rd, int64(meta.Size))}
+
+	// Load metadata and transfer reader release to the returned lease.
+	lookup, err := loadLookupMeta(ctx, lease, meta)
+	if err != nil {
+		lease.Release()
+		return nil, err
+	}
+	lease.lookup = lookup
+	return lease, nil
+}
+
+func (c *cacheCoordinator) finishLookupLoad(
+	lease *segmentCacheLease,
+	lookup *segment.LookupMeta,
+	loadErr error,
+) (*segmentCacheLease, error) {
+	// Resolve the loader state before waking competing acquisitions.
+	c.mu.Lock()
+	entry := lease.entry
+	loading := entry.loading
+	entry.loading = nil
+	var closers []*cachedSegmentFile
+	if loadErr != nil {
+		entry.removed = true
+	}
+
+	// Admit decoded metadata when capacity and lifecycle still allow it.
+	if loadErr == nil && !entry.removed && !c.closed {
+		charge := lookupMetaCharge(lookup)
+		var admitted bool
+		closers, admitted = c.reserveBytesLocked(charge)
+
+		// Publish admitted metadata and pin it for the loading operation.
+		if admitted {
+			resource := &cacheResource{
+				entry: entry,
+				kind:  cacheResourceLookup,
+				bytes: charge,
+			}
+			entry.lookup = lookup
+			entry.lookupResource = resource
+			c.addResourceLocked(resource)
+			c.pinResourceLocked(lease, resource)
+			c.stats.Admissions++
+		}
+
+		// Record metadata retained only by the current operation.
+		if !admitted {
+			c.stats.Bypasses++
+		}
+	}
+
+	// Publish the load result and release evicted handles outside the mutex.
+	lease.lookup = lookup
+	close(loading)
+	c.cond.Broadcast()
+	c.mu.Unlock()
+	c.closeFiles(closers)
+
+	// Roll back the lease after a failed metadata read.
+	if loadErr != nil {
+		lease.Release()
+		return nil, loadErr
+	}
+	return lease, nil
+}
+
+func (c *cacheCoordinator) failLookupLoad(lease *segmentCacheLease) {
+	// Retire the handle reservation and wake metadata waiters.
+	c.mu.Lock()
+	entry := lease.entry
+	loading := entry.loading
+	entry.loading = nil
+	entry.removed = true
+	close(loading)
+	c.cond.Broadcast()
+	c.mu.Unlock()
+
+	// Complete handle rollback through normal lease release.
+	lease.Release()
+}
+
+func (c *cacheCoordinator) newLeaseLocked(entry *cacheEntry) *segmentCacheLease {
+	entry.leases++
+	return &segmentCacheLease{
+		cache:     c,
+		entry:     entry,
+		resources: make(map[*cacheResource]struct{}),
+	}
+}
+
+func (c *cacheCoordinator) releaseLease(lease *segmentCacheLease) {
+	// Drop every resource pin held by the completed operation.
+	c.mu.Lock()
+	entry := lease.entry
+	for resource := range lease.resources {
+		resource.pins--
+		if resource.pins == 0 {
+			c.stats.PinnedBytes -= resource.bytes
+		}
+	}
+	entry.leases--
+
+	// Complete deferred retirement and detach an empty entry.
+	var closers []*cachedSegmentFile
+	if entry.removed {
+		c.removeIdleResourcesLocked(entry, false)
+	}
+	if file := c.detachIdleEntryLocked(entry); file != nil {
+		closers = append(closers, file)
+	}
+	c.cond.Broadcast()
+	c.mu.Unlock()
+
+	// Release detached driver handles outside the coordinator mutex.
+	c.closeFiles(closers)
+}
+
+func (c *cacheCoordinator) getBlock(
+	entry *cacheEntry,
+	lease *segmentCacheLease,
+	blockOff int64,
+) ([]byte, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	block := entry.blocks[blockOff]
+	if block == nil {
+		c.stats.Misses++
+		return nil, false
+	}
+	c.stats.Hits++
+	c.pinResourceLocked(lease, block.resource)
+	return block.data, true
+}
+
+func (c *cacheCoordinator) admitBlock(
+	entry *cacheEntry,
+	lease *segmentCacheLease,
+	blockOff int64,
+	data []byte,
+) []byte {
+	// Reuse a concurrent winner before reserving another allocation.
+	c.mu.Lock()
+	if block := entry.blocks[blockOff]; block != nil {
+		c.pinResourceLocked(lease, block.resource)
+		c.mu.Unlock()
+		return block.data
+	}
+
+	// Keep reads operation-local after retirement or engine close.
+	if entry.removed || c.closed {
+		c.stats.Bypasses++
+		c.mu.Unlock()
+		return data
+	}
+
+	// Preserve the per-segment span limit without evicting a pinned block.
+	var closers []*cachedSegmentFile
+	if len(entry.blocks) >= maxCachedSegmentBlocks {
+		resource := c.oldestBlockLocked(entry)
+		if resource == nil {
+			c.stats.Bypasses++
+			c.mu.Unlock()
+			return data
+		}
+		c.removeResourceLocked(resource, true)
+	}
+
+	// Reserve exact backing capacity or return the operation-local allocation.
+	charge := uint64(cap(data))
+	reservedClosers, admitted := c.reserveBytesLocked(charge)
+	closers = append(closers, reservedClosers...)
+	if !admitted {
+		c.stats.Bypasses++
+		c.mu.Unlock()
+		c.closeFiles(closers)
+		return data
+	}
+
+	// Publish and pin the admitted block before exposing it to the reader.
+	resource := &cacheResource{
+		entry:    entry,
+		kind:     cacheResourceBlock,
+		blockOff: blockOff,
+		bytes:    charge,
+	}
+	entry.blocks[blockOff] = &cachedBlock{data: data, resource: resource}
+	c.addResourceLocked(resource)
+	c.pinResourceLocked(lease, resource)
+	c.stats.Admissions++
+	c.mu.Unlock()
+	c.closeFiles(closers)
+	return data
+}
+
+func (c *cacheCoordinator) recordRead(n int) {
+	c.mu.Lock()
+	c.stats.ReadCalls++
+	c.stats.FetchedBytes += uint64(max(n, 0))
+	c.mu.Unlock()
+}
+
+func (c *cacheCoordinator) recordBypass() {
+	c.mu.Lock()
+	c.stats.Bypasses++
+	c.mu.Unlock()
+}
+
+func (c *cacheCoordinator) remove(key cacheKey) {
+	// Mark the entry retired and drop every idle resource.
+	c.mu.Lock()
+	entry := c.entries[key]
+	if entry == nil {
+		c.mu.Unlock()
+		return
+	}
+	entry.removed = true
+	c.removeIdleResourcesLocked(entry, false)
+	var closers []*cachedSegmentFile
+	if file := c.detachIdleEntryLocked(entry); file != nil {
+		closers = append(closers, file)
+	}
+	c.mu.Unlock()
+
+	// Release detached driver handles outside the coordinator mutex.
+	c.closeFiles(closers)
+}
+
+func (c *cacheCoordinator) retainVisible(shardID int, refs map[string]struct{}) {
+	// Retire every cached entry omitted by the shard manifest.
+	c.mu.Lock()
+	var closers []*cachedSegmentFile
+	for key, entry := range c.entries {
+		if key.shardID != shardID {
+			continue
+		}
+		if _, ok := refs[key.filename]; ok {
+			continue
+		}
+		entry.removed = true
+		c.removeIdleResourcesLocked(entry, false)
+		if file := c.detachIdleEntryLocked(entry); file != nil {
+			closers = append(closers, file)
+		}
+	}
+	c.mu.Unlock()
+
+	// Release detached driver handles outside the coordinator mutex.
+	c.closeFiles(closers)
+}
+
+func (c *cacheCoordinator) close() {
+	// Stop new acquisitions and wait for active lookup steps to release.
+	c.mu.Lock()
+	c.closed = true
+	for _, entry := range c.entries {
+		entry.removed = true
+	}
+	for c.hasActiveLeasesLocked() {
+		c.cond.Wait()
+	}
+
+	// Drain every resident resource and detach its handle.
+	var closers []*cachedSegmentFile
+	for _, entry := range c.entries {
+		c.removeIdleResourcesLocked(entry, false)
+		if file := c.detachIdleEntryLocked(entry); file != nil {
+			closers = append(closers, file)
+		}
+	}
+	c.mu.Unlock()
+
+	// Release detached driver handles after cache state reaches zero.
+	c.closeFiles(closers)
+}
+
+func (c *cacheCoordinator) snapshot() cacheStats {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.stats
+}
+
+func (c *cacheCoordinator) hasActiveLeasesLocked() bool {
+	for _, entry := range c.entries {
+		if entry.leases != 0 || entry.loading != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *cacheCoordinator) reserveHandleLocked() ([]*cachedSegmentFile, bool) {
+	if c.handleLimit == 0 {
+		return nil, false
+	}
+
+	// Evict idle resources until one cache handle reservation fits.
+	var closers []*cachedSegmentFile
+	for c.stats.LiveHandles >= c.handleLimit {
+		resource := c.oldestEvictableLocked(true)
+		if resource == nil {
+			return closers, false
+		}
+		entry := resource.entry
+		c.removeResourceLocked(resource, true)
+		if file := c.detachIdleEntryLocked(entry); file != nil {
+			closers = append(closers, file)
+		}
+	}
+	return closers, true
+}
+
+func (c *cacheCoordinator) reserveBytesLocked(charge uint64) ([]*cachedSegmentFile, bool) {
+	if charge > c.byteLimit {
+		return nil, false
+	}
+
+	// Evict idle resources until the exact byte charge fits.
+	var closers []*cachedSegmentFile
+	for c.stats.ChargedBytes+charge > c.byteLimit {
+		resource := c.oldestEvictableLocked(false)
+		if resource == nil {
+			return closers, false
+		}
+		entry := resource.entry
+		c.removeResourceLocked(resource, true)
+		if file := c.detachIdleEntryLocked(entry); file != nil {
+			closers = append(closers, file)
+		}
+	}
+	return closers, true
+}
+
+func (c *cacheCoordinator) oldestEvictableLocked(forHandle bool) *cacheResource {
+	for resource := c.lruHead; resource != nil; resource = resource.next {
+		if resource.pins != 0 {
+			continue
+		}
+		if forHandle && resource.entry.leases != 0 {
+			continue
+		}
+		return resource
+	}
+	return nil
+}
+
+func (c *cacheCoordinator) oldestBlockLocked(entry *cacheEntry) *cacheResource {
+	for resource := c.lruHead; resource != nil; resource = resource.next {
+		if resource.entry == entry && resource.kind == cacheResourceBlock && resource.pins == 0 {
+			return resource
+		}
+	}
+	return nil
+}
+
+func (c *cacheCoordinator) addResourceLocked(resource *cacheResource) {
+	// Link the resource at the recency tail.
+	resource.prev = c.lruTail
+	if c.lruTail == nil {
+		c.lruHead = resource
+	}
+	if c.lruTail != nil {
+		c.lruTail.next = resource
+	}
+	c.lruTail = resource
+
+	// Charge its exact retained payload by resource class.
+	c.stats.ChargedBytes += resource.bytes
+	c.stats.PeakChargedBytes = max(c.stats.PeakChargedBytes, c.stats.ChargedBytes)
+	switch resource.kind {
+	case cacheResourceLookup:
+		c.stats.MetadataBytes += resource.bytes
+	case cacheResourceBlock:
+		c.stats.BlockBytes += resource.bytes
+	}
+}
+
+func (c *cacheCoordinator) pinResourceLocked(lease *segmentCacheLease, resource *cacheResource) {
+	if _, ok := lease.resources[resource]; !ok {
+		if resource.pins == 0 {
+			c.stats.PinnedBytes += resource.bytes
+		}
+		resource.pins++
+		lease.resources[resource] = struct{}{}
+	}
+	c.touchResourceLocked(resource)
+}
+
+func (c *cacheCoordinator) touchResourceLocked(resource *cacheResource) {
+	if c.lruTail == resource {
+		return
+	}
+	if resource.prev == nil {
+		c.lruHead = resource.next
+	}
+	if resource.prev != nil {
+		resource.prev.next = resource.next
+	}
+	if resource.next != nil {
+		resource.next.prev = resource.prev
+	}
+	resource.prev = c.lruTail
+	resource.next = nil
+	if c.lruTail != nil {
+		c.lruTail.next = resource
+	}
+	c.lruTail = resource
+	if c.lruHead == nil {
+		c.lruHead = resource
+	}
+}
+
+func (c *cacheCoordinator) removeIdleResourcesLocked(entry *cacheEntry, eviction bool) {
+	if entry.lookupResource != nil && entry.lookupResource.pins == 0 {
+		c.removeResourceLocked(entry.lookupResource, eviction)
+	}
+	for _, block := range entry.blocks {
+		if block.resource.pins == 0 {
+			c.removeResourceLocked(block.resource, eviction)
+		}
+	}
+}
+
+func (c *cacheCoordinator) removeResourceLocked(resource *cacheResource, eviction bool) {
+	if resource.pins != 0 {
+		return
+	}
+
+	// Unlink the resource from the recency list.
+	if resource.prev == nil {
+		c.lruHead = resource.next
+	}
+	if resource.prev != nil {
+		resource.prev.next = resource.next
+	}
+	if resource.next == nil {
+		c.lruTail = resource.prev
+	}
+	if resource.next != nil {
+		resource.next.prev = resource.prev
+	}
+
+	// Remove the typed payload from its segment entry.
+	entry := resource.entry
+	switch resource.kind {
+	case cacheResourceLookup:
+		entry.lookup = nil
+		entry.lookupResource = nil
+		c.stats.MetadataBytes -= resource.bytes
+	case cacheResourceBlock:
+		delete(entry.blocks, resource.blockOff)
+		c.stats.BlockBytes -= resource.bytes
+	}
+
+	// Release its aggregate charge and record capacity eviction.
+	c.stats.ChargedBytes -= resource.bytes
+	if eviction {
+		c.stats.Evictions++
+	}
+}
+
+func (c *cacheCoordinator) detachIdleEntryLocked(entry *cacheEntry) *cachedSegmentFile {
+	// Keep entries with active operations or resident resources attached.
+	if entry.leases != 0 || entry.loading != nil || entry.lookupResource != nil || len(entry.blocks) != 0 {
+		return nil
+	}
+	if current := c.entries[entry.key]; current != entry {
+		return nil
+	}
+
+	// Remove the handle reservation before transferring driver release.
+	delete(c.entries, entry.key)
+	c.stats.LiveHandles--
+	if entry.file == nil {
+		return nil
+	}
+	file := entry.file
+	entry.file = nil
+	return file
+}
+
+func lookupMetaCharge(meta *segment.LookupMeta) uint64 {
+	bytes := uint64(unsafe.Sizeof(*meta))
+	bytes += uint64(unsafe.Sizeof(*meta.Header))
+	bytes += uint64(cap(meta.MinKey) + cap(meta.MaxKey))
+	bytes += uint64(cap(meta.Index)) * uint64(unsafe.Sizeof(segment.IndexEntry{}))
+	for i := range meta.Index {
+		bytes += uint64(cap(meta.Index[i].Key))
+	}
+	if meta.Bloom != nil {
+		bytes += uint64(unsafe.Sizeof(*meta.Bloom))
+		if meta.Header.BloomSize >= 5 {
+			bytes += uint64(meta.Header.BloomSize - 5)
+		}
+	}
+	return bytes
+}
+
+func (c *cacheCoordinator) closeFiles(files []*cachedSegmentFile) {
+	// Release each detached driver handle exactly once.
+	var failures uint64
+	for _, file := range files {
+		if err := closeSegmentReader(file.rd); err != nil {
+			failures++
+		}
+	}
+
+	// Preserve asynchronous release failures in observable cache state.
+	if failures != 0 {
+		c.mu.Lock()
+		c.stats.ReleaseErrors += failures
+		c.mu.Unlock()
+	}
+}
+
+func (c *cacheCoordinator) recordReleaseError() {
+	c.mu.Lock()
+	c.stats.ReleaseErrors++
+	c.mu.Unlock()
+}
+
+func closeSegmentReader(reader segmentReader) error {
+	closer, ok := reader.(io.Closer)
+	if !ok {
+		return nil
+	}
+	return closer.Close()
+}

--- a/db/volume/js/opfs/blockshard/cache-coordinator_test.go
+++ b/db/volume/js/opfs/blockshard/cache-coordinator_test.go
@@ -51,6 +51,66 @@ func (r *cacheCoordinatorTestReader) closeCount() int {
 	return r.closes
 }
 
+// readCount reports snapshot reads without exposing the test reader mutex.
+func (r *cacheCoordinatorTestReader) readCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.reads
+}
+
+// cacheCoordinatorBlockingReader pauses the first snapshot read for fill-sharing tests.
+type cacheCoordinatorBlockingReader struct {
+	*cacheCoordinatorTestReader
+	started  chan struct{}
+	unblock  chan struct{}
+	firstErr error
+}
+
+// ReadAt exposes the first in-flight read before returning scripted bytes or failure.
+func (r *cacheCoordinatorBlockingReader) ReadAt(p []byte, off int64) (int, error) {
+	r.mu.Lock()
+	r.reads++
+	call := r.reads
+	r.mu.Unlock()
+
+	// Hold the first call until a competing request joins its fill.
+	if call == 1 {
+		close(r.started)
+		<-r.unblock
+		if r.firstErr != nil {
+			return 0, r.firstErr
+		}
+	}
+
+	// Copy immutable fixture bytes with ReaderAt short-read semantics.
+	if off >= int64(len(r.data)) {
+		return 0, io.EOF
+	}
+	n := copy(p, r.data[off:])
+	if n < len(p) {
+		return n, io.EOF
+	}
+	return n, nil
+}
+
+// cacheCoordinatorReadResult carries one concurrent span request outcome.
+type cacheCoordinatorReadResult struct {
+	data []byte
+	n    int
+	err  error
+}
+
+// readCoordinatorSpan executes one lease read and publishes its complete outcome.
+func readCoordinatorSpan(
+	lease *segmentCacheLease,
+	size int,
+	results chan<- cacheCoordinatorReadResult,
+) {
+	data := make([]byte, size)
+	n, err := lease.ReadAt(data, 0)
+	results <- cacheCoordinatorReadResult{data: data, n: n, err: err}
+}
+
 func TestCacheCoordinatorChargesExactPayloadAndReleases(t *testing.T) {
 	// Size the cache for one exact fixture payload.
 	data, meta, key, expectedCharge := cacheCoordinatorFixture(t)
@@ -205,30 +265,192 @@ func TestCacheCoordinatorOpenFailureRollsBackHandle(t *testing.T) {
 	}
 }
 
-func TestCacheCoordinatorPerSegmentBlockLimitBypassesPinnedPressure(t *testing.T) {
-	// Build an immutable file spanning more blocks than one segment admits.
+func TestCacheCoordinatorPerSegmentSpanLimitBypassesPinnedPressure(t *testing.T) {
+	// Build an immutable file spanning more fills than one segment admits.
 	data, meta := cacheCoordinatorLargeFixture(t)
 	cache := newCacheCoordinator(^uint64(0), 2)
 	lease, _ := acquireCoordinatorFixture(t, cache, 0, meta.Filename, data, meta)
 
-	// Pin more aligned blocks than the shipping per-segment policy admits.
-	for i := range maxCachedSegmentBlocks + 2 {
+	// Pin more one-block spans than the shipping per-segment policy admits.
+	for i := range maxCachedSegmentSpans + 2 {
 		var dst [1]byte
 		if _, err := lease.ReadAt(dst[:], int64(i*cachedSegmentBlockSize)); err != nil {
 			t.Fatal(err)
 		}
 	}
 	stats := cache.snapshot()
-	if len(lease.entry.blocks) > maxCachedSegmentBlocks {
-		t.Fatalf("resident blocks: got %d limit %d", len(lease.entry.blocks), maxCachedSegmentBlocks)
+	if lease.entry.blockSpans > maxCachedSegmentSpans {
+		t.Fatalf("resident spans: got %d limit %d", lease.entry.blockSpans, maxCachedSegmentSpans)
+	}
+	if len(lease.entry.blocks) > maxCachedSegmentSpans {
+		t.Fatalf("resident block views: got %d limit %d", len(lease.entry.blocks), maxCachedSegmentSpans)
 	}
 	if stats.Bypasses == 0 {
-		t.Fatal("expected pinned block pressure to bypass admission")
+		t.Fatal("expected pinned span pressure to bypass admission")
 	}
 
 	// Release every retained resource after the pressure check.
 	lease.Release()
 	cache.close()
+}
+
+func TestCacheCoordinatorChargesOneBackingAllocationPerSpan(t *testing.T) {
+	// Read three consecutive missing blocks through one request-local allocation.
+	data := bytes.Repeat([]byte("span"), cachedSegmentBlockSize*3/4)
+	reader := &cacheCoordinatorTestReader{data: data}
+	cache := newCacheCoordinator(^uint64(0), 1)
+	lease, key := newCoordinatorDataLease(cache, reader, int64(len(data)))
+	got := make([]byte, len(data))
+	n, err := lease.ReadAt(got, 0)
+	if err != nil || n != len(got) {
+		t.Fatalf("span read: bytes=%d err=%v", n, err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Fatal("span read returned different bytes")
+	}
+
+	// Assert one read, one charge, one span, and three aligned block views.
+	stats := cache.snapshot()
+	wantCharge := uint64(len(data))
+	if reader.readCount() != 1 || stats.ReadCalls != 1 || stats.FetchedBytes != wantCharge {
+		t.Fatalf("snapshot reads: reader=%d calls=%d bytes=%d", reader.readCount(), stats.ReadCalls, stats.FetchedBytes)
+	}
+	if stats.ChargedBytes != wantCharge || stats.BlockBytes != wantCharge {
+		t.Fatalf("span charge: charged=%d blocks=%d want=%d", stats.ChargedBytes, stats.BlockBytes, wantCharge)
+	}
+	if lease.entry.blockSpans != 1 || len(lease.entry.blocks) != 3 {
+		t.Fatalf("resident span: spans=%d block_views=%d", lease.entry.blockSpans, len(lease.entry.blocks))
+	}
+	span := lease.entry.blocks[0].span
+	for off := int64(0); off < int64(len(data)); off += cachedSegmentBlockSize {
+		if block := lease.entry.blocks[off]; block == nil || block.span != span {
+			t.Fatalf("block view at %d does not share the backing span", off)
+		}
+	}
+
+	// Remove the idle span and its handle without leaving any block view or charge.
+	lease.Release()
+	cache.remove(key)
+	stats = cache.snapshot()
+	if len(lease.entry.blocks) != 0 || lease.entry.blockSpans != 0 {
+		t.Fatalf("removed span: spans=%d block_views=%d", lease.entry.blockSpans, len(lease.entry.blocks))
+	}
+	if stats.ChargedBytes != 0 || stats.BlockBytes != 0 || stats.LiveHandles != 0 {
+		t.Fatalf("removed charge: charged=%d blocks=%d handles=%d", stats.ChargedBytes, stats.BlockBytes, stats.LiveHandles)
+	}
+	if reader.closeCount() != 1 {
+		t.Fatalf("removed reader closes: got %d want 1", reader.closeCount())
+	}
+}
+
+func TestCacheCoordinatorSharesEqualInFlightSpan(t *testing.T) {
+	// Pause one two-block snapshot read while an equal request starts.
+	data := bytes.Repeat([]byte("fill"), cachedSegmentBlockSize*2/4)
+	reader := &cacheCoordinatorBlockingReader{
+		cacheCoordinatorTestReader: &cacheCoordinatorTestReader{data: data},
+		started:                    make(chan struct{}),
+		unblock:                    make(chan struct{}),
+	}
+	cache := newCacheCoordinator(^uint64(0), 1)
+	leaseA, key := newCoordinatorDataLease(cache, reader, int64(len(data)))
+	leaseB := newCoordinatorPeerLease(cache, leaseA.entry)
+	results := make(chan cacheCoordinatorReadResult, 2)
+	go readCoordinatorSpan(leaseA, len(data), results)
+	<-reader.started
+	go readCoordinatorSpan(leaseB, len(data), results)
+
+	// Wait until the equal request joins, then release the single underlying read.
+	cache.mu.Lock()
+	for cache.stats.SharedFills != 1 {
+		cache.cond.Wait()
+	}
+	cache.mu.Unlock()
+	close(reader.unblock)
+	first := <-results
+	second := <-results
+
+	// Require identical successful bytes from one snapshot call and one admission.
+	for i, result := range []cacheCoordinatorReadResult{first, second} {
+		if result.err != nil || result.n != len(data) {
+			t.Fatalf("result %d: bytes=%d err=%v", i, result.n, result.err)
+		}
+		if !bytes.Equal(result.data, data) {
+			t.Fatalf("result %d returned different bytes", i)
+		}
+	}
+	stats := cache.snapshot()
+	if reader.readCount() != 1 || stats.ReadCalls != 1 || stats.SharedFills != 1 || stats.Admissions != 1 {
+		t.Fatalf("shared fill: reader=%d calls=%d shared=%d admissions=%d", reader.readCount(), stats.ReadCalls, stats.SharedFills, stats.Admissions)
+	}
+
+	// Release both pins and retire the shared span.
+	leaseA.Release()
+	leaseB.Release()
+	cache.remove(key)
+}
+
+func TestCacheCoordinatorSharesFailureAndAllowsRetry(t *testing.T) {
+	// Pause one failing snapshot read while an equal request starts.
+	fillErr := errors.New("scripted fill failure")
+	data := bytes.Repeat([]byte("retry"), cachedSegmentBlockSize/5+1)[:cachedSegmentBlockSize]
+	reader := &cacheCoordinatorBlockingReader{
+		cacheCoordinatorTestReader: &cacheCoordinatorTestReader{data: data},
+		started:                    make(chan struct{}),
+		unblock:                    make(chan struct{}),
+		firstErr:                   fillErr,
+	}
+	cache := newCacheCoordinator(^uint64(0), 1)
+	leaseA, key := newCoordinatorDataLease(cache, reader, int64(len(data)))
+	leaseB := newCoordinatorPeerLease(cache, leaseA.entry)
+	results := make(chan cacheCoordinatorReadResult, 2)
+	go readCoordinatorSpan(leaseA, len(data), results)
+	<-reader.started
+	go readCoordinatorSpan(leaseB, len(data), results)
+
+	// Wait for fill sharing before publishing the leader failure.
+	cache.mu.Lock()
+	for cache.stats.SharedFills != 1 {
+		cache.cond.Wait()
+	}
+	cache.mu.Unlock()
+	close(reader.unblock)
+	first := <-results
+	second := <-results
+
+	// Require the same failure and no resident state from either request.
+	for i, result := range []cacheCoordinatorReadResult{first, second} {
+		if result.n != 0 || result.err != fillErr {
+			t.Fatalf("failure %d: bytes=%d err=%v", i, result.n, result.err)
+		}
+	}
+	stats := cache.snapshot()
+	if stats.ChargedBytes != 0 || stats.BlockBytes != 0 || stats.Admissions != 0 {
+		t.Fatalf("failed fill residency: charged=%d blocks=%d admissions=%d", stats.ChargedBytes, stats.BlockBytes, stats.Admissions)
+	}
+	if len(leaseA.entry.fills) != 0 || len(leaseA.entry.blocks) != 0 || leaseA.entry.blockSpans != 0 {
+		t.Fatalf("failed fill state: fills=%d block_views=%d spans=%d", len(leaseA.entry.fills), len(leaseA.entry.blocks), leaseA.entry.blockSpans)
+	}
+
+	// Start a new lease after failure and admit its successful retry.
+	retryLease := newCoordinatorPeerLease(cache, leaseA.entry)
+	leaseA.Release()
+	leaseB.Release()
+	got := make([]byte, len(data))
+	n, err := retryLease.ReadAt(got, 0)
+	if err != nil || n != len(got) {
+		t.Fatalf("retry: bytes=%d err=%v", n, err)
+	}
+	if !bytes.Equal(got, data) || reader.readCount() != 2 {
+		t.Fatalf("retry bytes or calls: equal=%t calls=%d", bytes.Equal(got, data), reader.readCount())
+	}
+	stats = cache.snapshot()
+	if stats.Admissions != 1 || stats.ReadCalls != 2 {
+		t.Fatalf("retry counters: admissions=%d calls=%d", stats.Admissions, stats.ReadCalls)
+	}
+
+	// Release and retire the successfully retried span.
+	retryLease.Release()
+	cache.remove(key)
 }
 
 func TestCacheCoordinatorTouchesGlobalLRU(t *testing.T) {
@@ -289,6 +511,37 @@ func TestCacheCoordinatorOversizeReadBypassesAdmission(t *testing.T) {
 	// Release the admitted entry after the operation-local read.
 	lease.Release()
 	cache.close()
+}
+
+// newCoordinatorDataLease constructs one admitted data-only entry for focused span tests.
+func newCoordinatorDataLease(
+	cache *cacheCoordinator,
+	reader segmentReader,
+	size int64,
+) (*segmentCacheLease, cacheKey) {
+	key := cacheKey{shardID: 0, filename: "data-only.sst"}
+	entry := &cacheEntry{
+		key:    key,
+		blocks: make(map[int64]*cachedBlock),
+		fills:  make(map[segmentFillRange]*segmentFill),
+		leases: 1,
+	}
+	entry.file = newCoordinatedSegmentFile(reader, size, cache, entry)
+	cache.entries[key] = entry
+	cache.stats.LiveHandles = 1
+	cache.stats.PeakLiveHandles = 1
+	return &segmentCacheLease{
+		cache:     cache,
+		entry:     entry,
+		resources: make(map[*cacheResource]struct{}),
+	}, key
+}
+
+// newCoordinatorPeerLease creates another operation lease for one admitted entry.
+func newCoordinatorPeerLease(cache *cacheCoordinator, entry *cacheEntry) *segmentCacheLease {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	return cache.newLeaseLocked(entry)
 }
 
 func cacheCoordinatorLargeFixture(t testing.TB) ([]byte, *SegmentMeta) {

--- a/db/volume/js/opfs/blockshard/cache-coordinator_test.go
+++ b/db/volume/js/opfs/blockshard/cache-coordinator_test.go
@@ -1,0 +1,360 @@
+//go:build js
+
+package blockshard
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"sync"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/s4wave/spacewave/db/volume/js/opfs/segment"
+)
+
+type cacheCoordinatorTestReader struct {
+	mu     sync.Mutex
+	data   []byte
+	reads  int
+	closes int
+}
+
+func (r *cacheCoordinatorTestReader) ReadAt(p []byte, off int64) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.reads++
+	if off >= int64(len(r.data)) {
+		return 0, io.EOF
+	}
+	n := copy(p, r.data[off:])
+	if n < len(p) {
+		return n, io.EOF
+	}
+	return n, nil
+}
+
+func (r *cacheCoordinatorTestReader) Size() (int64, error) {
+	return int64(len(r.data)), nil
+}
+
+func (r *cacheCoordinatorTestReader) Close() error {
+	r.mu.Lock()
+	r.closes++
+	r.mu.Unlock()
+	return nil
+}
+
+func (r *cacheCoordinatorTestReader) closeCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.closes
+}
+
+func TestCacheCoordinatorChargesExactPayloadAndReleases(t *testing.T) {
+	// Size the cache for one exact fixture payload.
+	data, meta, key, expectedCharge := cacheCoordinatorFixture(t)
+	cache := newCacheCoordinator(expectedCharge, 2)
+
+	// Admit one segment with one metadata allocation and one file block.
+	leaseA, readerA := acquireCoordinatorFixture(t, cache, 0, "a.sst", data, meta)
+	assertCoordinatorValue(t, leaseA, key)
+	leaseA.Release()
+	stats := cache.snapshot()
+	if stats.ChargedBytes != expectedCharge {
+		t.Fatalf("charged bytes: got %d want %d", stats.ChargedBytes, expectedCharge)
+	}
+	if stats.LiveHandles != 1 {
+		t.Fatalf("live handles: got %d want 1", stats.LiveHandles)
+	}
+
+	// Admit a second segment and evict the idle first segment within the limit.
+	leaseB, readerB := acquireCoordinatorFixture(t, cache, 1, "b.sst", data, meta)
+	assertCoordinatorValue(t, leaseB, key)
+	leaseB.Release()
+	stats = cache.snapshot()
+	if stats.ChargedBytes > expectedCharge {
+		t.Fatalf("charged bytes exceeded limit: got %d limit %d", stats.ChargedBytes, expectedCharge)
+	}
+	if stats.LiveHandles != 1 || stats.PeakLiveHandles > 2 {
+		t.Fatalf("handle counts: live=%d peak=%d", stats.LiveHandles, stats.PeakLiveHandles)
+	}
+	if stats.Evictions == 0 {
+		t.Fatal("expected capacity eviction")
+	}
+	if readerA.closeCount() != 1 {
+		t.Fatalf("first reader closes: got %d want 1", readerA.closeCount())
+	}
+
+	// Close the coordinator and release the final admitted handle exactly once.
+	cache.close()
+	if readerB.closeCount() != 1 {
+		t.Fatalf("second reader closes: got %d want 1", readerB.closeCount())
+	}
+	stats = cache.snapshot()
+	if stats.ChargedBytes != 0 || stats.PinnedBytes != 0 || stats.LiveHandles != 0 || stats.ReleaseErrors != 0 {
+		t.Fatalf("cache after close: charged=%d pinned=%d handles=%d release_errors=%d", stats.ChargedBytes, stats.PinnedBytes, stats.LiveHandles, stats.ReleaseErrors)
+	}
+}
+
+func TestCacheCoordinatorHandleLimitEvictsIdleEntry(t *testing.T) {
+	// Create one cache handle for two immutable fixture identities.
+	data, meta, _, _ := cacheCoordinatorFixture(t)
+	cache := newCacheCoordinator(^uint64(0), 1)
+
+	// Fill the one-handle cache twice to force idle entry eviction.
+	leaseA, readerA := acquireCoordinatorFixture(t, cache, 0, "a.sst", data, meta)
+	leaseA.Release()
+	leaseB, readerB := acquireCoordinatorFixture(t, cache, 1, "b.sst", data, meta)
+	leaseB.Release()
+
+	// Assert handle accounting and first-entry release.
+	stats := cache.snapshot()
+	if stats.LiveHandles != 1 || stats.PeakLiveHandles != 1 {
+		t.Fatalf("handle limit: live=%d peak=%d", stats.LiveHandles, stats.PeakLiveHandles)
+	}
+	if readerA.closeCount() != 1 {
+		t.Fatalf("evicted reader closes: got %d want 1", readerA.closeCount())
+	}
+
+	// Close the coordinator and release the remaining handle.
+	cache.close()
+	if readerB.closeCount() != 1 {
+		t.Fatalf("resident reader closes: got %d want 1", readerB.closeCount())
+	}
+}
+
+func TestCacheCoordinatorPinnedHandleBypassesAdmission(t *testing.T) {
+	// Create one cache handle for competing lookup operations.
+	data, meta, key, _ := cacheCoordinatorFixture(t)
+	cache := newCacheCoordinator(^uint64(0), 1)
+
+	// Keep the only admitted handle pinned through one lookup step.
+	leaseA, readerA := acquireCoordinatorFixture(t, cache, 0, "a.sst", data, meta)
+	assertCoordinatorValue(t, leaseA, key)
+
+	// Complete the competing lookup with operation-local state.
+	leaseB, readerB := acquireCoordinatorFixture(t, cache, 1, "b.sst", data, meta)
+	assertCoordinatorValue(t, leaseB, key)
+	leaseB.Release()
+	stats := cache.snapshot()
+	if stats.LiveHandles != 1 || stats.Bypasses == 0 {
+		t.Fatalf("pinned bypass: handles=%d bypasses=%d", stats.LiveHandles, stats.Bypasses)
+	}
+	if readerB.closeCount() != 1 {
+		t.Fatalf("bypassed reader closes: got %d want 1", readerB.closeCount())
+	}
+	if readerA.closeCount() != 0 {
+		t.Fatalf("pinned reader closed early: got %d", readerA.closeCount())
+	}
+
+	// Release the admitted handle after the competing operation completes.
+	leaseA.Release()
+	cache.close()
+	if readerA.closeCount() != 1 {
+		t.Fatalf("admitted reader closes: got %d want 1", readerA.closeCount())
+	}
+}
+
+func TestCacheCoordinatorPinnedRemovalDefersRelease(t *testing.T) {
+	// Hold one lease on a segment that manifest refresh will retire.
+	data, meta, key, _ := cacheCoordinatorFixture(t)
+	cache := newCacheCoordinator(^uint64(0), 2)
+	lease, reader := acquireCoordinatorFixture(t, cache, 7, "retired.sst", data, meta)
+
+	// Retire the entry while its lookup lease remains active.
+	cache.remove(cacheKey{shardID: 7, filename: "retired.sst"})
+	if reader.closeCount() != 0 {
+		t.Fatalf("pinned reader closed during removal: got %d", reader.closeCount())
+	}
+	assertCoordinatorValue(t, lease, key)
+	lease.Release()
+	if reader.closeCount() != 1 {
+		t.Fatalf("retired reader closes after release: got %d want 1", reader.closeCount())
+	}
+
+	// Confirm deferred release drains every charge and handle.
+	stats := cache.snapshot()
+	if stats.ChargedBytes != 0 || stats.LiveHandles != 0 {
+		t.Fatalf("retired cache state: charged=%d handles=%d", stats.ChargedBytes, stats.LiveHandles)
+	}
+}
+
+func TestCacheCoordinatorOpenFailureRollsBackHandle(t *testing.T) {
+	// Create one cache that can reserve a single file handle.
+	_, meta, _, _ := cacheCoordinatorFixture(t)
+	cache := newCacheCoordinator(^uint64(0), 1)
+
+	// Fail file opening after the coordinator reserves one handle.
+	_, err := cache.acquireSegment(
+		context.Background(),
+		cacheKey{shardID: 0, filename: "failure.sst"},
+		meta,
+		func() (segmentReader, error) {
+			return nil, errors.New("open failed")
+		},
+	)
+	if err == nil {
+		t.Fatal("expected open failure")
+	}
+
+	// Confirm the failed admission rolls its reservation back.
+	stats := cache.snapshot()
+	if stats.LiveHandles != 0 || stats.ChargedBytes != 0 {
+		t.Fatalf("failed admission state: handles=%d charged=%d", stats.LiveHandles, stats.ChargedBytes)
+	}
+}
+
+func TestCacheCoordinatorPerSegmentBlockLimitBypassesPinnedPressure(t *testing.T) {
+	// Build an immutable file spanning more blocks than one segment admits.
+	data, meta := cacheCoordinatorLargeFixture(t)
+	cache := newCacheCoordinator(^uint64(0), 2)
+	lease, _ := acquireCoordinatorFixture(t, cache, 0, meta.Filename, data, meta)
+
+	// Pin more aligned blocks than the shipping per-segment policy admits.
+	for i := range maxCachedSegmentBlocks + 2 {
+		var dst [1]byte
+		if _, err := lease.ReadAt(dst[:], int64(i*cachedSegmentBlockSize)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	stats := cache.snapshot()
+	if len(lease.entry.blocks) > maxCachedSegmentBlocks {
+		t.Fatalf("resident blocks: got %d limit %d", len(lease.entry.blocks), maxCachedSegmentBlocks)
+	}
+	if stats.Bypasses == 0 {
+		t.Fatal("expected pinned block pressure to bypass admission")
+	}
+
+	// Release every retained resource after the pressure check.
+	lease.Release()
+	cache.close()
+}
+
+func TestCacheCoordinatorTouchesGlobalLRU(t *testing.T) {
+	// Fill a two-handle cache with distinct immutable segments.
+	data, meta, key, _ := cacheCoordinatorFixture(t)
+	cache := newCacheCoordinator(^uint64(0), 2)
+	leaseA, readerA := acquireCoordinatorFixture(t, cache, 0, "a.sst", data, meta)
+	leaseA.Release()
+	leaseB, readerB := acquireCoordinatorFixture(t, cache, 1, "b.sst", data, meta)
+	leaseB.Release()
+
+	// Touch both metadata and data for the first segment.
+	leaseA, _ = acquireCoordinatorFixture(t, cache, 0, "a.sst", data, meta)
+	assertCoordinatorValue(t, leaseA, key)
+	leaseA.Release()
+
+	// Admit a third handle and evict the untouched second segment.
+	leaseC, readerC := acquireCoordinatorFixture(t, cache, 2, "c.sst", data, meta)
+	leaseC.Release()
+	if readerA.closeCount() != 0 {
+		t.Fatalf("recent reader closed early: got %d", readerA.closeCount())
+	}
+	if readerB.closeCount() != 1 {
+		t.Fatalf("least-recent reader closes: got %d want 1", readerB.closeCount())
+	}
+
+	// Close both remaining admitted handles.
+	cache.close()
+	if readerA.closeCount() != 1 || readerC.closeCount() != 1 {
+		t.Fatalf("resident reader closes: a=%d c=%d", readerA.closeCount(), readerC.closeCount())
+	}
+}
+
+func TestCacheCoordinatorOversizeReadBypassesAdmission(t *testing.T) {
+	// Admit metadata and initial blocks for one large immutable segment.
+	data, meta := cacheCoordinatorLargeFixture(t)
+	cache := newCacheCoordinator(^uint64(0), 2)
+	lease, _ := acquireCoordinatorFixture(t, cache, 0, meta.Filename, data, meta)
+	before := cache.snapshot()
+
+	// Read above the shipping threshold without changing retained charges.
+	dst := make([]byte, maxCachedSegmentRead+1)
+	n, err := lease.ReadAt(dst, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != len(dst) {
+		t.Fatalf("oversize read bytes: got %d want %d", n, len(dst))
+	}
+	after := cache.snapshot()
+	if after.ChargedBytes != before.ChargedBytes {
+		t.Fatalf("oversize retained bytes: before=%d after=%d", before.ChargedBytes, after.ChargedBytes)
+	}
+	if after.Bypasses != before.Bypasses+1 || after.ReadCalls != before.ReadCalls+1 {
+		t.Fatalf("oversize counters: bypasses=%d reads=%d", after.Bypasses-before.Bypasses, after.ReadCalls-before.ReadCalls)
+	}
+
+	// Release the admitted entry after the operation-local read.
+	lease.Release()
+	cache.close()
+}
+
+func cacheCoordinatorLargeFixture(t testing.TB) ([]byte, *SegmentMeta) {
+	t.Helper()
+	entries := make([]segment.Entry, 8)
+	for i := range entries {
+		entries[i] = segment.Entry{
+			Key:   []byte{byte(i)},
+			Value: bytes.Repeat([]byte{byte(i + 1)}, cachedSegmentBlockSize),
+		}
+	}
+	data := buildSegmentData(t, entries)
+	return data, &SegmentMeta{Filename: "large.sst", Size: uint32(len(data))}
+}
+
+func cacheCoordinatorFixture(t testing.TB) ([]byte, *SegmentMeta, []byte, uint64) {
+	t.Helper()
+	key := []byte("cache-key")
+	data := buildSegmentData(t, []segment.Entry{{Key: key, Value: []byte("cache-value")}})
+	lookup, err := segment.LoadLookupMeta(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	meta := &SegmentMeta{
+		Filename:   "fixture.sst",
+		EntryCount: 1,
+		Size:       uint32(len(data)),
+		MinKey:     key,
+		MaxKey:     key,
+	}
+	return data, meta, key, lookupMetaCharge(lookup) + uint64(len(data))
+}
+
+func acquireCoordinatorFixture(
+	t testing.TB,
+	cache *cacheCoordinator,
+	shardID int,
+	filename string,
+	data []byte,
+	meta *SegmentMeta,
+) (*segmentCacheLease, *cacheCoordinatorTestReader) {
+	t.Helper()
+	reader := &cacheCoordinatorTestReader{data: data}
+	copyMeta := *meta
+	copyMeta.Filename = filename
+	lease, err := cache.acquireSegment(
+		context.Background(),
+		cacheKey{shardID: shardID, filename: filename},
+		&copyMeta,
+		func() (segmentReader, error) {
+			return reader, nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return lease, reader
+}
+
+func assertCoordinatorValue(t testing.TB, lease *segmentCacheLease, key []byte) {
+	t.Helper()
+	value, found, err := lease.lookup.Get(lease, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found || string(value) != "cache-value" {
+		t.Fatalf("lookup returned found=%t value=%q", found, value)
+	}
+}

--- a/db/volume/js/opfs/blockshard/cache-policy-replay_test.go
+++ b/db/volume/js/opfs/blockshard/cache-policy-replay_test.go
@@ -1,0 +1,274 @@
+//go:build js
+
+package blockshard
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"os"
+	"runtime"
+	"slices"
+	"syscall/js"
+	"testing"
+	"time"
+
+	"github.com/s4wave/spacewave/db/opfs"
+	"github.com/s4wave/spacewave/db/volume/js/opfs/segment"
+)
+
+const cachePolicyReplayEnv = "SPACEWAVE_OPFS_CACHE_POLICY_REPLAY"
+
+// cachePolicyReplayFixture describes one immutable real-OPFS segment corpus.
+type cachePolicyReplayFixture struct {
+	filename string
+	data     []byte
+	meta     *SegmentMeta
+	keys     [][]byte
+	value    []byte
+}
+
+// cachePolicyReplayWorkload fixes one request order over an immutable fixture.
+type cachePolicyReplayWorkload struct {
+	name    string
+	fixture *cachePolicyReplayFixture
+	keys    [][]byte
+}
+
+// cachePolicyReplaySample retains one complete policy and workload observation.
+type cachePolicyReplaySample struct {
+	wall         time.Duration
+	goHeapDelta  int64
+	jsHeapDelta  int64
+	jsHeapStatus string
+	stats        cacheStats
+}
+
+func TestCachePolicyReplay(t *testing.T) {
+	// Keep the real-OPFS replay out of routine package checks.
+	if os.Getenv(cachePolicyReplayEnv) != "1" {
+		t.Skipf("set %s=1 to run the cache policy replay", cachePolicyReplayEnv)
+	}
+
+	// Create the point-scan and near-threshold immutable segment fixtures.
+	point := newCachePolicyReplayFixture(t, "point.sst", 4096, 176)
+	window := newCachePolicyReplayFixture(t, "window.sst", 64, 12<<10)
+	root, err := opfs.GetRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	const dirName = "blockshard-cache-policy-replay"
+	_ = opfs.DeleteEntry(root, dirName, true)
+	dir, err := opfs.GetDirectory(root, dirName, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := opfs.DeleteEntry(root, dirName, true); err != nil {
+			t.Error(err)
+		}
+	})
+	for _, fixture := range []*cachePolicyReplayFixture{point, window} {
+		if err := opfs.WriteFile(dir, fixture.filename, fixture.data); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Exercise fixed sequential, strided, hotset, and threshold-window orders.
+	workloads := []cachePolicyReplayWorkload{
+		{name: "point-sequential", fixture: point, keys: point.keys},
+		{name: "point-strided", fixture: point, keys: cachePolicyReplayStridedKeys(point.keys, 2053)},
+		{name: "point-hotset", fixture: point, keys: cachePolicyReplayRepeatedKeys(point.keys[2048:2112], 64)},
+		{name: "window-hot", fixture: window, keys: cachePolicyReplayRepeatedKeys(window.keys[32:33], 64)},
+	}
+	for _, workload := range workloads {
+		runCachePolicyReplayWorkload(t, dir, workload)
+	}
+}
+
+// runCachePolicyReplayWorkload records ten fresh-cache samples and one summary.
+func runCachePolicyReplayWorkload(
+	t *testing.T,
+	dir js.Value,
+	workload cachePolicyReplayWorkload,
+) {
+	t.Helper()
+	const repetitions = 10
+	samples := make([]cachePolicyReplaySample, repetitions)
+
+	// Run every repetition through a fresh coordinator and snapshot identity.
+	for repetition := range repetitions {
+		runtime.GC()
+		var goBefore runtime.MemStats
+		runtime.ReadMemStats(&goBefore)
+		jsBefore, jsStatus := cacheScaleJSHeap()
+		cache := newDefaultCacheCoordinator()
+		started := time.Now()
+
+		// Resolve every key through the production lease, lookup, and fill path.
+		for _, key := range workload.keys {
+			lease, err := cache.acquireSegment(
+				context.Background(),
+				cacheKey{shardID: 0, filename: workload.fixture.filename},
+				workload.fixture.meta,
+				func() (segmentReader, error) {
+					return opfs.OpenReadSnapshot(dir, workload.fixture.filename)
+				},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			value, found, err := lease.lookup.Get(lease, key)
+			lease.Release()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !found || !bytes.Equal(value, workload.fixture.value) {
+				t.Fatalf("workload %s returned found=%t bytes=%d", workload.name, found, len(value))
+			}
+		}
+		wall := time.Since(started)
+
+		// Capture retained cache and heap state before closing the coordinator.
+		runtime.GC()
+		var goAfter runtime.MemStats
+		runtime.ReadMemStats(&goAfter)
+		jsAfter, afterStatus := cacheScaleJSHeap()
+		if afterStatus != jsStatus {
+			jsStatus += "-then-" + afterStatus
+		}
+		jsDelta := int64(0)
+		if jsStatus == "available" {
+			jsDelta = int64(jsAfter) - int64(jsBefore)
+		}
+		sample := cachePolicyReplaySample{
+			wall:         wall,
+			goHeapDelta:  int64(goAfter.HeapAlloc) - int64(goBefore.HeapAlloc),
+			jsHeapDelta:  jsDelta,
+			jsHeapStatus: jsStatus,
+			stats:        cache.snapshot(),
+		}
+
+		// Close every admitted resource and retain the drained counters.
+		cache.close()
+		closed := cache.snapshot()
+		if closed.ChargedBytes != 0 || closed.LiveHandles != 0 {
+			t.Fatalf(
+				"workload %s close left charged=%d handles=%d",
+				workload.name,
+				closed.ChargedBytes,
+				closed.LiveHandles,
+			)
+		}
+		samples[repetition] = sample
+		logCachePolicyReplaySample(t, workload.name, repetition, sample)
+	}
+
+	// Report nearest-rank latency summaries for policy qualification.
+	walls := make([]time.Duration, len(samples))
+	for i := range samples {
+		walls[i] = samples[i].wall
+	}
+	slices.Sort(walls)
+	median := walls[(len(walls)-1)/2]
+	p95 := walls[(95*len(walls)+99)/100-1]
+	t.Logf(
+		"cache-policy-summary block_bytes=%d max_spans=%d threshold_bytes=%d workload=%s repetitions=%d median_us=%d p95_us=%d",
+		cachedSegmentBlockSize,
+		maxCachedSegmentSpans,
+		maxCachedSegmentRead,
+		workload.name,
+		len(samples),
+		median.Microseconds(),
+		p95.Microseconds(),
+	)
+}
+
+// logCachePolicyReplaySample emits one parseable source row for durable evidence.
+func logCachePolicyReplaySample(
+	t *testing.T,
+	workload string,
+	repetition int,
+	sample cachePolicyReplaySample,
+) {
+	t.Helper()
+	stats := sample.stats
+	t.Logf(
+		"cache-policy-sample block_bytes=%d max_spans=%d threshold_bytes=%d workload=%s repetition=%d wall_us=%d retained_block_bytes=%d retained_metadata_bytes=%d retained_bytes=%d peak_retained_bytes=%d go_heap_delta_bytes=%d js_heap_delta_bytes=%d js_heap_status=%s live_handles=%d peak_handles=%d reads=%d fetched_bytes=%d hits=%d misses=%d admissions=%d evictions=%d bypasses=%d shared_fills=%d release_errors=%d",
+		cachedSegmentBlockSize,
+		maxCachedSegmentSpans,
+		maxCachedSegmentRead,
+		workload,
+		repetition,
+		sample.wall.Microseconds(),
+		stats.BlockBytes,
+		stats.MetadataBytes,
+		stats.ChargedBytes,
+		stats.PeakChargedBytes,
+		sample.goHeapDelta,
+		sample.jsHeapDelta,
+		sample.jsHeapStatus,
+		stats.LiveHandles,
+		stats.PeakLiveHandles,
+		stats.ReadCalls,
+		stats.FetchedBytes,
+		stats.Hits,
+		stats.Misses,
+		stats.Admissions,
+		stats.Evictions,
+		stats.Bypasses,
+		stats.SharedFills,
+		stats.ReleaseErrors,
+	)
+}
+
+// newCachePolicyReplayFixture builds one deterministic SSTable and its metadata.
+func newCachePolicyReplayFixture(
+	t testing.TB,
+	filename string,
+	entryCount int,
+	valueSize int,
+) *cachePolicyReplayFixture {
+	t.Helper()
+	entries := make([]segment.Entry, entryCount)
+	keys := make([][]byte, entryCount)
+	value := bytes.Repeat([]byte("v"), valueSize)
+	for i := range entries {
+		key := make([]byte, 4)
+		binary.BigEndian.PutUint32(key, uint32(i))
+		keys[i] = key
+		entries[i] = segment.Entry{Key: key, Value: value}
+	}
+	data := buildSegmentData(t, entries)
+	return &cachePolicyReplayFixture{
+		filename: filename,
+		data:     data,
+		meta: &SegmentMeta{
+			Filename:   filename,
+			EntryCount: uint32(entryCount),
+			Size:       uint32(len(data)),
+			MinKey:     keys[0],
+			MaxKey:     keys[len(keys)-1],
+		},
+		keys:  keys,
+		value: value,
+	}
+}
+
+// cachePolicyReplayStridedKeys returns one deterministic full-corpus permutation.
+func cachePolicyReplayStridedKeys(keys [][]byte, stride int) [][]byte {
+	out := make([][]byte, len(keys))
+	for i := range out {
+		out[i] = keys[(i*stride)%len(keys)]
+	}
+	return out
+}
+
+// cachePolicyReplayRepeatedKeys repeats one fixed hot set in source order.
+func cachePolicyReplayRepeatedKeys(keys [][]byte, repetitions int) [][]byte {
+	out := make([][]byte, 0, len(keys)*repetitions)
+	for range repetitions {
+		out = append(out, keys...)
+	}
+	return out
+}

--- a/db/volume/js/opfs/blockshard/cache-scale_test.go
+++ b/db/volume/js/opfs/blockshard/cache-scale_test.go
@@ -1,0 +1,193 @@
+//go:build js
+
+package blockshard
+
+import (
+	"encoding/binary"
+	"os"
+	"runtime"
+	"strconv"
+	"syscall/js"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/s4wave/spacewave/db/opfs"
+	"github.com/s4wave/spacewave/db/volume/js/opfs/segment"
+)
+
+const cacheScaleSegmentsEnv = "SPACEWAVE_OPFS_CACHE_SCALE_SEGMENTS"
+
+type cacheScaleReader struct {
+	segmentReader
+	reads int64
+	bytes int64
+}
+
+func (r *cacheScaleReader) ReadAt(p []byte, off int64) (int, error) {
+	r.reads++
+	n, err := r.segmentReader.ReadAt(p, off)
+	r.bytes += int64(n)
+	return n, err
+}
+
+type cacheScaleSegment struct {
+	file   *opfs.AsyncFile
+	reader *cacheScaleReader
+	cache  *cachedSegmentFile
+	lookup *segment.LookupMeta
+}
+
+func TestCachedSegmentFileScale(t *testing.T) {
+	// Select one isolated geometric corpus size.
+	countText := os.Getenv(cacheScaleSegmentsEnv)
+	if countText == "" {
+		t.Skipf("set %s to the active segment count", cacheScaleSegmentsEnv)
+	}
+	count, err := strconv.Atoi(countText)
+	if err != nil || count < 1 {
+		t.Fatalf("%s=%q is not a positive integer", cacheScaleSegmentsEnv, countText)
+	}
+
+	// Build one deterministic SSTable shared by every active cache entry.
+	entries := make([]segment.Entry, 4096)
+	value := make([]byte, 176)
+	for i := range entries {
+		key := make([]byte, 4)
+		binary.BigEndian.PutUint32(key, uint32(i))
+		entries[i] = segment.Entry{Key: key, Value: value}
+	}
+	data := buildSegmentData(t, entries)
+
+	// Write the fixture through real browser OPFS.
+	root, err := opfs.GetRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	const dirName = "blockshard-cache-scale"
+	_ = opfs.DeleteEntry(root, dirName, true)
+	dir, err := opfs.GetDirectory(root, dirName, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := opfs.DeleteEntry(root, dirName, true); err != nil {
+			t.Error(err)
+		}
+	})
+	const filename = "segment.sst"
+	if err := opfs.WriteFile(dir, filename, data); err != nil {
+		t.Fatal(err)
+	}
+
+	// Capture the runtime baseline before retaining cache resources.
+	runtime.GC()
+	var goBefore runtime.MemStats
+	runtime.ReadMemStats(&goBefore)
+	jsBefore, jsStatus := cacheScaleJSHeap()
+	started := time.Now()
+	segments := make([]cacheScaleSegment, 0, count)
+	t.Cleanup(func() {
+		for i := range segments {
+			if err := segments[i].file.Close(); err != nil {
+				t.Error(err)
+			}
+		}
+	})
+
+	// Open and touch one independent cache entry per active segment.
+	for i := range count {
+		file, err := opfs.OpenAsyncFile(dir, filename)
+		if err != nil {
+			t.Fatalf("open segment %d: %v", i, err)
+		}
+		reader := &cacheScaleReader{segmentReader: file}
+		cache := newCachedSegmentFile(reader, int64(len(data)))
+		lookup, err := segment.LoadLookupMeta(cache, int64(len(data)))
+		if err != nil {
+			file.Close()
+			t.Fatalf("load segment %d metadata: %v", i, err)
+		}
+		key := entries[(i*2053)%len(entries)].Key
+		got, found, err := lookup.Get(cache, key)
+		if err != nil {
+			file.Close()
+			t.Fatalf("read segment %d: %v", i, err)
+		}
+		if !found || len(got) != len(value) {
+			file.Close()
+			t.Fatalf("read segment %d returned found=%t bytes=%d", i, found, len(got))
+		}
+		segments = append(segments, cacheScaleSegment{
+			file:   file,
+			reader: reader,
+			cache:  cache,
+			lookup: lookup,
+		})
+	}
+
+	// Capture heaps while every segment resource remains reachable.
+	runtime.GC()
+	var goAfter runtime.MemStats
+	runtime.ReadMemStats(&goAfter)
+	jsAfter, afterStatus := cacheScaleJSHeap()
+	if afterStatus != jsStatus {
+		jsStatus += "-then-" + afterStatus
+	}
+
+	// Count exact retained payloads and underlying I/O.
+	var blockBytes uint64
+	var metadataBytes uint64
+	var reads int64
+	var fetchedBytes int64
+	for i := range segments {
+		segments[i].cache.mu.Lock()
+		for _, block := range segments[i].cache.blocks {
+			blockBytes += uint64(cap(block))
+		}
+		segments[i].cache.mu.Unlock()
+		metadataBytes += cacheScaleLookupBytes(segments[i].lookup)
+		reads += segments[i].reader.reads
+		fetchedBytes += segments[i].reader.bytes
+	}
+
+	// Report one parseable row for the geometric evidence table.
+	jsDelta := int64(0)
+	if jsStatus == "available" {
+		jsDelta = int64(jsAfter) - int64(jsBefore)
+	}
+	t.Logf("cache-scale policy_block_bytes=%d policy_max_blocks=%d segments=%d retained_block_bytes=%d retained_metadata_bytes=%d go_heap_bytes=%d go_heap_delta_bytes=%d js_heap_bytes=%d js_heap_delta_bytes=%d js_heap_status=%s live_handles=%d reads=%d fetched_bytes=%d wall_ms=%d", cachedSegmentBlockSize, maxCachedSegmentBlocks, count, blockBytes, metadataBytes, goAfter.HeapAlloc, int64(goAfter.HeapAlloc)-int64(goBefore.HeapAlloc), jsAfter, jsDelta, jsStatus, len(segments), reads, fetchedBytes, time.Since(started).Milliseconds())
+}
+
+func cacheScaleLookupBytes(meta *segment.LookupMeta) uint64 {
+	bytes := uint64(unsafe.Sizeof(*meta))
+	bytes += uint64(unsafe.Sizeof(*meta.Header))
+	bytes += uint64(cap(meta.MinKey) + cap(meta.MaxKey))
+	bytes += uint64(cap(meta.Index)) * uint64(unsafe.Sizeof(segment.IndexEntry{}))
+	for i := range meta.Index {
+		bytes += uint64(cap(meta.Index[i].Key))
+	}
+	if meta.Bloom != nil {
+		bytes += uint64(unsafe.Sizeof(*meta.Bloom))
+		if meta.Header.BloomSize >= 5 {
+			bytes += uint64(meta.Header.BloomSize - 5)
+		}
+	}
+	return bytes
+}
+
+func cacheScaleJSHeap() (uint64, string) {
+	performance := js.Global().Get("performance")
+	if performance.Type() != js.TypeObject {
+		return 0, "performance-unavailable"
+	}
+	memory := performance.Get("memory")
+	if memory.Type() != js.TypeObject {
+		return 0, "performance-memory-unavailable"
+	}
+	used := memory.Get("usedJSHeapSize")
+	if used.Type() != js.TypeNumber {
+		return 0, "used-js-heap-size-unavailable"
+	}
+	return uint64(used.Float()), "available"
+}

--- a/db/volume/js/opfs/blockshard/cache-scale_test.go
+++ b/db/volume/js/opfs/blockshard/cache-scale_test.go
@@ -126,7 +126,7 @@ func TestCachedSegmentFileScale(t *testing.T) {
 	if jsStatus == "available" {
 		jsDelta = int64(jsAfter) - int64(jsBefore)
 	}
-	const rowFormat = "cache-scale policy_block_bytes=%d policy_max_blocks=%d " +
+	const rowFormat = "cache-scale policy_block_bytes=%d policy_max_spans=%d " +
 		"byte_limit=%d handle_limit=%d segments=%d entries_per_segment=%d " +
 		"retained_block_bytes=%d retained_metadata_bytes=%d retained_bytes=%d " +
 		"peak_retained_bytes=%d go_heap_bytes=%d go_heap_delta_bytes=%d " +
@@ -137,7 +137,7 @@ func TestCachedSegmentFileScale(t *testing.T) {
 	t.Logf(
 		rowFormat,
 		cachedSegmentBlockSize,
-		maxCachedSegmentBlocks,
+		maxCachedSegmentSpans,
 		defaultCacheByteLimit,
 		defaultCacheHandleLimit,
 		count,

--- a/db/volume/js/opfs/blockshard/cache-scale_test.go
+++ b/db/volume/js/opfs/blockshard/cache-scale_test.go
@@ -94,7 +94,7 @@ func TestCachedSegmentFileScale(t *testing.T) {
 			cacheKey{shardID: i, filename: filename},
 			meta,
 			func() (segmentReader, error) {
-				return opfs.OpenAsyncFile(dir, filename)
+				return opfs.OpenReadSnapshot(dir, filename)
 			},
 		)
 		if err != nil {

--- a/db/volume/js/opfs/blockshard/cache-scale_test.go
+++ b/db/volume/js/opfs/blockshard/cache-scale_test.go
@@ -3,6 +3,7 @@
 package blockshard
 
 import (
+	"context"
 	"encoding/binary"
 	"os"
 	"runtime"
@@ -10,36 +11,19 @@ import (
 	"syscall/js"
 	"testing"
 	"time"
-	"unsafe"
 
 	"github.com/s4wave/spacewave/db/opfs"
 	"github.com/s4wave/spacewave/db/volume/js/opfs/segment"
 )
 
-const cacheScaleSegmentsEnv = "SPACEWAVE_OPFS_CACHE_SCALE_SEGMENTS"
-
-type cacheScaleReader struct {
-	segmentReader
-	reads int64
-	bytes int64
-}
-
-func (r *cacheScaleReader) ReadAt(p []byte, off int64) (int, error) {
-	r.reads++
-	n, err := r.segmentReader.ReadAt(p, off)
-	r.bytes += int64(n)
-	return n, err
-}
-
-type cacheScaleSegment struct {
-	file   *opfs.AsyncFile
-	reader *cacheScaleReader
-	cache  *cachedSegmentFile
-	lookup *segment.LookupMeta
-}
+const (
+	cacheScaleSegmentsEnv    = "SPACEWAVE_OPFS_CACHE_SCALE_SEGMENTS"
+	cacheScaleEntriesEnv     = "SPACEWAVE_OPFS_CACHE_SCALE_ENTRIES"
+	defaultCacheScaleEntries = 4096
+)
 
 func TestCachedSegmentFileScale(t *testing.T) {
-	// Select one isolated geometric corpus size.
+	// Select one isolated geometric corpus size and fixture width.
 	countText := os.Getenv(cacheScaleSegmentsEnv)
 	if countText == "" {
 		t.Skipf("set %s to the active segment count", cacheScaleSegmentsEnv)
@@ -48,9 +32,16 @@ func TestCachedSegmentFileScale(t *testing.T) {
 	if err != nil || count < 1 {
 		t.Fatalf("%s=%q is not a positive integer", cacheScaleSegmentsEnv, countText)
 	}
+	entryCount := defaultCacheScaleEntries
+	if entriesText := os.Getenv(cacheScaleEntriesEnv); entriesText != "" {
+		entryCount, err = strconv.Atoi(entriesText)
+		if err != nil || entryCount < 1 {
+			t.Fatalf("%s=%q is not a positive integer", cacheScaleEntriesEnv, entriesText)
+		}
+	}
 
-	// Build one deterministic SSTable shared by every active cache entry.
-	entries := make([]segment.Entry, 4096)
+	// Build one deterministic SSTable shared by every cache identity.
+	entries := make([]segment.Entry, entryCount)
 	value := make([]byte, 176)
 	for i := range entries {
 		key := make([]byte, 4)
@@ -79,54 +70,48 @@ func TestCachedSegmentFileScale(t *testing.T) {
 	if err := opfs.WriteFile(dir, filename, data); err != nil {
 		t.Fatal(err)
 	}
+	meta := &SegmentMeta{
+		Filename:   filename,
+		EntryCount: uint32(len(entries)),
+		Size:       uint32(len(data)),
+		MinKey:     entries[0].Key,
+		MaxKey:     entries[len(entries)-1].Key,
+	}
 
-	// Capture the runtime baseline before retaining cache resources.
+	// Capture the runtime baseline before retaining coordinated resources.
 	runtime.GC()
 	var goBefore runtime.MemStats
 	runtime.ReadMemStats(&goBefore)
 	jsBefore, jsStatus := cacheScaleJSHeap()
 	started := time.Now()
-	segments := make([]cacheScaleSegment, 0, count)
-	t.Cleanup(func() {
-		for i := range segments {
-			if err := segments[i].file.Close(); err != nil {
-				t.Error(err)
-			}
-		}
-	})
+	cache := newDefaultCacheCoordinator()
+	t.Cleanup(cache.close)
 
-	// Open and touch one independent cache entry per active segment.
+	// Touch one independent segment identity and release each lookup pin.
 	for i := range count {
-		file, err := opfs.OpenAsyncFile(dir, filename)
+		lease, err := cache.acquireSegment(
+			context.Background(),
+			cacheKey{shardID: i, filename: filename},
+			meta,
+			func() (segmentReader, error) {
+				return opfs.OpenAsyncFile(dir, filename)
+			},
+		)
 		if err != nil {
-			t.Fatalf("open segment %d: %v", i, err)
-		}
-		reader := &cacheScaleReader{segmentReader: file}
-		cache := newCachedSegmentFile(reader, int64(len(data)))
-		lookup, err := segment.LoadLookupMeta(cache, int64(len(data)))
-		if err != nil {
-			file.Close()
-			t.Fatalf("load segment %d metadata: %v", i, err)
+			t.Fatalf("acquire segment %d: %v", i, err)
 		}
 		key := entries[(i*2053)%len(entries)].Key
-		got, found, err := lookup.Get(cache, key)
+		got, found, err := lease.lookup.Get(lease, key)
+		lease.Release()
 		if err != nil {
-			file.Close()
 			t.Fatalf("read segment %d: %v", i, err)
 		}
 		if !found || len(got) != len(value) {
-			file.Close()
 			t.Fatalf("read segment %d returned found=%t bytes=%d", i, found, len(got))
 		}
-		segments = append(segments, cacheScaleSegment{
-			file:   file,
-			reader: reader,
-			cache:  cache,
-			lookup: lookup,
-		})
 	}
 
-	// Capture heaps while every segment resource remains reachable.
+	// Capture heaps while the coordinator retains its bounded working set.
 	runtime.GC()
 	var goAfter runtime.MemStats
 	runtime.ReadMemStats(&goAfter)
@@ -134,46 +119,66 @@ func TestCachedSegmentFileScale(t *testing.T) {
 	if afterStatus != jsStatus {
 		jsStatus += "-then-" + afterStatus
 	}
-
-	// Count exact retained payloads and underlying I/O.
-	var blockBytes uint64
-	var metadataBytes uint64
-	var reads int64
-	var fetchedBytes int64
-	for i := range segments {
-		segments[i].cache.mu.Lock()
-		for _, block := range segments[i].cache.blocks {
-			blockBytes += uint64(cap(block))
-		}
-		segments[i].cache.mu.Unlock()
-		metadataBytes += cacheScaleLookupBytes(segments[i].lookup)
-		reads += segments[i].reader.reads
-		fetchedBytes += segments[i].reader.bytes
-	}
+	stats := cache.snapshot()
 
 	// Report one parseable row for the geometric evidence table.
 	jsDelta := int64(0)
 	if jsStatus == "available" {
 		jsDelta = int64(jsAfter) - int64(jsBefore)
 	}
-	t.Logf("cache-scale policy_block_bytes=%d policy_max_blocks=%d segments=%d retained_block_bytes=%d retained_metadata_bytes=%d go_heap_bytes=%d go_heap_delta_bytes=%d js_heap_bytes=%d js_heap_delta_bytes=%d js_heap_status=%s live_handles=%d reads=%d fetched_bytes=%d wall_ms=%d", cachedSegmentBlockSize, maxCachedSegmentBlocks, count, blockBytes, metadataBytes, goAfter.HeapAlloc, int64(goAfter.HeapAlloc)-int64(goBefore.HeapAlloc), jsAfter, jsDelta, jsStatus, len(segments), reads, fetchedBytes, time.Since(started).Milliseconds())
-}
+	const rowFormat = "cache-scale policy_block_bytes=%d policy_max_blocks=%d " +
+		"byte_limit=%d handle_limit=%d segments=%d entries_per_segment=%d " +
+		"retained_block_bytes=%d retained_metadata_bytes=%d retained_bytes=%d " +
+		"peak_retained_bytes=%d go_heap_bytes=%d go_heap_delta_bytes=%d " +
+		"js_heap_bytes=%d js_heap_delta_bytes=%d js_heap_status=%s " +
+		"live_handles=%d peak_handles=%d reads=%d fetched_bytes=%d hits=%d " +
+		"misses=%d admissions=%d evictions=%d bypasses=%d release_errors=%d " +
+		"wall_ms=%d"
+	t.Logf(
+		rowFormat,
+		cachedSegmentBlockSize,
+		maxCachedSegmentBlocks,
+		defaultCacheByteLimit,
+		defaultCacheHandleLimit,
+		count,
+		entryCount,
+		stats.BlockBytes,
+		stats.MetadataBytes,
+		stats.ChargedBytes,
+		stats.PeakChargedBytes,
+		goAfter.HeapAlloc,
+		int64(goAfter.HeapAlloc)-int64(goBefore.HeapAlloc),
+		jsAfter,
+		jsDelta,
+		jsStatus,
+		stats.LiveHandles,
+		stats.PeakLiveHandles,
+		stats.ReadCalls,
+		stats.FetchedBytes,
+		stats.Hits,
+		stats.Misses,
+		stats.Admissions,
+		stats.Evictions,
+		stats.Bypasses,
+		stats.ReleaseErrors,
+		time.Since(started).Milliseconds(),
+	)
+	if stats.ChargedBytes > defaultCacheByteLimit {
+		t.Fatalf("charged bytes exceeded limit: got %d limit %d", stats.ChargedBytes, defaultCacheByteLimit)
+	}
+	if stats.LiveHandles > defaultCacheHandleLimit {
+		t.Fatalf("live handles exceeded limit: got %d limit %d", stats.LiveHandles, defaultCacheHandleLimit)
+	}
+	if stats.ReleaseErrors != 0 {
+		t.Fatalf("driver release errors: got %d", stats.ReleaseErrors)
+	}
 
-func cacheScaleLookupBytes(meta *segment.LookupMeta) uint64 {
-	bytes := uint64(unsafe.Sizeof(*meta))
-	bytes += uint64(unsafe.Sizeof(*meta.Header))
-	bytes += uint64(cap(meta.MinKey) + cap(meta.MaxKey))
-	bytes += uint64(cap(meta.Index)) * uint64(unsafe.Sizeof(segment.IndexEntry{}))
-	for i := range meta.Index {
-		bytes += uint64(cap(meta.Index[i].Key))
+	// Prove phase closeout drains every admitted resource.
+	cache.close()
+	closed := cache.snapshot()
+	if closed.ChargedBytes != 0 || closed.LiveHandles != 0 {
+		t.Fatalf("cache close left charged=%d handles=%d", closed.ChargedBytes, closed.LiveHandles)
 	}
-	if meta.Bloom != nil {
-		bytes += uint64(unsafe.Sizeof(*meta.Bloom))
-		if meta.Header.BloomSize >= 5 {
-			bytes += uint64(meta.Header.BloomSize - 5)
-		}
-	}
-	return bytes
 }
 
 func cacheScaleJSHeap() (uint64, string) {

--- a/db/volume/js/opfs/blockshard/cache.go
+++ b/db/volume/js/opfs/blockshard/cache.go
@@ -26,9 +26,15 @@ type segmentReader interface {
 }
 
 type cachedSegmentFile struct {
+	// rd supplies immutable file bytes and size.
 	rd   segmentReader
 	size int64
 
+	// coordinator and entry select engine-wide admission.
+	coordinator *cacheCoordinator
+	entry       *cacheEntry
+
+	// mu guards standalone blocks and their recency order.
 	mu     sync.Mutex
 	blocks map[int64][]byte
 	order  []int64
@@ -47,23 +53,58 @@ func newCachedSegmentFile(rd segmentReader, size int64) *cachedSegmentFile {
 	}
 }
 
+func newCoordinatedSegmentFile(
+	rd segmentReader,
+	size int64,
+	coordinator *cacheCoordinator,
+	entry *cacheEntry,
+) *cachedSegmentFile {
+	if size == 0 {
+		if resolved, err := rd.Size(); err == nil {
+			size = resolved
+		}
+	}
+	return &cachedSegmentFile{
+		rd:          rd,
+		size:        size,
+		coordinator: coordinator,
+		entry:       entry,
+	}
+}
+
 func (f *cachedSegmentFile) ReadAt(p []byte, off int64) (int, error) {
+	return f.readAt(p, off, nil)
+}
+
+func (f *cachedSegmentFile) readAt(p []byte, off int64, lease *segmentCacheLease) (int, error) {
+	// Return immediately for an empty request.
 	if len(p) == 0 {
 		return 0, nil
 	}
+
+	// Bypass retained spans for requests above the shipping threshold.
 	if len(p) > maxCachedSegmentRead {
-		return f.rd.ReadAt(p, off)
+		if f.coordinator != nil {
+			f.coordinator.recordBypass()
+		}
+		n, err := f.rd.ReadAt(p, off)
+		if f.coordinator != nil {
+			f.coordinator.recordRead(n)
+		}
+		return n, err
 	}
+
+	// Clamp the cacheable request to immutable file bounds.
 	if off >= f.size {
 		return 0, io.EOF
 	}
-
 	readEnd := min(off+int64(len(p)), f.size)
 
+	// Copy every intersecting aligned block into the caller buffer.
 	startBlock := alignSegmentOffset(off)
 	endBlock := alignSegmentOffset(readEnd - 1)
 	for blockOff := startBlock; blockOff <= endBlock; blockOff += cachedSegmentBlockSize {
-		block, err := f.getBlock(blockOff)
+		block, err := f.getBlock(blockOff, lease)
 		if err != nil {
 			return 0, err
 		}
@@ -79,6 +120,7 @@ func (f *cachedSegmentFile) ReadAt(p []byte, off int64) (int, error) {
 		copy(p[copyStart:copyEnd], block[srcStart:srcEnd])
 	}
 
+	// Preserve short-read and EOF behavior at the final file block.
 	n := int(readEnd - off)
 	if n < len(p) {
 		return n, io.EOF
@@ -86,21 +128,35 @@ func (f *cachedSegmentFile) ReadAt(p []byte, off int64) (int, error) {
 	return n, nil
 }
 
-func (f *cachedSegmentFile) getBlock(blockOff int64) ([]byte, error) {
-	f.mu.Lock()
-	if block := f.blocks[blockOff]; block != nil {
-		f.touchBlockLocked(blockOff)
-		f.mu.Unlock()
-		return block, nil
+func (f *cachedSegmentFile) getBlock(blockOff int64, lease *segmentCacheLease) ([]byte, error) {
+	// Reuse a resident coordinated block.
+	if f.coordinator != nil {
+		if block, ok := f.coordinator.getBlock(f.entry, lease, blockOff); ok {
+			return block, nil
+		}
 	}
-	f.mu.Unlock()
 
+	// Reuse a resident standalone block.
+	if f.coordinator == nil {
+		f.mu.Lock()
+		if block := f.blocks[blockOff]; block != nil {
+			f.touchBlockLocked(blockOff)
+			f.mu.Unlock()
+			return block, nil
+		}
+		f.mu.Unlock()
+	}
+
+	// Read one exact aligned block from the immutable file.
 	blockEnd := min(blockOff+cachedSegmentBlockSize, f.size)
 	if blockEnd <= blockOff {
 		return nil, io.EOF
 	}
 	buf := make([]byte, blockEnd-blockOff)
 	n, err := f.rd.ReadAt(buf, blockOff)
+	if f.coordinator != nil {
+		f.coordinator.recordRead(n)
+	}
 	if err != nil && err != io.EOF {
 		return nil, err
 	}
@@ -109,18 +165,24 @@ func (f *cachedSegmentFile) getBlock(blockOff int64) ([]byte, error) {
 	}
 	block := buf[:n]
 
+	// Admit coordinated data through the engine-wide budget.
+	if f.coordinator != nil {
+		return f.coordinator.admitBlock(f.entry, lease, blockOff, block), nil
+	}
+
+	// Publish standalone data under the original per-file policy.
 	f.mu.Lock()
 	if existing := f.blocks[blockOff]; existing != nil {
 		f.touchBlockLocked(blockOff)
-		block = existing
-	} else {
-		f.blocks[blockOff] = block
-		f.order = append(f.order, blockOff)
-		if len(f.order) > maxCachedSegmentBlocks {
-			evict := f.order[0]
-			f.order = f.order[1:]
-			delete(f.blocks, evict)
-		}
+		f.mu.Unlock()
+		return existing, nil
+	}
+	f.blocks[blockOff] = block
+	f.order = append(f.order, blockOff)
+	if len(f.order) > maxCachedSegmentBlocks {
+		evict := f.order[0]
+		f.order = f.order[1:]
+		delete(f.blocks, evict)
 	}
 	f.mu.Unlock()
 	return block, nil
@@ -140,99 +202,43 @@ func (f *cachedSegmentFile) Size() (int64, error) {
 }
 
 func (s *Shard) setManifestLocked(m *Manifest) {
+	// Publish the newest observed manifest generation.
 	s.manifest = m
 	if m.Generation > s.latestGen {
 		s.latestGen = m.Generation
 	}
-	refs := m.ReferencedFiles()
-	for name := range s.lookupCache {
-		if _, ok := refs[name]; ok {
-			continue
-		}
-		delete(s.lookupCache, name)
-	}
-	for name := range s.segmentFileCache {
-		if _, ok := refs[name]; ok {
-			continue
-		}
-		delete(s.segmentFileCache, name)
-	}
+
+	// Retire cache entries omitted by the new manifest.
+	s.cache.retainVisible(s.id, m.ReferencedFiles())
 }
 
-func (s *Shard) cacheLookup(filename string, lookup *segment.LookupMeta) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.lookupCache == nil {
-		s.lookupCache = make(map[string]*segment.LookupMeta)
-	}
-	s.lookupCache[filename] = lookup
-}
-
-func (s *Shard) getLookup(ctx context.Context, meta *SegmentMeta) (*segment.LookupMeta, error) {
-	ctx, task := trace.NewTask(ctx, "hydra/opfs-blockshard/get-lookup")
+func (s *Shard) acquireSegment(ctx context.Context, meta *SegmentMeta) (*segmentCacheLease, error) {
+	ctx, task := trace.NewTask(ctx, "hydra/opfs-blockshard/acquire-segment")
 	defer task.End()
 
-	s.mu.Lock()
-	lookup := s.lookupCache[meta.Filename]
-	s.mu.Unlock()
-	if lookup != nil {
-		return lookup, nil
-	}
-	taskCtx, subtask := trace.NewTask(ctx, "hydra/opfs-blockshard/get-lookup/load-meta")
-	f, err := s.getSegmentFile(taskCtx, meta)
-	if err == nil {
-		lookup, err = loadLookupMeta(taskCtx, f, meta)
-	}
-	subtask.End()
-	if err != nil {
-		return nil, err
-	}
-	s.mu.Lock()
-	if existing := s.lookupCache[meta.Filename]; existing != nil {
-		lookup = existing
-	} else {
-		s.lookupCache[meta.Filename] = lookup
-	}
-	s.mu.Unlock()
-	return lookup, nil
-}
-
-func (s *Shard) getSegmentFile(ctx context.Context, meta *SegmentMeta) (*cachedSegmentFile, error) {
-	s.mu.Lock()
-	f := s.segmentFileCache[meta.Filename]
-	s.mu.Unlock()
-	if f != nil {
-		return f, nil
-	}
-
-	_, subtask := trace.NewTask(ctx, "hydra/opfs-blockshard/get-segment-file/open-file")
-	af, err := opfs.OpenAsyncFile(s.dir, meta.Filename)
-	subtask.End()
-	if err != nil {
-		return nil, err
-	}
-	f = newCachedSegmentFile(af, int64(meta.Size))
-
-	s.mu.Lock()
-	if existing := s.segmentFileCache[meta.Filename]; existing != nil {
-		f = existing
-	} else {
-		s.segmentFileCache[meta.Filename] = f
-	}
-	s.mu.Unlock()
-	return f, nil
+	// Delegate admission and immutable file opening to the engine coordinator.
+	return s.cache.acquireSegment(
+		ctx,
+		cacheKey{shardID: s.id, filename: meta.Filename},
+		meta,
+		func() (segmentReader, error) {
+			_, subtask := trace.NewTask(ctx, "hydra/opfs-blockshard/acquire-segment/open-file")
+			file, err := opfs.OpenAsyncFile(s.dir, meta.Filename)
+			subtask.End()
+			return file, err
+		},
+	)
 }
 
 func (s *Shard) dropSegmentFile(filename string) {
-	s.mu.Lock()
-	delete(s.segmentFileCache, filename)
-	s.mu.Unlock()
+	s.cache.remove(cacheKey{shardID: s.id, filename: filename})
 }
 
 func loadLookupMeta(ctx context.Context, f segmentReader, meta *SegmentMeta) (*segment.LookupMeta, error) {
 	ctx, task := trace.NewTask(ctx, "hydra/opfs-blockshard/load-lookup-meta")
 	defer task.End()
 
+	// Resolve file size when the manifest predates stored size metadata.
 	var err error
 	var subtask *trace.Task
 	size := int64(meta.Size)
@@ -244,6 +250,8 @@ func loadLookupMeta(ctx context.Context, f segmentReader, meta *SegmentMeta) (*s
 			return nil, errors.Wrap(err, "get segment size")
 		}
 	}
+
+	// Decode the sparse index, key range, and Bloom filter.
 	_, subtask = trace.NewTask(ctx, "hydra/opfs-blockshard/load-lookup-meta/load")
 	lookup, err := segment.LoadLookupMeta(f, size)
 	subtask.End()

--- a/db/volume/js/opfs/blockshard/cache.go
+++ b/db/volume/js/opfs/blockshard/cache.go
@@ -222,10 +222,10 @@ func (s *Shard) acquireSegment(ctx context.Context, meta *SegmentMeta) (*segment
 		cacheKey{shardID: s.id, filename: meta.Filename},
 		meta,
 		func() (segmentReader, error) {
-			_, subtask := trace.NewTask(ctx, "hydra/opfs-blockshard/acquire-segment/open-file")
-			file, err := opfs.OpenAsyncFile(s.dir, meta.Filename)
+			_, subtask := trace.NewTask(ctx, "hydra/opfs-blockshard/acquire-segment/open-snapshot")
+			snapshot, err := opfs.OpenReadSnapshot(s.dir, meta.Filename)
 			subtask.End()
-			return file, err
+			return snapshot, err
 		},
 	)
 }

--- a/db/volume/js/opfs/blockshard/cache.go
+++ b/db/volume/js/opfs/blockshard/cache.go
@@ -16,13 +16,39 @@ import (
 
 const (
 	cachedSegmentBlockSize = 64 * 1024
-	maxCachedSegmentBlocks = 4
-	maxCachedSegmentRead   = cachedSegmentBlockSize * maxCachedSegmentBlocks
+	maxCachedSegmentSpans  = 4
+	maxCachedSegmentRead   = cachedSegmentBlockSize * maxCachedSegmentSpans
 )
 
 type segmentReader interface {
 	io.ReaderAt
 	Size() (int64, error)
+}
+
+// segmentDataSpan is one request-local immutable range and its backing allocation.
+type segmentDataSpan struct {
+	start int64
+	data  []byte
+}
+
+// segmentFillRange identifies one exact aligned snapshot read.
+type segmentFillRange struct {
+	start int64
+	end   int64
+}
+
+// segmentFill publishes one in-flight range result to equal waiters.
+type segmentFill struct {
+	key      segmentFillRange
+	done     chan struct{}
+	span     segmentDataSpan
+	resource *cacheResource
+	err      error
+}
+
+// localCachedSpan retains one standalone span behind aligned block views.
+type localCachedSpan struct {
+	segmentDataSpan
 }
 
 type cachedSegmentFile struct {
@@ -34,10 +60,11 @@ type cachedSegmentFile struct {
 	coordinator *cacheCoordinator
 	entry       *cacheEntry
 
-	// mu guards standalone blocks and their recency order.
+	// mu guards standalone spans, fills, and recency.
 	mu     sync.Mutex
-	blocks map[int64][]byte
-	order  []int64
+	blocks map[int64]*localCachedSpan
+	order  []*localCachedSpan
+	fills  map[segmentFillRange]*segmentFill
 }
 
 func newCachedSegmentFile(rd segmentReader, size int64) *cachedSegmentFile {
@@ -49,7 +76,8 @@ func newCachedSegmentFile(rd segmentReader, size int64) *cachedSegmentFile {
 	return &cachedSegmentFile{
 		rd:     rd,
 		size:   size,
-		blocks: make(map[int64][]byte),
+		blocks: make(map[int64]*localCachedSpan),
+		fills:  make(map[segmentFillRange]*segmentFill),
 	}
 }
 
@@ -100,101 +128,166 @@ func (f *cachedSegmentFile) readAt(p []byte, off int64, lease *segmentCacheLease
 	}
 	readEnd := min(off+int64(len(p)), f.size)
 
-	// Copy every intersecting aligned block into the caller buffer.
-	startBlock := alignSegmentOffset(off)
+	// Fill and copy each resident or missing aligned span.
+	blockOff := alignSegmentOffset(off)
 	endBlock := alignSegmentOffset(readEnd - 1)
-	for blockOff := startBlock; blockOff <= endBlock; blockOff += cachedSegmentBlockSize {
-		block, err := f.getBlock(blockOff, lease)
+	copied := 0
+	for blockOff <= endBlock {
+		span, err := f.getSpan(blockOff, endBlock, lease)
 		if err != nil {
-			return 0, err
+			return copied, err
 		}
-		blockStart := max(off, blockOff)
-		blockEnd := min(readEnd, blockOff+int64(len(block)))
-		copyStart := blockStart - off
-		copyEnd := blockEnd - off
+		spanEnd := span.start + int64(len(span.data))
+		copyStart := max(off, blockOff)
+		copyEnd := min(readEnd, spanEnd)
 		if copyEnd <= copyStart {
-			continue
+			return copied, io.ErrUnexpectedEOF
 		}
-		srcStart := blockStart - blockOff
-		srcEnd := blockEnd - blockOff
-		copy(p[copyStart:copyEnd], block[srcStart:srcEnd])
+		copied += copy(
+			p[copyStart-off:copyEnd-off],
+			span.data[copyStart-span.start:copyEnd-span.start],
+		)
+		blockOff = alignSegmentOffset(spanEnd-1) + cachedSegmentBlockSize
 	}
 
-	// Preserve short-read and EOF behavior at the final file block.
-	n := int(readEnd - off)
-	if n < len(p) {
-		return n, io.EOF
+	// Preserve short-read and EOF behavior at the final file span.
+	if copied < len(p) {
+		return copied, io.EOF
 	}
-	return n, nil
+	return copied, nil
 }
 
-func (f *cachedSegmentFile) getBlock(blockOff int64, lease *segmentCacheLease) ([]byte, error) {
-	// Reuse a resident coordinated block.
+func (f *cachedSegmentFile) getSpan(
+	blockOff int64,
+	endBlock int64,
+	lease *segmentCacheLease,
+) (segmentDataSpan, error) {
+	// Coordinate resident spans and equal in-flight fills for engine entries.
 	if f.coordinator != nil {
-		if block, ok := f.coordinator.getBlock(f.entry, lease, blockOff); ok {
-			return block, nil
+		span, fill, leader := f.coordinator.startSpanFill(
+			f.entry,
+			lease,
+			blockOff,
+			endBlock,
+			f.size,
+		)
+		if fill == nil {
+			return span, nil
 		}
+		if !leader {
+			return f.coordinator.awaitSpanFill(fill, lease)
+		}
+		span, err := f.readSpan(fill.key)
+		return f.coordinator.finishSpanFill(f.entry, lease, fill, span, err)
 	}
 
-	// Reuse a resident standalone block.
-	if f.coordinator == nil {
-		f.mu.Lock()
-		if block := f.blocks[blockOff]; block != nil {
-			f.touchBlockLocked(blockOff)
-			f.mu.Unlock()
-			return block, nil
-		}
-		f.mu.Unlock()
-	}
+	// Use the standalone span cache for operation-local readers.
+	return f.getLocalSpan(blockOff, endBlock)
+}
 
-	// Read one exact aligned block from the immutable file.
-	blockEnd := min(blockOff+cachedSegmentBlockSize, f.size)
-	if blockEnd <= blockOff {
-		return nil, io.EOF
+func (f *cachedSegmentFile) readSpan(key segmentFillRange) (segmentDataSpan, error) {
+	// Read one exact request-bounded allocation from the immutable snapshot.
+	span := segmentDataSpan{
+		start: key.start,
+		data:  make([]byte, key.end-key.start),
 	}
-	buf := make([]byte, blockEnd-blockOff)
-	n, err := f.rd.ReadAt(buf, blockOff)
+	n, err := f.rd.ReadAt(span.data, key.start)
 	if f.coordinator != nil {
 		f.coordinator.recordRead(n)
 	}
 	if err != nil && err != io.EOF {
-		return nil, err
+		return segmentDataSpan{}, err
 	}
-	if n <= 0 {
-		return nil, io.EOF
+	if n != len(span.data) {
+		return segmentDataSpan{}, io.ErrUnexpectedEOF
 	}
-	block := buf[:n]
-
-	// Admit coordinated data through the engine-wide budget.
-	if f.coordinator != nil {
-		return f.coordinator.admitBlock(f.entry, lease, blockOff, block), nil
-	}
-
-	// Publish standalone data under the original per-file policy.
-	f.mu.Lock()
-	if existing := f.blocks[blockOff]; existing != nil {
-		f.touchBlockLocked(blockOff)
-		f.mu.Unlock()
-		return existing, nil
-	}
-	f.blocks[blockOff] = block
-	f.order = append(f.order, blockOff)
-	if len(f.order) > maxCachedSegmentBlocks {
-		evict := f.order[0]
-		f.order = f.order[1:]
-		delete(f.blocks, evict)
-	}
-	f.mu.Unlock()
-	return block, nil
+	return span, nil
 }
 
-func (f *cachedSegmentFile) touchBlockLocked(blockOff int64) {
-	idx := slices.Index(f.order, blockOff)
+func (f *cachedSegmentFile) getLocalSpan(blockOff, endBlock int64) (segmentDataSpan, error) {
+	// Reuse a resident standalone span.
+	f.mu.Lock()
+	if cached := f.blocks[blockOff]; cached != nil {
+		f.touchLocalSpanLocked(cached)
+		span := cached.segmentDataSpan
+		f.mu.Unlock()
+		return span, nil
+	}
+
+	// Join an equal fill or register the consecutive missing range.
+	key := f.localFillRangeLocked(blockOff, endBlock)
+	if fill := f.fills[key]; fill != nil {
+		f.mu.Unlock()
+		<-fill.done
+		return fill.span, fill.err
+	}
+	fill := &segmentFill{key: key, done: make(chan struct{})}
+	f.fills[key] = fill
+	f.mu.Unlock()
+
+	// Read the range without holding the standalone cache mutex.
+	span, err := f.readSpan(key)
+
+	// Publish one span when no unequal fill already covered its blocks.
+	f.mu.Lock()
+	fill.span = span
+	fill.err = err
+	if err == nil && !f.localRangeOverlapsLocked(key) {
+		if len(f.order) >= maxCachedSegmentSpans {
+			f.removeLocalSpanLocked(f.order[0])
+		}
+		cached := &localCachedSpan{segmentDataSpan: span}
+		for off := key.start; off < key.end; off += cachedSegmentBlockSize {
+			f.blocks[off] = cached
+		}
+		f.order = append(f.order, cached)
+	}
+	delete(f.fills, key)
+	close(fill.done)
+	f.mu.Unlock()
+	return span, err
+}
+
+func (f *cachedSegmentFile) localFillRangeLocked(blockOff, endBlock int64) segmentFillRange {
+	// Stop the missing run at the next resident block or request boundary.
+	end := min(endBlock+cachedSegmentBlockSize, f.size)
+	for off := blockOff + cachedSegmentBlockSize; off <= endBlock; off += cachedSegmentBlockSize {
+		if f.blocks[off] != nil {
+			end = off
+			break
+		}
+	}
+	return segmentFillRange{start: blockOff, end: end}
+}
+
+func (f *cachedSegmentFile) localRangeOverlapsLocked(key segmentFillRange) bool {
+	// Reject admission when an unequal concurrent fill already published a block.
+	for off := key.start; off < key.end; off += cachedSegmentBlockSize {
+		if f.blocks[off] != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func (f *cachedSegmentFile) touchLocalSpanLocked(span *localCachedSpan) {
+	// Move the reused backing allocation to the recency tail.
+	idx := slices.Index(f.order, span)
 	if idx < 0 || idx == len(f.order)-1 {
 		return
 	}
 	copy(f.order[idx:], f.order[idx+1:])
-	f.order[len(f.order)-1] = blockOff
+	f.order[len(f.order)-1] = span
+}
+
+func (f *cachedSegmentFile) removeLocalSpanLocked(span *localCachedSpan) {
+	// Remove every aligned block view backed by the evicted allocation.
+	for off := span.start; off < span.start+int64(len(span.data)); off += cachedSegmentBlockSize {
+		if f.blocks[off] == span {
+			delete(f.blocks, off)
+		}
+	}
+	f.order = f.order[1:]
 }
 
 func (f *cachedSegmentFile) Size() (int64, error) {

--- a/db/volume/js/opfs/blockshard/compaction.go
+++ b/db/volume/js/opfs/blockshard/compaction.go
@@ -38,30 +38,34 @@ func ExecuteCompaction(ctx context.Context, shard *Shard, plan *CompactionPlan) 
 		return err
 	}
 
+	// Pin every immutable input until the merge finishes.
 	iters := make([]*segment.EntryIterator, len(plan.InputSegs))
+	leases := make([]*segmentCacheLease, 0, len(plan.InputSegs))
+	defer func() {
+		for _, lease := range leases {
+			lease.Release()
+		}
+	}()
 	for i, meta := range plan.InputSegs {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		f, err := shard.getSegmentFile(ctx, &meta)
+		lease, err := shard.acquireSegment(ctx, &meta)
 		if err != nil {
-			return errors.Errorf("open input segment %s: %v", meta.Filename, err)
+			return errors.Errorf("acquire input segment %s: %v", meta.Filename, err)
 		}
+		leases = append(leases, lease)
 		size := int64(meta.Size)
 		if size == 0 {
-			size, err = f.Size()
+			size, err = lease.Size()
 			if err != nil {
 				return errors.Errorf("get input segment %s size: %v", meta.Filename, err)
 			}
 		}
-		if err := segment.VerifyChecksum(f, size); err != nil {
+		if err := segment.VerifyChecksum(lease, size); err != nil {
 			return errors.Errorf("verify input segment %s: %v", meta.Filename, err)
 		}
-		lookup, err := loadLookupMeta(ctx, f, &meta)
-		if err != nil {
-			return errors.Errorf("parse input segment %s: %v", meta.Filename, err)
-		}
-		iters[i] = segment.NewEntryIterator(f, lookup)
+		iters[i] = segment.NewEntryIterator(lease, lease.lookup)
 	}
 
 	writer := compactionOutputWriter{
@@ -119,9 +123,6 @@ func ExecuteCompaction(ctx context.Context, shard *Shard, plan *CompactionPlan) 
 
 	if err := shard.writeManifest(ctx, newManifest); err != nil {
 		return cleanupOutputs(errors.Wrap(err, "write compaction manifest"))
-	}
-	for i := range outputs {
-		shard.cacheLookup(outputs[i].Meta.Filename, outputs[i].Lookup)
 	}
 	return nil
 }

--- a/db/volume/js/opfs/blockshard/engine.go
+++ b/db/volume/js/opfs/blockshard/engine.go
@@ -158,6 +158,7 @@ type Engine struct {
 	maxEntryN   int
 	broadcaster *Broadcaster
 	listener    *Listener
+	cache       *cacheCoordinator
 }
 
 // NewEngine creates a new block shard engine in the given OPFS directory.
@@ -179,7 +180,8 @@ func NewEngineWithSettings(
 	settings = normalizeSettings(settings)
 	ctx, cancel := context.WithCancel(ctx)
 
-	// Allocate shard state, actors, pending buffers, and bridge listeners.
+	// Allocate shard state and one shared cache budget.
+	cache := newDefaultCacheCoordinator()
 	e := &Engine{
 		shards:      make([]*Shard, settings.ShardCount),
 		actors:      make([]*shardActor, settings.ShardCount),
@@ -190,21 +192,25 @@ func NewEngineWithSettings(
 		maxEntryN:   settings.MaxEntryValueBytes,
 		broadcaster: NewBroadcaster(lockPrefix),
 		listener:    NewListener(lockPrefix),
+		cache:       cache,
 	}
 
 	// Open and recover every shard before starting its write actor.
 	for i := range e.shards {
+		// Bind one immutable shard directory to the engine cache.
 		name := "shard-" + zeroPad(uint64(i), 2)
 		shardDir, err := opfs.GetDirectory(dir, name, true)
 		if err != nil {
 			cancel()
 			return nil, errors.Errorf("create shard %d directory: %v", i, err)
 		}
-		shard, err := NewShard(i, shardDir, lockPrefix, settings)
+		shard, err := newShard(i, shardDir, lockPrefix, settings, cache)
 		if err != nil {
 			cancel()
 			return nil, errors.Errorf("open shard %d: %v", i, err)
 		}
+
+		// Recover pending deletion and orphan state under the publish lock.
 		release, err := shard.AcquirePublishLockContext(ctx)
 		if err != nil {
 			cancel()
@@ -221,10 +227,11 @@ func NewEngineWithSettings(
 			return nil, errors.Errorf("clean shard %d orphans: %v", i, err)
 		}
 		release()
+
+		// Publish recovered shard state before starting its actor.
 		e.shards[i] = shard
 		e.actors[i] = newShardActor(i, shard)
 		e.pending[i] = newPendingBuffer()
-
 		e.wg.Add(1)
 		go e.runActor(ctx, e.actors[i])
 	}
@@ -236,11 +243,17 @@ func NewEngineWithSettings(
 	return e, nil
 }
 
-// Close stops all write actors and waits for them to drain.
+// Close stops engine activity and releases cache and broadcast resources.
 func (e *Engine) Close() {
+	// Stop engine goroutines and their cross-runtime broadcasts.
 	e.cancel()
 	e.wg.Wait()
 	e.broadcaster.Close()
+
+	// Wait for active lookups and release every cached file handle.
+	e.cache.close()
+
+	// Release the invalidation listener after cache shutdown.
 	e.listener.Close()
 }
 
@@ -534,31 +547,26 @@ func (e *Engine) getFromShard(
 	// Scan segments newest-first (last in manifest = newest).
 	for i := len(m.Segments) - 1; i >= 0; i-- {
 		seg := &m.Segments[i]
-
-		// Range check.
+		// Skip segments whose immutable key range excludes the request.
 		if string(key) < string(seg.MinKey) || string(key) > string(seg.MaxKey) {
 			continue
 		}
-		taskCtx, subtask := trace.NewTask(ctx, "hydra/opfs-blockshard/get-from-shard/load-lookup")
-		lookup, err := shard.getLookup(taskCtx, seg)
+
+		// Pin cache resources for this segment lookup step.
+		taskCtx, subtask := trace.NewTask(ctx, "hydra/opfs-blockshard/get-from-shard/acquire-segment")
+		lease, err := shard.acquireSegment(taskCtx, seg)
 		subtask.End()
 		if err != nil {
 			if e.shouldRetryAfterRefresh(ctx, shardIdx, m.Generation, retried, err) {
 				return e.getFromShard(ctx, shardIdx, key, true)
 			}
-			return nil, false, errors.Errorf("load segment %s lookup: %v", seg.Filename, err)
+			return nil, false, errors.Errorf("acquire segment %s: %v", seg.Filename, err)
 		}
-		taskCtx, subtask = trace.NewTask(ctx, "hydra/opfs-blockshard/get-from-shard/open-segment")
-		f, err := shard.getSegmentFile(taskCtx, seg)
-		subtask.End()
-		if err != nil {
-			if e.shouldRetryAfterRefresh(ctx, shardIdx, m.Generation, retried, err) {
-				return e.getFromShard(ctx, shardIdx, key, true)
-			}
-			return nil, false, errors.Errorf("open segment %s: %v", seg.Filename, err)
-		}
+
+		// Locate the key and release every segment resource pin.
 		taskCtx, subtask = trace.NewTask(ctx, "hydra/opfs-blockshard/get-from-shard/locate")
-		val, found, tombstone, err := lookup.Locate(f, key, true)
+		val, found, tombstone, err := lease.lookup.Locate(lease, key, true)
+		lease.Release()
 		subtask.End()
 		if err != nil {
 			if opfs.IsNotFound(err) {
@@ -627,7 +635,9 @@ func (e *Engine) getExistsFromShard(shardIdx int, key []byte, retried bool) (boo
 		if string(key) < string(seg.MinKey) || string(key) > string(seg.MaxKey) {
 			continue
 		}
-		lookup, err := shard.getLookup(ctx, seg)
+
+		// Pin cache resources while checking this segment.
+		lease, err := shard.acquireSegment(ctx, seg)
 		if err != nil {
 			if opfs.IsNotFound(err) {
 				shard.dropSegmentFile(seg.Filename)
@@ -635,16 +645,10 @@ func (e *Engine) getExistsFromShard(shardIdx int, key []byte, retried bool) (boo
 			if e.shouldRetryAfterRefresh(ctx, shardIdx, m.Generation, retried, err) {
 				return e.getExistsFromShard(shardIdx, key, true)
 			}
-			return false, errors.Errorf("load segment %s lookup: %v", seg.Filename, err)
+			return false, errors.Errorf("acquire segment %s: %v", seg.Filename, err)
 		}
-		f, err := shard.getSegmentFile(ctx, seg)
-		if err != nil {
-			if e.shouldRetryAfterRefresh(ctx, shardIdx, m.Generation, retried, err) {
-				return e.getExistsFromShard(shardIdx, key, true)
-			}
-			return false, errors.Errorf("open segment %s: %v", seg.Filename, err)
-		}
-		_, found, tombstone, err := lookup.Locate(f, key, false)
+		_, found, tombstone, err := lease.lookup.Locate(lease, key, false)
+		lease.Release()
 		if err != nil {
 			if opfs.IsNotFound(err) {
 				shard.dropSegmentFile(seg.Filename)
@@ -777,7 +781,9 @@ func (e *Engine) statFromShard(
 		if string(key) < string(seg.MinKey) || string(key) > string(seg.MaxKey) {
 			continue
 		}
-		lookup, err := shard.getLookup(ctx, seg)
+
+		// Pin cache resources while reading value metadata.
+		lease, err := shard.acquireSegment(ctx, seg)
 		if err != nil {
 			if opfs.IsNotFound(err) {
 				shard.dropSegmentFile(seg.Filename)
@@ -785,16 +791,10 @@ func (e *Engine) statFromShard(
 			if e.shouldRetryAfterRefresh(ctx, shardIdx, m.Generation, retried, err) {
 				return e.statFromShard(ctx, shardIdx, key, true)
 			}
-			return 0, false, errors.Errorf("load segment %s lookup: %v", seg.Filename, err)
+			return 0, false, errors.Errorf("acquire segment %s: %v", seg.Filename, err)
 		}
-		f, err := shard.getSegmentFile(ctx, seg)
-		if err != nil {
-			if e.shouldRetryAfterRefresh(ctx, shardIdx, m.Generation, retried, err) {
-				return e.statFromShard(ctx, shardIdx, key, true)
-			}
-			return 0, false, errors.Errorf("open segment %s: %v", seg.Filename, err)
-		}
-		stat, err := lookup.Stat(f, key)
+		stat, err := lease.lookup.Stat(lease, key)
+		lease.Release()
 		if err != nil {
 			if opfs.IsNotFound(err) {
 				shard.dropSegmentFile(seg.Filename)
@@ -860,7 +860,8 @@ func (e *Engine) getExistsBatchFromShard(
 			continue
 		}
 
-		lookup, err := shard.getLookup(ctx, seg)
+		// Pin cache resources for the batched segment step.
+		lease, err := shard.acquireSegment(ctx, seg)
 		if err != nil {
 			if opfs.IsNotFound(err) {
 				shard.dropSegmentFile(seg.Filename)
@@ -868,23 +869,18 @@ func (e *Engine) getExistsBatchFromShard(
 			if e.shouldRetryAfterRefresh(ctx, shardIdx, m.Generation, retried, err) {
 				return e.getExistsBatchFromShard(ctx, shardIdx, keys, true)
 			}
-			return nil, errors.Errorf("load segment %s lookup: %v", seg.Filename, err)
-		}
-		f, err := shard.getSegmentFile(ctx, seg)
-		if err != nil {
-			if e.shouldRetryAfterRefresh(ctx, shardIdx, m.Generation, retried, err) {
-				return e.getExistsBatchFromShard(ctx, shardIdx, keys, true)
-			}
-			return nil, errors.Errorf("open segment %s: %v", seg.Filename, err)
+			return nil, errors.Errorf("acquire segment %s: %v", seg.Filename, err)
 		}
 		if err := ctx.Err(); err != nil {
+			lease.Release()
 			return nil, err
 		}
 		candidateKeys := make([][]byte, len(candidates))
 		for i, j := range candidates {
 			candidateKeys[i] = keys[j]
 		}
-		results, err := lookup.LocateBatch(f, candidateKeys, false)
+		results, err := lease.lookup.LocateBatch(lease, candidateKeys, false)
+		lease.Release()
 		if err != nil {
 			if opfs.IsNotFound(err) {
 				shard.dropSegmentFile(seg.Filename)

--- a/db/volume/js/opfs/blockshard/shard.go
+++ b/db/volume/js/opfs/blockshard/shard.go
@@ -41,13 +41,25 @@ type Shard struct {
 	maxSegmentDataBytes int
 	buildSegmentFileFn  func(context.Context, string, *segment.Writer) (segment.BuildResult, error)
 
-	lookupCache      map[string]*segment.LookupMeta
-	segmentFileCache map[string]*cachedSegmentFile
+	// cache coordinates immutable segment resources across engine shards.
+	cache *cacheCoordinator
 }
 
-// NewShard opens or creates a shard in the given OPFS directory.
-// It reads both manifest slots and picks the higher valid generation.
+// NewShard opens or creates one standalone shard in an OPFS directory.
+// Immutable reads use operation-local resources because engine construction
+// supplies the shared cache lifecycle.
 func NewShard(id int, dir js.Value, lockPrefix string, settings *Settings) (*Shard, error) {
+	return newShard(id, dir, lockPrefix, settings, newCacheCoordinator(0, 0))
+}
+
+func newShard(
+	id int,
+	dir js.Value,
+	lockPrefix string,
+	settings *Settings,
+	cache *cacheCoordinator,
+) (*Shard, error) {
+	// Construct one shard around the supplied cache lifecycle.
 	settings = normalizeSettings(settings)
 	s := &Shard{
 		id:                  id,
@@ -57,10 +69,10 @@ func NewShard(id int, dir js.Value, lockPrefix string, settings *Settings) (*Sha
 		nowFn:               time.Now,
 		bloomFPR:            settings.BloomFPR,
 		maxSegmentDataBytes: settings.MaxSegmentDataBytes,
-		lookupCache:         make(map[string]*segment.LookupMeta),
-		segmentFileCache:    make(map[string]*cachedSegmentFile),
+		cache:               cache,
 	}
 
+	// Load the durable manifest before exposing shard state.
 	if err := s.reloadManifestFromDisk(context.Background()); err != nil {
 		return nil, err
 	}
@@ -136,9 +148,6 @@ func (s *Shard) Publish(ctx context.Context, entries []segment.Entry) error {
 			return errors.Wrapf(err, "clean failed publish segments: %v", cleanupErr)
 		}
 		return err
-	}
-	for i := range outputs {
-		s.cacheLookup(outputs[i].Meta.Filename, outputs[i].Lookup)
 	}
 	subtask.End()
 	return nil


### PR DESCRIPTION
Bound immutable OPFS segment reads with one engine-wide cache coordinator. Charge decoded lookup metadata and retained spans against fixed byte and handle limits, pin active resources, evict idle resources by recency, and release snapshots through one lifecycle.

Add explicit immutable read snapshots across direct, TinyGo, and remote drivers. Coalesce consecutive missing blocks into one charged fill and share equal concurrent fills.

Keep the existing 64 KiB by four policy after bounded real-OPFS and Drive replay. Add opt-in replay and geometric fixtures for future policy decisions.